### PR TITLE
fix(ci): support subscription auth for ultrareview and explain launch failures

### DIFF
--- a/.github/workflows/claude-agent-review.yml
+++ b/.github/workflows/claude-agent-review.yml
@@ -322,14 +322,25 @@ jobs:
         id: ultrareview
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.pr.outputs.number }}
         run: |
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "::error::ANTHROPIC_API_KEY is not configured — ultrareview cannot run."
+          # ultrareview is a cloud-hosted session, so it depends on what the
+          # credential is entitled to rather than on raw model access. Prefer a
+          # subscription token when one is configured, and drop the API key in
+          # that case so the precedence is unambiguous.
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            unset ANTHROPIC_API_KEY
+            AUTH="CLAUDE_CODE_OAUTH_TOKEN (subscription)"
+          elif [ -n "$ANTHROPIC_API_KEY" ]; then
+            AUTH="ANTHROPIC_API_KEY (API key)"
+          else
+            echo "::error::No Claude credential configured — set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN."
             exit 1
           fi
+          echo "Auth: ${AUTH}"
 
           # `claude ultrareview <PR#>` is the real subcommand; there is no
           # --non-interactive flag (the CLI rejects it as an unknown option),
@@ -339,7 +350,13 @@ jobs:
           cat ultrareview.txt
 
           if [ "$status" -ne 0 ]; then
-            echo "::error::claude ultrareview exited ${status} for PR #${PR_NUM}."
+            if grep -qi "currently unavailable" ultrareview.txt; then
+              # Observed on every dispatch so far with API-key auth (3 runs
+              # across ~17h). Say what to check instead of just "exited 1".
+              echo "::error::ultrareview could not launch using ${AUTH}. It is a cloud-hosted session whose availability depends on the credential's entitlement. If only an API key is configured, add a CLAUDE_CODE_OAUTH_TOKEN repo secret from \`claude setup-token\` (requires a Claude subscription). If a subscription token is already in use, the service is likely temporarily unavailable — retry later."
+            else
+              echo "::error::claude ultrareview exited ${status} for PR #${PR_NUM} (auth: ${AUTH})."
+            fi
             exit "$status"
           fi
           if [ ! -s ultrareview.txt ]; then


### PR DESCRIPTION
## 概要

PR #4360 で `ultrareview` ジョブの配管を修正し dispatch で実証したが、`claude ultrareview` 本体が起動しない問題が残った。その後の追加調査を踏まえ、**認証経路を用意し、失敗を実行可能な情報に変える**。

**本 PR は原因を証明していないし、修正を主張してもいない。** 3 回とも同じ症状が出る現象に対して、最有力の経路を通せるようにし、次に失敗したときログだけで判断できるようにするもの。

## 追加でわかったこと

**① 症状は 17 時間にわたり完全に再現する**

| dispatch | 時刻 (UTC) | 結果 |
|---|---|---|
| [30295992298](https://github.com/kanta13jp1/my_web_app/actions/runs/30295992298) | 07-27 18:56 | `Ultrareview is currently unavailable.` |
| [30296254983](https://github.com/kanta13jp1/my_web_app/actions/runs/30296254983) | 07-27 19:00 | 同上 |
| [30355367648](https://github.com/kanta13jp1/my_web_app/actions/runs/30355367648) | 07-28 11:35 | 同上 |

いずれも `PR_NUM` は正しく解決され、約 1 秒でサーバー側が launch を拒否。**一時的な不調としては再現しすぎている。**

**② CLI バイナリの文字列から機能の性質が読める**

`Ultrareview is currently unavailable.` の周辺には `blocked` / `tengu_review_overage_blocked` / `needs-confirm` / `Est. cost` が同居し、`Ultrareview could not launch` の周辺には `allow_remote_sessions` / `cli_ultrareview_policy_disallowed` と、**組織ポリシー用の別メッセージ** "Cloud sessions are disabled by your organization's policy." が存在する。

- 今回は**組織ポリシーのメッセージではない** → ポリシーによるブロックではない。
- ultrareview は **cloud/remote session** であり、可否は**資格情報のエンタイトルメント**に依存する。

**③ `CLAUDE_CODE_OAUTH_TOKEN` は実在する env var**

CLI バイナリ内に文字列として存在することを確認済み(推測ではない)。一方、本リポジトリの secret は `ANTHROPIC_API_KEY` のみ(`gh secret list` 実測)で、`claude setup-token` の説明は "requires Claude subscription"。

## 変更内容

- `CLAUDE_CODE_OAUTH_TOKEN` を env に追加。**設定されていれば `ANTHROPIC_API_KEY` を `unset`** して資格情報の優先順位を曖昧にしない(CLI 側の優先順位が未文書のため、意図を明示する)。
- 前提条件を「`ANTHROPIC_API_KEY` が必要」から「**どちらか一方があればよい**」に変更。
- `currently unavailable` を検出したときは、**どの資格情報で試したか** と **次に何を確認すべきか** をログに出す。従来は `exited 1` のみで、原因の切り分けができなかった。

secret が未設定なら env は空文字なので、**現状の挙動は一切変わらない**(退行リスクなし)。

## 検証

CI では失敗経路しか踏めないため、`PATH` 上にスタブした `claude` を置いて 4 ケースを実測した。

> スタブ検証時、`C:/...` 形式の PATH エントリはコロンが POSIX の PATH 区切りと衝突して実体の CLI が解決されてしまう。`command -v claude` がスタブを指すことを**確認してから**各ケースを実行している。

| ケース | 期待 | 結果 |
|---|---|---|
| API キーのみ (= 現在の CI) | API キーと明示 + 専用診断 | ✓ `Auth: ANTHROPIC_API_KEY (API key)` + `could not launch using ...` |
| 両方設定 | subscription を優先 | ✓ `Auth: CLAUDE_CODE_OAUTH_TOKEN (subscription)` |
| どちらも無し | 明確なエラーで停止 | ✓ `No Claude credential configured` |
| 成功経路 | exit 0 / `ran=true` | ✓ `exit=0` / `GITHUB_OUTPUT: ran=true` |

## 次の一手 (ユーザー側)

購読認証済みの環境で `claude setup-token` を実行し、得たトークンを `CLAUDE_CODE_OAUTH_TOKEN` として repo secret に登録 → 再 dispatch。これで起動すれば原因は認証ティアで確定し、`High-risk ultrareview gate` の **evidence 経路が CI で初めて成立**する。なお起動しなければ、新しいログが subscription を使った旨を明示するのでサービス側要因と切り分けられる。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ultrareview cannot launch in CI at all, which is the very defect under investigation; the change is verified with a stubbed CLI instead

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CI workflow definition only (.github/), no application code path; covered by a four-case stubbed-CLI check of the auth selection and failure branches.
