### PR TITLE
fix(x-growth): score every acquisition term on one period basis

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -28,6 +28,7 @@ import { pickBestVariant, pickConfidentVariant } from "./x_best_variant.ts";
 import {
   buildAcquisitionRankingLine,
   computeAcquisitionScore,
+  resolveAcquisitionScoreInput,
 } from "./x_acquisition_score.ts";
 import {
   buildAccountAcquisitionLine,
@@ -1061,17 +1062,24 @@ function buildXPerformanceContextFromLogs(
         rankingUrlClickRate: sample?.urlClickRate ?? null,
         // R24: 学習ランキングの基準値。到達ではなく獲得(URL クリック最上位・
         // impressions は上限キャップ付き補助項)で並べる (x_acquisition_score.ts)。
-        acquisitionScore: computeAcquisitionScore({
-          urlClicks: row.urlClicks,
-          profileClicks: row.profileClicks,
-          bookmarkCount: row.bookmarkCount,
-          replyCount: row.replyCount,
-          repostCount: row.repostCount,
-          likeCount: row.likeCount,
-          impressions: comparisonWindow
-            ? normalizedValue ?? row.impressions
-            : row.impressions,
-        }),
+        // R24 fix: 全項を同じ期間基準で渡す (all-or-nothing)。従来は
+        // impressions だけ窓の値・残り 6 項が lifetime 累積で、重み 1000 の
+        // urlClicks に年齢バイアスが丸ごと残っていた (上限 100 点の
+        // impressions 項では埋め合わせ不可能)。
+        acquisitionScore: computeAcquisitionScore(
+          resolveAcquisitionScoreInput(sample, {
+            urlClicks: row.urlClicks,
+            profileClicks: row.profileClicks,
+            bookmarkCount: row.bookmarkCount,
+            replyCount: row.replyCount,
+            repostCount: row.repostCount,
+            likeCount: row.likeCount,
+            impressions: row.impressions,
+          }).input,
+        ),
+        acquisitionBasis: resolveAcquisitionScoreInput(sample, {
+          impressions: row.impressions,
+        }).basis,
       };
     })
     .sort((left, right) =>
@@ -1338,7 +1346,11 @@ function buildXPerformanceContextFromLogs(
         : "Target: 10K impressions. No post-age comparable winner yet.",
       // R24: 目的は「サイトへ 1 人送ること」。手本の選定基準は到達ではなく獲得。
       `Ranking basis: acquisition score (url clicks weighted first, ` +
-      `impressions capped); age cohort = ${comparisonLabel} ` +
+      `impressions capped; every term read from the same period basis — ` +
+      `${
+        learningRows.filter((r) => r.acquisitionBasis === "window").length
+      }/${learningRows.length} rows scored on the age window, the rest on ` +
+      `lifetime cumulative); age cohort = ${comparisonLabel} ` +
       `(comparable n=${learningRows.length}; total measured n=${rows.length}). ` +
       `Optimize for site visits and replies, not for raw reach.`,
       ...(acquisitionLine ? [acquisitionLine] : []),

--- a/supabase/functions/growth-hub/x_acquisition_score.ts
+++ b/supabase/functions/growth-hub/x_acquisition_score.ts
@@ -121,3 +121,45 @@ export function buildAcquisitionRankingLine<T>(
   );
   return parts.join(" ");
 }
+
+/// R24 fix: 獲得スコアの入力は**全項が同じ期間基準**でなければならない。
+///
+/// 初版は `impressions` だけ年齢正規化窓の値を渡し、`urlClicks` ほか 6 項は
+/// lifetime 累積を渡していた。`urlClicks` の重みは 1000、`impressions` 項は
+/// 上限 100 点なので、支配項に年齢バイアスが丸ごと残り、正規化した項では
+/// 原理的に埋め合わせられない。結果、3 ヶ月前の投稿 (lifetime 5 クリック) が
+/// 2 日前の投稿 (同一窓 4 クリック) を恒久的に上回り、
+/// 「Rank every post against one shared age window」という同ファイルの
+/// 不変条件に正面から反していた。
+///
+/// ここでは all-or-nothing で基準を選ぶ。窓のサンプルがあれば**全項**を窓から、
+/// 無ければ**全項**を累積から取る。項ごとのフォールバックは同じバグを再発させる
+/// ので行わない。
+export interface AcquisitionScoreBasis {
+  input: AcquisitionScoreInput;
+  /// "window" = 年齢を揃えた窓の値 / "cumulative" = lifetime 累積。
+  basis: "window" | "cumulative";
+}
+
+export function resolveAcquisitionScoreInput(
+  sample: AcquisitionScoreInput | null | undefined,
+  cumulative: AcquisitionScoreInput,
+): AcquisitionScoreBasis {
+  // 窓サンプルは impressions を必ず持つ (無い窓はそもそも作られない)。
+  // impressions が取れない sample は窓として不完全なので累積へ倒す。
+  if (sample && typeof sample.impressions === "number") {
+    return {
+      basis: "window",
+      input: {
+        urlClicks: sample.urlClicks ?? 0,
+        profileClicks: sample.profileClicks ?? 0,
+        bookmarkCount: sample.bookmarkCount ?? 0,
+        replyCount: sample.replyCount ?? 0,
+        repostCount: sample.repostCount ?? 0,
+        likeCount: sample.likeCount ?? 0,
+        impressions: sample.impressions,
+      },
+    };
+  }
+  return { basis: "cumulative", input: cumulative };
+}

--- a/supabase/functions/growth-hub/x_acquisition_score_test.ts
+++ b/supabase/functions/growth-hub/x_acquisition_score_test.ts
@@ -8,6 +8,7 @@ import {
   IMPRESSION_CAP,
   IMPRESSION_MAX_POINTS,
   impressionTerm,
+  resolveAcquisitionScoreInput,
 } from "./x_acquisition_score.ts";
 
 // 実測サンプル (account_analytics_content 2026-04-27〜2026-07-25)。
@@ -127,4 +128,64 @@ Deno.test("buildAcquisitionRankingLine omits the warning when both winners agree
   assert(out !== null);
   assert(!out!.includes("Divergence warning"));
   assert(out!.includes("Click coverage: 2/2"));
+});
+
+// R24 fix: 期間基準の混在バグ (PR #4355 レビュー指摘) の回帰テスト。
+const CUMULATIVE = {
+  urlClicks: 5,
+  profileClicks: 40,
+  bookmarkCount: 2,
+  replyCount: 1,
+  repostCount: 3,
+  likeCount: 10,
+  impressions: 90000,
+};
+const WINDOW_SAMPLE = {
+  urlClicks: 4,
+  profileClicks: 6,
+  bookmarkCount: 0,
+  replyCount: 0,
+  repostCount: 1,
+  likeCount: 2,
+  impressions: 3000,
+};
+
+Deno.test("resolveAcquisitionScoreInput takes every term from the window when present", () => {
+  const resolved = resolveAcquisitionScoreInput(WINDOW_SAMPLE, CUMULATIVE);
+  assertEquals(resolved.basis, "window");
+  // 1 項でも累積が混ざったら、この等値は壊れる。
+  assertEquals(resolved.input, WINDOW_SAMPLE);
+});
+
+Deno.test("resolveAcquisitionScoreInput falls back wholly to cumulative", () => {
+  for (const sample of [null, undefined, { urlClicks: 4 }]) {
+    const resolved = resolveAcquisitionScoreInput(sample, CUMULATIVE);
+    assertEquals(resolved.basis, "cumulative");
+    assertEquals(resolved.input, CUMULATIVE);
+  }
+});
+
+Deno.test("窓の値で採点すると、古い投稿が新しい投稿を年齢だけで上回らない", () => {
+  // 3ヶ月前の投稿: lifetime 5 クリック。2日前の投稿: 同一窓 4 クリック。
+  const oldPostWindow = { ...WINDOW_SAMPLE, urlClicks: 1, impressions: 800 };
+  const freshWindow = { ...WINDOW_SAMPLE, urlClicks: 4, impressions: 3000 };
+
+  // 修正前の挙動 (累積 vs 窓の混在) を再現すると、古い投稿が勝ってしまう。
+  const mixedOld = computeAcquisitionScore({ ...CUMULATIVE, impressions: 800 });
+  const mixedFresh = computeAcquisitionScore(
+    resolveAcquisitionScoreInput(freshWindow, CUMULATIVE).input,
+  );
+  assert(
+    mixedOld > mixedFresh,
+    "混在時は古い投稿が勝つ (これが修正前のバグ)",
+  );
+
+  // 修正後: 両方とも窓基準なので、同じ窓のクリック数どおりに並ぶ。
+  const normalizedOld = computeAcquisitionScore(
+    resolveAcquisitionScoreInput(oldPostWindow, CUMULATIVE).input,
+  );
+  assert(
+    mixedFresh > normalizedOld,
+    `窓基準なら 4 クリックが 1 クリックを上回る (${mixedFresh} vs ${normalizedOld})`,
+  );
 });


### PR DESCRIPTION
## なぜ（自分が出した #4355 の欠陥）

[#4355](https://github.com/kanta13jp1/my_web_app/pull/4355) の `computeAcquisitionScore` は、渡す入力の**期間基準が項ごとに食い違っていた**。

| 項 | 重み | 渡していた値 |
|---|---:|---|
| `impressions` | 上限100点 | 年齢正規化窓の値 (`normalizedValue`) |
| `urlClicks` | **1000** | `latest.*` の **lifetime 累積** |
| `profileClicks` / `bookmarkCount` / `replyCount` / `repostCount` / `likeCount` | 60〜2 | 同上（累積） |

支配項に年齢バイアスが丸ごと残り、上限100点の `impressions` 項では**原理的に埋め合わせられない**。結果、3ヶ月前の投稿（lifetime 5クリック）が2日前の投稿（同一窓 4クリック）を恒久的に上回る。

同ファイルのコメントが明示していた不変条件 —

> Rank every post against one shared age window. This prevents a mature post's cumulative 72-hour count from competing with a fresh post's 3-hour count.

— に正面から反していた。しかも窓単位の `urlClicks` は `XMetricWindowSample` に既に存在し、**同じ map ブロック内の `sample` 変数で参照できた**のに使われていなかった（`rankingUrlClickRate` は `sample?.urlClickRate` を使っている）。

**純関数の単体テストはこれを絶対に捕まえない。** テストは関数に数値を直接渡すので、呼び出し側が何を渡すかは検証範囲外。#4355 は 74件緑のままこれを通した。

## 何を変えたか

1. `resolveAcquisitionScoreInput()` を追加し、**all-or-nothing** で基準を選ぶ。窓サンプルがあれば**全項**を窓から、無ければ**全項**を累積から。項ごとのフォールバックは同じバグを再発させるので行わない。
2. どちらの基準で採点されたかを `performance_context` の Ranking basis 行に件数で出す（窓 n/全 n）。無言で基準が混ざる状態に戻らないようにする。
3. 回帰テスト3件。うち1件は**修正前の混在なら古い投稿が勝つことを明示的に再現**してから、修正後に順序が正されることを確認する。

## Minimal E2E Gate

- 検証は **実装詳細に依存しない** 入出力ベース: 窓サンプルと累積の2つを渡し、返る `basis` と `input` の等値、および2投稿のスコア順序だけで判定する。内部の分岐構造には触れない。
- **最小限の3ケース**: (1) 窓がある → 全項が窓の値と等値 (2) 窓が無い/不完全 → 全項が累積と等値 (3) 古い投稿と新しい投稿の順序が窓基準で正しくなる（混在時は逆転することも同時に確認）。
- E2E-Exception: 変更は Deno Edge Function の純ロジックで、Flutter Web のアプリバンドルに入らない。ブラウザ E2E から到達する UI 経路が無いため integration_test / playwright の対象にならない。`deno test` の入出力レベルで固定した。

## 検証

- `x_acquisition_score_test.ts`: **10 passed**（新規3）
- pre-commit fast quality gate: `flutter analyze` No issues found / deno lint 190 files

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は growth-hub の学習ランキング算出のみで、投稿・課金・認証の経路に触れていない。追加した解決関数は既存の窓サンプルを読むだけで新しい外部入力を導入せず、窓が無い場合は従来どおり累積へ倒れる。新規3件を含む10件のテストと全体 analyze / deno lint で回帰を確認済み。

Refs #4355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
