### PR TITLE
fix(campaign): 風刺画の実画像をWebで表示 (CanvasKit CORS回避)

### DIFF
--- a/lib/pages/sobriety_campaign_page.dart
+++ b/lib/pages/sobriety_campaign_page.dart
@@ -454,6 +454,10 @@ class _VideoCard extends StatelessWidget {
 
 /// Wikimedia Commons の実画像を表示する。読み込み中・取得失敗時は透明を返し、
 /// 背後の絵文字土台がそのまま見えるようにする (フレームが空にならない)。
+///
+/// Web(CanvasKit)は cross-origin 画像を canvas に描けず失敗するため、
+/// [WebHtmlElementStrategy.fallback] で失敗時に HTML の `<img>` 要素へ切り替え、
+/// CORS 制約下でも Commons 画像を表示できるようにする (非Web環境では無視される)。
 class _PrintImage extends StatelessWidget {
   const _PrintImage({required this.file});
 
@@ -465,6 +469,7 @@ class _PrintImage extends StatelessWidget {
       _commonsImageUrl(file),
       fit: BoxFit.cover,
       gaplessPlayback: true,
+      webHtmlElementStrategy: WebHtmlElementStrategy.fallback,
       loadingBuilder: (context, child, progress) {
         if (progress == null) return child;
         return const SizedBox.shrink();


### PR DESCRIPTION
## Minimal E2E Gate

- [x] Implementation-detail independent: 「Web で実画像が表示されるか」というユーザー可視の出力に対する修正。
- [x] Minimal scope: CORS 失敗時の HTML `<img>` フォールバック追加（1点）。
- [ ] E2E included: ランタイム不在のため未追加。
- [x] Exception reason: 本セッション環境は proxy 制限で Wikimedia へ到達できず、Web レンダラの in-browser 検証も不可。公式サポートの `Image.network` パラメータ追加のみで、**失敗時は従来どおり絵文字土台へフォールバック（無回帰）**。`flutter analyze` / `build web` を CI で検証。

## 📝 変更内容

先にマージした #4248 で「動画フレームが空にならない」フォールバックは入れたが、**実際の風刺画そのもの**は本番（Flutter Web / CanvasKit）で表示されないままだった。原因は CanvasKit が cross-origin 画像を canvas に描画できず失敗するため。

`_PrintImage` の `Image.network` に **`webHtmlElementStrategy: WebHtmlElementStrategy.fallback`** を指定し、CanvasKit デコードが CORS で失敗した場合に HTML の `<img>` 要素へ自動フォールバックさせることで、Wikimedia Commons の画像を CORS 制約下でも表示できるようにする。

## 🎯 変更の目的

キャンペーンの核心である「風刺画を取り込んだ動画」を、本番で実際の絵として表示する。

## 📋 実装の詳細

- `Image.network(..., webHtmlElementStrategy: WebHtmlElementStrategy.fallback)`（Flutter 3.29+ / 本リポは 3.38.x）。
- 非 Web 環境ではこのパラメータは無視される。
- 取得自体が失敗（存在しないファイル名等）した場合は従来の `errorBuilder` → 絵文字土台フォールバックが働くため、**表示が今より悪化することはない**。

### 既知の制約

- 当セッション環境は proxy が Wikimedia を遮断しており、実 URL の解決可否と in-browser 表示は検証できていない。特定作品が出ない場合は Commons ファイル名の不一致が原因で、`imageFile` の修正（別途ネットワーク到達可能な環境での照合）で対応可能。

## 🚨 Breaking Changes

- [x] なし（`Image.network` へのパラメータ追加のみ）

## ✅ チェックリスト

- [ ] `flutter analyze` 0エラー — ⚠️ 本環境未実行。**CI で最終検証**（`WebHtmlElementStrategy` の API 名含む）。
- [ ] `dart format .` — ⚠️ 同上未実行。80桁・整形を手動整合済。**CI で最終検証**。
- [x] 無回帰（失敗時は既存フォールバックが働く）

## 💬 追加コメント

#4248 マージ済みのため本ブランチは最新 main の上へ載せ替え済み（フォローアップ1コミット）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbwavQrsoVHYUw27aXMp9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbwavQrsoVHYUw27aXMp9U)_