### PR TITLE
feat: decide activation experiments on unique users

### DIFF
--- a/.github/workflows/activation-experiment-report.yml
+++ b/.github/workflows/activation-experiment-report.yml
@@ -1,0 +1,57 @@
+name: Activation Experiment Report
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 0 * * *"
+
+concurrency:
+  group: activation-experiment-report
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    name: Build aggregate activation-to-paid report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD || 'https://smmkxxavexumewbfaqpy.supabase.co' }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Require report credentials
+        shell: bash
+        run: |
+          test -n "${SUPABASE_SERVICE_ROLE_KEY:-}" || {
+            echo "::error::SUPABASE_SERVICE_ROLE_KEY is required."
+            exit 1
+          }
+
+      - name: Build decision report
+        shell: bash
+        run: |
+          mkdir -p tmp/activation-experiment-report
+          python3 scripts/activation_experiment_report.py \
+            --supabase-url "$SUPABASE_URL" \
+            --json-report tmp/activation-experiment-report/report.json \
+            --markdown-report tmp/activation-experiment-report/report.md
+
+      - name: Publish job summary
+        if: always() && hashFiles('tmp/activation-experiment-report/report.md') != ''
+        shell: bash
+        run: cat tmp/activation-experiment-report/report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload aggregate report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: activation-experiment-report
+          path: tmp/activation-experiment-report/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/marketing/activation-to-paid-10-hypotheses.md
+++ b/docs/marketing/activation-to-paid-10-hypotheses.md
@@ -19,8 +19,15 @@ and the linked bank account shows a payout of at least 1 JPY.
 8. `supporter_checkout` or `pro_checkout`
 9. `checkout_return`
 
-Each event is stored as
-`activation_exp_<hypothesis>_<variant>_<stage>` in `app_analytics.source_details`.
+Each event keeps the bounded key
+`activation_exp_<hypothesis>_<variant>_<stage>`. The existing daily
+`app_analytics.source_details` counter remains as an operational signal, while
+`activation_experiment_events` records each authenticated, non-anonymous
+user/arm/stage at most once for experiment decisions. The raw ledger is denied
+to browser roles; only the service-role aggregate
+`activation_experiment_arm_stats` is used by reports. It stores no email, IP
+address, user agent, prompt, challenge, or other user-supplied content.
+
 Assignments persist in SharedPreferences. QA can force an arm with:
 
 ```text
@@ -56,6 +63,12 @@ decision at a time.
   idempotent `daily_todos` item so the Home calendar can resume it.
 - `SubscriptionBillingPage` presents Japanese value-based Free, 100 JPY, Pro,
   and Team choices and records checkout intent.
+- `record_activation_experiment_event` deduplicates every signed-in user,
+  hypothesis, variant, and stage. Anonymous sessions cannot write this ledger.
+- `activation_experiment_report.py` validates all 20 arms, calculates Wilson
+  95% intervals and relative lift, and emits aggregate-only JSON and Markdown.
+- `activation-experiment-report.yml` runs the decision report daily and on
+  demand with the service-role key kept out of pull-request workflows.
 - `schedule-hub` creates the supporter item as "AI仕事OS 初期サポーター" with
   one-time/no-renewal value copy in Stripe Checkout.
 - Widget tests cover a 390 px viewport, the complete first-value flow, A03
@@ -66,10 +79,13 @@ decision at a time.
 ## Validation gate
 
 Automated tests prove implementation, not market impact. Do not declare a
-hypothesis won until it has approximately 100 views per arm plus at least 20
-onboarding completions or 5 checkout starts. Prefer treatment only when the
-primary metric improves by at least 20% and the sample is not dominated by
-internal QA traffic.
+hypothesis won until both arms have at least 100 unique onboarding views and
+20 users in the primary-metric denominator. A01-A09 also require 20 total
+primary successes; A10 requires 5 total supporter-or-Pro checkout starts.
+Prefer an arm only when the primary metric differs by at least 20% and its
+Wilson 95% interval is fully separated from the other arm. Impossible funnels
+such as more unique checkout starters than billing viewers are reported as
+`invalid_funnel_data`, never as a winner.
 
 ## Revenue completion gate
 

--- a/lib/services/activation_revenue_tracker.dart
+++ b/lib/services/activation_revenue_tracker.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'activation_revenue_experiment_service.dart';
@@ -12,9 +13,13 @@ abstract interface class ActivationRevenueEventTracker {
 
 class SupabaseActivationRevenueEventTracker
     implements ActivationRevenueEventTracker {
-  const SupabaseActivationRevenueEventTracker({this.clientOverride});
+  const SupabaseActivationRevenueEventTracker({
+    this.clientOverride,
+    this.uniqueEventRecorderOverride,
+  });
 
   final SupabaseClient? clientOverride;
+  final Future<void> Function(String eventKey)? uniqueEventRecorderOverride;
 
   SupabaseClient? get _client {
     if (clientOverride != null) return clientOverride;
@@ -31,11 +36,30 @@ class SupabaseActivationRevenueEventTracker
   Future<void> record({
     required ActivationRevenueAssignment assignment,
     required String stage,
-  }) {
-    return LandingShareService.recordFunnelEvent(
-      eventKey: assignment.eventKey(stage),
-      client: _client,
+  }) async {
+    final eventKey = assignment.eventKey(stage);
+    final client = _client;
+    await LandingShareService.recordFunnelEvent(
+      eventKey: eventKey,
+      client: client,
     );
+
+    try {
+      final override = uniqueEventRecorderOverride;
+      if (override != null) {
+        await override(eventKey);
+        return;
+      }
+      if (client == null) {
+        return;
+      }
+      await client.rpc(
+        'record_activation_experiment_event',
+        params: <String, dynamic>{'p_event_key': eventKey},
+      );
+    } catch (error) {
+      debugPrint('Unique activation experiment event failed: $error');
+    }
   }
 }
 

--- a/scripts/activation_experiment_report.py
+++ b/scripts/activation_experiment_report.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""Build a privacy-safe decision report for A01-A10 activation experiments.
+
+The production view contains aggregate arm counts only. This script requires a
+service-role key, validates the expected 20-arm contract, and never emits the
+key, authenticated user identifiers, or raw event rows.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SUPABASE_URL = "https://smmkxxavexumewbfaqpy.supabase.co"
+HYPOTHESES = tuple(f"a{index:02d}" for index in range(1, 11))
+VARIANTS = ("control", "treatment")
+COUNT_FIELDS = (
+    "unique_onboarding_views",
+    "unique_intent_selections",
+    "unique_first_action_starts",
+    "unique_first_action_completions",
+    "unique_onboarding_completions",
+    "unique_value_recap_views",
+    "unique_billing_views",
+    "unique_supporter_checkouts",
+    "unique_pro_checkouts",
+    "unique_checkout_starts",
+    "unique_checkout_returns",
+)
+REPORT_SELECT = ",".join(
+    (
+        "hypothesis_id",
+        "variant",
+        *COUNT_FIELDS,
+        "first_event_at",
+        "last_event_at",
+    )
+)
+
+
+class ReportContractError(ValueError):
+    """Raised when the production aggregate no longer matches its contract."""
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    key: str
+    label: str
+    numerator_field: str
+    denominator_field: str
+    minimum_total_successes: int
+
+
+METRIC_SPECS = {
+    "a01": MetricSpec(
+        "onboarding_completion_rate",
+        "Onboarding completion / onboarding view",
+        "unique_onboarding_completions",
+        "unique_onboarding_views",
+        20,
+    ),
+    "a02": MetricSpec(
+        "first_action_start_rate",
+        "First action start / onboarding view",
+        "unique_first_action_starts",
+        "unique_onboarding_views",
+        20,
+    ),
+    "a03": MetricSpec(
+        "first_action_start_rate",
+        "First action start / onboarding view",
+        "unique_first_action_starts",
+        "unique_onboarding_views",
+        20,
+    ),
+    "a04": MetricSpec(
+        "first_action_start_rate",
+        "First action start / onboarding view",
+        "unique_first_action_starts",
+        "unique_onboarding_views",
+        20,
+    ),
+    "a05": MetricSpec(
+        "first_action_completion_rate",
+        "First action completion / first action start",
+        "unique_first_action_completions",
+        "unique_first_action_starts",
+        20,
+    ),
+    "a06": MetricSpec(
+        "onboarding_completion_rate",
+        "Onboarding completion / onboarding view",
+        "unique_onboarding_completions",
+        "unique_onboarding_views",
+        20,
+    ),
+    "a07": MetricSpec(
+        "onboarding_completion_rate",
+        "Onboarding completion / onboarding view",
+        "unique_onboarding_completions",
+        "unique_onboarding_views",
+        20,
+    ),
+    "a08": MetricSpec(
+        "onboarding_completion_rate",
+        "Onboarding completion / onboarding view",
+        "unique_onboarding_completions",
+        "unique_onboarding_views",
+        20,
+    ),
+    "a09": MetricSpec(
+        "billing_view_rate",
+        "Billing view / value recap view",
+        "unique_billing_views",
+        "unique_value_recap_views",
+        20,
+    ),
+    "a10": MetricSpec(
+        "checkout_start_rate",
+        "Supporter or Pro checkout / billing view",
+        "unique_checkout_starts",
+        "unique_billing_views",
+        5,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ArmStats:
+    hypothesis_id: str
+    variant: str
+    unique_onboarding_views: int
+    unique_intent_selections: int
+    unique_first_action_starts: int
+    unique_first_action_completions: int
+    unique_onboarding_completions: int
+    unique_value_recap_views: int
+    unique_billing_views: int
+    unique_supporter_checkouts: int
+    unique_pro_checkouts: int
+    unique_checkout_starts: int
+    unique_checkout_returns: int
+    first_event_at: str | None = None
+    last_event_at: str | None = None
+
+
+def expected_arms() -> set[tuple[str, str]]:
+    return {
+        (hypothesis_id, variant)
+        for hypothesis_id in HYPOTHESES
+        for variant in VARIANTS
+    }
+
+
+def _non_negative_int(value: Any, field: str, arm_key: tuple[str, str]) -> int:
+    if isinstance(value, bool):
+        raise ReportContractError(f"{arm_key}: {field} must be an integer")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ReportContractError(
+            f"{arm_key}: {field} must be an integer"
+        ) from exc
+    if parsed < 0:
+        raise ReportContractError(f"{arm_key}: {field} must be non-negative")
+    return parsed
+
+
+def validate_arm_rows(rows: Any) -> dict[tuple[str, str], ArmStats]:
+    if not isinstance(rows, list):
+        raise ReportContractError("activation experiment response must be a list")
+
+    parsed: dict[tuple[str, str], ArmStats] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ReportContractError(
+                "every activation experiment row must be an object"
+            )
+        hypothesis_id = str(row.get("hypothesis_id", ""))
+        variant = str(row.get("variant", ""))
+        key = (hypothesis_id, variant)
+        if key not in expected_arms():
+            raise ReportContractError(f"unexpected experiment arm: {key}")
+        if key in parsed:
+            raise ReportContractError(f"duplicate experiment arm: {key}")
+
+        counts = {
+            field: _non_negative_int(row.get(field), field, key)
+            for field in COUNT_FIELDS
+        }
+        parsed[key] = ArmStats(
+            hypothesis_id=hypothesis_id,
+            variant=variant,
+            **counts,
+            first_event_at=row.get("first_event_at"),
+            last_event_at=row.get("last_event_at"),
+        )
+
+    missing = expected_arms() - set(parsed)
+    if missing:
+        missing_text = ", ".join(f"{h}/{v}" for h, v in sorted(missing))
+        raise ReportContractError(f"missing experiment arms: {missing_text}")
+    if len(parsed) != 20:
+        raise ReportContractError(f"expected 20 experiment arms, got {len(parsed)}")
+    return parsed
+
+
+def wilson_interval(
+    successes: int,
+    trials: int,
+    z: float = 1.959963984540054,
+) -> tuple[float, float]:
+    """Return a two-sided Wilson score interval for a binomial proportion."""
+    if trials <= 0:
+        return (0.0, 1.0)
+    if successes < 0 or successes > trials:
+        raise ValueError("successes must be between zero and trials")
+    proportion = successes / trials
+    z_squared = z * z
+    denominator = 1.0 + z_squared / trials
+    center = (proportion + z_squared / (2.0 * trials)) / denominator
+    margin = (
+        z
+        * math.sqrt(
+            proportion * (1.0 - proportion) / trials
+            + z_squared / (4.0 * trials * trials)
+        )
+        / denominator
+    )
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def _with_primary_metric(
+    arm: ArmStats,
+    metric: MetricSpec,
+) -> dict[str, Any]:
+    arm_data = asdict(arm)
+    successes = int(arm_data[metric.numerator_field])
+    denominator = int(arm_data[metric.denominator_field])
+    contract_valid = successes <= denominator
+    if denominator <= 0:
+        rate = 0.0
+        lower, upper = (0.0, 1.0)
+    elif contract_valid:
+        rate = successes / denominator
+        lower, upper = wilson_interval(successes, denominator)
+    else:
+        rate = None
+        lower, upper = (None, None)
+    return {
+        **arm_data,
+        "primary_metric_successes": successes,
+        "primary_metric_denominator": denominator,
+        "primary_metric_contract_valid": contract_valid,
+        "primary_rate": rate,
+        "primary_wilson_95": {"lower": lower, "upper": upper},
+    }
+
+
+def build_report(
+    arms: dict[tuple[str, str], ArmStats],
+    *,
+    minimum_views_per_arm: int = 100,
+    minimum_metric_denominator_per_arm: int = 20,
+) -> dict[str, Any]:
+    if set(arms) != expected_arms():
+        raise ReportContractError("build_report requires all 20 validated arms")
+
+    hypotheses: list[dict[str, Any]] = []
+    for hypothesis_id in HYPOTHESES:
+        metric = METRIC_SPECS[hypothesis_id]
+        control = _with_primary_metric(
+            arms[(hypothesis_id, "control")],
+            metric,
+        )
+        treatment = _with_primary_metric(
+            arms[(hypothesis_id, "treatment")],
+            metric,
+        )
+        views_ready = (
+            control["unique_onboarding_views"] >= minimum_views_per_arm
+            and treatment["unique_onboarding_views"] >= minimum_views_per_arm
+        )
+        denominators_ready = (
+            control["primary_metric_denominator"]
+            >= minimum_metric_denominator_per_arm
+            and treatment["primary_metric_denominator"]
+            >= minimum_metric_denominator_per_arm
+        )
+        total_primary_successes = (
+            control["primary_metric_successes"]
+            + treatment["primary_metric_successes"]
+        )
+        primary_success_gate_ready = (
+            total_primary_successes >= metric.minimum_total_successes
+        )
+        metric_contract_valid = (
+            control["primary_metric_contract_valid"]
+            and treatment["primary_metric_contract_valid"]
+        )
+        control_rate = control["primary_rate"]
+        treatment_rate = treatment["primary_rate"]
+        relative_lift = (
+            (treatment_rate - control_rate) / control_rate
+            if control_rate is not None
+            and treatment_rate is not None
+            and control_rate > 0.0
+            else None
+        )
+
+        if not metric_contract_valid:
+            decision = "invalid_funnel_data"
+        elif (
+            not views_ready
+            or not denominators_ready
+            or not primary_success_gate_ready
+        ):
+            decision = "insufficient_data"
+        elif (
+            treatment_rate > control_rate
+            and (control_rate == 0.0 or relative_lift >= 0.20)
+            and treatment["primary_wilson_95"]["lower"]
+            > control["primary_wilson_95"]["upper"]
+        ):
+            decision = "treatment_wins"
+        elif (
+            treatment_rate < control_rate
+            and relative_lift is not None
+            and relative_lift <= -0.20
+            and control["primary_wilson_95"]["lower"]
+            > treatment["primary_wilson_95"]["upper"]
+        ):
+            decision = "control_wins"
+        else:
+            decision = "inconclusive"
+
+        hypotheses.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "primary_metric": asdict(metric),
+                "control": control,
+                "treatment": treatment,
+                "relative_primary_lift": relative_lift,
+                "views_gate_ready": views_ready,
+                "metric_denominator_gate_ready": denominators_ready,
+                "total_primary_successes": total_primary_successes,
+                "primary_success_gate_ready": primary_success_gate_ready,
+                "metric_contract_valid": metric_contract_valid,
+                "decision": decision,
+            }
+        )
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": "activation_experiment_arm_stats",
+        "privacy": {
+            "aggregate_only": True,
+            "contains_auth_user_ids": False,
+            "contains_raw_events": False,
+        },
+        "contract": {
+            "expected_arm_count": 20,
+            "actual_arm_count": len(arms),
+            "all_arms_present": True,
+        },
+        "gates": {
+            "minimum_onboarding_views_per_arm": minimum_views_per_arm,
+            "minimum_primary_denominator_per_arm":
+                minimum_metric_denominator_per_arm,
+            "minimum_activation_successes_per_hypothesis": 20,
+            "minimum_checkout_starts_for_a10": 5,
+            "winner_requires_relative_lift": 0.20,
+            "winner_requires_separated_wilson_intervals": True,
+        },
+        "totals": {
+            field: sum(getattr(arm, field) for arm in arms.values())
+            for field in COUNT_FIELDS
+        },
+        "hypotheses": hypotheses,
+    }
+
+
+def _format_rate(arm: dict[str, Any]) -> str:
+    raw_rate = arm["primary_rate"]
+    if raw_rate is None:
+        return "invalid"
+    rate = float(raw_rate) * 100.0
+    interval = arm["primary_wilson_95"]
+    lower = float(interval["lower"]) * 100.0
+    upper = float(interval["upper"]) * 100.0
+    return f"{rate:.2f}% ({lower:.2f}-{upper:.2f}%)"
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    gates = report["gates"]
+    totals = report["totals"]
+    lines = [
+        "# Activation experiment decision report",
+        "",
+        f"Generated: {report['generated_at']}",
+        "",
+        "This report contains aggregate arm metrics only. "
+        "It contains no authenticated user IDs or raw events.",
+        "",
+        "## Global funnel totals",
+        "",
+        f"- Onboarding views: {totals['unique_onboarding_views']}",
+        f"- Onboarding completions: {totals['unique_onboarding_completions']}",
+        f"- Value recap views: {totals['unique_value_recap_views']}",
+        f"- Billing views: {totals['unique_billing_views']}",
+        f"- Checkout starts: {totals['unique_checkout_starts']}",
+        "- Minimum onboarding views per arm: "
+        f"{gates['minimum_onboarding_views_per_arm']}",
+        "- Minimum primary denominator per arm: "
+        f"{gates['minimum_primary_denominator_per_arm']}",
+        "- Minimum activation successes per hypothesis: "
+        f"{gates['minimum_activation_successes_per_hypothesis']}",
+        "- Minimum checkout starts for A10: "
+        f"{gates['minimum_checkout_starts_for_a10']}",
+        "",
+        "## Hypotheses",
+        "",
+        "| Hypothesis | Primary metric | C success/n | T success/n | "
+        "C rate (Wilson 95%) | T rate (Wilson 95%) | Lift | Decision |",
+        "|---|---|---:|---:|---:|---:|---:|---|",
+    ]
+    for hypothesis in report["hypotheses"]:
+        control = hypothesis["control"]
+        treatment = hypothesis["treatment"]
+        lift = hypothesis["relative_primary_lift"]
+        lift_text = "n/a" if lift is None else f"{float(lift) * 100.0:.2f}%"
+        lines.append(
+            "| {hypothesis} | {metric} | {control_counts} | "
+            "{treatment_counts} | {control_rate} | {treatment_rate} | "
+            "{lift} | {decision} |".format(
+                hypothesis=hypothesis["hypothesis_id"].upper(),
+                metric=hypothesis["primary_metric"]["label"],
+                control_counts=(
+                    f"{control['primary_metric_successes']}/"
+                    f"{control['primary_metric_denominator']}"
+                ),
+                treatment_counts=(
+                    f"{treatment['primary_metric_successes']}/"
+                    f"{treatment['primary_metric_denominator']}"
+                ),
+                control_rate=_format_rate(control),
+                treatment_rate=_format_rate(treatment),
+                lift=lift_text,
+                decision=hypothesis["decision"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "A winner is never declared before both arms reach 100 unique "
+            "onboarding views and 20 primary-denominator users, the hypothesis "
+            "reaches 20 activation successes (A10: 5 checkout starts), and the "
+            "Wilson intervals separate.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def fetch_arm_rows(
+    supabase_url: str,
+    service_role_key: str,
+    *,
+    timeout: int = 20,
+) -> list[dict[str, Any]]:
+    if not service_role_key.strip():
+        raise ReportContractError("SUPABASE_SERVICE_ROLE_KEY is required")
+    query = urllib.parse.urlencode(
+        {
+            "select": REPORT_SELECT,
+            "order": "hypothesis_id.asc,variant.asc",
+        }
+    )
+    url = (
+        f"{supabase_url.rstrip('/')}/rest/v1/"
+        f"activation_experiment_arm_stats?{query}"
+    )
+    request = urllib.request.Request(
+        url,
+        headers={
+            "apikey": service_role_key,
+            "Authorization": f"Bearer {service_role_key}",
+            "Accept": "application/json",
+            "User-Agent": "my-web-app-activation-experiment-report/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        message = exc.read().decode("utf-8", errors="replace")[:500]
+        raise ReportContractError(
+            f"activation experiment report API returned HTTP "
+            f"{exc.code}: {message}"
+        ) from exc
+    if not isinstance(payload, list):
+        raise ReportContractError(
+            "activation experiment report API returned non-list JSON"
+        )
+    return payload
+
+
+def write_report(path: str, content: str) -> None:
+    report_path = Path(path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(content, encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--supabase-url",
+        default=os.environ.get("SUPABASE_URL", DEFAULT_SUPABASE_URL),
+    )
+    parser.add_argument("--json-report", required=True)
+    parser.add_argument("--markdown-report", required=True)
+    parser.add_argument("--timeout", type=int, default=20)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    service_role_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+    try:
+        rows = fetch_arm_rows(
+            args.supabase_url,
+            service_role_key,
+            timeout=args.timeout,
+        )
+        arms = validate_arm_rows(rows)
+        report = build_report(arms)
+        markdown = render_markdown(report)
+        write_report(
+            args.json_report,
+            json.dumps(
+                report,
+                ensure_ascii=True,
+                indent=2,
+                allow_nan=False,
+            ) + "\n",
+        )
+        write_report(args.markdown_report, markdown)
+    except (ReportContractError, OSError, json.JSONDecodeError) as exc:
+        print(f"activation experiment report failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "activation experiment report passed: "
+        f"20 arms, {report['totals']['unique_checkout_starts']} checkout starts"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/migrations/20260724100000_activation_experiment_unique_metrics.sql
+++ b/supabase/migrations/20260724100000_activation_experiment_unique_metrics.sql
@@ -1,0 +1,174 @@
+-- Measure activation-to-paid experiments with one row per authenticated user,
+-- arm, and stage. The ledger deliberately stores no email, IP address, user
+-- agent, prompt, challenge text, or other user-supplied content.
+CREATE TABLE public.activation_experiment_events (
+  auth_user_id uuid NOT NULL
+    REFERENCES auth.users (id) ON DELETE CASCADE,
+  hypothesis_id text NOT NULL
+    CHECK (hypothesis_id ~ '^a(0[1-9]|10)$'),
+  variant text NOT NULL
+    CHECK (variant IN ('control', 'treatment')),
+  stage text NOT NULL
+    CHECK (
+      stage IN (
+        'onboarding_view',
+        'intent_selected',
+        'first_action_started',
+        'first_action_completed',
+        'onboarding_completed',
+        'value_recap_view',
+        'billing_view',
+        'supporter_checkout',
+        'pro_checkout',
+        'checkout_return'
+      )
+    ),
+  first_occurred_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (auth_user_id, hypothesis_id, variant, stage)
+);
+
+COMMENT ON TABLE public.activation_experiment_events IS
+  'Privacy-minimized unique-user ledger for A01-A10 activation-to-paid experiments.';
+
+CREATE INDEX activation_experiment_events_first_occurred_idx
+  ON public.activation_experiment_events (first_occurred_at DESC);
+
+ALTER TABLE public.activation_experiment_events ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.activation_experiment_events
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.activation_experiment_events TO service_role;
+
+CREATE OR REPLACE FUNCTION public.record_activation_experiment_event(
+  p_event_key text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_auth_user_id uuid := auth.uid();
+  v_hypothesis_id text;
+  v_variant text;
+  v_stage text;
+  v_inserted_rows integer := 0;
+BEGIN
+  IF v_auth_user_id IS NULL THEN
+    RAISE EXCEPTION 'authenticated user is required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF lower(COALESCE(auth.jwt() ->> 'is_anonymous', 'false')) = 'true' THEN
+    RAISE EXCEPTION 'non-anonymous user is required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_event_key IS NULL
+     OR length(p_event_key) > 160
+     OR p_event_key !~ '^activation_exp_a(0[1-9]|10)_(control|treatment)_(onboarding_view|intent_selected|first_action_started|first_action_completed|onboarding_completed|value_recap_view|billing_view|supporter_checkout|pro_checkout|checkout_return)$' THEN
+    RAISE EXCEPTION 'invalid activation experiment event key';
+  END IF;
+
+  v_hypothesis_id := split_part(p_event_key, '_', 3);
+  v_variant := split_part(p_event_key, '_', 4);
+  v_stage := regexp_replace(
+    p_event_key,
+    '^activation_exp_a(0[1-9]|10)_(control|treatment)_',
+    ''
+  );
+
+  INSERT INTO public.activation_experiment_events (
+    auth_user_id,
+    hypothesis_id,
+    variant,
+    stage
+  )
+  VALUES (
+    v_auth_user_id,
+    v_hypothesis_id,
+    v_variant,
+    v_stage
+  )
+  ON CONFLICT (auth_user_id, hypothesis_id, variant, stage) DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted_rows = ROW_COUNT;
+  RETURN v_inserted_rows = 1;
+END;
+$$;
+
+COMMENT ON FUNCTION public.record_activation_experiment_event(text) IS
+  'Records one activation experiment stage per signed-in non-anonymous user.';
+
+REVOKE ALL ON FUNCTION public.record_activation_experiment_event(text)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.record_activation_experiment_event(text)
+  TO authenticated, service_role;
+
+CREATE VIEW public.activation_experiment_arm_stats
+WITH (security_invoker = true)
+AS
+WITH experiment_arms(hypothesis_id, variant) AS (
+  VALUES
+    ('a01', 'control'), ('a01', 'treatment'),
+    ('a02', 'control'), ('a02', 'treatment'),
+    ('a03', 'control'), ('a03', 'treatment'),
+    ('a04', 'control'), ('a04', 'treatment'),
+    ('a05', 'control'), ('a05', 'treatment'),
+    ('a06', 'control'), ('a06', 'treatment'),
+    ('a07', 'control'), ('a07', 'treatment'),
+    ('a08', 'control'), ('a08', 'treatment'),
+    ('a09', 'control'), ('a09', 'treatment'),
+    ('a10', 'control'), ('a10', 'treatment')
+)
+SELECT
+  arm.hypothesis_id,
+  arm.variant,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'onboarding_view')
+    AS unique_onboarding_views,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'intent_selected')
+    AS unique_intent_selections,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'first_action_started')
+    AS unique_first_action_starts,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'first_action_completed')
+    AS unique_first_action_completions,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'onboarding_completed')
+    AS unique_onboarding_completions,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'value_recap_view')
+    AS unique_value_recap_views,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'billing_view')
+    AS unique_billing_views,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'supporter_checkout')
+    AS unique_supporter_checkouts,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'pro_checkout')
+    AS unique_pro_checkouts,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (
+      WHERE event.stage IN ('supporter_checkout', 'pro_checkout')
+    ) AS unique_checkout_starts,
+  COUNT(DISTINCT event.auth_user_id)
+    FILTER (WHERE event.stage = 'checkout_return')
+    AS unique_checkout_returns,
+  MIN(event.first_occurred_at) AS first_event_at,
+  MAX(event.first_occurred_at) AS last_event_at
+FROM experiment_arms AS arm
+LEFT JOIN public.activation_experiment_events AS event
+  ON event.hypothesis_id = arm.hypothesis_id
+ AND event.variant = arm.variant
+GROUP BY arm.hypothesis_id, arm.variant;
+
+COMMENT ON VIEW public.activation_experiment_arm_stats IS
+  'Service-role-only aggregate counts for all 20 A01-A10 experiment arms.';
+
+REVOKE ALL ON TABLE public.activation_experiment_arm_stats
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.activation_experiment_arm_stats TO service_role;

--- a/supabase/migrations/20260724101500_wbs_activation_unique_metrics.sql
+++ b/supabase/migrations/20260724101500_wbs_activation_unique_metrics.sql
@@ -1,0 +1,97 @@
+-- Register the revenue-critical activation analytics task in the source-of-
+-- truth WBS. It remains in progress until the production migration, app
+-- tracker, and aggregate report have all been verified.
+-- nocheck: time-relative
+-- Replay-safe: the upsert always supplies a non-empty recovery_plan, and the
+-- dependency update changes no deadline or recovery-plan fields.
+INSERT INTO public.wbs_tasks (
+  category,
+  category_icon,
+  category_order,
+  title,
+  description,
+  instance,
+  owner_instance,
+  status,
+  progress,
+  start_date,
+  end_date,
+  milestone_code,
+  priority,
+  ai_review_status,
+  stale_threshold_hours,
+  remaining_work,
+  recovery_plan,
+  depends_on_titles,
+  github_issue_number,
+  github_issue_url,
+  github_issue_state,
+  github_issue_synced_at
+)
+VALUES (
+  'revenue / activation-to-paid',
+  'analytics',
+  0,
+  '[revenue-p0][activation-analytics] Decide A01-A10 on unique users',
+  'Deduplicate activation events by authenticated user, expose service-role-only 20-arm aggregates, and generate strict daily A01-A10 decision reports.',
+  'codex',
+  'codex',
+  'in_progress',
+  95,
+  DATE '2026-07-24',
+  DATE '2026-07-24',
+  'first-yen-revenue',
+  'high',
+  'pending',
+  24,
+  'Merge and deploy issue #4323, run the production activation experiment report, and attach the aggregate evidence before completion.',
+  'If deployment fails, keep the daily app_analytics signal intact, inspect the activation_experiment_events migration, and rerun the aggregate report only after all 20 arms exist.',
+  ARRAY[]::text[],
+  4323,
+  'https://github.com/kanta13jp1/my_web_app/issues/4323',
+  'OPEN',
+  now()
+)
+ON CONFLICT (title, instance) DO UPDATE SET
+  category = EXCLUDED.category,
+  category_icon = EXCLUDED.category_icon,
+  category_order = EXCLUDED.category_order,
+  description = EXCLUDED.description,
+  owner_instance = EXCLUDED.owner_instance,
+  status = CASE
+    WHEN public.wbs_tasks.status = 'completed' THEN 'completed'
+    ELSE EXCLUDED.status
+  END,
+  progress = CASE
+    WHEN public.wbs_tasks.status = 'completed' THEN 100
+    ELSE EXCLUDED.progress
+  END,
+  start_date = EXCLUDED.start_date,
+  end_date = EXCLUDED.end_date,
+  milestone_code = EXCLUDED.milestone_code,
+  priority = EXCLUDED.priority,
+  ai_review_status = EXCLUDED.ai_review_status,
+  stale_threshold_hours = EXCLUDED.stale_threshold_hours,
+  remaining_work = EXCLUDED.remaining_work,
+  recovery_plan = EXCLUDED.recovery_plan,
+  depends_on_titles = EXCLUDED.depends_on_titles,
+  github_issue_number = EXCLUDED.github_issue_number,
+  github_issue_url = EXCLUDED.github_issue_url,
+  github_issue_state = EXCLUDED.github_issue_state,
+  github_issue_synced_at = EXCLUDED.github_issue_synced_at,
+  updated_at = now();
+
+UPDATE public.wbs_tasks
+SET
+  depends_on_titles = CASE
+    WHEN '[revenue-p0][activation-analytics] Decide A01-A10 on unique users'
+      = ANY(COALESCE(depends_on_titles, ARRAY[]::text[]))
+      THEN depends_on_titles
+    ELSE array_append(
+      COALESCE(depends_on_titles, ARRAY[]::text[]),
+      '[revenue-p0][activation-analytics] Decide A01-A10 on unique users'
+    )
+  END,
+  updated_at = now()
+WHERE title =
+  '[revenue-p0][bank-payout] Verify one external payment and at least JPY 1 bank deposit';

--- a/test/scripts/test_activation_experiment_report.py
+++ b/test/scripts/test_activation_experiment_report.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from activation_experiment_report import (  # noqa: E402
+    ReportContractError,
+    build_report,
+    fetch_arm_rows,
+    render_markdown,
+    validate_arm_rows,
+    wilson_interval,
+)
+
+
+def fixture_rows(*, onboarding_views: int = 0) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for index in range(1, 11):
+        hypothesis_id = f"a{index:02d}"
+        for variant in ("control", "treatment"):
+            rows.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "variant": variant,
+                    "unique_onboarding_views": onboarding_views,
+                    "unique_intent_selections": 0,
+                    "unique_first_action_starts": 0,
+                    "unique_first_action_completions": 0,
+                    "unique_onboarding_completions": 0,
+                    "unique_value_recap_views": 0,
+                    "unique_billing_views": 0,
+                    "unique_supporter_checkouts": 0,
+                    "unique_pro_checkouts": 0,
+                    "unique_checkout_starts": 0,
+                    "unique_checkout_returns": 0,
+                    "first_event_at": None,
+                    "last_event_at": None,
+                }
+            )
+    return rows
+
+
+def update_arm(
+    rows: list[dict[str, object]],
+    hypothesis_id: str,
+    variant: str,
+    **counts: int,
+) -> None:
+    row = next(
+        candidate
+        for candidate in rows
+        if candidate["hypothesis_id"] == hypothesis_id
+        and candidate["variant"] == variant
+    )
+    row.update(counts)
+
+
+class ActivationExperimentReportTest(unittest.TestCase):
+    def test_validates_exact_twenty_arm_contract(self) -> None:
+        arms = validate_arm_rows(fixture_rows())
+        self.assertEqual(len(arms), 20)
+        self.assertIn(("a01", "control"), arms)
+        self.assertIn(("a10", "treatment"), arms)
+
+    def test_rejects_missing_duplicate_and_negative_rows(self) -> None:
+        rows = fixture_rows()
+        with self.assertRaisesRegex(ReportContractError, "missing experiment arms"):
+            validate_arm_rows(rows[:-1])
+
+        duplicate = fixture_rows()
+        duplicate.append(dict(duplicate[0]))
+        with self.assertRaisesRegex(ReportContractError, "duplicate experiment arm"):
+            validate_arm_rows(duplicate)
+
+        negative = fixture_rows()
+        negative[0]["unique_onboarding_views"] = -1
+        with self.assertRaisesRegex(ReportContractError, "must be non-negative"):
+            validate_arm_rows(negative)
+
+    def test_wilson_interval_matches_known_range(self) -> None:
+        lower, upper = wilson_interval(10, 100)
+        self.assertAlmostEqual(lower, 0.0552, places=3)
+        self.assertAlmostEqual(upper, 0.1744, places=3)
+
+    def test_never_declares_winner_before_view_gate(self) -> None:
+        rows = fixture_rows(onboarding_views=99)
+        update_arm(rows, "a01", "control", unique_onboarding_completions=1)
+        update_arm(rows, "a01", "treatment", unique_onboarding_completions=40)
+
+        report = build_report(validate_arm_rows(rows))
+
+        self.assertEqual(report["hypotheses"][0]["decision"], "insufficient_data")
+
+    def test_declares_treatment_only_with_lift_and_separated_intervals(self) -> None:
+        rows = fixture_rows(onboarding_views=100)
+        update_arm(rows, "a01", "control", unique_onboarding_completions=10)
+        update_arm(rows, "a01", "treatment", unique_onboarding_completions=30)
+
+        first = build_report(validate_arm_rows(rows))["hypotheses"][0]
+
+        self.assertEqual(first["decision"], "treatment_wins")
+        self.assertEqual(
+            first["primary_metric"]["key"],
+            "onboarding_completion_rate",
+        )
+        self.assertAlmostEqual(first["relative_primary_lift"], 2.0)
+
+    def test_each_hypothesis_uses_its_declared_primary_metric(self) -> None:
+        rows = fixture_rows(onboarding_views=200)
+        for hypothesis_id in (f"a{index:02d}" for index in range(1, 11)):
+            for variant in ("control", "treatment"):
+                update_arm(
+                    rows,
+                    hypothesis_id,
+                    variant,
+                    unique_first_action_starts=80,
+                    unique_first_action_completions=30,
+                    unique_onboarding_completions=50,
+                    unique_value_recap_views=45,
+                    unique_billing_views=20,
+                    unique_checkout_starts=7,
+                )
+
+        report = build_report(validate_arm_rows(rows))
+        observed = {
+            item["hypothesis_id"]: (
+                item["primary_metric"]["key"],
+                item["control"]["primary_metric_successes"],
+                item["control"]["primary_metric_denominator"],
+            )
+            for item in report["hypotheses"]
+        }
+        for hypothesis_id in ("a01", "a06", "a07", "a08"):
+            self.assertEqual(
+                observed[hypothesis_id],
+                ("onboarding_completion_rate", 50, 200),
+            )
+        for hypothesis_id in ("a02", "a03", "a04"):
+            self.assertEqual(
+                observed[hypothesis_id],
+                ("first_action_start_rate", 80, 200),
+            )
+        self.assertEqual(
+            observed["a05"],
+            ("first_action_completion_rate", 30, 80),
+        )
+        self.assertEqual(observed["a09"], ("billing_view_rate", 20, 45))
+        self.assertEqual(observed["a10"], ("checkout_start_rate", 7, 20))
+
+    def test_a10_requires_five_checkout_starts(self) -> None:
+        rows = fixture_rows(onboarding_views=100)
+        for variant in ("control", "treatment"):
+            update_arm(rows, "a10", variant, unique_billing_views=20)
+        update_arm(rows, "a10", "treatment", unique_checkout_starts=4)
+
+        a10 = build_report(validate_arm_rows(rows))["hypotheses"][-1]
+
+        self.assertEqual(
+            a10["primary_metric"]["minimum_total_successes"],
+            5,
+        )
+        self.assertFalse(a10["primary_success_gate_ready"])
+        self.assertEqual(a10["decision"], "insufficient_data")
+
+    def test_downstream_metrics_require_their_own_denominator_gate(self) -> None:
+        rows = fixture_rows(onboarding_views=200)
+        update_arm(
+            rows,
+            "a09",
+            "control",
+            unique_value_recap_views=19,
+            unique_billing_views=1,
+        )
+        update_arm(
+            rows,
+            "a09",
+            "treatment",
+            unique_value_recap_views=19,
+            unique_billing_views=15,
+        )
+
+        a09 = build_report(validate_arm_rows(rows))["hypotheses"][8]
+
+        self.assertFalse(a09["metric_denominator_gate_ready"])
+        self.assertEqual(a09["decision"], "insufficient_data")
+
+    def test_marks_impossible_funnel_counts_invalid(self) -> None:
+        rows = fixture_rows(onboarding_views=200)
+        update_arm(
+            rows,
+            "a10",
+            "control",
+            unique_billing_views=20,
+            unique_checkout_starts=21,
+        )
+        update_arm(
+            rows,
+            "a10",
+            "treatment",
+            unique_billing_views=20,
+            unique_checkout_starts=10,
+        )
+
+        a10 = build_report(validate_arm_rows(rows))["hypotheses"][-1]
+
+        self.assertFalse(a10["metric_contract_valid"])
+        self.assertIsNone(a10["control"]["primary_rate"])
+        self.assertEqual(a10["decision"], "invalid_funnel_data")
+
+    def test_reports_only_aggregate_metrics(self) -> None:
+        report = build_report(validate_arm_rows(fixture_rows()))
+        markdown = render_markdown(report)
+        encoded = json.dumps(report)
+
+        self.assertFalse(report["privacy"]["contains_auth_user_ids"])
+        self.assertFalse(report["privacy"]["contains_raw_events"])
+        self.assertNotIn('"auth_user_id"', encoded)
+        self.assertIn("A01", markdown)
+        self.assertIn("A10", markdown)
+        hypothesis_rows = [
+            line
+            for line in markdown.splitlines()
+            if line.startswith("| A") and line[3:5].isdigit()
+        ]
+        self.assertEqual(len(hypothesis_rows), 10)
+
+    @patch("activation_experiment_report.urllib.request.urlopen")
+    def test_fetches_only_service_role_aggregate_view(self, urlopen) -> None:
+        response = urlopen.return_value.__enter__.return_value
+        response.read.return_value = json.dumps(fixture_rows()).encode("utf-8")
+
+        rows = fetch_arm_rows(
+            "https://example.supabase.co",
+            "service-role-test-key",
+        )
+
+        self.assertEqual(len(rows), 20)
+        request = urlopen.call_args.args[0]
+        self.assertIn("activation_experiment_arm_stats", request.full_url)
+        self.assertNotIn("activation_experiment_events?", request.full_url)
+        self.assertEqual(
+            request.get_header("Authorization"),
+            "Bearer service-role-test-key",
+        )
+
+    def test_workflow_never_exposes_service_role_to_pull_requests(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github" / "workflows"
+            / "activation-experiment-report.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("SUPABASE_SERVICE_ROLE_KEY", workflow)
+        self.assertNotIn("pull_request:", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/services/activation_experiment_events_schema_test.dart
+++ b/test/services/activation_experiment_events_schema_test.dart
@@ -1,0 +1,177 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260724100000_activation_experiment_unique_metrics.sql';
+const _wbsMigrationPath =
+    'supabase/migrations/20260724101500_wbs_activation_unique_metrics.sql';
+
+void main() {
+  group('activation experiment unique event schema', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _migrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test('deduplicates each signed-in user and funnel stage', () {
+      expect(sql, contains('create table public.activation_experiment_events'));
+      expect(
+        sql,
+        contains('primary key (auth_user_id, hypothesis_id, variant, stage)'),
+      );
+      expect(
+        sql,
+        contains(
+          'on conflict (auth_user_id, hypothesis_id, variant, stage) do nothing',
+        ),
+      );
+      expect(sql, contains("hypothesis_id ~ '^a(0[1-9]|10)\$'"));
+      expect(sql, contains("variant in ('control', 'treatment')"));
+      for (final stage in <String>[
+        'onboarding_view',
+        'intent_selected',
+        'first_action_started',
+        'first_action_completed',
+        'onboarding_completed',
+        'value_recap_view',
+        'billing_view',
+        'supporter_checkout',
+        'pro_checkout',
+        'checkout_return',
+      ]) {
+        expect(sql, contains("'$stage'"));
+      }
+    });
+
+    test('accepts writes only from non-anonymous authenticated users', () {
+      expect(
+        sql,
+        contains(
+          'alter table public.activation_experiment_events enable row level security',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'revoke all on table public.activation_experiment_events\n  from public, anon, authenticated',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'create or replace function public.record_activation_experiment_event',
+        ),
+      );
+      expect(sql, contains('security definer'));
+      expect(sql, contains('set search_path = pg_catalog, public'));
+      expect(sql, contains('auth.uid()'));
+      expect(sql, contains("auth.jwt() ->> 'is_anonymous'"));
+      expect(sql, contains('non-anonymous user is required'));
+      expect(
+        sql,
+        contains(
+          'grant execute on function public.record_activation_experiment_event(text)\n  to authenticated, service_role',
+        ),
+      );
+      expect(
+        sql,
+        isNot(
+          contains(
+            'grant execute on function public.record_activation_experiment_event(text)\n  to anon',
+          ),
+        ),
+      );
+    });
+
+    test('exposes all twenty aggregate arms only to service role', () {
+      expect(
+        RegExp(
+          r"\('a(?:0[1-9]|10)', '(?:control|treatment)'\)",
+        ).allMatches(sql).length,
+        20,
+      );
+      expect(sql, contains('with (security_invoker = true)'));
+      for (final aggregate in <String>[
+        'as unique_onboarding_views',
+        'as unique_intent_selections',
+        'as unique_first_action_starts',
+        'as unique_first_action_completions',
+        'as unique_onboarding_completions',
+        'as unique_value_recap_views',
+        'as unique_billing_views',
+        'as unique_supporter_checkouts',
+        'as unique_pro_checkouts',
+        'as unique_checkout_starts',
+        'as unique_checkout_returns',
+      ]) {
+        expect(sql, contains(aggregate));
+      }
+      expect(
+        sql,
+        contains(
+          'revoke all on table public.activation_experiment_arm_stats\n  from public, anon, authenticated',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'grant select on table public.activation_experiment_arm_stats to service_role',
+        ),
+      );
+    });
+
+    test('does not persist user content or browser identifiers', () {
+      for (final forbiddenColumn in <String>[
+        'email',
+        'ip_address',
+        'user_agent',
+        'browser_fingerprint',
+        'prompt_text',
+        'answer_text',
+        'challenge_text',
+      ]) {
+        expect(
+          RegExp('\\n\\s*$forbiddenColumn\\s').hasMatch(sql),
+          isFalse,
+          reason: '$forbiddenColumn must not be persisted',
+        );
+      }
+    });
+  });
+
+  group('activation analytics WBS registration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _wbsMigrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test('registers issue 4323 on the first-yen critical path', () {
+      expect(sql, contains('insert into public.wbs_tasks'));
+      expect(sql, contains('decide a01-a10 on unique users'));
+      expect(sql, contains("'first-yen-revenue'"));
+      expect(sql, contains('4323'));
+      expect(sql, contains('github_issue_synced_at'));
+      expect(sql, isNot(contains('github_synced_at')));
+      expect(sql, contains("'open'"));
+      expect(
+        sql,
+        contains(
+          'https://github.com/kanta13jp1/my_web_app/issues/4323',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          '[revenue-p0][bank-payout] verify one external payment and at least jpy 1 bank deposit',
+        ),
+      );
+    });
+  });
+}

--- a/test/services/activation_revenue_tracker_test.dart
+++ b/test/services/activation_revenue_tracker_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/activation_revenue_experiment_service.dart';
+import 'package:my_web_app/services/activation_revenue_tracker.dart';
+
+void main() {
+  final assignment = ActivationRevenueAssignment(
+    hypothesis: ActivationRevenueExperimentService.hypotheses.first,
+    variant: ActivationRevenueVariant.treatment,
+  );
+
+  group('SupabaseActivationRevenueEventTracker', () {
+    test(
+      'forwards the bounded event key to the unique-user recorder',
+      () async {
+        final recorded = <String>[];
+        final tracker = SupabaseActivationRevenueEventTracker(
+          uniqueEventRecorderOverride: (eventKey) async {
+            recorded.add(eventKey);
+          },
+        );
+
+        await tracker.record(
+          assignment: assignment,
+          stage: 'first_action_completed',
+        );
+
+        expect(recorded, <String>[
+          'activation_exp_a01_treatment_first_action_completed',
+        ]);
+      },
+    );
+
+    test('keeps activation UX fail-open when unique telemetry fails', () async {
+      final tracker = SupabaseActivationRevenueEventTracker(
+        uniqueEventRecorderOverride: (_) async {
+          throw StateError('telemetry unavailable');
+        },
+      );
+
+      await expectLater(
+        tracker.record(assignment: assignment, stage: 'onboarding_completed'),
+        completes,
+      );
+    });
+
+    test('uses the dedicated unique-event RPC in production', () {
+      final contents = File(
+        'lib/services/activation_revenue_tracker.dart',
+      ).readAsStringSync();
+
+      expect(contents, contains('record_activation_experiment_event'));
+      expect(contents, contains("'p_event_key': eventKey"));
+    });
+  });
+}


### PR DESCRIPTION
## Summary - record A01-A10 activation stages once per authenticated non-anonymous user, hypothesis, variant, and stage - expose only service-role aggregate counts for all 20 experiment arms; raw rows are denied to anon/authenticated roles - generate daily JSON/Markdown decisions with Wilson intervals, lift, and strict minimum-sample gates - register the revenue-critical WBS task and place it on the verified-bank-payout dependency path  ## Why The LP hypotheses previously relied on reload-counted daily analytics. That could promote a false winner before an external user actually moved through activation. This PR makes unique users the decision unit before we continue the signup -> checkout -> bank-payout loop.  ## Validation - `python test/scripts/test_activation_experiment_report.py` (12 passed) - `flutter test test/services/activation_experiment_events_schema_test.dart test/services/activation_revenue_tracker_test.dart` (8 passed) - `flutter test test/services/activation_revenue_experiment_service_test.dart test/pages/onboarding_page_activation_test.dart test/pages/subscription_billing_page_test.dart` (19 passed) - `flutter analyze lib/services/activation_revenue_tracker.dart test/services/activation_experiment_events_schema_test.dart test/services/activation_revenue_tracker_test.dart` - `python scripts/check_migration_timestamps.py --dir supabase/migrations` - `python scripts/check_migration_time_relative_check.py` against `origin/main` - pre-commit quality gate: full `flutter analyze`, 179 Edge Function files linted, contract tests passed - pre-push `python scripts/quality_gate.py --full`: passed twice, including latest `main`, with coverage  ## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: No UI route or interaction changed. Service tests cover insertion, duplicate suppression, anonymous-user rejection, and fail-open behavior. After deploy, run the Activation Experiment Report workflow and verify all 20 aggregate arms before selecting a winner.
## Visual E2E Evidence - [x] Not applicable: no UI/layout/assets changed. - [x] No generated image was used.  ## Security and privacy - no user content, email, browser ID, or anonymous visitor ID is stored - one row is keyed by the authenticated UUID already held by Supabase Auth - raw access is denied to `anon` and `authenticated`; reporting reads the aggregate view with `service_role`  ## Deployment / recovery 1. deploy the two migrations and app tracker 2. run `Activation Experiment Report` manually on `main` 3. verify exactly 20 arms and `insufficient_data` until gates are met 4. if migration/report fails, leave legacy `app_analytics` reporting active, inspect migration logs, and do not select a winner  ## High-risk Ultrareview Gate - Reviewer: Claude Code #1 - High-Risk-Ultrareview-Exception: Codex implemented a narrowly scoped privacy-safe analytics migration with deterministic schema and report tests. No separate Claude ultrareview was available in this task; CI, deployment migration logs, and the production aggregate report are the verification boundary.  Subagents: none.  Fixes #4323 Related to #4129