### PR TITLE
ci: 保護ツリーの tracked ファイル 0 byte 化を PR で拒否する guard を追加

### DIFF
--- a/.github/workflows/protected-files-nonempty-guard.yml
+++ b/.github/workflows/protected-files-nonempty-guard.yml
@@ -1,0 +1,72 @@
+name: Protected Files Non-empty Guard
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".claude/**"
+      - "scripts/check_protected_files_nonempty.py"
+      - "test/scripts/test_check_protected_files_nonempty.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".claude/**"
+      - "scripts/check_protected_files_nonempty.py"
+      - "test/scripts/test_check_protected_files_nonempty.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: protected-files-nonempty-guard-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Check protected files emptied
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Resolve comparison refs
+        id: refs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${GITHUB_SHA}"
+            if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+              base="${head}^"
+            fi
+          fi
+          git fetch --no-tags origin "$base" "$head" || true
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "head=$head" >> "$GITHUB_OUTPUT"
+
+      - name: Run guard
+        run: |
+          python scripts/check_protected_files_nonempty.py \
+            --base-ref "${{ steps.refs.outputs.base }}" \
+            --head-ref "${{ steps.refs.outputs.head }}"
+
+      - name: Run unit tests
+        run: python -m unittest discover -s test/scripts -p "test_check_protected_files_nonempty.py"

--- a/scripts/check_protected_files_nonempty.py
+++ b/scripts/check_protected_files_nonempty.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Guard protected config trees against tracked files being emptied to 0 bytes.
+
+On 2026-07-21 eight tracked files were truncated to 0 bytes in a working tree
+(six GitHub Actions workflows plus ``.claude/settings.json`` and
+``.claude/commands/wrap-up.md``). Nothing staged them, so nothing shipped, but a
+blind ``git add -A`` would have committed the removal of the entire CI/CD
+pipeline and the agent hook/permission config.
+
+Scope is deliberately narrow. ``.github/workflows/`` and ``.claude/`` are the two
+trees that fail *silently* when emptied: a 0-byte workflow simply never runs, and
+a 0-byte settings.json simply drops every hook. Damage elsewhere is loud -- an
+emptied file under ``lib/`` breaks the build, an emptied script fails when run --
+so those trees do not need this guard.
+
+Emptying a file in these trees is never the right operation: to retire a workflow
+you delete it, which this guard allows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Iterable
+
+
+PROTECTED_PREFIXES = (".github/workflows/", ".claude/")
+
+
+@dataclass(frozen=True)
+class FileState:
+    """Sizes of one path on both sides. ``None`` means the path is absent there."""
+
+    path: str
+    base_size: int | None
+    head_size: int | None
+
+
+@dataclass(frozen=True)
+class EmptiedFinding:
+    path: str
+    base_size: int
+
+
+def is_protected(path: str) -> bool:
+    return path.startswith(PROTECTED_PREFIXES)
+
+
+def find_emptied_files(states: Iterable[FileState]) -> list[EmptiedFinding]:
+    """Return findings for protected files that are non-empty at base but empty at head."""
+    findings: list[EmptiedFinding] = []
+    for state in states:
+        if not is_protected(state.path):
+            continue
+        if state.head_size is None:
+            # Deleted by this change. Removing a workflow outright is legitimate.
+            continue
+        if state.head_size != 0:
+            continue
+        if state.base_size is None:
+            # Brand-new empty file: nothing existed upstream, so nothing was destroyed.
+            continue
+        if state.base_size == 0:
+            # Already empty upstream (e.g. a tracked .gitkeep). Not a regression.
+            continue
+        findings.append(EmptiedFinding(path=state.path, base_size=state.base_size))
+    return findings
+
+
+def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def changed_paths(base_ref: str, head_ref: str) -> list[str]:
+    """Paths this change touches, via three-dot diff.
+
+    Three-dot (merge-base..head) attributes only what this change did. A two-dot
+    diff would also report everything main moved on to since the fork, which is a
+    known source of false positives in this repo's PR gates.
+    """
+    proc = run_git(["diff", "--name-only", f"{base_ref}...{head_ref}"])
+    if proc.returncode != 0:
+        print(proc.stderr.strip(), file=sys.stderr)
+        raise SystemExit(proc.returncode)
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def blob_size(ref: str, path: str) -> int | None:
+    """Byte size of ``path`` at ``ref``, or ``None`` when it does not exist there."""
+    proc = run_git(["cat-file", "-s", f"{ref}:{path}"])
+    if proc.returncode != 0:
+        return None
+    try:
+        return int(proc.stdout.strip())
+    except ValueError:
+        return None
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--head-ref", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    protected = [path for path in changed_paths(args.base_ref, args.head_ref) if is_protected(path)]
+    if not protected:
+        print("No protected files changed; guard passed.")
+        return 0
+
+    # Sizes are compared against the base *tip*, not the merge base. A file that
+    # main gained after the fork point is absent at the merge base, so a
+    # merge-base comparison would silently miss an empty version of it landing
+    # here and shadowing main's real content.
+    states = [
+        FileState(
+            path=path,
+            base_size=blob_size(args.base_ref, path),
+            head_size=blob_size(args.head_ref, path),
+        )
+        for path in protected
+    ]
+
+    print(f"Checked {len(states)} protected file(s):")
+    for state in states:
+        base = "absent" if state.base_size is None else f"{state.base_size}B"
+        head = "absent" if state.head_size is None else f"{state.head_size}B"
+        print(f"- {state.path}: base={base} head={head}")
+
+    findings = find_emptied_files(states)
+    if findings:
+        print()
+        print("Protected files emptied to 0 bytes:")
+        for finding in findings:
+            print(f"- {finding.path} was {finding.base_size} bytes at base, now 0 bytes")
+        print()
+        print(
+            "A 0-byte workflow never runs and a 0-byte .claude config drops every hook, "
+            "both without any error. To retire one of these files, delete it instead of "
+            "emptying it."
+        )
+        return 1
+
+    print("Protected files non-empty guard passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/scripts/test_check_protected_files_nonempty.py
+++ b/test/scripts/test_check_protected_files_nonempty.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.check_protected_files_nonempty import (
+    FileState,
+    find_emptied_files,
+    is_protected,
+)
+
+
+class IsProtectedTest(unittest.TestCase):
+    def test_workflow_and_claude_trees_are_protected(self) -> None:
+        self.assertTrue(is_protected(".github/workflows/ci.yml"))
+        self.assertTrue(is_protected(".claude/settings.json"))
+        self.assertTrue(is_protected(".claude/commands/wrap-up.md"))
+
+    def test_other_trees_are_not_protected(self) -> None:
+        # Emptying these is loud: the build or the script itself fails.
+        self.assertFalse(is_protected("lib/main.dart"))
+        self.assertFalse(is_protected("scripts/sync_inject_rules.py"))
+        self.assertFalse(is_protected("docs/GROWTH_STRATEGY_ROADMAP.md"))
+        self.assertFalse(is_protected(".github/dependabot.yml"))
+
+
+class FindEmptiedFilesTest(unittest.TestCase):
+    def test_flags_workflow_emptied_from_non_empty(self) -> None:
+        states = [FileState(".github/workflows/ci.yml", base_size=17413, head_size=0)]
+
+        findings = find_emptied_files(states)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].path, ".github/workflows/ci.yml")
+        self.assertEqual(findings[0].base_size, 17413)
+
+    def test_flags_claude_config_emptied_from_non_empty(self) -> None:
+        states = [FileState(".claude/settings.json", base_size=12371, head_size=0)]
+
+        self.assertEqual(len(find_emptied_files(states)), 1)
+
+    def test_flags_empty_file_shadowing_real_upstream_content(self) -> None:
+        # The feature-releases-sync.yml case: absent from the branch's own history
+        # but present with content on main, so it arrives as an *addition* of an
+        # empty file. Comparing against the merge base would miss this entirely;
+        # comparing against the base tip catches it.
+        states = [
+            FileState(".github/workflows/feature-releases-sync.yml", base_size=1299, head_size=0)
+        ]
+
+        self.assertEqual(len(find_emptied_files(states)), 1)
+
+    def test_allows_deletion(self) -> None:
+        # Retiring a workflow is legitimate; only emptying it in place is not.
+        states = [FileState(".github/workflows/old.yml", base_size=5000, head_size=None)]
+
+        self.assertEqual(find_emptied_files(states), [])
+
+    def test_allows_new_empty_file_with_no_upstream_content(self) -> None:
+        states = [FileState(".claude/placeholder.txt", base_size=None, head_size=0)]
+
+        self.assertEqual(find_emptied_files(states), [])
+
+    def test_allows_file_already_empty_upstream(self) -> None:
+        # Tracked 0-byte markers such as .gitkeep stay 0 bytes on both sides.
+        states = [FileState(".claude/keep/.gitkeep", base_size=0, head_size=0)]
+
+        self.assertEqual(find_emptied_files(states), [])
+
+    def test_allows_ordinary_edit(self) -> None:
+        states = [FileState(".github/workflows/ci.yml", base_size=17413, head_size=16775)]
+
+        self.assertEqual(find_emptied_files(states), [])
+
+    def test_ignores_emptied_file_outside_protected_trees(self) -> None:
+        states = [FileState("lib/main.dart", base_size=4200, head_size=0)]
+
+        self.assertEqual(find_emptied_files(states), [])
+
+    def test_reports_every_emptied_file(self) -> None:
+        # The 2026-07-21 incident emptied eight files at once.
+        states = [
+            FileState(f".github/workflows/w{index}.yml", base_size=1000, head_size=0)
+            for index in range(6)
+        ] + [
+            FileState(".claude/settings.json", base_size=12371, head_size=0),
+            FileState(".claude/commands/wrap-up.md", base_size=11113, head_size=0),
+        ]
+
+        self.assertEqual(len(find_emptied_files(states)), 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

2026-07-21、作業ツリーで tracked 8 ファイルが 0 byte 化した (workflows 6 本 + `.claude/settings.json` + `.claude/commands/wrap-up.md`)。ステージされていなかったため出荷はされなかったが、盲目的な `git add -A` が拾えば **CI/CD パイプライン一式とエージェントの hook/権限設定の削除がコミットされていた**。

原因は現在も未証明で、3 晩再発していない。よって本 PR は原因対策ではなく、**「次に同じことが起きても履歴に入らない」ための拒否ゲート**を置く。

## なぜこの 2 つの木だけか

`.github/workflows/` と `.claude/` は**空にされても無言で壊れる**。0 byte の workflow は単に走らず、0 byte の `.claude` 設定は単に全 hook を落とす — どちらもエラーを出さない。

他ツリーは damage が大きな音を立てる: `lib/` が空になれば build が即失敗し、script が空なら実行時に落ちる。よって射程を沈黙する 2 つに絞り、誤検知をほぼゼロにしている。

## 述語

**PR base (main) で非空 かつ head で 0 byte** のとき fail。

- 変更ファイル集合は **three-dot** で取得 — two-dot は fork 後に main が進んだ分まで拾う既知の誤検知源のため
- サイズ比較は merge-base ではなく **base tip** — main が fork 後に追加したファイルは merge-base に存在しないので、merge-base 比較だとその空版が着地して main の実体を潰すケースを**取り逃す**。実在例として `.github/workflows/feature-releases-sync.yml` (branch の履歴になく main には 1299 bytes) がある

通すもの: **削除**(workflow の retire は削除が正しい操作)/ main に存在しない新規空ファイル / 上流で既に 0 byte のもの (`.gitkeep` 等)。

例外機構は設けていない。この 2 つの木では「空にする」が正しい操作になる場面がなく、必要なら削除すればよいため。

## 検証

単体 11 件に加え、**実際の git ref で end-to-end 検証**した (発火しないゲートは無価値なため):

| ケース | 期待 | 結果 |
|---|---|---|
| workflow + `.claude` 設定を空に | fail | ✅ 2 件検出・exit 1 |
| 同時に `lib/main.dart` も空に | 射程外で無視 | ✅ 報告されず |
| workflow を削除 | pass | ✅ exit 0 |
| workflow を通常編集 | pass | ✅ exit 0 |
| 保護対象に触れない変更 | pass | ✅ exit 0 |

ローカル品質ゲートは完走して通過している (`flutter analyze: No issues found` / deno lint 190 ファイル / no-verify bypass チェック緑)。

## E2E について

CI 設定のみの変更で、アプリのコード・UI・データ経路に一切触れないため `no-e2e-needed`。ガードのロジックは上記の通り単体テストと実 git ref での end-to-end 検証で担保している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
