### PR TITLE
feat(x-growth): rank X learning on site acquisition, not reach

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -17,13 +17,16 @@ import '../services/local_election_plan_service.dart';
 import '../utils/web_image_downloader.dart';
 import '../services/local_election_reality_service.dart';
 import '../services/prefecture_election_news_service.dart';
+import '../services/growth_acquisition_service.dart';
 import '../services/local_election_share_service.dart';
 import '../services/public_memo_service.dart';
+import 'landing_page.dart';
 import '../widgets/election_japan_map.dart';
 import '../widgets/election_progress_chart.dart';
 import '../widgets/election_regional_kpi_chart.dart';
 import '../widgets/election_news_badge.dart';
 import '../widgets/election_x_post_composer_dialog.dart';
+import '../widgets/public_tracker_cta_card.dart';
 
 class ElectionVictoryPage extends StatefulWidget {
   final bool publicView;
@@ -748,9 +751,25 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     );
   }
 
+  /// R24: 外部へ配る公開ダッシュボードURL。実測でサイト流入の 94% を占める
+  /// 経路なのに UTM が無く、着地を計測できていなかった。共有・コピー経路だけ
+  /// UTM を付ける (ページ内表示用の素の URL はそのまま)。
+  /// `utm_source=x` + `utm_campaign=first_user_growth` は
+  /// GrowthAcquisitionService.isFirstUserGrowthUri の判定条件に合わせる。
+  static String get _shareablePublicDashboardUrl => Uri.parse(
+        _publicLocalElectionDashboardUrl,
+      ).replace(
+        queryParameters: const <String, String>{
+          'utm_source': 'x',
+          'utm_medium': 'data_report',
+          'utm_campaign': 'first_user_growth',
+          'utm_content': 'local_election_700',
+        },
+      ).toString();
+
   Future<void> _copyPublicDashboardLink() async {
     await Clipboard.setData(
-      const ClipboardData(text: _publicLocalElectionDashboardUrl),
+      ClipboardData(text: _shareablePublicDashboardUrl),
     );
     if (!mounted) {
       return;
@@ -792,7 +811,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
       final memo = await _shareService.publishPlanDashboard(
         plan: plan,
         snapshot: snapshot,
-        publicDashboardUrl: _publicLocalElectionDashboardUrl,
+        publicDashboardUrl: _shareablePublicDashboardUrl,
       );
       if (!mounted) {
         return memo;
@@ -924,7 +943,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     final memo =
         _publishedKpiMemo ?? (canPublishMemo ? await _publishKpiMemo() : null);
     final publicUrl = memo == null
-        ? _publicLocalElectionDashboardUrl
+        ? _shareablePublicDashboardUrl
         : PublicMemoService.buildPublicMemoUrl(memo.id);
     final uri = _shareService.buildPlanDashboardXShareIntentUri(
       plan: plan,
@@ -1176,7 +1195,19 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         ],
       ),
       body: _isLoading || plan == null
-          ? const Center(child: CircularProgressIndicator())
+          // R24: 公開ビューは X からの着地点 (実測でサイト流入の 94%)。
+          // 読み込み中や取得失敗でスピナーだけを出すと、訪問者は「何のサイトか」
+          // を 1 文字も読めないまま離脱する。データを待たずに導線だけは見せる。
+          ? (_isPublicView
+              ? ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    _buildPublicTrackerCtaCard(),
+                    const SizedBox(height: 24),
+                    const Center(child: CircularProgressIndicator()),
+                  ],
+                )
+              : const Center(child: CircularProgressIndicator()))
           : RefreshIndicator(
               onRefresh: _refreshAll,
               child: ListView(
@@ -1185,6 +1216,8 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                 padding: const EdgeInsets.all(16),
                 children: [
                   if (_isPublicView) ...[
+                    _buildPublicTrackerCtaCard(),
+                    const SizedBox(height: 16),
                     _buildPublicViewNotice(),
                     const SizedBox(height: 16),
                   ],
@@ -1371,6 +1404,37 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildPublicTrackerCtaCard() {
+    return PublicTrackerCtaCard(
+      headline: 'この集計は「自分株式会社」が毎日自動更新しています',
+      description: '公式ページを定期取得して、現職数・目標との差分・残り日数を自動で計算しています。'
+          '同じ仕組みを、家計や資産、仕事ログ、AIツールの定点観測にも使えるように作っている個人向けのダッシュボードです。',
+      onActionPressed: _openLandingPageFromPublicTracker,
+    );
+  }
+
+  Future<void> _openLandingPageFromPublicTracker() async {
+    // 計測は遷移を待たせない (fire-and-forget)。await すると、未ログインや
+    // ネットワーク不調で計測が失敗・遅延したときにボタンが無反応になる。
+    // 着地点最大の CTA なので、計測の失敗が導線を殺してはいけない。
+    unawaited(
+      const GrowthAcquisitionService()
+          .recordPublicTrackerSignUpCta()
+          .catchError((Object error) {
+        debugPrint('public tracker CTA signal failed: $error');
+      }),
+    );
+    if (!mounted) {
+      return;
+    }
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        settings: const RouteSettings(name: '/'),
+        builder: (_) => const LandingPage(),
       ),
     );
   }

--- a/lib/services/growth_acquisition_service.dart
+++ b/lib/services/growth_acquisition_service.dart
@@ -126,12 +126,20 @@ class GrowthAcquisitionService {
   static const String touchReferral = 'touch_referral';
   static const String touchComparison = 'touch_comparison';
 
+  /// R24: 公開データトラッカー (例 `/public/local-election-700`) への着地。
+  /// 実測 (X analytics 2026-04-27〜07-25 / 350 投稿) では、サイトへの URL
+  /// クリック 304 件のうち 286 件 (94%) がこの公開トラッカーへ着地していた。
+  /// これまで着地点にプロダクト導線も計測もなく、最大の流入がそのまま
+  /// 行き止まりになっていたため、専用のタッチポイントとして計上する。
+  static const String touchPublicTracker = 'touch_public_tracker';
+
   static const String importPreviewNotion = 'import_preview_notion';
   static const String importPreviewEvernote = 'import_preview_evernote';
   static const String importPreviewMarkdown = 'import_preview_markdown';
 
   static const String importSignupCta = 'import_signup_cta';
   static const String publicMemoSignupCta = 'public_memo_signup_cta';
+  static const String publicTrackerSignupCta = 'public_tracker_signup_cta';
 
   static const String signupSubmitLanding = 'signup_submit_landing';
   static const String signupSubmitProfile = 'signup_submit_profile';
@@ -141,6 +149,8 @@ class GrowthAcquisitionService {
   static const String signupSubmitPublicMemo = 'signup_submit_public_memo';
   static const String signupSubmitReferral = 'signup_submit_referral';
   static const String signupSubmitComparison = 'signup_submit_comparison';
+  static const String signupSubmitPublicTracker =
+      'signup_submit_public_tracker';
 
   static const String _latestTouchpointKey = 'growth_latest_touchpoint';
   static const String _latestTouchpointUpdatedAtKey =
@@ -195,6 +205,10 @@ class GrowthAcquisitionService {
       case '/public-memo':
       case '/public-memos':
         return touchPublicMemo;
+      // 公開トラッカーは UTM 無しの生 URL で共有されてきた実績があるため、
+      // ルートパスからも必ず計上する (UTM 付き着地は utm 側の判定が優先)。
+      case '/public/local-election-700':
+        return touchPublicTracker;
       case '/referral':
         return touchReferral;
       default:
@@ -247,6 +261,8 @@ class GrowthAcquisitionService {
         return signupSubmitReferral;
       case touchComparison:
         return signupSubmitComparison;
+      case touchPublicTracker:
+        return signupSubmitPublicTracker;
       default:
         return signupSubmitLanding;
     }
@@ -309,6 +325,12 @@ class GrowthAcquisitionService {
   Future<void> recordPublicMemoSignUpCta() async {
     await _persistLatestTouchpoint(touchPublicMemo);
     await _recordSignal(publicMemoSignupCta);
+  }
+
+  /// 公開トラッカーの着地ページに置いた「本体を試す」CTA の押下を記録する。
+  Future<void> recordPublicTrackerSignUpCta() async {
+    await _persistLatestTouchpoint(touchPublicTracker);
+    await _recordSignal(publicTrackerSignupCta);
   }
 
   Future<void> recordLandingSignupSubmit() async {

--- a/lib/widgets/public_tracker_cta_card.dart
+++ b/lib/widgets/public_tracker_cta_card.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+/// R24: 公開データトラッカーの着地点に置くプロダクト導線。
+///
+/// 実測 (X analytics 2026-04-27〜07-25 / 350 投稿): サイトへの URL クリック
+/// 304 件のうち 286 件 (94%) が公開ダッシュボードへ着地していたが、着地後に
+/// 「何のサイトか」「次に何をすればいいか」を示す導線が 1 つも無く、アカウント
+/// 最大の流入がそのまま行き止まりになっていた。
+///
+/// 売り込みではなく「この数字を作っている仕組みの説明 + 低摩擦の次の一手」を
+/// 置く。公開トラッカーは今後増える想定 (家計/AIツール定点観測) なので、
+/// ページ内の private メソッドではなく再利用可能なウィジェットにする。
+class PublicTrackerCtaCard extends StatelessWidget {
+  /// 「この集計は〜」の見出し。トラッカーごとに主語を変えられる。
+  final String headline;
+
+  /// 仕組みの説明。誇張せず、実際に動いている処理を書く。
+  final String description;
+
+  /// 低摩擦の次の一手。押下時にプロダクト本体へ送る。
+  final String actionLabel;
+
+  /// 押下ハンドラ。計測はここで fire-and-forget にし、遷移を待たせないこと。
+  final VoidCallback onActionPressed;
+
+  const PublicTrackerCtaCard({
+    super.key,
+    required this.headline,
+    required this.description,
+    required this.onActionPressed,
+    this.actionLabel = '5分だけ試す',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      color: theme.colorScheme.primaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              headline,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w800,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              description,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+            const SizedBox(height: 14),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                FilledButton.icon(
+                  onPressed: onActionPressed,
+                  icon: const Icon(Icons.arrow_forward),
+                  label: Text(actionLabel),
+                ),
+                Text(
+                  '登録なしで中身を見られます',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onPrimaryContainer
+                        .withValues(alpha: 0.82),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -26,6 +26,20 @@ import {
 } from "./x_duplicate_content.ts";
 import { pickBestVariant, pickConfidentVariant } from "./x_best_variant.ts";
 import {
+  buildAcquisitionRankingLine,
+  computeAcquisitionScore,
+} from "./x_acquisition_score.ts";
+import {
+  buildAccountAcquisitionLine,
+  buildAnalyticsImportMetadata,
+  parseXAnalyticsCsv,
+} from "./x_analytics_import.ts";
+import {
+  buildArchetypeTopicInteractionLine,
+  buildTopicLiftLine,
+  classifyPostTopic,
+} from "./x_topic_audience.ts";
+import {
   buildSignupSlackPayload,
   isRecentSignupCreatedAt,
   resolveSignupChannel,
@@ -517,6 +531,12 @@ const SUPPORTED_ACQUISITION_SIGNALS = new Set([
   "signup_submit_referral",
   "signup_submit_comparison",
   "signup_submit_guitar",
+  // R24: 公開データトラッカー (/public/local-election-700) の着地と CTA。
+  // 実測でサイトへの URL クリック 304 件中 286 件 (94%) がこの着地点だった。
+  // 許可リストに無いと EF が 400 を返し、クライアントが送っても計上されない。
+  "touch_public_tracker",
+  "public_tracker_signup_cta",
+  "signup_submit_public_tracker",
 ]);
 
 function formatDateKey(date: Date): string {
@@ -964,6 +984,16 @@ function buildXPerformanceContextFromLogs(
           firstString(metadata.text, latest.text),
           Array.isArray(metadata.reply_texts) ? metadata.reply_texts : [],
         ),
+        // R24: 「どの既存オーディエンスに乗ったか」の軸 (x_topic_audience.ts)。
+        // archetype と独立に測らないと、勝ち型の移植失敗を繰り返す。
+        topic: classifyPostTopic(
+          [
+            firstString(metadata.text, latest.text),
+            ...(Array.isArray(metadata.reply_texts)
+              ? metadata.reply_texts.map((entry: unknown) => String(entry))
+              : []),
+          ].join("\n"),
+        ),
         linkInReply: latest.link_in_reply === true ||
           metadata.link_in_reply === true,
         threadReplyCount: firstNumber(
@@ -1029,6 +1059,19 @@ function buildXPerformanceContextFromLogs(
         rankingBookmarkRate: sample?.bookmarkRate ?? null,
         rankingProfileClickRate: sample?.profileClickRate ?? null,
         rankingUrlClickRate: sample?.urlClickRate ?? null,
+        // R24: 学習ランキングの基準値。到達ではなく獲得(URL クリック最上位・
+        // impressions は上限キャップ付き補助項)で並べる (x_acquisition_score.ts)。
+        acquisitionScore: computeAcquisitionScore({
+          urlClicks: row.urlClicks,
+          profileClicks: row.profileClicks,
+          bookmarkCount: row.bookmarkCount,
+          replyCount: row.replyCount,
+          repostCount: row.repostCount,
+          likeCount: row.likeCount,
+          impressions: comparisonWindow
+            ? normalizedValue ?? row.impressions
+            : row.impressions,
+        }),
       };
     })
     .sort((left, right) =>
@@ -1051,8 +1094,16 @@ function buildXPerformanceContextFromLogs(
       (left.historicalBenchmarkImpressions ?? 0)
     );
 
-  const winners = learningRows.slice(0, 5);
-  const underperformers = learningRows.slice(-5).reverse();
+  // R24: 勝ち/負け exemplar は獲得スコア順で選ぶ。到達順のままだと
+  // 「122,978 imp / 0 クリック」の投稿が「500 imp / 3 クリック」を永久に
+  // 上回り、サイトへ 1 人も送っていない投稿を LLM に手本提示してしまう。
+  // 年齢コホート (learningRows) の絞り込みは従来どおり効かせる。
+  const acquisitionRanked = [...learningRows].sort((left, right) =>
+    right.acquisitionScore - left.acquisitionScore ||
+    (right.rankingImpressions ?? -1) - (left.rankingImpressions ?? -1)
+  );
+  const winners = acquisitionRanked.slice(0, 5);
+  const underperformers = acquisitionRanked.slice(-5).reverse();
   const byVariant = new Map<
     string,
     { variant: string; count: number; totalScore: number; maxScore: number }
@@ -1066,7 +1117,8 @@ function buildXPerformanceContextFromLogs(
       maxScore: 0,
     };
     current.count += 1;
-    const rankingScore = row.rankingImpressions ?? row.score;
+    // R24: 型ごとの優劣も獲得スコアで測る (到達平均ではない)。
+    const rankingScore = row.acquisitionScore;
     current.totalScore += rankingScore;
     current.maxScore = Math.max(current.maxScore, rankingScore);
     byVariant.set(key, current);
@@ -1090,12 +1142,11 @@ function buildXPerformanceContextFromLogs(
   // して LLM へ渡す。データが薄い間は行自体を出さない(=実質 default-off で、
   // 投稿が貯まるほど自動的に有効化される)。従来は top-1 variant と逸話的な
   // winner 行のみで、集計済みの variants ランキングが未提示だった。
+  // R24: 構造 lift の平均も獲得スコア基準へ統一する。到達平均のままだと
+  // 「メディアありは到達が高い」等の結論が、クリック 0 でも勝ちに見える。
   const avgScore = (list: typeof rows): number =>
     list.length === 0 ? 0 : Math.round(
-      list.reduce(
-        (sum, row) => sum + (row.rankingImpressions ?? row.score),
-        0,
-      ) / list.length,
+      list.reduce((sum, row) => sum + row.acquisitionScore, 0) / list.length,
     );
   const structuralLines: string[] = [];
   if (comparisonWindow) {
@@ -1109,7 +1160,7 @@ function buildXPerformanceContextFromLogs(
   const withoutMedia = learningRows.filter((r) => !r.hasMedia);
   if (withMedia.length >= 2 && withoutMedia.length >= 2) {
     structuralLines.push(
-      `Structural lift (media): avg score with media=${
+      `Structural lift (media): avg acquisition score with media=${
         avgScore(withMedia)
       } (n=${withMedia.length}) vs without=${
         avgScore(withoutMedia)
@@ -1123,7 +1174,7 @@ function buildXPerformanceContextFromLogs(
   const mediaLine = buildMediaLiftLine(
     learningRows,
     (row) => row.mediaType,
-    (row) => row.rankingImpressions ?? row.score,
+    (row) => row.acquisitionScore,
   );
   if (mediaLine) structuralLines.push(mediaLine);
   // R23: 内容アーキタイプ別 lift。実測(2026-07-12 同日3連投: データレポート型
@@ -1140,11 +1191,27 @@ function buildXPerformanceContextFromLogs(
     (row) => row.i72h ?? Number.NaN,
   );
   if (archetypeLine) structuralLines.push(archetypeLine);
+  // R24: topic 単独の lift と、archetype × topic の交互作用。
+  // 実測では同一の data_report 型が topic 違いで 122,978 → 58 まで落ちており、
+  // archetype 単独の結論だけを渡すと勝ち型の移植失敗を再生産する。
+  const topicLine = buildTopicLiftLine(
+    learningRows,
+    (row) => row.topic,
+    (row) => row.acquisitionScore,
+  );
+  if (topicLine) structuralLines.push(topicLine);
+  const interactionLine = buildArchetypeTopicInteractionLine(
+    learningRows,
+    (row) => row.archetype,
+    (row) => row.topic,
+    (row) => row.acquisitionScore,
+  );
+  if (interactionLine) structuralLines.push(interactionLine);
   const linkReply = learningRows.filter((r) => r.linkInReply);
   const linkLead = learningRows.filter((r) => !r.linkInReply);
   if (linkReply.length >= 2 && linkLead.length >= 2) {
     structuralLines.push(
-      `Structural lift (link placement): avg score link-in-reply=${
+      `Structural lift (link placement): avg acquisition score link-in-reply=${
         avgScore(linkReply)
       } (n=${linkReply.length}) vs link-in-lead=${
         avgScore(linkLead)
@@ -1174,7 +1241,7 @@ function buildXPerformanceContextFromLogs(
       buckets.sort((a, b) => avgScore(b[1]) - avgScore(a[1]));
       const [label, list] = buckets[0];
       structuralLines.push(
-        `Best thread length so far: ${label} (avg score ${
+        `Best thread length so far: ${label} (avg acquisition score ${
           avgScore(list)
         }, n=${list.length}).`,
       );
@@ -1225,7 +1292,7 @@ function buildXPerformanceContextFromLogs(
   }
   const distinctVariants = variants.filter((v) => v.variant !== "unknown");
   const rankingLine = distinctVariants.length >= 2
-    ? `Variant ranking (avg ${comparisonLabel} impressions, n): ${
+    ? `Variant ranking (avg acquisition score, n): ${
       distinctVariants.slice(0, 5).map((v) =>
         `${v.variant}=${v.averageScore} (n=${v.count})`
       ).join(", ")
@@ -1236,6 +1303,16 @@ function buildXPerformanceContextFromLogs(
   const ownDataLine = buildOwnDataFactsLine(
     learningRows,
     (row) => row.rankingImpressions,
+  );
+  // R24: 獲得ランキングと、到達 1 位 ≠ 獲得 1 位のときの乖離警告。
+  // 実測 (90 日 350 投稿) では URL クリックの 94% が単一シリーズに集中し、
+  // 到達上位の共感型 (57K/いいね 2.5K) のクリックは 0 だった。
+  const acquisitionLine = buildAcquisitionRankingLine(
+    learningRows,
+    (row) => row.acquisitionScore,
+    (row) => row.rankingImpressions ?? row.impressions,
+    (row) => row.text,
+    (row) => row.urlClicks,
   );
   const historicalBenchmarkLine = historicalBenchmarks.length === 0
     ? ""
@@ -1259,10 +1336,16 @@ function buildXPerformanceContextFromLogs(
       confidentBest
         ? `Target: 10K impressions. Current best variant: ${confidentBest.variant} (n=${confidentBest.count}).`
         : "Target: 10K impressions. No post-age comparable winner yet.",
-      `Ranking basis: ${comparisonLabel} impressions ` +
-      `(comparable n=${learningRows.length}; total measured n=${rows.length}).`,
+      // R24: 目的は「サイトへ 1 人送ること」。手本の選定基準は到達ではなく獲得。
+      `Ranking basis: acquisition score (url clicks weighted first, ` +
+      `impressions capped); age cohort = ${comparisonLabel} ` +
+      `(comparable n=${learningRows.length}; total measured n=${rows.length}). ` +
+      `Optimize for site visits and replies, not for raw reach.`,
+      ...(acquisitionLine ? [acquisitionLine] : []),
       ...winners.map((row, index) =>
-        `Winner ${index + 1}: variant=${row.variant}, impressions=${
+        `Winner ${
+          index + 1
+        }: acquisition=${row.acquisitionScore}, variant=${row.variant}, impressions=${
           row.impressions ?? "unknown"
         }, comparison=${row.rankingMetric}:${
           row.rankingImpressions ?? "unknown"
@@ -1287,7 +1370,7 @@ function buildXPerformanceContextFromLogs(
       ...underperformers.slice(0, 3).map((row, index) =>
         `Avoid ${
           index + 1
-        }: variant=${row.variant}, comparison=${row.rankingMetric}:${
+        }: acquisition=${row.acquisitionScore}, variant=${row.variant}, comparison=${row.rankingMetric}:${
           row.rankingImpressions ?? "unknown"
         }, score=${row.score}, media=${row.hasMedia}, linkInReply=${row.linkInReply}, replies=${row.threadReplyCount}, hook="${row.text}"`
       ),
@@ -1324,6 +1407,93 @@ function buildXPerformanceContextFromLogs(
       ? X_METRIC_LEARNING_SELECTION_RULE
       : "latest cumulative fallback because no normalized cohort has 3 posts",
     promptContext,
+  };
+}
+
+/// R24: X Analytics CSV をパースして x_post_log へ upsert する。
+/// 既に公式 X API で計測済みの行 (metric_provenance='x_api') は上書きしない
+/// — CSV は lifetime cumulative の観測値で、API の窓付き実測より弱いため。
+async function importXAnalyticsCsv(
+  admin: SupabaseClient,
+  userId: string,
+  options: { csv: string; exportRange: string; dryRun: boolean },
+) {
+  const rows = parseXAnalyticsCsv(options.csv);
+  if (rows.length === 0) {
+    return {
+      success: false,
+      imported: 0,
+      skipped: 0,
+      error: "No rows parsed. Expected the X Analytics content CSV export.",
+    };
+  }
+  const observedAt = new Date().toISOString();
+  const accountAcquisitionLine = buildAccountAcquisitionLine(rows);
+  if (options.dryRun) {
+    return {
+      success: true,
+      dryRun: true,
+      parsed: rows.length,
+      imported: 0,
+      skipped: 0,
+      accountAcquisitionLine,
+    };
+  }
+
+  const tweetIds = rows.map((row) => row.postId);
+  const { data: existingRows, error: existingError } = await admin
+    .from("hub_data")
+    .select("id, metadata")
+    .eq("source", "x_post_log")
+    .filter("metadata->>tweet_id", "in", `(${tweetIds.join(",")})`);
+  if (existingError) {
+    throw new Error(`x_analytics_import lookup: ${existingError.message}`);
+  }
+  const existingByTweetId = new Map(
+    (existingRows ?? []).map((
+      item: { id: string; metadata: unknown },
+    ) => [firstString(asRecord(item.metadata).tweet_id), item]),
+  );
+
+  let imported = 0;
+  let skipped = 0;
+  for (const row of rows) {
+    const metadata = buildAnalyticsImportMetadata(row, {
+      userId,
+      archetype: classifyPostArchetype(row.text),
+      observedAt,
+      exportRange: options.exportRange,
+    });
+    const existing = existingByTweetId.get(row.postId);
+    if (existing === undefined) {
+      const { error } = await admin
+        .from("hub_data")
+        .insert({ source: "x_post_log", metadata });
+      if (error) throw new Error(`x_analytics_import insert: ${error.message}`);
+      imported += 1;
+      continue;
+    }
+    const existingMetadata = asRecord(existing.metadata);
+    // 公式 API 実測が既にある行は、CSV の累積値で塗り潰さない。
+    if (firstString(existingMetadata.metric_provenance) === "x_api") {
+      skipped += 1;
+      continue;
+    }
+    const { error } = await admin
+      .from("hub_data")
+      .update({ metadata: { ...existingMetadata, ...metadata } })
+      .eq("id", existing.id)
+      .eq("source", "x_post_log");
+    if (error) throw new Error(`x_analytics_import update: ${error.message}`);
+    imported += 1;
+  }
+  return {
+    success: true,
+    parsed: rows.length,
+    imported,
+    skipped,
+    observedAt,
+    accountAcquisitionLine,
   };
 }
 
@@ -2752,6 +2922,22 @@ serve(async (req: Request) => {
               "Check X API read access. If impression fields are unavailable, public engagement metrics will be used when possible.",
           }, 502);
         }
+      }
+
+      // R24: X Analytics のコンテンツ CSV エクスポートをそのまま学習母集団へ
+      // 取り込む。アプリ経由の投稿しか見ていなかった学習ループに、アカウント
+      // 全体の実績 (= 実測でサイト流入の 99% を生んでいた手動投稿) を入れる。
+      case "x.analytics_import": {
+        if (!await isXOperator(admin, userId!)) {
+          return json({ error: "Forbidden: X operator role required" }, 403);
+        }
+        return json(
+          await importXAnalyticsCsv(admin, userId!, {
+            csv: String(body.csv ?? ""),
+            exportRange: String(body.exportRange ?? body.export_range ?? ""),
+            dryRun: body.dryRun === true || body.dry_run === true,
+          }),
+        );
       }
 
       case "x.metrics_normalized": {

--- a/supabase/functions/growth-hub/x_acquisition_score.ts
+++ b/supabase/functions/growth-hub/x_acquisition_score.ts
@@ -1,0 +1,123 @@
+// R24: X 投稿の学習ランキング基準を「到達(impressions)」から「獲得(URL クリック)」
+// へ差し替えるための純ロジック。x_media_type.ts / x_post_archetype.ts と同じ抽出
+// パターンで、growth-hub/index.ts から使う score 計算と x.performance_context に
+// 出す集計行の生成をここへ切り出してテスト可能にする。
+//
+// 実測根拠 (account_analytics_content 2026-04-27〜2026-07-25 / 350 投稿):
+//   - アカウント全体: impressions 983,216 / URL クリック 304 / 新規フォロー 24。
+//   - URL クリックが 1 以上あった投稿は 350 本中 13 本のみ。
+//   - クリック上位 5 本 (国民民主党 地方議員集計) だけで 286 クリック = 全体の 94%。
+//   - 一方で「いいね」上位 (女系天皇 57K/2.5K いいね, 政府専用機 35K/1.3K いいね)
+//     の URL クリックは 0-2。到達・共感とサイト獲得は同じ順序に並ばない。
+//
+// したがって impressions 単独ランキングは「到達は大きいがサイトへ 1 人も送って
+// いない投稿」を勝ち exemplar として LLM に手本提示してしまう。ここでは
+// クリックを最上位の重みに置き、impressions は上限キャップ付きの補助項として
+// 残す (到達ゼロの投稿を勝ちにしないための下支え)。
+
+/// 獲得スコアの入力。すべて「最新の実測値」を渡す (欠損は 0 / null)。
+export interface AcquisitionScoreInput {
+  urlClicks?: number | null;
+  profileClicks?: number | null;
+  bookmarkCount?: number | null;
+  replyCount?: number | null;
+  repostCount?: number | null;
+  likeCount?: number | null;
+  impressions?: number | null;
+}
+
+/// 重み。獲得(サイト着地)への距離が近い指標ほど大きい。
+/// urlClicks = 実際にサイトへ着地した人数そのものなので最上位。
+/// profileClicks = プロフィール経由の二次導線 (実測 2,296 / 90 日)。
+/// bookmark/reply = 保存・会話 (後日の再訪と関係の芽)。
+/// repost/like = 拡散と共感。実測でクリックへの寄与が最も弱い。
+export const ACQUISITION_WEIGHTS = {
+  urlClicks: 1000,
+  profileClicks: 60,
+  bookmarkCount: 25,
+  replyCount: 20,
+  repostCount: 8,
+  likeCount: 2,
+} as const;
+
+/// impressions は「上限キャップ付きの補助項」。10K を満点 100 点として頭打ちに
+/// する = 130K の到達は 10K の 13 倍の価値を持たない、という測定上の立場。
+/// これが無いと 122,978 imp / 0 クリックの投稿が、500 imp / 3 クリックの投稿を
+/// 永久に上回り続ける。
+export const IMPRESSION_CAP = 10_000;
+export const IMPRESSION_MAX_POINTS = 100;
+
+function num(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : 0;
+}
+
+/// 到達の寄与分 (0..IMPRESSION_MAX_POINTS)。
+export function impressionTerm(impressions: number | null | undefined): number {
+  const value = num(impressions);
+  if (value <= 0) return 0;
+  return Math.round(
+    (Math.min(value, IMPRESSION_CAP) / IMPRESSION_CAP) * IMPRESSION_MAX_POINTS,
+  );
+}
+
+/// クリック最上位の複合獲得スコア。impressions は上限キャップ付きで加算する。
+export function computeAcquisitionScore(input: AcquisitionScoreInput): number {
+  return Math.round(
+    num(input.urlClicks) * ACQUISITION_WEIGHTS.urlClicks +
+      num(input.profileClicks) * ACQUISITION_WEIGHTS.profileClicks +
+      num(input.bookmarkCount) * ACQUISITION_WEIGHTS.bookmarkCount +
+      num(input.replyCount) * ACQUISITION_WEIGHTS.replyCount +
+      num(input.repostCount) * ACQUISITION_WEIGHTS.repostCount +
+      num(input.likeCount) * ACQUISITION_WEIGHTS.likeCount +
+      impressionTerm(input.impressions),
+  );
+}
+
+/// x.performance_context の "Acquisition ranking" 行を作る。
+/// 到達ランキングの 1 位と獲得ランキングの 1 位が食い違うときは、その乖離を
+/// 測定事実として明示する (到達だけを見て手本を選ばせないための警告行)。
+/// rows が 2 件未満、または獲得スコアが全件ゼロのときは null (=沈黙)。
+export function buildAcquisitionRankingLine<T>(
+  rows: readonly T[],
+  acquisitionOf: (row: T) => number,
+  reachOf: (row: T) => number | null,
+  hookOf: (row: T) => string,
+  urlClicksOf: (row: T) => number,
+): string | null {
+  if (rows.length < 2) return null;
+  const scored = rows.filter((row) => acquisitionOf(row) > 0);
+  if (scored.length === 0) return null;
+  const byAcquisition = [...scored].sort((left, right) =>
+    acquisitionOf(right) - acquisitionOf(left)
+  );
+  const byReach = [...rows].sort((left, right) =>
+    (reachOf(right) ?? -1) - (reachOf(left) ?? -1)
+  );
+  const top = byAcquisition[0];
+  const reachTop = byReach[0];
+  const parts = [
+    `Acquisition ranking (URL clicks weighted first, impressions capped at ` +
+    `${IMPRESSION_CAP}): top=${acquisitionOf(top)} ` +
+    `(${urlClicksOf(top)} url clicks, reach=${reachOf(top) ?? "unknown"}) ` +
+    `hook="${hookOf(top)}".`,
+  ];
+  if (reachTop !== top) {
+    parts.push(
+      `Divergence warning: the highest-reach post ` +
+        `(reach=${reachOf(reachTop) ?? "unknown"}, ` +
+        `${urlClicksOf(reachTop)} url clicks) is NOT the acquisition winner. ` +
+        `Do not copy the highest-reach post when its url clicks are lower — ` +
+        `reach without clicks did not put anyone on the site.`,
+    );
+  }
+  const zeroClick = rows.filter((row) => urlClicksOf(row) === 0).length;
+  parts.push(
+    `Click coverage: ${
+      rows.length - zeroClick
+    }/${rows.length} measured posts ` +
+      `produced at least one url click.`,
+  );
+  return parts.join(" ");
+}

--- a/supabase/functions/growth-hub/x_acquisition_score_test.ts
+++ b/supabase/functions/growth-hub/x_acquisition_score_test.ts
@@ -1,0 +1,130 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildAcquisitionRankingLine,
+  computeAcquisitionScore,
+  IMPRESSION_CAP,
+  IMPRESSION_MAX_POINTS,
+  impressionTerm,
+} from "./x_acquisition_score.ts";
+
+// 実測サンプル (account_analytics_content 2026-04-27〜2026-07-25)。
+// A: 国民民主党 地方議員集計 2026/07/14 — 到達も獲得も 1 位。
+const DATA_REPORT = {
+  impressions: 122978,
+  urlClicks: 66,
+  profileClicks: 129,
+  likeCount: 12,
+  repostCount: 0,
+  replyCount: 0,
+  bookmarkCount: 0,
+};
+// B: 女系天皇 — 到達 57K・いいね 2.5K だが URL クリック 0。
+const HIGH_ENGAGEMENT_ZERO_CLICK = {
+  impressions: 57000,
+  urlClicks: 0,
+  profileClicks: 0,
+  likeCount: 2500,
+  repostCount: 575,
+  replyCount: 44,
+  bookmarkCount: 0,
+};
+// C: AIコーディングツール定点観測 — 同じ data_report 型だが 176 imp / 0 クリック。
+const LOW_REACH_ZERO_CLICK = {
+  impressions: 176,
+  urlClicks: 0,
+  profileClicks: 0,
+  likeCount: 0,
+  repostCount: 0,
+  replyCount: 0,
+  bookmarkCount: 0,
+};
+
+Deno.test("impressionTerm caps reach so 130K is not 13x more valuable than 10K", () => {
+  assertEquals(impressionTerm(0), 0);
+  assertEquals(impressionTerm(null), 0);
+  assertEquals(impressionTerm(IMPRESSION_CAP), IMPRESSION_MAX_POINTS);
+  // キャップ超過は頭打ち。122,978 も 983,216 も満点で同じ。
+  assertEquals(impressionTerm(122978), IMPRESSION_MAX_POINTS);
+  assertEquals(impressionTerm(983216), IMPRESSION_MAX_POINTS);
+  assertEquals(impressionTerm(5000), 50);
+});
+
+Deno.test("computeAcquisitionScore puts url clicks above everything else", () => {
+  // 1 クリック(=1000) は、いいね 100 件(=200)・リポスト 100 件(=800) より重い。
+  const oneClick = computeAcquisitionScore({ urlClicks: 1 });
+  assertEquals(oneClick, 1000);
+  assert(oneClick > computeAcquisitionScore({ likeCount: 100 }));
+  assert(oneClick > computeAcquisitionScore({ repostCount: 100 }));
+});
+
+Deno.test("computeAcquisitionScore ranks the measured cohorts click-first", () => {
+  const a = computeAcquisitionScore(DATA_REPORT);
+  const b = computeAcquisitionScore(HIGH_ENGAGEMENT_ZERO_CLICK);
+  const c = computeAcquisitionScore(LOW_REACH_ZERO_CLICK);
+  // 66 クリック + 129 プロフィールクリックの実データレポートが最上位。
+  assert(a > b, `data report ${a} must outrank zero-click viral ${b}`);
+  // 共感は大きいがクリック 0 の投稿でも、到達ゼロの投稿よりは上に残る。
+  assert(b > c, `viral ${b} must outrank low-reach zero-click ${c}`);
+  assertEquals(a, 66 * 1000 + 129 * 60 + 12 * 2 + 100);
+});
+
+Deno.test("computeAcquisitionScore ignores negative and non-finite inputs", () => {
+  assertEquals(computeAcquisitionScore({}), 0);
+  assertEquals(
+    computeAcquisitionScore({ urlClicks: -5, impressions: Number.NaN }),
+    0,
+  );
+});
+
+type Row = {
+  acq: number;
+  reach: number | null;
+  hook: string;
+  clicks: number;
+};
+const line = (rows: Row[]) =>
+  buildAcquisitionRankingLine(
+    rows,
+    (r) => r.acq,
+    (r) => r.reach,
+    (r) => r.hook,
+    (r) => r.clicks,
+  );
+
+Deno.test("buildAcquisitionRankingLine stays silent on sparse or click-free data", () => {
+  assertEquals(line([]), null);
+  assertEquals(line([{ acq: 5, reach: 100, hook: "a", clicks: 1 }]), null);
+  // 全件が獲得スコア 0 = 学習材料なし。断定しない。
+  assertEquals(
+    line([
+      { acq: 0, reach: 100, hook: "a", clicks: 0 },
+      { acq: 0, reach: 200, hook: "b", clicks: 0 },
+    ]),
+    null,
+  );
+});
+
+Deno.test("buildAcquisitionRankingLine warns when reach winner is not the acquisition winner", () => {
+  const out = line([
+    { acq: 100, reach: 130000, hook: "reach winner", clicks: 0 },
+    { acq: 3000, reach: 500, hook: "click winner", clicks: 3 },
+  ]);
+  assert(out !== null);
+  assert(out!.includes('hook="click winner"'));
+  assert(out!.includes("Divergence warning"));
+  assert(out!.includes("reach without clicks did not put anyone on the site"));
+  assert(out!.includes("Click coverage: 1/2"));
+});
+
+Deno.test("buildAcquisitionRankingLine omits the warning when both winners agree", () => {
+  const out = line([
+    { acq: 66100, reach: 122978, hook: "data report", clicks: 66 },
+    { acq: 1000, reach: 500, hook: "other", clicks: 1 },
+  ]);
+  assert(out !== null);
+  assert(!out!.includes("Divergence warning"));
+  assert(out!.includes("Click coverage: 2/2"));
+});

--- a/supabase/functions/growth-hub/x_analytics_import.ts
+++ b/supabase/functions/growth-hub/x_analytics_import.ts
@@ -1,0 +1,254 @@
+// R24: X Analytics のコンテンツ CSV エクスポートを学習母集団へ取り込むための
+// 純ロジック。x_post_archetype.ts / x_acquisition_score.ts と同じ抽出パターン。
+//
+// なぜ必要か: これまで x.performance_context が見ていたのは x_post_log =
+// 「アプリの AI シェア経由で投稿したもの」だけだった。実測 (2026-04-27〜07-25 /
+// 350 投稿) では、サイトへの URL クリック 304 件のうち 302 件がアプリ外の手動
+// 投稿から出ており、学習ループはアカウント最大の勝ち筋を一度も見ていなかった。
+// アカウント全体を取り込む既存の手段は「1 投稿ごとの手書きマイグレーション +
+// 目視の概算インプレッション」(20260712143000_backfill_election_post_a...) で、
+// 同シリーズの実測 122,978-129,889 に対し 8,000 と桁を取り違えていた。
+//
+// CSV は lifetime cumulative (投稿からの経過時間がバラバラ) なので、取り込んだ
+// 行は learning_cohort='historical_benchmark' として、投稿年齢を揃えた勝ち
+// exemplar のランキングには入れない。アカウント水準の獲得事実の供給に使う。
+
+export interface XAnalyticsCsvRow {
+  postId: string;
+  date: string;
+  text: string;
+  link: string;
+  impressions: number;
+  likes: number;
+  engagements: number;
+  bookmarks: number;
+  shares: number;
+  newFollows: number;
+  replies: number;
+  reposts: number;
+  profileVisits: number;
+  detailExpands: number;
+  urlClicks: number;
+  hashtagClicks: number;
+  permalinkClicks: number;
+}
+
+const HEADER_TO_KEY: Record<string, keyof XAnalyticsCsvRow> = {
+  "post id": "postId",
+  "date": "date",
+  "post text": "text",
+  "post link": "link",
+  "impressions": "impressions",
+  "likes": "likes",
+  "engagements": "engagements",
+  "bookmarks": "bookmarks",
+  "shares": "shares",
+  "new follows": "newFollows",
+  "replies": "replies",
+  "reposts": "reposts",
+  "profile visits": "profileVisits",
+  "detail expands": "detailExpands",
+  "url clicks": "urlClicks",
+  "hashtag clicks": "hashtagClicks",
+  "permalink clicks": "permalinkClicks",
+};
+
+const NUMERIC_KEYS = new Set<keyof XAnalyticsCsvRow>([
+  "impressions",
+  "likes",
+  "engagements",
+  "bookmarks",
+  "shares",
+  "newFollows",
+  "replies",
+  "reposts",
+  "profileVisits",
+  "detailExpands",
+  "urlClicks",
+  "hashtagClicks",
+  "permalinkClicks",
+]);
+
+/// RFC4180 相当の最小 CSV スプリッタ。X の Date 列は `"Wed, Jul 22, 2026"` の
+/// ように引用符内にカンマを含み、本文には改行も含まれうるため、素朴な
+/// `split(",")` / `split("\n")` では壊れる。
+export function splitCsvRows(input: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let quoted = false;
+  const text = (input ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quoted) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 1;
+        } else {
+          quoted = false;
+        }
+      } else {
+        field += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      quoted = true;
+    } else if (ch === ",") {
+      row.push(field);
+      field = "";
+    } else if (ch === "\n") {
+      row.push(field);
+      field = "";
+      if (row.some((cell) => cell.trim() !== "")) rows.push(row);
+      row = [];
+    } else {
+      field += ch;
+    }
+  }
+  row.push(field);
+  if (row.some((cell) => cell.trim() !== "")) rows.push(row);
+  return rows;
+}
+
+function toNumber(raw: string): number {
+  const parsed = Number((raw ?? "").replace(/[",\s]/g, ""));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+/// X Analytics のコンテンツ CSV をパースする。列順とヘッダ表記の揺れを許容し、
+/// Post id が空の行は捨てる。未知の列は無視する。
+export function parseXAnalyticsCsv(input: string): XAnalyticsCsvRow[] {
+  const rows = splitCsvRows(input);
+  if (rows.length < 2) return [];
+  const header = rows[0].map((cell) => cell.trim().toLowerCase());
+  const indexByKey = new Map<keyof XAnalyticsCsvRow, number>();
+  header.forEach((name, index) => {
+    const key = HEADER_TO_KEY[name];
+    if (key !== undefined && !indexByKey.has(key)) indexByKey.set(key, index);
+  });
+  if (!indexByKey.has("postId")) return [];
+  const cell = (cells: string[], key: keyof XAnalyticsCsvRow): string => {
+    const index = indexByKey.get(key);
+    return index === undefined ? "" : (cells[index] ?? "").trim();
+  };
+  const parsed: XAnalyticsCsvRow[] = [];
+  for (const cells of rows.slice(1)) {
+    const postId = cell(cells, "postId");
+    if (!/^\d{5,}$/.test(postId)) continue;
+    const row: XAnalyticsCsvRow = {
+      postId,
+      date: cell(cells, "date"),
+      text: cell(cells, "text"),
+      link: cell(cells, "link"),
+      impressions: 0,
+      likes: 0,
+      engagements: 0,
+      bookmarks: 0,
+      shares: 0,
+      newFollows: 0,
+      replies: 0,
+      reposts: 0,
+      profileVisits: 0,
+      detailExpands: 0,
+      urlClicks: 0,
+      hashtagClicks: 0,
+      permalinkClicks: 0,
+    };
+    for (const key of NUMERIC_KEYS) {
+      (row[key] as number) = toNumber(cell(cells, key));
+    }
+    parsed.push(row);
+  }
+  return parsed;
+}
+
+/// 取り込み 1 行分の x_post_log metadata を作る。
+/// CSV は lifetime cumulative なので historical_benchmark コホートに入れ、
+/// 投稿年齢を揃えた勝ち exemplar ランキングは汚さない。
+export function buildAnalyticsImportMetadata(
+  row: XAnalyticsCsvRow,
+  options: {
+    userId: string;
+    archetype: string;
+    observedAt: string;
+    exportRange?: string;
+  },
+): Record<string, unknown> {
+  return {
+    user_id: options.userId,
+    tweet_id: row.postId,
+    status: "tracked_existing",
+    text: row.text,
+    reply_texts: [],
+    source: "x_analytics_csv_import",
+    variant: "account_history",
+    experiment_key: "x_first_user_growth_10k",
+    content_kind: "text",
+    content_archetype: options.archetype,
+    learning_cohort: "historical_benchmark",
+    metric_observation_kind: "lifetime_cumulative",
+    metric_provenance: "x_analytics_csv",
+    historical_benchmark_impressions: row.impressions,
+    historical_benchmark_observed_at: options.observedAt,
+    historical_benchmark_provenance: "x_analytics_csv_export",
+    analytics_export_range: options.exportRange ?? "",
+    observed_at: options.observedAt,
+    posted_at: row.date,
+    impressions: row.impressions,
+    latest_metrics: {
+      tweet_id: row.postId,
+      tweet_role: "lead",
+      text: row.text,
+      source: "x_analytics_csv_import",
+      variant: "account_history",
+      impressions: row.impressions,
+      engagements: row.engagements,
+      like_count: row.likes,
+      reply_count: row.replies,
+      repost_count: row.reposts,
+      bookmark_count: row.bookmarks,
+      url_clicks: row.urlClicks,
+      profile_clicks: row.profileVisits,
+      new_follows: row.newFollows,
+      detail_expands: row.detailExpands,
+      metric_observation_kind: "lifetime_cumulative",
+    },
+  };
+}
+
+/// x.performance_context に出すアカウント水準の獲得事実。
+/// 「到達は出ているのにサイトへ人が来ていない」構造を、逸話ではなく分布で渡す。
+/// 3 行未満、または URL クリックが全件ゼロのときは null (=沈黙)。
+export function buildAccountAcquisitionLine(
+  rows: readonly XAnalyticsCsvRow[],
+): string | null {
+  if (rows.length < 3) return null;
+  const totalImpressions = rows.reduce((sum, r) => sum + r.impressions, 0);
+  const totalClicks = rows.reduce((sum, r) => sum + r.urlClicks, 0);
+  if (totalClicks <= 0) return null;
+  const clicked = rows.filter((r) => r.urlClicks > 0);
+  const ranked = [...clicked].sort((a, b) => b.urlClicks - a.urlClicks);
+  const topShare = Math.round(
+    (ranked.slice(0, 5).reduce((sum, r) => sum + r.urlClicks, 0) /
+      totalClicks) * 100,
+  );
+  const compact = (value: string) =>
+    value.replace(/\s+/g, " ").slice(0, 60).trim();
+  return [
+    `Account-wide acquisition (imported X analytics, n=${rows.length}, ` +
+    `lifetime cumulative): impressions=${totalImpressions}, ` +
+    `url clicks=${totalClicks}, posts with >=1 click=${clicked.length}.`,
+    `The top ${Math.min(5, ranked.length)} click drivers account for ` +
+    `${topShare}% of all url clicks. Top driver hooks: ` +
+    `${
+      ranked.slice(0, 3).map((r) =>
+        `"${compact(r.text)}" (${r.urlClicks} clicks, ${r.impressions} imp)`
+      ).join(" | ")
+    }.`,
+    `Reach alone did not convert: copy what the click drivers did ` +
+    `(named specifics, real numbers, the link in the lead), not what merely ` +
+    `reached many people.`,
+  ].join(" ");
+}

--- a/supabase/functions/growth-hub/x_analytics_import_test.ts
+++ b/supabase/functions/growth-hub/x_analytics_import_test.ts
@@ -1,0 +1,110 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildAccountAcquisitionLine,
+  buildAnalyticsImportMetadata,
+  parseXAnalyticsCsv,
+  splitCsvRows,
+  type XAnalyticsCsvRow,
+} from "./x_analytics_import.ts";
+
+// 実 CSV (account_analytics_content_2026-04-27_2026-07-25.csv) の縮約サンプル。
+// Date 列が引用符内にカンマを含む点が素朴な split(",") を壊す実際の形。
+const SAMPLE_CSV = [
+  "Post id,Date,Post text,Post Link,Impressions,Likes,Engagements,Bookmarks,Shares,New follows,Replies,Reposts,Profile visits,Detail Expands,URL Clicks,Hashtag Clicks,Permalink Clicks",
+  '2074000000000000001,"Tue, Jul 14, 2026",国民民主党 地方議員集計 2026/07/14,https://x.com/kanta13jp1/status/2074000000000000001,122978,12,300,0,0,0,0,0,129,200,66,0,0',
+  '2073000000000000002,"Sun, Jul 13, 2026",女系天皇は認めないと言いつつ,https://x.com/kanta13jp1/status/2073000000000000002,57000,2500,4000,0,0,3,44,575,0,0,0,0,0',
+  '2079000000000000003,"Wed, Jul 22, 2026",この定点観測はアプリ内のAIツール監視cronが毎日生成しています。,https://x.com/kanta13jp1/status/2079000000000000003,17,0,0,0,0,0,0,0,0,0,0,0,0',
+].join("\n");
+
+Deno.test("splitCsvRows keeps quoted commas and embedded newlines in one field", () => {
+  const rows = splitCsvRows('a,"b,c",d\n1,"line1\nline2",3\n');
+  assertEquals(rows.length, 2);
+  assertEquals(rows[0], ["a", "b,c", "d"]);
+  assertEquals(rows[1], ["1", "line1\nline2", "3"]);
+});
+
+Deno.test("splitCsvRows unescapes doubled quotes and drops blank rows", () => {
+  const rows = splitCsvRows('a,b\n"he said ""hi""",2\n\n\n');
+  assertEquals(rows.length, 2);
+  assertEquals(rows[1][0], 'he said "hi"');
+});
+
+Deno.test("parseXAnalyticsCsv reads the real export shape", () => {
+  const rows = parseXAnalyticsCsv(SAMPLE_CSV);
+  assertEquals(rows.length, 3);
+  const [dataReport, viral, tracker] = rows;
+  assertEquals(dataReport.postId, "2074000000000000001");
+  assertEquals(dataReport.date, "Tue, Jul 14, 2026");
+  assertEquals(dataReport.impressions, 122978);
+  assertEquals(dataReport.urlClicks, 66);
+  assertEquals(dataReport.profileVisits, 129);
+  // 到達も共感も大きいがクリック 0 の投稿。
+  assertEquals(viral.likes, 2500);
+  assertEquals(viral.urlClicks, 0);
+  assertEquals(tracker.impressions, 17);
+});
+
+Deno.test("parseXAnalyticsCsv tolerates column reordering and unknown columns", () => {
+  const csv = [
+    "Date,URL Clicks,Post id,Impressions,Some New Column",
+    '"Tue, Jul 14, 2026",66,2074000000000000001,122978,ignored',
+  ].join("\n");
+  const rows = parseXAnalyticsCsv(csv);
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].urlClicks, 66);
+  assertEquals(rows[0].impressions, 122978);
+});
+
+Deno.test("parseXAnalyticsCsv rejects malformed, headerless and empty input", () => {
+  assertEquals(parseXAnalyticsCsv(""), []);
+  assertEquals(parseXAnalyticsCsv("Post id,Impressions"), []);
+  // Post id が数値IDでない行は捨てる (合計/注釈行の混入対策)。
+  assertEquals(
+    parseXAnalyticsCsv("Post id,Impressions\nTotal,999").length,
+    0,
+  );
+  // 必須の Post id 列が無ければ何も取り込まない。
+  assertEquals(parseXAnalyticsCsv("Date,Impressions\nx,1"), []);
+});
+
+Deno.test("buildAnalyticsImportMetadata keeps imports out of the age-comparable cohort", () => {
+  const row = parseXAnalyticsCsv(SAMPLE_CSV)[0];
+  const meta = buildAnalyticsImportMetadata(row, {
+    userId: "user-1",
+    archetype: "data_report",
+    observedAt: "2026-07-25T00:00:00Z",
+    exportRange: "2026-04-27_2026-07-25",
+  });
+  // lifetime cumulative なので勝ち exemplar ランキングには入れない。
+  assertEquals(meta.learning_cohort, "historical_benchmark");
+  assertEquals(meta.metric_observation_kind, "lifetime_cumulative");
+  assertEquals(meta.metric_provenance, "x_analytics_csv");
+  assertEquals(meta.historical_benchmark_impressions, 122978);
+  assertEquals(meta.content_archetype, "data_report");
+  const latest = meta.latest_metrics as Record<string, unknown>;
+  assertEquals(latest.url_clicks, 66);
+  assertEquals(latest.profile_clicks, 129);
+});
+
+Deno.test("buildAccountAcquisitionLine reports the click concentration", () => {
+  const rows = parseXAnalyticsCsv(SAMPLE_CSV);
+  const line = buildAccountAcquisitionLine(rows);
+  assert(line !== null);
+  assert(line!.includes("url clicks=66"));
+  assert(line!.includes("posts with >=1 click=1"));
+  assert(line!.includes("100% of all url clicks"));
+  assert(line!.includes("Reach alone did not convert"));
+});
+
+Deno.test("buildAccountAcquisitionLine stays silent without clicks or samples", () => {
+  const rows = parseXAnalyticsCsv(SAMPLE_CSV);
+  assertEquals(buildAccountAcquisitionLine(rows.slice(0, 2)), null);
+  const zeroClick: XAnalyticsCsvRow[] = rows.map((row) => ({
+    ...row,
+    urlClicks: 0,
+  }));
+  assertEquals(buildAccountAcquisitionLine(zeroClick), null);
+});

--- a/supabase/functions/growth-hub/x_topic_audience.ts
+++ b/supabase/functions/growth-hub/x_topic_audience.ts
@@ -1,0 +1,194 @@
+// R24: X 投稿の「どの既存オーディエンスに乗ったか」を第1級の A/B 次元へ昇格する
+// ための純ロジック。x_post_archetype.ts (情報ペイロードの型) と対になる軸で、
+// 両者の交互作用こそが実測を説明する。
+//
+// 実測 (account_analytics_content 2026-04-27〜2026-07-25 / 350 投稿):
+//   同一の data_report 型・同一の自動生成・同一の末尾 URL でも、
+//     - 日本政治 (国民民主党 地方議員集計) : n=5  中央値 122,978 imp / 286 クリック
+//     - AI・テック (AIコーディングツール定点観測): n=16 中央値     58 imp /   0 クリック
+//     - 家計・資産                              : n=57 中央値      9 imp /   0 クリック
+//   4 桁の差。archetype 単独では説明できず、効いているのは「国民民主党」という
+//   既存の巨大な受け手集団に固有名詞で乗っていること。
+//
+// したがって archetype lift だけを見て「データレポート型が勝ち」と学習すると、
+// 型を移植したのに 58 imp しか出ない失敗を繰り返す。ここでは topic を明示的な
+// 次元として測り、archetype × topic の組み合わせで勝ち負けを判定させる。
+
+export type TopicBucket =
+  | "japan_politics"
+  | "ai_tech"
+  | "household_finance"
+  | "product"
+  | "general";
+
+/// 既存オーディエンスを持つ固有名詞アンカー。ここに載る語が本文にあると、
+/// その語のフォロワー/検索面に乗る (= 自力のフォロワー数を超えて配信される)。
+const POLITICS_ANCHORS = [
+  "国民民主党",
+  "自民党",
+  "立憲民主党",
+  "公明党",
+  "日本維新",
+  "参政党",
+  "れいわ",
+  "社民",
+  "高市",
+  "統一地方選",
+  "衆院",
+  "参院",
+  "内閣",
+  "皇室",
+  "天皇",
+  "議員",
+  "選挙",
+];
+const AI_TECH_ANCHORS = [
+  "openai",
+  "chatgpt",
+  "claude",
+  "gemini",
+  "cursor",
+  "devin",
+  "copilot",
+  "notebooklm",
+  "flutter",
+  "supabase",
+  "ai",
+];
+const FINANCE_ANCHORS = [
+  "家計",
+  "資産",
+  "給料日",
+  "負債",
+  "給与明細",
+  "支出",
+  "節約",
+  "投資",
+  "税",
+];
+const PRODUCT_ANCHORS = [
+  "自分株式会社",
+  "ai仕事os",
+  "my-web-app-b67f4",
+  "5分だけ",
+  "buildinpublic",
+];
+
+function hits(haystack: string, needles: readonly string[]): number {
+  return needles.filter((needle) => haystack.includes(needle)).length;
+}
+
+export function normalizeTopicBucket(raw: string): TopicBucket {
+  const v = (raw ?? "").toLowerCase().trim();
+  if (
+    v === "japan_politics" || v === "ai_tech" || v === "household_finance" ||
+    v === "product" || v === "general"
+  ) {
+    return v;
+  }
+  return "general";
+}
+
+/// 本文から「乗っている既存オーディエンス」を決定的に分類する。
+/// 政治アンカーは他ジャンルと同居しても優先する (実測でリーチを支配するのは
+/// そちらのため)。製品語しか無いものは product = 自前の受け手しかいない投稿。
+export function classifyPostTopic(text: string): TopicBucket {
+  const body = (text ?? "").toLowerCase();
+  const politics = hits(text ?? "", POLITICS_ANCHORS);
+  const finance = hits(text ?? "", FINANCE_ANCHORS);
+  const aiTech = hits(body, AI_TECH_ANCHORS);
+  const product = hits(body, PRODUCT_ANCHORS);
+  if (politics >= 1) return "japan_politics";
+  if (finance >= 1 && finance >= aiTech) return "household_finance";
+  if (aiTech >= 1) return "ai_tech";
+  if (product >= 1) return "product";
+  return "general";
+}
+
+/// x.performance_context の "Topic lift" 行を作る。
+/// n>=2 のバケットだけ平均を出し、比較可能なバケットが 2 つ以上あるときに
+/// 勝ちトピックを推奨する。データが薄い間は null (=沈黙 / 実質 default-off)。
+export function buildTopicLiftLine<T>(
+  rows: readonly T[],
+  topicOf: (row: T) => string,
+  scoreOf: (row: T) => number,
+): string | null {
+  const buckets = new Map<TopicBucket, T[]>();
+  for (const row of rows) {
+    const bucket = normalizeTopicBucket(topicOf(row));
+    const list = buckets.get(bucket) ?? [];
+    list.push(row);
+    buckets.set(bucket, list);
+  }
+  const avg = (list: T[]): number =>
+    list.length === 0 ? 0 : Math.round(
+      list.reduce((sum, row) => sum + scoreOf(row), 0) / list.length,
+    );
+  const order: TopicBucket[] = [
+    "japan_politics",
+    "ai_tech",
+    "household_finance",
+    "product",
+    "general",
+  ];
+  const shown = order
+    .map((bucket) => [bucket, buckets.get(bucket) ?? []] as [TopicBucket, T[]])
+    .filter(([, list]) => list.length >= 2);
+  if (shown.length < 2) return null;
+  const parts = shown.map(([bucket, list]) =>
+    `${bucket} avg=${avg(list)} (n=${list.length})`
+  );
+  const winner =
+    [...shown].sort((left, right) => avg(right[1]) - avg(left[1]))[0][0];
+  return `Topic lift (by audience the post rode): ${parts.join(", ")}. ` +
+    `Best measured topic: ${winner}. Topic is a separate dimension from ` +
+    `content archetype — the same data-report format collapsed by orders of ` +
+    `magnitude when moved to a topic without an existing audience. Pick the ` +
+    `topic first (named entities a large audience already follows), then ` +
+    `apply the winning archetype inside it.`;
+}
+
+/// archetype × topic の交互作用行。同じ archetype が topic 違いでどれだけ
+/// 変わるかを明示する。両方のセルに n>=2 が揃ったときだけ出す。
+export function buildArchetypeTopicInteractionLine<T>(
+  rows: readonly T[],
+  archetypeOf: (row: T) => string,
+  topicOf: (row: T) => string,
+  scoreOf: (row: T) => number,
+): string | null {
+  const cells = new Map<string, T[]>();
+  for (const row of rows) {
+    const key = `${archetypeOf(row)}|${normalizeTopicBucket(topicOf(row))}`;
+    const list = cells.get(key) ?? [];
+    list.push(row);
+    cells.set(key, list);
+  }
+  const avg = (list: T[]): number =>
+    list.length === 0 ? 0 : Math.round(
+      list.reduce((sum, row) => sum + scoreOf(row), 0) / list.length,
+    );
+  const eligible = [...cells.entries()].filter(([, list]) => list.length >= 2);
+  if (eligible.length < 2) return null;
+  const byArchetype = new Map<string, [string, T[]][]>();
+  for (const [key, list] of eligible) {
+    const archetype = key.split("|")[0];
+    byArchetype.set(archetype, [
+      ...(byArchetype.get(archetype) ?? []),
+      [key.split("|")[1], list],
+    ]);
+  }
+  const split = [...byArchetype.entries()]
+    .filter(([, entries]) => entries.length >= 2);
+  if (split.length === 0) return null;
+  const described = split.map(([archetype, entries]) => {
+    const sorted = [...entries].sort((left, right) =>
+      avg(right[1]) - avg(left[1])
+    );
+    return `${archetype}: ` +
+      sorted.map(([topic, list]) => `${topic}=${avg(list)} (n=${list.length})`)
+        .join(" vs ");
+  });
+  return `Archetype x topic interaction: ${described.join("; ")}. ` +
+    `The same archetype does not transfer across topics — do not reuse a ` +
+    `winning format on a topic where it has not been measured.`;
+}

--- a/supabase/functions/growth-hub/x_topic_audience_test.ts
+++ b/supabase/functions/growth-hub/x_topic_audience_test.ts
@@ -1,0 +1,106 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildArchetypeTopicInteractionLine,
+  buildTopicLiftLine,
+  classifyPostTopic,
+  normalizeTopicBucket,
+} from "./x_topic_audience.ts";
+
+// 実測 3 コホートの縮約サンプル (同一 data_report 型・topic 違い)。
+const POLITICS =
+  "国民民主党 地方議員集計 2026/07/14 取得日時: ... 公式地方議員数: 383人";
+const AI_TECH =
+  "AIコーディングツール定点観測 2026/7/22 Cursor changelog / Devin release notes";
+const FINANCE = "家計の定点観測: 今月の支出と給料日サイクルの残高推移";
+const PRODUCT = "自分株式会社を5分だけ触ってみてください #buildinpublic";
+
+Deno.test("classifyPostTopic separates the measured cohorts", () => {
+  assertEquals(classifyPostTopic(POLITICS), "japan_politics");
+  assertEquals(classifyPostTopic(AI_TECH), "ai_tech");
+  assertEquals(classifyPostTopic(FINANCE), "household_finance");
+  assertEquals(classifyPostTopic(PRODUCT), "product");
+  assertEquals(classifyPostTopic("今日は良い天気でした。"), "general");
+});
+
+Deno.test("classifyPostTopic prefers the politics anchor when topics mix", () => {
+  // 実測でリーチを支配したのは政治アンカー側。AI 語が同居しても politics。
+  assertEquals(
+    classifyPostTopic("高市内閣のAI政策をChatGPTで整理しました"),
+    "japan_politics",
+  );
+});
+
+Deno.test("normalizeTopicBucket keeps known values and defaults to general", () => {
+  assertEquals(normalizeTopicBucket("ai_tech"), "ai_tech");
+  assertEquals(normalizeTopicBucket("JAPAN_POLITICS"), "japan_politics");
+  assertEquals(normalizeTopicBucket(""), "general");
+  assertEquals(normalizeTopicBucket("weird"), "general");
+});
+
+type Row = { topic: string; archetype: string; score: number };
+const topicLine = (rows: Row[]) =>
+  buildTopicLiftLine(rows, (r) => r.topic, (r) => r.score);
+
+Deno.test("buildTopicLiftLine stays silent until two topics have samples", () => {
+  assertEquals(topicLine([]), null);
+  assertEquals(
+    topicLine([
+      { topic: "japan_politics", archetype: "data_report", score: 70000 },
+      { topic: "japan_politics", archetype: "data_report", score: 66000 },
+    ]),
+    null,
+  );
+});
+
+Deno.test("buildTopicLiftLine names the winning audience and the transfer warning", () => {
+  const out = topicLine([
+    { topic: "japan_politics", archetype: "data_report", score: 73864 },
+    { topic: "japan_politics", archetype: "data_report", score: 66000 },
+    { topic: "ai_tech", archetype: "data_report", score: 2 },
+    { topic: "ai_tech", archetype: "data_report", score: 1 },
+  ]);
+  assert(out !== null);
+  assert(out!.includes("japan_politics avg=69932 (n=2)"));
+  assert(out!.includes("ai_tech avg=2 (n=2)"));
+  assert(out!.includes("Best measured topic: japan_politics"));
+  assert(out!.includes("Pick the topic first"));
+});
+
+Deno.test("buildArchetypeTopicInteractionLine exposes the non-transfer", () => {
+  const out = buildArchetypeTopicInteractionLine(
+    [
+      { topic: "japan_politics", archetype: "data_report", score: 73864 },
+      { topic: "japan_politics", archetype: "data_report", score: 66000 },
+      { topic: "ai_tech", archetype: "data_report", score: 2 },
+      { topic: "ai_tech", archetype: "data_report", score: 1 },
+    ],
+    (r) => r.archetype,
+    (r) => r.topic,
+    (r) => r.score,
+  );
+  assert(out !== null);
+  assert(out!.includes("data_report: japan_politics=69932 (n=2)"));
+  assert(out!.includes("ai_tech=2 (n=2)"));
+  assert(out!.includes("does not transfer across topics"));
+});
+
+Deno.test("buildArchetypeTopicInteractionLine is silent without a split archetype", () => {
+  // 同じ archetype が 1 トピックにしか無ければ交互作用は測れない。
+  assertEquals(
+    buildArchetypeTopicInteractionLine(
+      [
+        { topic: "japan_politics", archetype: "data_report", score: 10 },
+        { topic: "japan_politics", archetype: "data_report", score: 12 },
+        { topic: "ai_tech", archetype: "news_briefing", score: 3 },
+        { topic: "ai_tech", archetype: "news_briefing", score: 4 },
+      ],
+      (r) => r.archetype,
+      (r) => r.topic,
+      (r) => r.score,
+    ),
+    null,
+  );
+});

--- a/test/services/growth_acquisition_service_test.dart
+++ b/test/services/growth_acquisition_service_test.dart
@@ -22,7 +22,22 @@ void main() {
       GrowthAcquisitionService.signalForPagePath('/referral'),
       GrowthAcquisitionService.touchReferral,
     );
+    // R24: サイト流入の 94% を占める公開トラッカーは、UTM 無しの生 URL で
+    // 共有されてきたためルートパスからも計上する。
+    expect(
+      GrowthAcquisitionService.signalForPagePath('/public/local-election-700'),
+      GrowthAcquisitionService.touchPublicTracker,
+    );
     expect(GrowthAcquisitionService.signalForPagePath('/unknown'), isNull);
+  });
+
+  test('public tracker touchpoint resolves its own signup submit signal', () {
+    expect(
+      GrowthAcquisitionService.resolveSignupSubmitSignal(
+        GrowthAcquisitionService.touchPublicTracker,
+      ),
+      GrowthAcquisitionService.signupSubmitPublicTracker,
+    );
   });
 
   test('maps preview source types to import preview signals', () {

--- a/test/widgets/public_tracker_cta_card_test.dart
+++ b/test/widgets/public_tracker_cta_card_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/public_tracker_cta_card.dart';
+
+void main() {
+  Widget host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  testWidgets('renders the explanation and the low-friction action', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        PublicTrackerCtaCard(
+          headline: 'この集計は「自分株式会社」が毎日自動更新しています',
+          description: '公式ページを定期取得して差分を計算しています。',
+          onActionPressed: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('この集計は「自分株式会社」が毎日自動更新しています'), findsOneWidget);
+    expect(find.text('公式ページを定期取得して差分を計算しています。'), findsOneWidget);
+    // X から来た訪問者が最初に必要とするのは「何のサイトか」と次の一手。
+    expect(find.text('5分だけ試す'), findsOneWidget);
+    expect(find.text('登録なしで中身を見られます'), findsOneWidget);
+  });
+
+  testWidgets('fires the action callback exactly once per tap', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      host(
+        PublicTrackerCtaCard(
+          headline: 'headline',
+          description: 'description',
+          onActionPressed: () => taps += 1,
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('5分だけ試す'));
+    await tester.pump();
+
+    expect(taps, 1);
+  });
+
+  testWidgets('allows a tracker-specific action label', (tester) async {
+    await tester.pumpWidget(
+      host(
+        PublicTrackerCtaCard(
+          headline: 'headline',
+          description: 'description',
+          actionLabel: '家計トラッカーを見る',
+          onActionPressed: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('家計トラッカーを見る'), findsOneWidget);
+    expect(find.text('5分だけ試す'), findsNothing);
+  });
+}


### PR DESCRIPTION
## なぜ

90日分の X Analytics 実測 (`account_analytics_content_2026-04-27_2026-07-25.csv` / 350投稿) を、既存の学習ループの実装と突き合わせた結果、前提が2つ壊れていた。

| コホート | 本数 | imp 合計 | URLクリック | 新規フォロー |
|---|---:|---:|---:|---:|
| 国民民主党 地方議員集計 | 5 | 560,609 | **286** | 3 |
| プロダクト系 (AI仕事OS / 5分だけ / ブリーフィング) | 24 | 5,619 | **2** | **0** |
| アカウント全体 | 350 | 983,216 | 304 | 24 |

### 壊れていた前提① ランキング基準が「到達」だった

`_shared/x-client.ts` の `score = impressions ?? 加重エンゲージメント` により、impressions が取得できる限り **score = impressions そのもの**。122,978 imp / 0クリックの投稿が 500 imp / 3クリックの投稿を永久に上回り、サイトへ1人も送っていない投稿を勝ち exemplar として LLM に手本提示していた。

### 壊れていた前提② 学習母集団がアプリ経由の投稿だけだった

`listXPostLogs` (= `x_post_log`) しか見ておらず、URLクリック304件のうち302件を生んだ手動投稿を一度も学習していない。既存の取込手段は1投稿ごとの手書きマイグレーションで、同シリーズ実測 122,978 に対し `historical_benchmark_impressions: 8000` と桁を取り違えていた。

### 副次的に判明: 型 (archetype) の結論が交絡していた

同一の `data_report` 型・同一の自動生成・同一の末尾URLでも、topic を変えると4桁落ちる。

| 同じ data_report 型 | 本数 | imp 中央値 | URLクリック |
|---|---:|---:|---:|
| 日本政治 (地方議員集計) | 5 | 122,978 | 286 |
| AI・テック (AIツール定点観測) | 16 | 58 | 0 |
| 家計・資産 | 57 | 9 | 0 |

効いていたのは型ではなく「既存の巨大オーディエンスに固有名詞で乗っていること」。

## 何を変えたか

1. **`x_acquisition_score.ts` (新規)** — URLクリック最上位・impressions は 10K で頭打ちの複合スコア。winner / underperformer / variant / 構造 lift の基準を全て差し替え、到達1位 ≠ 獲得1位のときは乖離警告行を出す。
2. **`x_analytics_import.ts` + `x.analytics_import` action (新規)** — X Analytics の CSV エクスポートを取り込む。lifetime cumulative なので `historical_benchmark` コホートに入れ、投稿年齢を揃えた exemplar ランキングは汚さない。公式API実測がある行は上書きしない。
3. **`x_topic_audience.ts` (新規)** — topic lift と archetype × topic 交互作用行。勝ち型の移植失敗を再生産させない。
4. **着地導線** (実測でサイト流入の94%が `/public/local-election-700`)
   - 着地点にプロダクト導線が1つも無かった → `PublicTrackerCtaCard` を追加
   - `plan` 未取得時は本文がスピナーのみで「何のサイトか」が読めなかった → 公開ビューは読み込み中もCTAを表示
   - 共有URLにUTMが無く着地を計測できなかった → 共有/コピー経路に付与
   - 新シグナルキーが EF の許可リストに無く **400 で弾かれていた**（実ブラウザのコンソールで確認）→ `SUPPORTED_ACQUISITION_SIGNALS` に追加
   - CTA が計測を `await` していた → fire-and-forget 化（計測失敗が導線を殺さないように）

## Minimal E2E Gate

- 検証方針は **実装詳細に依存しない** 入出力ベース (black-box)。内部の重み定数ではなく「入力メトリクス → 順位・出力文字列」で判定する。
- **最小限の3ケース** を各純モジュールに置いた:
  1. 実測3コホート (データレポート / 高共感ゼロクリック / 低到達ゼロクリック) の順位が獲得基準で正しく並ぶ
  2. 到達1位 ≠ 獲得1位のときに乖離警告が出て、一致するときは出ない
  3. サンプル希薄・クリック皆無のときは断定せず沈黙する (null)
- E2E-Exception: この差分の主要部は Deno Edge Function の純ロジックとサーバ側集計行で、integration_test / playwright のブラウザ E2E からは到達できない。UI 側追加分は `test/widgets/public_tracker_cta_card_test.dart` の widget test で描画とコールバックを実測済み。

## 検証

- growth-hub 純モジュール suite: **74 passed / 0 failed**
- `public_tracker_cta_card_test.dart`: 3 passed
- `growth_acquisition_service_test.dart`: 9 passed
- `flutter analyze` (全体, pre-commit gate): No issues found
- `deno lint`: 190 files checked
- `flutter build web`: 成功
- ブラウザ実測: `/public/local-election-700` で CTA カードと「5分だけ試す」ボタンの描画を確認。コンソールから上記の 400 拒否を発見して修正。
- **未検証**: CTA 押下後の LandingPage への遷移。ローカルビルドは描画時点で既存の `setState() during build` 例外が出ており、対照実験として既存の AppBar 戻るボタンも同様に無反応だったため、環境側の問題と判断。本番相当環境での確認が必要。

## 判断の記録

「実測の勝ち筋が政治コンテンツである以上、着地導線の強化はプロダクトのブランドを党派性と結びつける」点はユーザーに提示済みで、その上で進める判断を得ている。本PRは着地点に**政治的主張を追加していない** — 追加したのは「この集計を作っている仕組み」の説明と次の一手のみ。

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更の中核は新規追加の純関数モジュール3本とその単体テストで、既存の投稿・課金・認証パスを書き換えていない。既存コードへの変更はランキング基準の差し替えとシグナル許可リストへの追記に限定され、pre-commit の全体 flutter analyze と deno lint、growth-hub 純 suite 74件で回帰を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
