### PR TITLE
feat: join first-user X traffic to the paid funnel

### DIFF
--- a/.github/workflows/x-post-metrics-optimizer.yml
+++ b/.github/workflows/x-post-metrics-optimizer.yml
@@ -14,6 +14,10 @@ on:
         description: "Number of recent X post logs to collect"
         required: false
         default: "100"
+      utm_content:
+        description: "First-user campaign variant to join to the LP funnel"
+        required: false
+        default: "outcome_first_a"
 
 concurrency:
   group: x-post-metrics-optimizer
@@ -67,3 +71,59 @@ jobs:
           INPUT_LIMIT: ${{ github.event.inputs.limit }}
           EVENT_SCHEDULE: ${{ github.event.schedule }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+      - name: Build first-user acquisition funnel checkpoint
+        shell: bash
+        run: |
+          utm_content="${INPUT_UTM_CONTENT:-outcome_first_a}"
+          payload=$(jq -cn \
+            --arg utm_content "${utm_content}" \
+            '{
+              action: "x.first_user_funnel",
+              limit: 100,
+              utmMedium: "organic",
+              utmContent: $utm_content
+            }')
+          http_code=$(curl --silent --show-error \
+            --output "${RUNNER_TEMP}/first-user-funnel.json" \
+            --write-out "%{http_code}" \
+            --request POST \
+            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Content-Type: application/json" \
+            --data "${payload}" \
+            "https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/growth-hub")
+          cat "${RUNNER_TEMP}/first-user-funnel.json"
+          success=$(jq -r '.success // false' \
+            "${RUNNER_TEMP}/first-user-funnel.json")
+          if [ "${http_code}" != "200" ] || [ "${success}" != "true" ]; then
+            echo "::error::First-user funnel report failed (HTTP ${http_code})."
+            exit 1
+          fi
+          {
+            echo "## First-user acquisition checkpoint"
+            echo
+            echo "- Attribution: \`x / organic / first_user_growth / ${utm_content}\`"
+            echo "- X window: $(jq -r '.x.metricWindowLabel // "awaiting publish"' "${RUNNER_TEMP}/first-user-funnel.json")"
+            echo "- Impressions: $(jq -r '.x.impressions // 0' "${RUNNER_TEMP}/first-user-funnel.json")"
+            echo "- Unique views: $(jq -r '.funnel.counts.view // 0' "${RUNNER_TEMP}/first-user-funnel.json")"
+            echo "- Trials: $(jq -r '.funnel.counts.trial // 0' "${RUNNER_TEMP}/first-user-funnel.json")"
+            echo "- Signup completes: $(jq -r '.funnel.counts.signup_complete // 0' "${RUNNER_TEMP}/first-user-funnel.json")"
+            echo "- First actions: $(jq -r '.funnel.counts.first_action_completed // 0' "${RUNNER_TEMP}/first-user-funnel.json")"
+            echo "- Supporter checkouts: $(jq -r '.funnel.counts.supporter_checkout // 0' "${RUNNER_TEMP}/first-user-funnel.json")"
+            echo "- Revenue JPY: $(jq -r '.revenue.revenueJpy // 0' "${RUNNER_TEMP}/first-user-funnel.json")"
+            echo "- Decision: \`$(jq -r '.decision.stage' "${RUNNER_TEMP}/first-user-funnel.json")\`"
+            echo "- Change one variable: \`$(jq -r '.decision.nextVariable' "${RUNNER_TEMP}/first-user-funnel.json")\`"
+            echo "- Next action: $(jq -r '.decision.nextAction' "${RUNNER_TEMP}/first-user-funnel.json")"
+          } >> "${GITHUB_STEP_SUMMARY}"
+        env:
+          INPUT_UTM_CONTENT: ${{ github.event.inputs.utm_content }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+      - name: Upload first-user funnel evidence
+        uses: actions/upload-artifact@v6
+        with:
+          name: first-user-funnel-${{ github.run_id }}
+          path: ${{ runner.temp }}/first-user-funnel.json
+          if-no-files-found: error
+          retention-days: 30

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -23,6 +23,7 @@ class LandingPage extends StatefulWidget {
   final LandingConversionExperimentService conversionExperimentService;
   final LandingSignupCompletionService signupCompletionService;
   final PendingLandingTrialService pendingTrialService;
+  final GrowthAcquisitionService acquisitionService;
   final LandingExperimentAssignment? experimentAssignment;
   final bool? analyticsEnabled;
   final Uri? landingUri;
@@ -34,6 +35,7 @@ class LandingPage extends StatefulWidget {
     LandingConversionExperimentService? conversionExperimentService,
     LandingSignupCompletionService? signupCompletionService,
     PendingLandingTrialService? pendingTrialService,
+    GrowthAcquisitionService? acquisitionService,
     this.experimentAssignment,
     this.analyticsEnabled,
     this.landingUri,
@@ -43,6 +45,8 @@ class LandingPage extends StatefulWidget {
             pendingTrialService ?? const PendingLandingTrialService(),
         signupCompletionService =
             signupCompletionService ?? const LandingSignupCompletionService(),
+        acquisitionService =
+            acquisitionService ?? const GrowthAcquisitionService(),
         conversionExperimentService = conversionExperimentService ??
             const LandingConversionExperimentService();
 
@@ -74,8 +78,6 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   final _trialEmailFocusNode = FocusNode();
   final GlobalKey _trialSectionKey = GlobalKey();
   final GlobalKey _authSectionKey = GlobalKey();
-  final GrowthAcquisitionService _acquisitionService =
-      const GrowthAcquisitionService();
 
   StreamSubscription<AuthState>? _authSubscription;
   Timer? _magicLinkCooldownTimer;
@@ -106,6 +108,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   bool _landingIntentHandled = false;
 
   Uri? get _landingUri => widget.landingUri ?? (kIsWeb ? Uri.base : null);
+  GrowthAcquisitionService get _acquisitionService => widget.acquisitionService;
 
   bool get _analyticsEnabled {
     final override = widget.analyticsEnabled;
@@ -193,9 +196,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     if (!_analyticsEnabled) {
       return;
     }
+    String? visitorId;
     try {
       final assignment = await _resolveExperimentAssignment();
-      final visitorId = await _resolveExperimentVisitorId();
+      visitorId = await _resolveExperimentVisitorId();
       if (!_recordedExperimentStages.add(stage)) {
         return;
       }
@@ -205,6 +209,19 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       );
     } catch (error) {
       debugPrint('LP conversion event failed ($stage): $error');
+    }
+    if (visitorId == null ||
+        !GrowthAcquisitionService.firstUserFunnelStages.contains(stage)) {
+      return;
+    }
+    try {
+      await _acquisitionService.recordFirstUserFunnelStage(
+        stage: stage,
+        visitorId: visitorId,
+        currentUri: _landingUri,
+      );
+    } catch (error) {
+      debugPrint('First-user LP funnel event failed ($stage): $error');
     }
   }
 

--- a/lib/pages/onboarding_page.dart
+++ b/lib/pages/onboarding_page.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/activation_revenue_experiment_service.dart';
 import '../services/activation_revenue_tracker.dart';
+import '../services/growth_acquisition_service.dart';
 import '../services/onboarding_activation_gateway.dart';
 import '../services/pending_landing_trial_service.dart';
 
@@ -15,6 +16,7 @@ class OnboardingPage extends StatefulWidget {
     this.tracker = const SupabaseActivationRevenueEventTracker(),
     this.experimentService = const ActivationRevenueExperimentService(),
     this.pendingTrialService = const PendingLandingTrialService(),
+    this.acquisitionService = const GrowthAcquisitionService(),
     this.assignment,
     this.initialUri,
   });
@@ -23,6 +25,7 @@ class OnboardingPage extends StatefulWidget {
   final ActivationRevenueEventTracker tracker;
   final ActivationRevenueExperimentService experimentService;
   final PendingLandingTrialService pendingTrialService;
+  final GrowthAcquisitionService acquisitionService;
   final ActivationRevenueAssignment? assignment;
   final Uri? initialUri;
 
@@ -78,6 +81,15 @@ class _OnboardingPageState extends State<OnboardingPage> {
   }
 
   Future<void> _record(String stage) async {
+    if (stage == 'first_action_completed') {
+      try {
+        await widget.acquisitionService.recordFirstUserFunnelStage(
+          stage: stage,
+        );
+      } catch (error) {
+        debugPrint('First-user activation event failed: $error');
+      }
+    }
     final assignment = _assignment ?? widget.assignment;
     if (assignment == null) return;
     try {

--- a/lib/pages/subscription_billing_page.dart
+++ b/lib/pages/subscription_billing_page.dart
@@ -58,6 +58,11 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
     if (!mounted) return;
     setState(() => _assignment = assignment);
     unawaited(_record('billing_view'));
+    unawaited(
+      widget.acquisitionService.recordFirstUserFunnelStage(
+        stage: 'billing_view',
+      ),
+    );
     if (_returnNotice != null) unawaited(_record('checkout_return'));
     await _fetchBillingInfo();
   }
@@ -106,16 +111,22 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
 
   Future<void> _openSupporterCheckout() async {
     await _record('supporter_checkout');
-    await _openStripeSession(() {
-      return widget.acquisitionService.loadLatestTouchpoint().then(
-            (latestTouchpoint) => _service.createSupporterCheckoutSession(
-              returnUrl: _currentReturnUrl,
-              attribution: BillingSupporterAttribution.fromUri(
-                _sourceUri,
-                fallbackTouchpoint: latestTouchpoint,
-              ),
-            ),
-          );
+    await widget.acquisitionService.recordFirstUserFunnelStage(
+      stage: 'supporter_checkout',
+    );
+    await _openStripeSession(() async {
+      final latestTouchpoint =
+          await widget.acquisitionService.loadLatestTouchpoint();
+      final firstUserAttribution =
+          await widget.acquisitionService.loadFirstUserAttribution();
+      return _service.createSupporterCheckoutSession(
+        returnUrl: _currentReturnUrl,
+        attribution: BillingSupporterAttribution.fromUri(
+          _sourceUri,
+          fallbackTouchpoint: latestTouchpoint,
+          firstUserAttribution: firstUserAttribution,
+        ),
+      );
     });
   }
 

--- a/lib/services/billing_service.dart
+++ b/lib/services/billing_service.dart
@@ -130,25 +130,34 @@ class BillingSupporterAttribution {
     Uri uri, {
     String landingTouchpoint = 'subscription_billing',
     String? fallbackTouchpoint,
+    FirstUserGrowthAttribution? firstUserAttribution,
   }) {
     final params = uri.queryParameters;
     final isXProfile =
         fallbackTouchpoint == GrowthAcquisitionService.touchProfile;
-    final isXFirstUserGrowth = isXProfile ||
+    final isXFirstUserGrowth = firstUserAttribution != null ||
+        isXProfile ||
         fallbackTouchpoint == GrowthAcquisitionService.touchXFirstUserGrowth;
     return BillingSupporterAttribution(
-      utmSource: params['utm_source'] ?? (isXFirstUserGrowth ? 'x' : null),
+      utmSource: params['utm_source'] ??
+          firstUserAttribution?.utmSource ??
+          (isXFirstUserGrowth ? 'x' : null),
       utmMedium: params['utm_medium'] ??
+          firstUserAttribution?.utmMedium ??
           (isXFirstUserGrowth ? (isXProfile ? 'profile' : 'organic') : null),
       utmCampaign: params['utm_campaign'] ??
+          firstUserAttribution?.utmCampaign ??
           (isXFirstUserGrowth ? 'first_user_growth' : null),
       utmContent: params['utm_content'] ??
+          firstUserAttribution?.utmContent ??
           (isXFirstUserGrowth ? 'activation_to_paid' : null),
       experimentKey: params['experiment_key'] ??
           params['utm_campaign'] ??
+          firstUserAttribution?.utmCampaign ??
           (isXFirstUserGrowth ? 'first_user_growth' : null),
       variant: params['variant'] ??
           params['utm_content'] ??
+          firstUserAttribution?.utmContent ??
           (isXFirstUserGrowth ? 'activation_to_paid' : null),
       sourceLogId: params['source_log_id'] ?? params['x_post_log_id'],
       landingTouchpoint: fallbackTouchpoint ?? landingTouchpoint,

--- a/lib/services/growth_acquisition_service.dart
+++ b/lib/services/growth_acquisition_service.dart
@@ -1,6 +1,121 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+
+class FirstUserGrowthAttribution {
+  const FirstUserGrowthAttribution({
+    required this.visitorId,
+    required this.utmSource,
+    required this.utmMedium,
+    required this.utmCampaign,
+    required this.utmContent,
+    required this.capturedAt,
+  });
+
+  static final RegExp _visitorIdPattern = RegExp(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+  );
+  static final RegExp _tokenPattern = RegExp(r'^[a-z0-9_-]{1,64}$');
+
+  final String visitorId;
+  final String utmSource;
+  final String utmMedium;
+  final String utmCampaign;
+  final String utmContent;
+  final DateTime capturedAt;
+
+  static FirstUserGrowthAttribution? fromUri({
+    required Uri uri,
+    required String visitorId,
+    DateTime? capturedAt,
+  }) {
+    final normalizedVisitorId = visitorId.trim().toLowerCase();
+    final params = uri.queryParameters;
+    final source = _token(params['utm_source']);
+    final campaign = _token(params['utm_campaign']);
+    if (!_visitorIdPattern.hasMatch(normalizedVisitorId) ||
+        source != 'x' ||
+        campaign != 'first_user_growth') {
+      return null;
+    }
+    final medium = _token(params['utm_medium'], fallback: 'organic');
+    final content = _token(params['utm_content'], fallback: 'unknown');
+    if (!_tokenPattern.hasMatch(medium) || !_tokenPattern.hasMatch(content)) {
+      return null;
+    }
+    return FirstUserGrowthAttribution(
+      visitorId: normalizedVisitorId,
+      utmSource: source,
+      utmMedium: medium,
+      utmCampaign: campaign,
+      utmContent: content,
+      capturedAt: (capturedAt ?? DateTime.now()).toUtc(),
+    );
+  }
+
+  static FirstUserGrowthAttribution? fromJson(Object? value) {
+    if (value is! Map) return null;
+    final json = Map<String, dynamic>.from(value);
+    final visitorId = json['visitor_id']?.toString().trim().toLowerCase() ?? '';
+    final source = _token(json['utm_source']);
+    final medium = _token(json['utm_medium']);
+    final campaign = _token(json['utm_campaign']);
+    final content = _token(json['utm_content']);
+    final capturedAt = DateTime.tryParse(
+      json['captured_at']?.toString() ?? '',
+    )?.toUtc();
+    if (!_visitorIdPattern.hasMatch(visitorId) ||
+        source != 'x' ||
+        campaign != 'first_user_growth' ||
+        !_tokenPattern.hasMatch(medium) ||
+        !_tokenPattern.hasMatch(content) ||
+        capturedAt == null) {
+      return null;
+    }
+    return FirstUserGrowthAttribution(
+      visitorId: visitorId,
+      utmSource: source,
+      utmMedium: medium,
+      utmCampaign: campaign,
+      utmContent: content,
+      capturedAt: capturedAt,
+    );
+  }
+
+  bool isExpired(DateTime now, Duration ttl) {
+    return now.toUtc().difference(capturedAt) >= ttl;
+  }
+
+  FirstUserGrowthAttribution withVisitorId(String value) {
+    final normalized = value.trim().toLowerCase();
+    if (!_visitorIdPattern.hasMatch(normalized)) return this;
+    return FirstUserGrowthAttribution(
+      visitorId: normalized,
+      utmSource: utmSource,
+      utmMedium: utmMedium,
+      utmCampaign: utmCampaign,
+      utmContent: utmContent,
+      capturedAt: capturedAt,
+    );
+  }
+
+  Map<String, Object> toJson() => <String, Object>{
+        'version': 1,
+        'visitor_id': visitorId,
+        'utm_source': utmSource,
+        'utm_medium': utmMedium,
+        'utm_campaign': utmCampaign,
+        'utm_content': utmContent,
+        'captured_at': capturedAt.toUtc().toIso8601String(),
+      };
+
+  static String _token(Object? value, {String fallback = ''}) {
+    final normalized = value?.toString().trim().toLowerCase() ?? '';
+    return normalized.isEmpty ? fallback : normalized;
+  }
+}
 
 class GrowthAcquisitionService {
   static const String touchLanding = 'touch_landing';
@@ -30,6 +145,23 @@ class GrowthAcquisitionService {
   static const String _latestTouchpointKey = 'growth_latest_touchpoint';
   static const String _latestTouchpointUpdatedAtKey =
       'growth_latest_touchpoint_updated_at';
+  static const String firstUserAttributionStorageKey =
+      'growth_first_user_attribution_v1';
+  static const Duration firstUserAttributionTtl = Duration(days: 7);
+  static const Set<String> firstUserFunnelStages = <String>{
+    'view',
+    'trial',
+    'signup_submit',
+    'signup_complete',
+    'first_action_completed',
+    'billing_view',
+    'supporter_checkout',
+  };
+  static const Set<String> _landingFirstUserFunnelStages = <String>{
+    'view',
+    'trial',
+    'signup_submit',
+  };
 
   final SupabaseClient? _clientOverride;
 
@@ -182,6 +314,102 @@ class GrowthAcquisitionService {
   Future<void> recordLandingSignupSubmit() async {
     final latestTouchpoint = await loadLatestTouchpoint();
     await _recordSignal(resolveSignupSubmitSignal(latestTouchpoint));
+  }
+
+  Future<bool> recordFirstUserFunnelStage({
+    required String stage,
+    String? visitorId,
+    Uri? currentUri,
+    SharedPreferences? preferences,
+    DateTime? now,
+  }) async {
+    if (!firstUserFunnelStages.contains(stage)) {
+      throw ArgumentError.value(
+        stage,
+        'stage',
+        'Unsupported first-user funnel stage',
+      );
+    }
+    final clock = (now ?? DateTime.now()).toUtc();
+    final prefs = preferences ?? await SharedPreferences.getInstance();
+    FirstUserGrowthAttribution? attribution;
+
+    if (currentUri != null && isFirstUserGrowthUri(currentUri)) {
+      final normalizedVisitorId = visitorId?.trim() ?? '';
+      attribution = FirstUserGrowthAttribution.fromUri(
+        uri: currentUri,
+        visitorId: normalizedVisitorId,
+        capturedAt: clock,
+      );
+      if (attribution == null) return false;
+      await prefs.setString(
+        firstUserAttributionStorageKey,
+        jsonEncode(attribution.toJson()),
+      );
+    } else {
+      // A direct/non-campaign LP visit must not inherit an older X campaign.
+      // Post-auth activation and billing routes intentionally load the stored
+      // seven-day attribution because auth redirects strip the original UTM.
+      if (_landingFirstUserFunnelStages.contains(stage)) {
+        return false;
+      }
+      attribution = await loadFirstUserAttribution(
+        preferences: prefs,
+        now: clock,
+      );
+      if (attribution == null) return false;
+      final normalizedVisitorId = visitorId?.trim() ?? '';
+      if (normalizedVisitorId.isNotEmpty) {
+        attribution = attribution.withVisitorId(normalizedVisitorId);
+      }
+    }
+
+    final client = _client;
+    if (client == null) return false;
+    try {
+      final response = await client.functions.invoke(
+        'growth-hub',
+        body: <String, dynamic>{
+          'action': 'acquisition.funnel_signal',
+          'stage': stage,
+          'visitorId': attribution.visitorId,
+          'utmSource': attribution.utmSource,
+          'utmMedium': attribution.utmMedium,
+          'utmCampaign': attribution.utmCampaign,
+          'utmContent': attribution.utmContent,
+        },
+      );
+      final payload = _asMap(response.data);
+      return payload['success'] == true || payload['duplicate'] == true;
+    } catch (error, stackTrace) {
+      debugPrint('First-user funnel signal failed ($stage): $error');
+      debugPrintStack(stackTrace: stackTrace);
+      return false;
+    }
+  }
+
+  Future<FirstUserGrowthAttribution?> loadFirstUserAttribution({
+    SharedPreferences? preferences,
+    DateTime? now,
+  }) async {
+    final prefs = preferences ?? await SharedPreferences.getInstance();
+    final encoded = prefs.getString(firstUserAttributionStorageKey);
+    if (encoded == null || encoded.isEmpty) return null;
+    FirstUserGrowthAttribution? attribution;
+    try {
+      attribution = FirstUserGrowthAttribution.fromJson(jsonDecode(encoded));
+    } catch (_) {
+      attribution = null;
+    }
+    if (attribution == null ||
+        attribution.isExpired(
+          (now ?? DateTime.now()).toUtc(),
+          firstUserAttributionTtl,
+        )) {
+      await prefs.remove(firstUserAttributionStorageKey);
+      return null;
+    }
+    return attribution;
   }
 
   Future<void> notifySignupSuccess({

--- a/lib/services/landing_signup_completion_service.dart
+++ b/lib/services/landing_signup_completion_service.dart
@@ -185,6 +185,15 @@ class LandingSignupCompletionService {
         eventKey: pending.eventKey,
         visitorId: pending.visitorId,
       );
+      try {
+        await _acquisitionService.recordFirstUserFunnelStage(
+          stage: 'signup_complete',
+          visitorId: pending.visitorId,
+        );
+      } catch (error, stackTrace) {
+        debugPrint('First-user signup completion signal failed: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
       await _acquisitionService.notifySignupSuccess(signupUserId: signupUserId);
       await _removeIfCurrent(prefs, pending);
       return true;

--- a/supabase/functions/growth-hub/first_user_funnel.ts
+++ b/supabase/functions/growth-hub/first_user_funnel.ts
@@ -1,0 +1,305 @@
+import type {
+  NormalizedXPostMetrics,
+  XMetricWindowSample,
+} from "./x_metric_windows.ts";
+
+export const FIRST_USER_FUNNEL_STAGES = [
+  "view",
+  "trial",
+  "signup_submit",
+  "signup_complete",
+  "first_action_completed",
+  "billing_view",
+  "supporter_checkout",
+] as const;
+
+export type FirstUserFunnelStage = typeof FIRST_USER_FUNNEL_STAGES[number];
+
+export type FirstUserAcquisitionEvent = {
+  visitor_id: string;
+  stage: string;
+  first_occurred_at: string;
+};
+
+export type FirstUserPayment = {
+  amountJpy: number;
+  createdAt: string;
+};
+
+export type FirstUserXPost = {
+  sourceLogId: string;
+  tweetId: string;
+  postedAt: string;
+  latestImpressions: number | null;
+  latestUrlClicks: number | null;
+  normalized: NormalizedXPostMetrics | null;
+};
+
+type FirstUserFunnelInput = {
+  utmMedium: string;
+  utmContent: string;
+  post: FirstUserXPost | null;
+  events: readonly FirstUserAcquisitionEvent[];
+  payments: readonly FirstUserPayment[];
+  nowMs?: number;
+};
+
+const countUnique = (
+  events: readonly FirstUserAcquisitionEvent[],
+  stage: FirstUserFunnelStage,
+): number =>
+  new Set(
+    events
+      .filter((event) => event.stage === stage)
+      .map((event) => event.visitor_id),
+  ).size;
+
+const rate = (numerator: number, denominator: number): number | null =>
+  denominator > 0 ? Number((numerator / denominator).toFixed(4)) : null;
+
+function latestWindow(post: FirstUserXPost | null): {
+  key: "i3h" | "i24h" | "latest" | null;
+  label: string | null;
+  impressions: number | null;
+  sample: XMetricWindowSample | null;
+} {
+  if (!post) {
+    return { key: null, label: null, impressions: null, sample: null };
+  }
+  const normalized = post.normalized;
+  if (normalized?.i24h !== null && normalized?.i24h !== undefined) {
+    return {
+      key: "i24h",
+      label: "24h",
+      impressions: normalized.i24h,
+      sample: normalized.windows.i24h,
+    };
+  }
+  if (normalized?.i3h !== null && normalized?.i3h !== undefined) {
+    return {
+      key: "i3h",
+      label: "3h",
+      impressions: normalized.i3h,
+      sample: normalized.windows.i3h,
+    };
+  }
+  return {
+    key: "latest",
+    label: "latest",
+    impressions: post.latestImpressions,
+    sample: null,
+  };
+}
+
+function decision(
+  post: FirstUserXPost | null,
+  ageHours: number | null,
+  impressions: number | null,
+  urlClicks: number,
+  counts: Record<FirstUserFunnelStage, number>,
+  paidPayments: number,
+): {
+  stage: string;
+  nextVariable: string;
+  nextAction: string;
+} {
+  if (!post) {
+    return {
+      stage: "awaiting_publish",
+      nextVariable: "publish",
+      nextAction:
+        "Obtain explicit owner approval, publish the prepared X candidate once, and keep every other variable fixed.",
+    };
+  }
+  if ((ageHours ?? 0) < 3) {
+    return {
+      stage: "collecting_3h",
+      nextVariable: "none",
+      nextAction:
+        "Keep the post unchanged until the first comparable 3-hour X window is available.",
+    };
+  }
+  if ((impressions ?? 0) < 100) {
+    return {
+      stage: "reach_bottleneck",
+      nextVariable: "hook",
+      nextAction:
+        "For the next approved post, change only the opening hook and retain the image, CTA, and landing URL.",
+    };
+  }
+  if (urlClicks === 0 && counts.view === 0) {
+    return {
+      stage: "click_bottleneck",
+      nextVariable: "link_placement",
+      nextAction:
+        "For the next approved post, change only link placement and keep the hook, image, and offer unchanged.",
+    };
+  }
+  if (counts.view > 0 && counts.trial === 0) {
+    return {
+      stage: "trial_bottleneck",
+      nextVariable: "trial_prompt",
+      nextAction:
+        "Change only the above-the-fold trial prompt; preserve the campaign post and signup flow.",
+    };
+  }
+  if (counts.trial > 0 && counts.signup_submit === 0) {
+    return {
+      stage: "signup_submit_bottleneck",
+      nextVariable: "signup_cta",
+      nextAction:
+        "Change only the save-and-register CTA copy after the trial result.",
+    };
+  }
+  if (counts.signup_submit > 0 && counts.signup_complete === 0) {
+    return {
+      stage: "signup_completion_bottleneck",
+      nextVariable: "magic_link_handoff",
+      nextAction:
+        "Change only the Magic Link completion handoff and inbox guidance.",
+    };
+  }
+  if (
+    counts.signup_complete > 0 &&
+    counts.first_action_completed === 0
+  ) {
+    return {
+      stage: "activation_bottleneck",
+      nextVariable: "trial_carryover",
+      nextAction:
+        "Change only the trial-to-onboarding carryover so the saved result becomes the first action.",
+    };
+  }
+  if (
+    counts.first_action_completed > 0 &&
+    counts.supporter_checkout === 0
+  ) {
+    return {
+      stage: "checkout_bottleneck",
+      nextVariable: "support_offer",
+      nextAction:
+        "Change only the supporter offer framing shown after first value.",
+    };
+  }
+  if (counts.supporter_checkout > 0 && paidPayments === 0) {
+    return {
+      stage: "payment_bottleneck",
+      nextVariable: "checkout_trust",
+      nextAction:
+        "Change only the checkout trust cue; keep price, product value, and traffic source fixed.",
+    };
+  }
+  if (paidPayments > 0) {
+    return {
+      stage: "payment_received",
+      nextVariable: "bank_payout_verification",
+      nextAction:
+        "Keep the winning acquisition path unchanged and verify at least JPY 1 in the linked bank account.",
+    };
+  }
+  return {
+    stage: "collecting_funnel",
+    nextVariable: "none",
+    nextAction:
+      "Collect more unique-user funnel evidence before changing the campaign.",
+  };
+}
+
+export function buildFirstUserFunnelReport(
+  input: FirstUserFunnelInput,
+): Record<string, unknown> {
+  const counts = Object.fromEntries(
+    FIRST_USER_FUNNEL_STAGES.map((stage) => [
+      stage,
+      countUnique(input.events, stage),
+    ]),
+  ) as Record<FirstUserFunnelStage, number>;
+  const postDateMs = input.post ? Date.parse(input.post.postedAt) : Number.NaN;
+  const nowMs = input.nowMs ?? Date.now();
+  const ageHours = Number.isFinite(postDateMs)
+    ? Number(((nowMs - postDateMs) / 3_600_000).toFixed(2))
+    : null;
+  const window = latestWindow(input.post);
+  const urlClicks = window.sample?.urlClicks ??
+    input.post?.latestUrlClicks ??
+    0;
+  const revenueJpy = input.payments.reduce(
+    (sum, payment) => sum + Math.max(0, payment.amountJpy),
+    0,
+  );
+  const next = decision(
+    input.post,
+    ageHours,
+    window.impressions,
+    urlClicks,
+    counts,
+    input.payments.length,
+  );
+
+  return {
+    success: true,
+    target: {
+      unknownUserSignupCompletes: 1,
+      firstRevenueJpy: 1,
+      xImpressionsPerPost: 10000,
+    },
+    attribution: {
+      utmSource: "x",
+      utmMedium: input.utmMedium,
+      utmCampaign: "first_user_growth",
+      utmContent: input.utmContent,
+    },
+    x: input.post
+      ? {
+        sourceLogId: input.post.sourceLogId,
+        tweetId: input.post.tweetId,
+        postedAt: input.post.postedAt,
+        ageHours,
+        metricWindow: window.key,
+        metricWindowLabel: window.label,
+        impressions: window.impressions,
+        urlClicks,
+        profileClicks: window.sample?.profileClicks ?? null,
+        engagements: window.sample?.engagements ?? null,
+      }
+      : null,
+    funnel: {
+      counts,
+      rates: {
+        trialPerView: rate(counts.trial, counts.view),
+        signupSubmitPerTrial: rate(counts.signup_submit, counts.trial),
+        signupCompletePerSubmit: rate(
+          counts.signup_complete,
+          counts.signup_submit,
+        ),
+        firstActionPerSignup: rate(
+          counts.first_action_completed,
+          counts.signup_complete,
+        ),
+        checkoutPerFirstAction: rate(
+          counts.supporter_checkout,
+          counts.first_action_completed,
+        ),
+        paidPerCheckout: rate(
+          input.payments.length,
+          counts.supporter_checkout,
+        ),
+      },
+    },
+    revenue: {
+      paidPayments: input.payments.length,
+      revenueJpy,
+    },
+    decision: next,
+    privacy: {
+      aggregateOnly: true,
+      containsEmail: false,
+      containsName: false,
+      containsPromptText: false,
+      containsRawVisitorIds: false,
+    },
+    paymentCaptured: revenueJpy >= 1,
+    bankPayoutVerified: false,
+    sessionGoalComplete: false,
+  };
+}

--- a/supabase/functions/growth-hub/first_user_funnel_test.ts
+++ b/supabase/functions/growth-hub/first_user_funnel_test.ts
@@ -1,0 +1,119 @@
+import {
+  assertEquals,
+  assertObjectMatch,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { buildFirstUserFunnelReport } from "./first_user_funnel.ts";
+
+const post = {
+  sourceLogId: "log-1",
+  tweetId: "tweet-1",
+  postedAt: "2026-07-24T00:00:00.000Z",
+  latestImpressions: 80,
+  latestUrlClicks: 0,
+  normalized: null,
+};
+
+Deno.test("first user funnel waits for publish without leaking visitors", () => {
+  const report = buildFirstUserFunnelReport({
+    utmMedium: "organic",
+    utmContent: "outcome_first_a",
+    post: null,
+    events: [],
+    payments: [],
+    nowMs: Date.parse("2026-07-24T03:00:00.000Z"),
+  });
+
+  assertObjectMatch(report, {
+    success: true,
+    attribution: {
+      utmSource: "x",
+      utmMedium: "organic",
+      utmCampaign: "first_user_growth",
+      utmContent: "outcome_first_a",
+    },
+    decision: {
+      stage: "awaiting_publish",
+      nextVariable: "publish",
+    },
+    paymentCaptured: false,
+    bankPayoutVerified: false,
+    sessionGoalComplete: false,
+  });
+  assertEquals(
+    (report.privacy as Record<string, unknown>).containsRawVisitorIds,
+    false,
+  );
+});
+
+Deno.test("first user funnel counts each visitor once and changes one variable", () => {
+  const events = [
+    {
+      visitor_id: "visitor-1",
+      stage: "view",
+      first_occurred_at: "2026-07-24T00:05:00.000Z",
+    },
+    {
+      visitor_id: "visitor-1",
+      stage: "view",
+      first_occurred_at: "2026-07-24T00:06:00.000Z",
+    },
+  ];
+  const report = buildFirstUserFunnelReport({
+    utmMedium: "organic",
+    utmContent: "outcome_first_a",
+    post,
+    events,
+    payments: [],
+    nowMs: Date.parse("2026-07-24T04:00:00.000Z"),
+  });
+  const funnel = report.funnel as Record<string, unknown>;
+
+  assertEquals(
+    (funnel.counts as Record<string, number>).view,
+    1,
+  );
+  assertObjectMatch(report, {
+    decision: {
+      stage: "reach_bottleneck",
+      nextVariable: "hook",
+    },
+  });
+});
+
+Deno.test("first user funnel advances to payout verification after paid event", () => {
+  const stages = [
+    "view",
+    "trial",
+    "signup_submit",
+    "signup_complete",
+    "first_action_completed",
+    "billing_view",
+    "supporter_checkout",
+  ];
+  const report = buildFirstUserFunnelReport({
+    utmMedium: "organic",
+    utmContent: "outcome_first_a",
+    post: { ...post, latestImpressions: 12000, latestUrlClicks: 50 },
+    events: stages.map((stage) => ({
+      visitor_id: "visitor-1",
+      stage,
+      first_occurred_at: "2026-07-24T01:00:00.000Z",
+    })),
+    payments: [{
+      amountJpy: 100,
+      createdAt: "2026-07-24T02:00:00.000Z",
+    }],
+    nowMs: Date.parse("2026-07-25T01:00:00.000Z"),
+  });
+
+  assertObjectMatch(report, {
+    revenue: { paidPayments: 1, revenueJpy: 100 },
+    decision: {
+      stage: "payment_received",
+      nextVariable: "bank_payout_verification",
+    },
+    paymentCaptured: true,
+    bankPayoutVerified: false,
+    sessionGoalComplete: false,
+  });
+});

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -85,6 +85,13 @@ import {
   LandingTrialInputError,
   normalizeLandingTrialPrompt,
 } from "./landing_trial.ts";
+import {
+  buildFirstUserFunnelReport,
+  FIRST_USER_FUNNEL_STAGES,
+  type FirstUserAcquisitionEvent,
+  type FirstUserPayment,
+  type FirstUserXPost,
+} from "./first_user_funnel.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -428,6 +435,12 @@ const TOUCHPOINT_DEFS = [
     signupSignal: "signup_submit_profile",
   },
   {
+    id: "x_first_user_growth",
+    label: "X first-user campaign",
+    touchSignal: "touch_x_first_user_growth",
+    signupSignal: "signup_submit_x_first_user_growth",
+  },
+  {
     id: "import",
     label: "Import",
     touchSignal: "touch_import",
@@ -498,6 +511,7 @@ const SUPPORTED_ACQUISITION_SIGNALS = new Set([
   "x_first_user_feedback_x_intent",
   "signup_submit_landing",
   "signup_submit_profile",
+  "signup_submit_x_first_user_growth",
   "signup_submit_import",
   "signup_submit_public_memo",
   "signup_submit_referral",
@@ -570,6 +584,78 @@ async function recordAcquisitionSignal(
     .eq("date", dateKey);
   if (error) throw new Error(error.message);
   return { success: true, signalKey, dateKey };
+}
+
+const firstUserFunnelStageSet = new Set<string>(FIRST_USER_FUNNEL_STAGES);
+const firstUserTokenPattern = /^[a-z0-9_-]{1,64}$/;
+
+async function recordFirstUserFunnelSignal(
+  admin: SupabaseClient,
+  actorUserId: string | null,
+  body: Record<string, unknown>,
+) {
+  const visitorId = firstString(body.visitorId, body.visitor_id).toLowerCase();
+  const stage = firstString(body.stage).toLowerCase();
+  const utmSource = firstString(
+    body.utmSource,
+    body.utm_source,
+  ).toLowerCase();
+  const utmMedium = firstString(
+    body.utmMedium,
+    body.utm_medium,
+  ).toLowerCase();
+  const utmCampaign = firstString(
+    body.utmCampaign,
+    body.utm_campaign,
+  ).toLowerCase();
+  const utmContent = firstString(
+    body.utmContent,
+    body.utm_content,
+  ).toLowerCase();
+
+  if (
+    !isUuid(visitorId) ||
+    !firstUserFunnelStageSet.has(stage) ||
+    utmSource !== "x" ||
+    utmCampaign !== "first_user_growth" ||
+    !firstUserTokenPattern.test(utmMedium) ||
+    !firstUserTokenPattern.test(utmContent)
+  ) {
+    return {
+      success: false,
+      error: "invalid first-user funnel signal",
+    };
+  }
+
+  const { data, error } = await admin
+    .from("first_user_acquisition_events")
+    .upsert({
+      visitor_id: visitorId,
+      auth_user_id: actorUserId && isUuid(actorUserId) ? actorUserId : null,
+      stage,
+      utm_source: utmSource,
+      utm_medium: utmMedium,
+      utm_campaign: utmCampaign,
+      utm_content: utmContent,
+    }, {
+      onConflict:
+        "visitor_id,utm_source,utm_medium,utm_campaign,utm_content,stage",
+      ignoreDuplicates: true,
+    })
+    .select("visitor_id")
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return {
+    success: true,
+    duplicate: data === null,
+    stage,
+    attribution: {
+      utmSource,
+      utmMedium,
+      utmCampaign,
+      utmContent,
+    },
+  };
 }
 
 type XPostLogItem = {
@@ -1520,6 +1606,112 @@ async function buildRevenueFunnelReport(
   };
 }
 
+async function buildFirstUserAcquisitionReport(
+  admin: SupabaseClient,
+  userId: string,
+  rawUtmMedium: unknown,
+  rawUtmContent: unknown,
+  rawLimit: unknown,
+) {
+  const utmMedium = firstString(rawUtmMedium, "organic").toLowerCase();
+  const utmContent = firstString(rawUtmContent, "outcome_first_a")
+    .toLowerCase();
+  if (
+    !firstUserTokenPattern.test(utmMedium) ||
+    !firstUserTokenPattern.test(utmContent)
+  ) {
+    throw new Error("invalid first-user UTM");
+  }
+  const limit = Math.max(
+    10,
+    Math.min(100, Math.trunc(firstNumber(rawLimit) ?? 50)),
+  );
+  const logs = (await listXPostLogs(admin, userId, limit)) as XPostLogItem[];
+  const matchingLogs = logs.filter((item) => {
+    const metadata = asRecord(item.metadata);
+    const variants = [
+      metadata.utm_content,
+      metadata.utmContent,
+      metadata.variant,
+      metadata.selected_variant,
+    ].map((value) => firstString(value).toLowerCase());
+    return firstString(metadata.tweet_id) !== "" &&
+      variants.includes(utmContent);
+  });
+  const latestLog = matchingLogs[0] ?? null;
+  let post: FirstUserXPost | null = null;
+  if (latestLog) {
+    const normalized = await loadNormalizedXMetricWindows(
+      admin,
+      userId,
+      [latestLog],
+    );
+    const metadata = asRecord(latestLog.metadata);
+    const latestMetrics = asRecord(metadata.latest_metrics);
+    post = {
+      sourceLogId: latestLog.id,
+      tweetId: firstString(metadata.tweet_id),
+      postedAt: firstString(metadata.posted_at, latestLog.created_at),
+      latestImpressions: firstNumber(
+        latestMetrics.impressions,
+        metadata.impressions,
+      ),
+      latestUrlClicks: firstNumber(latestMetrics.url_clicks),
+      normalized: normalized[0] ?? null,
+    };
+  }
+
+  let eventQuery = admin
+    .from("first_user_acquisition_events")
+    .select("visitor_id,stage,first_occurred_at")
+    .eq("utm_source", "x")
+    .eq("utm_medium", utmMedium)
+    .eq("utm_campaign", "first_user_growth")
+    .eq("utm_content", utmContent)
+    .order("first_occurred_at", { ascending: true });
+  if (post?.postedAt) {
+    eventQuery = eventQuery.gte("first_occurred_at", post.postedAt);
+  }
+  const { data: eventData, error: eventError } = await eventQuery;
+  if (eventError) throw new Error(eventError.message);
+
+  let paymentQuery = admin
+    .from("hub_data")
+    .select("metadata,created_at")
+    .eq("source", "stripe_supporter_payment")
+    .filter("metadata->>payment_status", "eq", "paid")
+    .filter("metadata->>utm_source", "eq", "x")
+    .filter("metadata->>utm_medium", "eq", utmMedium)
+    .filter("metadata->>utm_campaign", "eq", "first_user_growth")
+    .filter("metadata->>utm_content", "eq", utmContent)
+    .order("created_at", { ascending: true });
+  if (post?.postedAt) {
+    paymentQuery = paymentQuery.gte("created_at", post.postedAt);
+  }
+  const { data: paymentData, error: paymentError } = await paymentQuery;
+  if (paymentError) throw new Error(paymentError.message);
+
+  const payments = (paymentData ?? []).map((row): FirstUserPayment => {
+    const metadata = asRecord(row.metadata);
+    return {
+      amountJpy: firstNumber(metadata.amount_jpy, metadata.amount_total) ?? 0,
+      createdAt: firstString(row.created_at),
+    };
+  });
+  const report = buildFirstUserFunnelReport({
+    utmMedium,
+    utmContent,
+    post,
+    events: (eventData ?? []) as FirstUserAcquisitionEvent[],
+    payments,
+  });
+  return {
+    ...report,
+    issue: 3883,
+    reportGeneratedAt: new Date().toISOString(),
+  };
+}
+
 async function buildAcquisitionTouchpointReport(
   admin: SupabaseClient,
   rawWindowDays: unknown,
@@ -1968,6 +2160,7 @@ serve(async (req: Request) => {
       "waitlist.notify",
       "acquisition.report",
       "acquisition.signal",
+      "acquisition.funnel_signal",
       "acquisition.track",
       "acquisition.touchpoint_report",
       "landing.trial",
@@ -2084,6 +2277,16 @@ serve(async (req: Request) => {
           admin,
           body.signalKey,
           body.dateKey,
+        );
+        return json(result, result.success ? 200 : 400);
+      }
+
+      case "acquisition.funnel_signal": {
+        const actorUserId = await getUserId(req);
+        const result = await recordFirstUserFunnelSignal(
+          admin,
+          actorUserId,
+          body,
         );
         return json(result, result.success ? 200 : 400);
       }
@@ -2562,6 +2765,21 @@ serve(async (req: Request) => {
         const scopeUserId = await xReadScopeUserId(admin, userId!);
         return json(
           await buildXPerformanceContext(admin, scopeUserId, body.limit),
+        );
+      }
+
+      case "x.first_user_funnel": {
+        if (!await isXOperator(admin, userId!)) {
+          return json({ error: "Forbidden: X operator role required" }, 403);
+        }
+        return json(
+          await buildFirstUserAcquisitionReport(
+            admin,
+            "service_role",
+            body.utmMedium ?? body.utm_medium,
+            body.utmContent ?? body.utm_content,
+            body.limit,
+          ),
         );
       }
 

--- a/supabase/migrations/20260724120000_first_user_acquisition_events.sql
+++ b/supabase/migrations/20260724120000_first_user_acquisition_events.sql
@@ -1,0 +1,54 @@
+-- Join the first unknown-user X campaign to the downstream activation and
+-- payment funnel without storing email, name, prompt text, IP address, or user
+-- agent. One visitor can contribute at most once to each campaign stage.
+CREATE TABLE public.first_user_acquisition_events (
+  visitor_id uuid NOT NULL,
+  auth_user_id uuid
+    REFERENCES auth.users (id) ON DELETE SET NULL,
+  stage text NOT NULL
+    CHECK (
+      stage IN (
+        'view',
+        'trial',
+        'signup_submit',
+        'signup_complete',
+        'first_action_completed',
+        'billing_view',
+        'supporter_checkout'
+      )
+    ),
+  utm_source text NOT NULL
+    CHECK (utm_source = 'x'),
+  utm_medium text NOT NULL
+    CHECK (utm_medium ~ '^[a-z0-9_-]{1,64}$'),
+  utm_campaign text NOT NULL
+    CHECK (utm_campaign = 'first_user_growth'),
+  utm_content text NOT NULL
+    CHECK (utm_content ~ '^[a-z0-9_-]{1,64}$'),
+  first_occurred_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (
+    visitor_id,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_content,
+    stage
+  )
+);
+
+COMMENT ON TABLE public.first_user_acquisition_events IS
+  'Privacy-minimized unique-visitor funnel for the unknown-user first_user_growth X campaign.';
+
+CREATE INDEX first_user_acquisition_events_report_idx
+  ON public.first_user_acquisition_events (
+    utm_campaign,
+    utm_content,
+    first_occurred_at DESC
+  );
+
+ALTER TABLE public.first_user_acquisition_events ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.first_user_acquisition_events
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT ON TABLE public.first_user_acquisition_events
+  TO service_role;

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/pages/landing_page.dart';
+import 'package:my_web_app/services/growth_acquisition_service.dart';
 import 'package:my_web_app/services/landing_conversion_experiment_service.dart';
 import 'package:my_web_app/services/landing_page_adapter.dart';
 import 'package:my_web_app/services/landing_signup_completion_service.dart';
@@ -102,6 +103,24 @@ class _DelayedExperimentService extends LandingConversionExperimentService {
   }
 }
 
+class _RecordingAcquisitionService extends GrowthAcquisitionService {
+  _RecordingAcquisitionService();
+
+  final List<String> stages = <String>[];
+
+  @override
+  Future<bool> recordFirstUserFunnelStage({
+    required String stage,
+    String? visitorId,
+    Uri? currentUri,
+    SharedPreferences? preferences,
+    DateTime? now,
+  }) async {
+    stages.add(stage);
+    return true;
+  }
+}
+
 LandingConversionHypothesis _hypothesis(String id) {
   return LandingConversionExperimentService.hypotheses.firstWhere(
     (hypothesis) => hypothesis.id == id,
@@ -140,6 +159,7 @@ void main() {
     bool? analyticsEnabled,
     Uri? landingUri,
     LandingConversionExperimentService? conversionExperimentService,
+    GrowthAcquisitionService? acquisitionService,
   }) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = size;
@@ -157,6 +177,7 @@ void main() {
           adapter: adapter,
           experimentAssignment: assignment,
           conversionExperimentService: conversionExperimentService,
+          acquisitionService: acquisitionService,
           analyticsEnabled: analyticsEnabled,
           landingUri: landingUri,
         ),
@@ -282,6 +303,7 @@ void main() {
   testWidgets(
     'first-user X traffic gets a one-tap trial before registration',
     (tester) async {
+      final acquisition = _RecordingAcquisitionService();
       final adapter = await pumpLanding(
         tester,
         assignment: _assignment('h03', LandingExperimentVariant.control),
@@ -291,6 +313,7 @@ void main() {
           '&utm_campaign=first_user_growth'
           '&utm_content=outcome_first_a',
         ),
+        acquisitionService: acquisition,
       );
       await tester.pumpAndSettle();
 
@@ -306,6 +329,7 @@ void main() {
         find.byKey(const Key('first_user_growth_trial_reassurance')),
         findsOneWidget,
       );
+      expect(acquisition.stages, contains('view'));
 
       await tester.tap(
         find.byKey(const Key('first_user_growth_one_tap_trial')),
@@ -313,6 +337,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(adapter.trialRuns, 1);
+      expect(acquisition.stages, contains('trial'));
       expect(
         adapter.lastTrialPrompt,
         '仕事が多すぎて、何から始めるか決められない',

--- a/test/pages/onboarding_page_activation_test.dart
+++ b/test/pages/onboarding_page_activation_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/pages/onboarding_page.dart';
 import 'package:my_web_app/services/activation_revenue_experiment_service.dart';
 import 'package:my_web_app/services/activation_revenue_tracker.dart';
+import 'package:my_web_app/services/growth_acquisition_service.dart';
 import 'package:my_web_app/services/onboarding_activation_gateway.dart';
 import 'package:my_web_app/services/pending_landing_trial_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -23,12 +24,14 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
     final gateway = _FakeOnboardingGateway();
     final tracker = _FakeTracker();
+    final acquisition = _RecordingAcquisitionService();
 
     await tester.pumpWidget(
       MaterialApp(
         home: OnboardingPage(
           gateway: gateway,
           tracker: tracker,
+          acquisitionService: acquisition,
           assignment: _assignment('a10', ActivationRevenueVariant.treatment),
         ),
       ),
@@ -76,6 +79,7 @@ void main() {
         'value_recap_view',
       ]),
     );
+    expect(acquisition.stages, <String>['first_action_completed']);
     expect(tester.takeException(), isNull);
   });
 
@@ -330,6 +334,24 @@ void main() {
     expect(find.textContaining('自動更新なし'), findsOneWidget);
     expect(find.text('ProでAI利用量を増やす'), findsOneWidget);
   });
+}
+
+class _RecordingAcquisitionService extends GrowthAcquisitionService {
+  _RecordingAcquisitionService();
+
+  final List<String> stages = <String>[];
+
+  @override
+  Future<bool> recordFirstUserFunnelStage({
+    required String stage,
+    String? visitorId,
+    Uri? currentUri,
+    SharedPreferences? preferences,
+    DateTime? now,
+  }) async {
+    stages.add(stage);
+    return true;
+  }
 }
 
 Future<void> _pumpArm(

--- a/test/pages/subscription_billing_page_test.dart
+++ b/test/pages/subscription_billing_page_test.dart
@@ -4,6 +4,8 @@ import 'package:my_web_app/pages/subscription_billing_page.dart';
 import 'package:my_web_app/services/activation_revenue_experiment_service.dart';
 import 'package:my_web_app/services/activation_revenue_tracker.dart';
 import 'package:my_web_app/services/billing_service.dart';
+import 'package:my_web_app/services/growth_acquisition_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   testWidgets('shows success confirmation and refreshes billing status', (
@@ -104,6 +106,43 @@ void main() {
     expect(find.textContaining('自動更新なし'), findsWidgets);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'carries the original X variant into the supporter checkout',
+    (tester) async {
+      final billing = _FakeBillingGateway();
+      final acquisition = _RecordingAcquisitionService();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SubscriptionBillingPage(
+            service: billing,
+            acquisitionService: acquisition,
+            tracker: const NoopActivationRevenueEventTracker(),
+            assignment: _treatment,
+            initialUri: Uri.parse(
+              'https://example.com/subscription-billing?entry=onboarding',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(acquisition.stages, contains('billing_view'));
+      final checkoutButton = find.byKey(
+        const Key('billing_supporter_checkout_button'),
+      );
+      await tester.ensureVisible(checkoutButton);
+      await tester.tap(checkoutButton);
+      await tester.pumpAndSettle();
+
+      expect(acquisition.stages, contains('supporter_checkout'));
+      expect(
+        billing.supporterAttribution?.toJson(),
+        containsPair('utm_content', 'outcome_first_a'),
+      );
+    },
+  );
 }
 
 final _treatment = ActivationRevenueAssignment(
@@ -113,6 +152,7 @@ final _treatment = ActivationRevenueAssignment(
 
 class _FakeBillingGateway implements BillingGateway {
   int fetchStatusCount = 0;
+  BillingSupporterAttribution? supporterAttribution;
 
   @override
   Future<BillingStatus> fetchStatus() async {
@@ -140,6 +180,7 @@ class _FakeBillingGateway implements BillingGateway {
     BillingSupporterAttribution attribution =
         const BillingSupporterAttribution(),
   }) async {
+    supporterAttribution = attribution;
     return const BillingCheckoutSession(url: 'https://stripe.example.test');
   }
 
@@ -148,5 +189,43 @@ class _FakeBillingGateway implements BillingGateway {
     required String returnUrl,
   }) async {
     return const BillingPortalSession(url: 'https://stripe.example.test');
+  }
+}
+
+class _RecordingAcquisitionService extends GrowthAcquisitionService {
+  _RecordingAcquisitionService();
+
+  final List<String> stages = <String>[];
+
+  @override
+  Future<bool> recordFirstUserFunnelStage({
+    required String stage,
+    String? visitorId,
+    Uri? currentUri,
+    SharedPreferences? preferences,
+    DateTime? now,
+  }) async {
+    stages.add(stage);
+    return true;
+  }
+
+  @override
+  Future<String?> loadLatestTouchpoint() async {
+    return GrowthAcquisitionService.touchXFirstUserGrowth;
+  }
+
+  @override
+  Future<FirstUserGrowthAttribution?> loadFirstUserAttribution({
+    SharedPreferences? preferences,
+    DateTime? now,
+  }) async {
+    return FirstUserGrowthAttribution(
+      visitorId: '00000000-0000-4000-8000-000000000001',
+      utmSource: 'x',
+      utmMedium: 'organic',
+      utmCampaign: 'first_user_growth',
+      utmContent: 'outcome_first_a',
+      capturedAt: DateTime.utc(2026, 7, 24),
+    );
   }
 }

--- a/test/services/billing_service_attribution_test.dart
+++ b/test/services/billing_service_attribution_test.dart
@@ -55,4 +55,29 @@ void main() {
       });
     },
   );
+
+  test('keeps the original X variant through auth and internal navigation', () {
+    final attribution = BillingSupporterAttribution.fromUri(
+      Uri.parse('https://example.com/subscription-billing?entry=onboarding'),
+      fallbackTouchpoint: GrowthAcquisitionService.touchXFirstUserGrowth,
+      firstUserAttribution: FirstUserGrowthAttribution(
+        visitorId: '00000000-0000-4000-8000-000000000001',
+        utmSource: 'x',
+        utmMedium: 'organic',
+        utmCampaign: 'first_user_growth',
+        utmContent: 'outcome_first_a',
+        capturedAt: DateTime.utc(2026, 7, 24),
+      ),
+    );
+
+    expect(attribution.toJson(), {
+      'utm_source': 'x',
+      'utm_medium': 'organic',
+      'utm_campaign': 'first_user_growth',
+      'utm_content': 'outcome_first_a',
+      'experiment_key': 'first_user_growth',
+      'variant': 'outcome_first_a',
+      'landing_touchpoint': 'touch_x_first_user_growth',
+    });
+  });
 }

--- a/test/services/first_user_acquisition_events_schema_test.dart
+++ b/test/services/first_user_acquisition_events_schema_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260724120000_first_user_acquisition_events.sql';
+
+void main() {
+  group('first user acquisition event schema', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _migrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test('deduplicates every visitor, campaign variant, and funnel stage', () {
+      expect(
+        sql,
+        contains('create table public.first_user_acquisition_events'),
+      );
+      expect(sql, contains('visitor_id uuid not null'));
+      expect(sql, contains("utm_source = 'x'"));
+      expect(sql, contains("utm_campaign = 'first_user_growth'"));
+      expect(
+        sql,
+        contains(
+          'primary key (\n'
+          '    visitor_id,\n'
+          '    utm_source,\n'
+          '    utm_medium,\n'
+          '    utm_campaign,\n'
+          '    utm_content,\n'
+          '    stage\n'
+          '  )',
+        ),
+      );
+      for (final stage in <String>[
+        'view',
+        'trial',
+        'signup_submit',
+        'signup_complete',
+        'first_action_completed',
+        'billing_view',
+        'supporter_checkout',
+      ]) {
+        expect(sql, contains("'$stage'"));
+      }
+    });
+
+    test('keeps raw rows private and service-role only', () {
+      expect(
+        sql,
+        contains(
+          'alter table public.first_user_acquisition_events enable row level security',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'revoke all on table public.first_user_acquisition_events\n'
+          '  from public, anon, authenticated',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'grant select, insert on table public.first_user_acquisition_events\n'
+          '  to service_role',
+        ),
+      );
+    });
+
+    test('does not persist user content or direct personal identifiers', () {
+      for (final forbiddenColumn in <String>[
+        'email',
+        'name',
+        'ip_address',
+        'user_agent',
+        'browser_fingerprint',
+        'prompt_text',
+        'answer_text',
+        'challenge_text',
+      ]) {
+        expect(
+          RegExp('\\n\\s*$forbiddenColumn\\s').hasMatch(sql),
+          isFalse,
+          reason: '$forbiddenColumn must not be persisted',
+        );
+      }
+    });
+  });
+}

--- a/test/services/growth_acquisition_service_test.dart
+++ b/test/services/growth_acquisition_service_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/growth_acquisition_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('maps page paths to acquisition touch signals', () {
     expect(
       GrowthAcquisitionService.signalForPagePath('/'),
@@ -96,6 +99,121 @@ void main() {
     expect(
       GrowthAcquisitionService.resolveSignupSubmitSignal(null),
       GrowthAcquisitionService.signupSubmitLanding,
+    );
+  });
+
+  test('persists privacy-minimized first-user UTM attribution', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    const visitorId = '00000000-0000-4000-8000-000000000001';
+    final now = DateTime.utc(2026, 7, 24, 1);
+    const service = GrowthAcquisitionService();
+    final uri = Uri.parse(
+      'https://my-web-app-b67f4.web.app/'
+      '?utm_source=x&utm_medium=organic&utm_campaign=first_user_growth'
+      '&utm_content=outcome_first_a',
+    );
+
+    expect(
+      await service.recordFirstUserFunnelStage(
+        stage: 'view',
+        visitorId: visitorId,
+        currentUri: uri,
+        now: now,
+      ),
+      isFalse,
+    );
+
+    final attribution = await service.loadFirstUserAttribution(
+      now: now.add(const Duration(hours: 1)),
+    );
+    expect(attribution?.visitorId, visitorId);
+    expect(attribution?.utmSource, 'x');
+    expect(attribution?.utmCampaign, 'first_user_growth');
+    expect(attribution?.utmContent, 'outcome_first_a');
+    final prefs = await SharedPreferences.getInstance();
+    final encoded = prefs.getString(
+      GrowthAcquisitionService.firstUserAttributionStorageKey,
+    );
+    expect(encoded, isNotNull);
+    expect(encoded, isNot(contains('@')));
+    expect(encoded, isNot(contains('prompt')));
+  });
+
+  test('does not inherit a prior X campaign on a direct LP view', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    const visitorId = '00000000-0000-4000-8000-000000000001';
+    final now = DateTime.utc(2026, 7, 24, 1);
+    const service = GrowthAcquisitionService();
+    await service.recordFirstUserFunnelStage(
+      stage: 'view',
+      visitorId: visitorId,
+      currentUri: Uri.parse(
+        'https://my-web-app-b67f4.web.app/'
+        '?utm_source=x&utm_medium=organic&utm_campaign=first_user_growth'
+        '&utm_content=outcome_first_a',
+      ),
+      now: now,
+    );
+
+    expect(
+      await service.recordFirstUserFunnelStage(
+        stage: 'view',
+        visitorId: visitorId,
+        currentUri: Uri.parse('https://my-web-app-b67f4.web.app/'),
+        now: now.add(const Duration(hours: 1)),
+      ),
+      isFalse,
+    );
+  });
+
+  test('does not inherit a prior X campaign when an LP URI is unavailable',
+      () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    const visitorId = '00000000-0000-4000-8000-000000000001';
+    final now = DateTime.utc(2026, 7, 24, 1);
+    const service = GrowthAcquisitionService();
+    await service.recordFirstUserFunnelStage(
+      stage: 'view',
+      visitorId: visitorId,
+      currentUri: Uri.parse(
+        'https://my-web-app-b67f4.web.app/'
+        '?utm_source=x&utm_medium=organic&utm_campaign=first_user_growth'
+        '&utm_content=outcome_first_a',
+      ),
+      now: now,
+    );
+
+    expect(
+      await service.recordFirstUserFunnelStage(
+        stage: 'trial',
+        visitorId: visitorId,
+        now: now.add(const Duration(hours: 1)),
+      ),
+      isFalse,
+    );
+  });
+
+  test('expires first-user attribution after seven days', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    const visitorId = '00000000-0000-4000-8000-000000000001';
+    final now = DateTime.utc(2026, 7, 24, 1);
+    const service = GrowthAcquisitionService();
+    await service.recordFirstUserFunnelStage(
+      stage: 'view',
+      visitorId: visitorId,
+      currentUri: Uri.parse(
+        'https://my-web-app-b67f4.web.app/'
+        '?utm_source=x&utm_campaign=first_user_growth'
+        '&utm_content=outcome_first_a',
+      ),
+      now: now,
+    );
+
+    expect(
+      await service.loadFirstUserAttribution(
+        now: now.add(const Duration(days: 7)),
+      ),
+      isNull,
     );
   });
 }

--- a/test/services/landing_signup_completion_service_test.dart
+++ b/test/services/landing_signup_completion_service_test.dart
@@ -26,6 +26,19 @@ class _RecordingAcquisitionService extends GrowthAcquisitionService {
   _RecordingAcquisitionService();
 
   final List<String> notifiedUserIds = <String>[];
+  final List<String> funnelStages = <String>[];
+
+  @override
+  Future<bool> recordFirstUserFunnelStage({
+    required String stage,
+    String? visitorId,
+    Uri? currentUri,
+    SharedPreferences? preferences,
+    DateTime? now,
+  }) async {
+    funnelStages.add('$stage:$visitorId');
+    return true;
+  }
 
   @override
   Future<void> notifySignupSuccess({required String? signupUserId}) async {
@@ -75,6 +88,9 @@ void main() {
 
       expect(adapter.eventKeys, <String>[eventKey]);
       expect(adapter.visitorIds, <String>[visitorId]);
+      expect(acquisitionService.funnelStages, <String>[
+        'signup_complete:$visitorId',
+      ]);
       expect(acquisitionService.notifiedUserIds, <String>['user-1']);
       final prefs = await SharedPreferences.getInstance();
       expect(
@@ -179,6 +195,9 @@ void main() {
         true,
       ]);
       expect(adapter.eventKeys, hasLength(1));
+      expect(acquisitionService.funnelStages, <String>[
+        'signup_complete:$visitorId',
+      ]);
       expect(acquisitionService.notifiedUserIds, <String>['user-4']);
     },
   );


### PR DESCRIPTION
## What changed

- Added a privacy-minimized `first_user_acquisition_events` ledger for the exact `x / organic / first_user_growth / outcome_first_a` acquisition path.
- Tracked unique visitors across LP view, trial, signup submit, signup completion, first action, billing view, and supporter checkout.
- Preserved the original campaign attribution through Magic Link redirects and internal navigation into Stripe metadata.
- Joined normalized X 3h/24h metrics, funnel stages, and paid supporter revenue in `x.first_user_funnel`.
- Added the checkpoint to the existing metrics workflow with a 30-day JSON evidence artifact and a deterministic one-variable-next decision.

## Why

The LP experiments can improve conversion, but issue #3883 could not tell whether an approved X post produced an unknown signup, activation, checkout, or payment. This closes that measurement gap without storing email, name, prompt text, raw IP, or user agent in the campaign ledger.

## Impact

After deployment, one approved campaign post can be evaluated from impressions through payment using the same UTM variant. The report deliberately keeps bank payout verification false until external bank evidence exists, so it cannot incorrectly mark the session goal complete.

This PR does not publish anything to X and does not automate DMs, follows, or engagement.

## Validation

- `flutter test` on LP, onboarding, billing, attribution, signup completion, and schema tests: 57 passed
- `flutter analyze` on changed app sources: no issues
- `deno test --allow-env supabase/functions/growth-hub`: 126 passed
- `deno check --node-modules-dir=auto supabase/functions/growth-hub/index.ts`: passed
- Workflow YAML parse: passed
- Full pre-commit quality gate: passed (`flutter analyze`, Deno lint, Actions Node runtime floor)
- Post-deploy production smoke: run `x.first_user_funnel` for `outcome_first_a` and confirm `awaiting_publish` with zero leaked identifiers before any approved public post.

## Minimal E2E Gate

- Implementation-detail independent: the tests assert user-visible input/output and aggregate funnel outcomes, not private internals.
- Minimal scope: about 3 cases (campaign happy path, direct-traffic exclusion, attribution expiry/recovery).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: No new browser-only route is introduced; focused LP widget tests, Edge report tests, migration contract tests, and post-deploy production smoke cover this instrumentation change.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 is unavailable in this Codex session; focused security, rollback, data migration, production smoke, and observability checks are documented and enforced by CI.

Refs #3883
Refs #3745
Refs #4129