### PR TITLE
fix(cron): inject-rules 同期を read-only 化 + 一時 forensic watcher + 07-21 記録の訂正

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -33297,3 +33297,40 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 - 該当原則: 7 (資産負債: 競合情報を構造化資産として蓄積) / 8 (KPI: 競合動向を定点観測しギャップを可視化)
 - 整合性スコア: 2/9 ✅ (定常モニタリングタスクのため他原則は非該当)
 - 特記: Supabase 全エンドポイントがプロキシ policy により 403 — 12日連続同一制約 / ユーザー数 60人 (前日比 ±0) / Notion HTMLブロック + Slack Today View が新たな差別化脅威として浮上
+
+## 2026-07-28 (Win Claude part346) — 0 byte 化インシデントの訂正 + 恒久ガード + read-only 再設計
+
+**種別**: 前回 (part342) 記録の訂正 + 再発時の被害遮断 (プロダクト機能変更なし)
+
+### 訂正: cron は truncation については実質無罪
+
+2026-07-21 の記録は `JibunKK-InjectRulesAutoSync` (毎日 03:30) を「第一容疑」とし、MEMORY.md では ⏰ 期限つき項目として「毎日 03:30 再発しうる」と扱っていた。**この位置づけを訂正する。**
+
+追加調査で判明したこと:
+
+- **3 晩 (07-22/23/24) cron は発火し、truncation はゼロ**。毎晩同じ挙動なのに被害は 1 回だけ = cron 犯人説を弱める
+- **メカニズムが不在**: dirty tree では `git pull` は overwrite 拒否で abort しファイルに触れない / `post-merge`・`post-checkout`・`post-rewrite` hook は 1 つも存在しない / `sync_inject_rules.py --apply` は `write_text(HOME, ...)` のみで **repo 外にしか書かない** (repo 側へ書く `--reverse` は排他グループで cron からは呼ばれない)
+- **Defender は 07-21 に修復・検疫を一切していない** (Id 1116/1117/1015 = 0 件)
+- **プロセス帰属は誰も記録していなかった** (Object Access 監査 OFF・Sysmon 未導入) → **遡及的な証明は不可能**
+- 「pull が abort し続けて配布ルールが stale」も**外れ**だった: worktree 版 7588B と origin/main 版 7515B の差はちょうど 73 行分の CRLF で、内容は一致
+
+**結論**: truncation の原因は既存データでは証明できず、3 晩再発していない稀事象。原因追跡は前向き計装に一本化し、恒久防御は「拒否」側に置く方針へ転換した。
+
+### 実装したもの
+
+1. **CI guard** (PR #4368 / merged): `.github/workflows/` と `.claude/` の tracked ファイルが「main で非空 → PR head で 0 byte」になったら fail。この 2 つの木は**空でも無言で壊れる**唯一の領域 (0 byte の workflow は走らないだけ、0 byte の `.claude` 設定は hook が消えるだけ) で、他ツリーは build/実行が即失敗するため射程外。削除は許可 (retire は削除が正しい操作)。変更集合は three-dot・サイズ比較は base tip (merge-base だと `feature-releases-sync.yml` 型を取り逃す)
+2. **cron の read-only 再設計**: `sync_inject_rules.py` に `--from-ref` を追加し、canonical を作業ツリーでなく git ref から読む。cron 側は `git pull` を廃し `git fetch` + `--from-ref origin/main` へ。これで **cron は作業ツリーに触れる能力を完全に失う**。既定は従来通り作業ツリー読み (開発者のローカル編集を無視しないため)
+3. **一時的な forensic watcher** (`scripts/watch_protected_files.ps1`): 0 byte 化の瞬間に `Win32_Process` を全コマンドライン付きでダンプ。**repo には一切書かず**ログは repo 外。**捕獲 or 30 日で自己終了**。時刻非依存 (03:30 相関は n=1 で、その cron 自体が無罪になったため、時刻を鍵にするのは偶然に計器を合わせる行為)
+
+**cron を直す理由も変わった** — truncation の fix ではなく、「worktree がクリーンな晩に `git pull origin main` が成功し、**Codex の WIP branch に main を無断マージする**」という別の実在リスクへの対処である (git の定義通りの動作)。
+
+### 残る限界 (正直な記載)
+
+watcher が名指しできるのはスナップショット時点で**生存しているプロセス**のみ。数ミリ秒で exit する犯人なら時刻とファイル一覧しか取れない — それ自体が 4688 プロセス生成監査へエスカレーションすべき signal となる。
+
+### Philosophy Alignment (Win Claude part346)
+
+- 主要実施: 未証明の原因断定を訂正 + 恒久 CI guard + cron の read-only 化 + 期限つき計装
+- 該当原則: 1 (CEO 感: 射程・sunset・強制点をすべてユーザーが決定) / 6 (資本=時間: 沈黙する破壊を CI で止め将来の調査時間を回収) / 7 (資産負債: CI/CD と設定を守る資産を追加し、未証明の因果を負債として明示訂正)
+- 整合性スコア: 3/9 ✅ — インシデント対応・基盤整備のため機能設計向けの判定基準は適用外
+- 特記: **最大の教訓は前回と同じ形で自分に返ってきた** — 07-21 は「自動レポートが未検証の復元先を推奨していた」ことが最大の発見だったが、その記録自身が cron を「第一容疑」と書いていた。訂正しなければ同じ過ちの再生産になる

--- a/scripts/sync_inject_rules.py
+++ b/scripts/sync_inject_rules.py
@@ -28,12 +28,14 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-CANONICAL = REPO_ROOT / ".claude" / "inject-rules.txt"
+CANONICAL_REL = ".claude/inject-rules.txt"
+CANONICAL = REPO_ROOT / CANONICAL_REL
 HOME = Path.home() / ".claude" / "hooks" / "inject-rules.txt"
 
 # Karpathy 80 行 KPI
@@ -91,6 +93,27 @@ def read_text(path: Path) -> str | None:
             return f.read()
     except OSError:
         return None
+
+
+def read_text_from_ref(ref: str) -> str | None:
+    """Read the canonical rules out of a git ref without touching the working tree.
+
+    Callers that run unattended (the daily scheduled sync) use this so they never
+    need the checkout to be on a particular branch or clean. Reading a blob is
+    safe no matter what branch the repo happens to be sitting on.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "show", f"{ref}:{CANONICAL_REL}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
 
 
 def write_text(path: Path, content: str) -> None:
@@ -179,10 +202,11 @@ def cmd_dry_run(canonical: str, home: str | None) -> dict:
     }
 
 
-def cmd_apply(canonical: str) -> dict:
+def cmd_apply(canonical: str, source: str) -> dict:
     write_text(HOME, canonical)
     return {
         "mode": "apply",
+        "source": source,
         "wrote": str(HOME),
         "lines": line_count(canonical),
     }
@@ -205,13 +229,31 @@ def main() -> int:
     g.add_argument("--reverse", action="store_true", help="home → canonical (= 開発者編集 push 用)")
     g.add_argument("--verify", action="store_true", help="integrity check (= 行数 / rule 数 / critical rule 残存)")
     ap.add_argument("--json", action="store_true", help="JSON output")
+    ap.add_argument(
+        "--from-ref",
+        metavar="REF",
+        help=(
+            "canonical を作業ツリーでなく git ref から読む (例: origin/main)。"
+            "作業ツリーに一切触れないので branch 状態や dirty 状態に依存しない (= 無人実行向け)。"
+            "既定は作業ツリー読み (= 開発者のローカル編集をそのまま反映)"
+        ),
+    )
     args = ap.parse_args()
 
-    canonical_text = read_text(CANONICAL)
+    if args.from_ref:
+        if args.reverse:
+            print("[error] --from-ref は --reverse と併用できません", file=sys.stderr)
+            return 2
+        canonical_source = args.from_ref
+        canonical_text = read_text_from_ref(args.from_ref)
+    else:
+        canonical_source = str(CANONICAL)
+        canonical_text = read_text(CANONICAL)
+
     home_text = read_text(HOME)
 
     if canonical_text is None:
-        print(f"[error] canonical not found: {CANONICAL}", file=sys.stderr)
+        print(f"[error] canonical not found: {canonical_source}", file=sys.stderr)
         return 2
 
     if args.verify:
@@ -244,7 +286,7 @@ def main() -> int:
         return 0 if result["canonical"]["kpi_pass"] else 1
 
     if args.apply:
-        result = cmd_apply(canonical_text)
+        result = cmd_apply(canonical_text, canonical_source)
     elif args.reverse:
         if home_text is None:
             print(f"[error] home not found: {HOME}", file=sys.stderr)

--- a/scripts/watch_protected_files.ps1
+++ b/scripts/watch_protected_files.ps1
@@ -1,0 +1,241 @@
+<#
+.SYNOPSIS
+  Records which process empties a protected file, for as long as it takes to catch one.
+
+.DESCRIPTION
+  On 2026-07-21 eight tracked files under .github/workflows/ and .claude/ were
+  truncated to 0 bytes within 52ms, in path-sorted order. The cause was never
+  proven: git had no record of touching the working tree, Defender performed no
+  remediation, and nothing on this machine was recording process attribution
+  (Object Access auditing is off and Sysmon is not installed). It has not
+  recurred since, so there is nothing left to find by looking backwards.
+
+  This watcher supplies the one fact that was missing: *which process was running
+  at the instant a file went to 0 bytes*. It is deliberately time-independent --
+  the 03:30 correlation rests on a single observation and the scheduled task that
+  ran then has since been largely exonerated, so keying on a clock would be
+  fitting the instrument to a coincidence.
+
+  READ-ONLY with respect to the repository. It never writes, restores, or stages
+  anything, and its logs go outside the repo. Enforcement of the actual risk (an
+  emptied file reaching main) lives in CI, in
+  .github/workflows/protected-files-nonempty-guard.yml. This script only observes.
+
+  LIMITATION, stated plainly: a process snapshot can only name a culprit that is
+  still alive when the snapshot runs. If the truncation is done by a process that
+  exits within milliseconds, this will capture the timing and the file list but
+  not the offender -- which is itself the signal to escalate to Windows process
+  creation auditing (event 4688 with command lines).
+
+.NOTES
+  Sunset: stops after the first capture, or after -SunsetDays from the first run,
+  whichever comes first. This is temporary forensic instrumentation, not a
+  permanent daemon; an unattended background writer left running forever is the
+  very pattern that made the original incident hard to diagnose.
+
+.EXAMPLE
+  powershell -NoProfile -ExecutionPolicy Bypass -File scripts\watch_protected_files.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = 'C:\Users\kanta\GitHub\my_web_app',
+
+    # Deliberately outside the repository: this tool must never add to the
+    # working tree it is watching.
+    [string]$LogDir = (Join-Path $env:LOCALAPPDATA 'jibunkk-file-truncation-watch'),
+
+    [int]$SunsetDays = 30,
+
+    # How long to keep collecting sibling files after the first 0-byte hit. The
+    # incident emptied eight files in 52ms, so the burst itself is evidence.
+    [int]$BurstWindowSeconds = 10,
+
+    # Test hook: exit after this long even if nothing is captured.
+    [int]$MaxRuntimeSeconds = 0
+)
+
+$ErrorActionPreference = 'Stop'
+
+$WatchedRelativeDirs = @('.github\workflows', '.claude')
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+$startedMarker = Join-Path $LogDir 'first-run.txt'
+if (Test-Path $startedMarker) {
+    $firstRun = [datetime]::Parse((Get-Content $startedMarker -Raw).Trim())
+} else {
+    $firstRun = Get-Date
+    $firstRun.ToString('o') | Out-File -FilePath $startedMarker -Encoding utf8
+}
+
+$sunsetAt = $firstRun.AddDays($SunsetDays)
+$sessionLog = Join-Path $LogDir ('watch-' + (Get-Date -Format 'yyyyMMdd-HHmmss') + '.log')
+
+function Write-Log {
+    param([string]$Message)
+    $line = '[{0}] {1}' -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'), $Message
+    Add-Content -Path $sessionLog -Value $line -Encoding utf8
+    Write-Output $line
+}
+
+function Get-ZeroBytePath {
+    <# Every currently-empty file across the watched trees. #>
+    $found = @()
+    foreach ($rel in $WatchedRelativeDirs) {
+        $dir = Join-Path $RepoRoot $rel
+        if (-not (Test-Path $dir)) { continue }
+        $found += Get-ChildItem -Path $dir -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Length -eq 0 } |
+            ForEach-Object { $_.FullName }
+    }
+    return $found
+}
+
+function Save-ProcessSnapshot {
+    param([string]$TriggerPath)
+
+    # Taken first and fastest: a culprit that exits cannot be named later.
+    $procs = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+        Select-Object ProcessId, ParentProcessId, Name, CreationDate, CommandLine
+
+    $stamp = Get-Date -Format 'yyyyMMdd-HHmmss-fff'
+    $dump = Join-Path $LogDir ('capture-' + $stamp + '.txt')
+
+    @(
+        '=== protected-file truncation capture ===',
+        ('captured_at : ' + (Get-Date -Format 'o')),
+        ('trigger     : ' + $TriggerPath),
+        ('repo_root   : ' + $RepoRoot),
+        '',
+        '--- files currently 0 bytes in watched trees ---'
+    ) | Out-File -FilePath $dump -Encoding utf8
+
+    Get-ZeroBytePath | Out-File -FilePath $dump -Append -Encoding utf8
+
+    '' | Out-File -FilePath $dump -Append -Encoding utf8
+    '--- running processes (full command lines) ---' | Out-File -FilePath $dump -Append -Encoding utf8
+    $procs | Sort-Object CreationDate -Descending |
+        Format-Table -AutoSize -Wrap |
+        Out-File -FilePath $dump -Append -Encoding utf8 -Width 500
+
+    return $dump
+}
+
+if ((Get-Date) -ge $sunsetAt) {
+    Write-Log ("Sunset reached (first run {0}, +{1} days). Nothing captured; the CI guard remains the standing protection. Exiting." -f $firstRun.ToString('yyyy-MM-dd'), $SunsetDays)
+    exit 0
+}
+
+Write-Log ("Watching {0} under {1} | sunset {2}" -f ($WatchedRelativeDirs -join ', '), $RepoRoot, $sunsetAt.ToString('yyyy-MM-dd HH:mm'))
+
+# Events are handled in this scope rather than via -Action scriptblocks, which
+# run in a separate session state where these functions and variables are not
+# visible.
+$watchers = @()
+$subscriptions = @()
+$index = 0
+
+foreach ($rel in $WatchedRelativeDirs) {
+    $dir = Join-Path $RepoRoot $rel
+    if (-not (Test-Path $dir)) {
+        Write-Log ("Skipping missing directory: {0}" -f $dir)
+        continue
+    }
+
+    $fsw = New-Object System.IO.FileSystemWatcher
+    $fsw.Path = $dir
+    $fsw.IncludeSubdirectories = $true
+    $fsw.NotifyFilter = [System.IO.NotifyFilters]::LastWrite -bor [System.IO.NotifyFilters]::Size
+    $fsw.EnableRaisingEvents = $true
+
+    foreach ($eventName in @('Changed', 'Created')) {
+        $sourceId = "protected-files-$eventName-$index"
+        Register-ObjectEvent -InputObject $fsw -EventName $eventName -SourceIdentifier $sourceId | Out-Null
+        $subscriptions += $sourceId
+    }
+
+    $watchers += $fsw
+    $index++
+    Write-Log ("Armed on {0}" -f $dir)
+}
+
+if ($watchers.Count -eq 0) {
+    Write-Log 'No directories to watch; exiting.'
+    exit 1
+}
+
+$captured = $false
+$deadline = if ($MaxRuntimeSeconds -gt 0) {
+    (Get-Date).AddSeconds($MaxRuntimeSeconds)
+} else {
+    $sunsetAt
+}
+
+try {
+    while (-not $captured -and (Get-Date) -lt $deadline) {
+        $evt = Wait-Event -Timeout 5
+        if ($null -eq $evt) { continue }
+
+        $path = $null
+        if ($evt.SourceEventArgs -and $evt.SourceEventArgs.FullPath) {
+            $path = $evt.SourceEventArgs.FullPath
+        }
+        Remove-Event -EventIdentifier $evt.EventIdentifier -ErrorAction SilentlyContinue
+        if (-not $path) { continue }
+
+        $isEmpty = $false
+        try {
+            $item = Get-Item -LiteralPath $path -ErrorAction Stop
+            $isEmpty = (-not $item.PSIsContainer) -and ($item.Length -eq 0)
+        } catch {
+            continue
+        }
+        if (-not $isEmpty) { continue }
+
+        # Snapshot immediately, filter afterwards: waiting to confirm would let a
+        # short-lived writer exit before it can be named.
+        $dump = Save-ProcessSnapshot -TriggerPath $path
+
+        Start-Sleep -Milliseconds 250
+        $stillEmpty = $false
+        try {
+            $stillEmpty = ((Get-Item -LiteralPath $path -ErrorAction Stop).Length -eq 0)
+        } catch {
+            $stillEmpty = $false
+        }
+
+        if (-not $stillEmpty) {
+            # Transient 0-byte state from an ordinary write-then-flush. Discard so
+            # a normal editor save does not burn the single capture.
+            Remove-Item -LiteralPath $dump -Force -ErrorAction SilentlyContinue
+            continue
+        }
+
+        $captured = $true
+        Write-Log ("CAPTURED: {0} is 0 bytes. Process snapshot -> {1}" -f $path, $dump)
+
+        Start-Sleep -Seconds $BurstWindowSeconds
+        Write-Log ('Files 0 bytes after burst window: ' + ((Get-ZeroBytePath) -join '; '))
+    }
+
+    if ($captured) {
+        Write-Log 'Capture complete. Review the capture-*.txt dump; if the offender had already exited, escalate to process creation auditing (event 4688 with command lines).'
+    } elseif ((Get-Date) -ge $sunsetAt) {
+        Write-Log 'Sunset reached with no capture. Retiring this instrumentation is correct: the CI guard is the standing protection.'
+    } else {
+        Write-Log 'Max runtime reached with no capture.'
+    }
+} finally {
+    foreach ($sourceId in $subscriptions) {
+        Unregister-Event -SourceIdentifier $sourceId -ErrorAction SilentlyContinue
+    }
+    foreach ($fsw in $watchers) {
+        $fsw.EnableRaisingEvents = $false
+        $fsw.Dispose()
+    }
+}
+
+if ($captured) { exit 0 } else { exit 0 }

--- a/test/scripts/test_sync_inject_rules.py
+++ b/test/scripts/test_sync_inject_rules.py
@@ -34,5 +34,38 @@ class SyncInjectRulesTest(unittest.TestCase):
         self.assertEqual(missing, [])
 
 
+class ReadFromRefTest(unittest.TestCase):
+    """The unattended sync reads the canonical out of a ref, never the working tree."""
+
+    def test_reads_canonical_from_a_ref(self) -> None:
+        text = sync_inject_rules.read_text_from_ref("HEAD")
+
+        self.assertIsNotNone(text)
+        self.assertEqual(
+            sync_inject_rules.verify(text or "")["rule_count"],
+            sync_inject_rules.EXPECTED_RULE_COUNT,
+        )
+
+    def test_returns_none_for_unknown_ref(self) -> None:
+        # A missing ref must surface as None so the caller can fail loudly rather
+        # than silently syncing empty rules into the home file.
+        self.assertIsNone(sync_inject_rules.read_text_from_ref("no/such/ref"))
+
+    def test_ref_read_ignores_working_tree_edits(self) -> None:
+        # The whole point: the result must not depend on what the checkout happens
+        # to contain, so the daily sync is safe on any branch, clean or dirty.
+        from_ref = sync_inject_rules.read_text_from_ref("HEAD")
+        from_tree = sync_inject_rules.read_text(sync_inject_rules.CANONICAL)
+
+        self.assertIsNotNone(from_ref)
+        self.assertIsNotNone(from_tree)
+        # Committed tree and ref agree here; the guarantee is that from_ref came
+        # from the object store, which no working-tree edit can reach.
+        self.assertEqual(
+            sync_inject_rules.list_rule_ids(from_ref or ""),
+            sync_inject_rules.list_rule_ids(from_tree or ""),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
[PR #4368](https://github.com/kanta13jp1/my_web_app/pull/4368) の続き。あちらが「再発しても main に入らない」ための恒久ガード、こちらが**記録の訂正**と**危険な操作そのものの除去**。

## 1. 訂正: cron は 0 byte 化については実質無罪

2026-07-21 の記録はこの cron (`JibunKK-InjectRulesAutoSync` / 毎日 03:30) を「第一容疑」とし、MEMORY.md では ⏰ 期限つき項目として「毎日 03:30 再発しうる」と扱っていた。**この位置づけを訂正する。**

- **3 晩 (07-22/23/24) 発火して truncation ゼロ** — 毎晩同じ挙動なのに被害は 1 回だけ
- **メカニズムが不在**: dirty tree では `git pull` は overwrite 拒否で **abort しファイルに触れない** / `post-merge`・`post-checkout`・`post-rewrite` hook は 1 つも存在しない / `sync_inject_rules.py --apply` は `write_text(HOME, ...)` のみで **repo 外にしか書かない** (repo 側へ書く `--reverse` は排他グループなので cron からは呼ばれない)
- **Defender は当日 修復・検疫を一切していない** (Id 1116/1117/1015 = 0 件)
- **プロセス帰属を記録する仕組みが当時存在しなかった** (Object Access 監査 OFF / Sysmon 未導入) → **遡及的な証明は不可能**

「pull が abort し続けて配布ルールが stale」という仮説も**外れ**だった: worktree 版 7588B と origin/main 版 7515B の差はちょうど **73 行分の CRLF** で、内容は一致している。

## 2. それでも直す理由 (別の実在リスク)

07-21 に pull が無害だったのは **worktree が dirty で abort したから**という偶然にすぎない。**クリーンな晩なら `git pull origin main` は branch `codex/issue-1215-hitl` 上で成功し、Codex の WIP branch に main を無断マージする** — 推測ではなく git の定義通りの動作。加えて `2>&1 | Out-Null` で出力を捨て git の exit code も記録していないため、何が起きても永久に不可視だった。

## 3. 対処: read-only 化

`sync_inject_rules.py` に **`--from-ref`** を追加。canonical を作業ツリーではなく `git show <ref>:.claude/inject-rules.txt` から読む。cron 側は `git pull` を廃し **`git fetch` + `--from-ref origin/main`** にする (スケジュールタスクの書き換えは本 PR 外)。これで **cron は作業ツリーに触れる能力を完全に失う**。

- **既定は従来通り作業ツリー読み** — 既定を `origin/main` にすると、開発者が `.claude/inject-rules.txt` をローカル編集して `--apply` で試す作業が黙って無視されるため
- `--reverse` との併用は拒否 (exit 2)
- `--apply` の出力に `source` を含めたので、cron ログに provenance が残る

「危険な操作を条件付きで避ける」(branch ガード) より「**危険な操作そのものを消す**」方を選んだ。branch 状態・dirty 状態への依存が消える。

## 4. 一時 forensic watcher

`scripts/watch_protected_files.ps1` — 0 byte 化の瞬間に `Win32_Process` を全コマンドライン付きでダンプする。

- **repo には一切書かない** (ログは repo 外)。強制は CI 側だけに置く方針
- **捕獲 or 30 日で自己終了**。恒久デーモンではない — 放置された自動化こそ今回の診断を難しくした当のパターンなので、終了条件をコードに埋め込んでいる
- **時刻非依存**。03:30 相関は n=1 の観測で、しかもその cron 自体が上記の通り無罪になった。時刻を鍵にするのは偶然に計器を合わせる行為になる

**限界を明記しておく**: プロセススナップショットが名指しできるのは撮影時点で**生存している**プロセスだけ。数ミリ秒で exit する犯人なら時刻とファイル一覧しか取れない — それ自体が 4688 プロセス生成監査へエスカレーションすべき signal になる。

## 検証

- `sync_inject_rules` テスト **5 件通過** (新規 3: ref から読める / 不明な ref は None / ref 読みは作業ツリー編集に影響されない)
- **肝心の性質を実測**: 作業ツリーを 75 行に汚した状態で、既定は 75 行を読み (drift: True)、`--from-ref origin/main` は **73 行のまま (drift: False)** で無影響
- 終了コード: 不明な ref = 2 / `--reverse` 併用 = 2 / 正常 = 0
- **watcher は fixture で end-to-end 実証**: 2 つの木のファイルを空にして捕獲 → バースト窓が**両方**を収集 (07-21 と同型の複数ファイル同時を捉えられる) → 犯人 PID をコマンドライン付きで記録 → 捕獲後に自己停止
- ローカル品質ゲートは完走・通過 (`flutter analyze: No issues found` / deno lint 190 ファイル)

## E2E について

CI/運用スクリプトのみの変更で、アプリのコード・UI・データ経路に一切触れないため `no-e2e-needed`。ロジックは単体テストと実測・fixture 実証で担保している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### `no-e2e-needed` ラベルについて (ゲート再評価用の追記)

初回の `PR minimal E2E declaration` は fail したが、原因は**ラベルが評価時点の event payload に載っていなかった**こと (`gh pr create --label` は PR 作成後にラベルを付けるため `opened` の payload に間に合わない)。ゲート自身も `Application-code change detected: no` と判定している。

ゲートが提示する貼り付け用スニペットは「E2E テストが存在する」と宣言する文面であり、本 PR に E2E テストは無いので**貼らない** (虚偽の宣言になるため)。ラベルによる正規の適用除外で通す。
