### PR TITLE
fix: reuse issue-synced activation WBS row

### DIFF
--- a/supabase/migrations/20260724101500_wbs_activation_unique_metrics.sql
+++ b/supabase/migrations/20260724101500_wbs_activation_unique_metrics.sql
@@ -4,6 +4,37 @@
 -- nocheck: time-relative
 -- Replay-safe: the upsert always supplies a non-empty recovery_plan, and the
 -- dependency update changes no deadline or recovery-plan fields.
+UPDATE public.wbs_tasks
+SET
+  category = 'revenue / activation-to-paid',
+  category_icon = 'analytics',
+  category_order = 0,
+  description = 'Deduplicate activation events by authenticated user, expose service-role-only 20-arm aggregates, and generate strict daily A01-A10 decision reports.',
+  owner_instance = 'codex',
+  status = CASE
+    WHEN status = 'completed' THEN 'completed'
+    ELSE 'in_progress'
+  END,
+  progress = CASE
+    WHEN status = 'completed' THEN 100
+    ELSE 95
+  END,
+  start_date = DATE '2026-07-24',
+  end_date = DATE '2026-07-24',
+  milestone_code = 'first-yen-revenue',
+  priority = 'high',
+  ai_review_status = 'pending',
+  stale_threshold_hours = 24,
+  remaining_work = 'Merge and deploy issue #4323, run the production activation experiment report, and attach the aggregate evidence before completion.',
+  recovery_plan = 'If deployment fails, keep the daily app_analytics signal intact, inspect the activation_experiment_events migration, and rerun the aggregate report only after all 20 arms exist.',
+  github_issue_url = 'https://github.com/kanta13jp1/my_web_app/issues/4323',
+  github_issue_state = 'OPEN',
+  github_issue_synced_at = now(),
+  updated_at = now()
+WHERE github_issue_number = 4323
+  AND instance = 'codex'
+  AND status <> 'completed';
+
 INSERT INTO public.wbs_tasks (
   category,
   category_icon,
@@ -28,7 +59,7 @@ INSERT INTO public.wbs_tasks (
   github_issue_state,
   github_issue_synced_at
 )
-VALUES (
+SELECT
   'revenue / activation-to-paid',
   'analytics',
   0,
@@ -51,6 +82,11 @@ VALUES (
   'https://github.com/kanta13jp1/my_web_app/issues/4323',
   'OPEN',
   now()
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.wbs_tasks
+  WHERE github_issue_number = 4323
+    AND instance = 'codex'
 )
 ON CONFLICT (title, instance) DO UPDATE SET
   category = EXCLUDED.category,
@@ -81,17 +117,28 @@ ON CONFLICT (title, instance) DO UPDATE SET
   github_issue_synced_at = EXCLUDED.github_issue_synced_at,
   updated_at = now();
 
-UPDATE public.wbs_tasks
+WITH activation_task AS (
+  SELECT title
+  FROM public.wbs_tasks
+  WHERE github_issue_number = 4323
+    AND instance = 'codex'
+  ORDER BY
+    CASE WHEN status <> 'completed' THEN 0 ELSE 1 END,
+    updated_at DESC
+  LIMIT 1
+)
+UPDATE public.wbs_tasks AS payout_task
 SET
   depends_on_titles = CASE
-    WHEN '[revenue-p0][activation-analytics] Decide A01-A10 on unique users'
-      = ANY(COALESCE(depends_on_titles, ARRAY[]::text[]))
-      THEN depends_on_titles
+    WHEN activation_task.title
+      = ANY(COALESCE(payout_task.depends_on_titles, ARRAY[]::text[]))
+      THEN payout_task.depends_on_titles
     ELSE array_append(
-      COALESCE(depends_on_titles, ARRAY[]::text[]),
-      '[revenue-p0][activation-analytics] Decide A01-A10 on unique users'
+      COALESCE(payout_task.depends_on_titles, ARRAY[]::text[]),
+      activation_task.title
     )
   END,
   updated_at = now()
-WHERE title =
+FROM activation_task
+WHERE payout_task.title =
   '[revenue-p0][bank-payout] Verify one external payment and at least JPY 1 bank deposit';

--- a/test/services/activation_experiment_events_schema_test.dart
+++ b/test/services/activation_experiment_events_schema_test.dart
@@ -173,5 +173,17 @@ void main() {
         ),
       );
     });
+
+    test('reuses an issue-synced WBS row before attempting insert', () {
+      final updateIndex = sql.indexOf('update public.wbs_tasks\nset');
+      final insertIndex = sql.indexOf('insert into public.wbs_tasks');
+
+      expect(updateIndex, greaterThanOrEqualTo(0));
+      expect(insertIndex, greaterThan(updateIndex));
+      expect(sql, contains('where github_issue_number = 4323'));
+      expect(sql, contains('where not exists ('));
+      expect(sql, contains('with activation_task as ('));
+      expect(sql, contains('from activation_task'));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- reuse the active `wbs_tasks` row already created by GitHub Issues WBS Sync for issue #4323
- insert a new row only when no active issue/instance row exists
- resolve the actual activation task title before adding the bank-payout dependency
- add a migration regression test for update-before-insert and dynamic dependency lookup

## Production failure addressed
The production deployment run https://github.com/kanta13jp1/my_web_app/actions/runs/30074762127 stopped in `Run Supabase migrations` with SQLSTATE `23505` on `wbs_tasks_issue_instance_active_unique`.

The issue sync workflow had already created the active `(github_issue_number=4323, instance=codex)` row. The migration then tried to insert a second active row with the same identity. This change updates and reuses that row instead.

## Validation
- `flutter test test/services/activation_experiment_events_schema_test.dart` (6 passed)
- `flutter analyze test/services/activation_experiment_events_schema_test.dart` (no issues)
- pre-commit full analyze and Deno lint
- pre-push full quality gate and coverage
- `git diff --check`

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: No UI route or interaction changed. The regression test checks the migration's observable ordering and deduplication contract; production redeploy proves it against the issue-synced row that caused the failure.

Related to #4323
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Narrow idempotency-only WBS metadata migration fix. RLS and application security are unchanged; rollback is reverting this migration edit; production migration rerun is the smoke test, and the activation report plus deploy logs provide observability.
