### PR TITLE
[CI/CD自動最適化] deploy pub cache 追加 2026-07-26

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -66,6 +66,14 @@ jobs:
           channel: 'stable'
           cache: true
 
+      - name: Cache Flutter pub
+        uses: actions/cache@v6
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
       - name: Install dependencies
         run: flutter pub get
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -71,6 +71,14 @@ jobs:
           channel: 'stable'
           cache: true
 
+      - name: Cache Flutter pub
+        uses: actions/cache@v6
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
       - name: Install dependencies
         run: flutter pub get
 


### PR DESCRIPTION
## 変更概要

`deploy-dev.yml` と `deploy-staging.yml` に Flutter pub キャッシュを追加。

### 問題

`subosito/flutter-action@v2` の `cache: true` は Flutter SDK (バイナリ) のみをキャッシュ。  
`~/.pub-cache` (pub パッケージ) はキャッシュされず、`flutter pub get` が毎 run フルダウンロード (30〜60 秒/run)。

一方、`ci.yml` には既に `actions/cache@v6` で pub cache が設定済み — deploy 系が抜けていた。

### 変更内容

| ファイル | 追加 |
|---------|------|
| `.github/workflows/deploy-dev.yml` | `actions/cache@v6` for `~/.pub-cache` |
| `.github/workflows/deploy-staging.yml` | 同上 |

キャッシュキー: `${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}`

### 推定削減効果

- cache hit 時: `flutter pub get` が 30〜60s → 3〜5s (約 25〜55 秒/run 短縮)
- deploy-dev + deploy-staging 合計: **~90〜270 ubuntu-min/月** 削減

### 安全性

- cache miss 時は通常の `flutter pub get` にフォールバック — 機能に影響なし
- `pubspec.lock` 変更時はキャッシュミスで再取得 — 正確な依存関係を保証
- CI.yml の既存 pub cache と同一パターン — 実績あり

### 監査レポート

`docs/ci-cd-audit/2026-07-26.md`

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI-only pub cache addition (actions/cache@v6 for ~/.pub-cache). No deploy logic, routing, auth, secrets, or concurrency changed. Cache miss falls back gracefully to full flutter pub get — zero functional risk.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.