### PR TITLE
feat(asset): 月次返済報告カード (借金返済コミュニティ向け・第1弾)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -83,6 +83,7 @@ import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_waste_training_snapshot_inputs.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
+import 'package:my_web_app/services/debt_progress_card_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
 import 'package:my_web_app/services/disposable_balance_asset_liability_adapter.dart';
 import 'package:my_web_app/services/disposable_balance_service.dart';
@@ -98,6 +99,7 @@ import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
+import 'package:my_web_app/widgets/debt_progress_share_dialog.dart';
 import 'package:my_web_app/widgets/asset_alert_center_card.dart';
 import 'package:my_web_app/widgets/asset_cashflow_statement_card.dart';
 import 'package:my_web_app/widgets/asset_dashboard_grid.dart';
@@ -22302,6 +22304,37 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  /// 返済進捗カードのプレビューを開く。
+  ///
+  /// 🔴 ここでは投稿しない。カード画像と下書き文面を用意するだけで、
+  /// 公開するかどうかは必ず本人が決める (取り消し不能な個人情報のため)。
+  Future<void> _openDebtProgressShare() async {
+    final workbook = _buildCurrentAssetLiabilityWorkbook();
+    if (workbook == null) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('資産負債データを読み込めませんでした')));
+      return;
+    }
+    const service = DebtProgressCardService();
+    final data = service.build(
+      workbook: workbook,
+      priorBalancesByAccountId: _assetDebtTrendPriorBalances,
+    );
+    if (!mounted) return;
+    if (data == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('返済対象の負債がありません')));
+      return;
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (_) => DebtProgressShareDialog(data: data, month: _now),
+    );
+  }
+
   Widget _buildAssetManagementMonthlyDebtTrendList(
     List<AssetDebtTrendInsight> insights,
   ) {
@@ -22338,6 +22371,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     height: 1.4,
                   ),
                 ),
+              ),
+              IconButton(
+                key: const Key('debt_progress_share_button'),
+                tooltip: '今月の返済報告カードを作る',
+                icon: Icon(Icons.ios_share, color: headerColor, size: 18),
+                onPressed: _openDebtProgressShare,
               ),
               if (_householdTrackerScheduleAllowed)
                 IconButton(

--- a/lib/services/debt_progress_card_service.dart
+++ b/lib/services/debt_progress_card_service.dart
@@ -1,0 +1,202 @@
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_repayment_simulation_service.dart';
+
+/// 借金返済の月次進捗カード用データ (借金返済コミュニティ向けの公開投稿)。
+///
+/// 🔒 **開示範囲は型で固定する**。このカードは当事者として実名で公開の場に
+/// 投稿されるため、身元特定・与信審査・就業に波及しうる情報は
+/// **フィールドとして持たない**。載せる/載せないの判断をUI側の書き忘れに
+/// 依存させると、一度の事故で取り消し不能な開示になる。
+///
+/// 載せる: 残債総額 / 今月の返済予定額 / 完済予定 / 利息見込み / 前月比 / 件数
+/// 載せない: 年収・月収 / 口座残高 / 借入先名 / 勤務先 / 支払元口座
+class DebtProgressCardData {
+  /// 残債総額 (円 / 正の値)。
+  final double totalDebt;
+
+  /// 今月の返済予定額の合計 (円)。
+  final double monthlyPayment;
+
+  /// 現在の返済額を続けた場合の完済までの月数。
+  /// null = 現在の返済額では完済しない (返済が利息に追いつかない等)。
+  final int? payoffMonths;
+
+  /// 完済までに支払う利息の見込み総額 (円)。
+  /// payoffMonths が null のときは信頼できる総額を出せないので null。
+  final double? estimatedInterest;
+
+  /// 前月比の残債増減 (円 / 負値 = 減った)。
+  /// null = 比較できる前月データが無い。
+  final double? monthOverMonthDelta;
+
+  /// 返済対象の負債件数。**名前は持たない** (借入先が分かると特定に繋がる)。
+  final int debtCount;
+
+  const DebtProgressCardData({
+    required this.totalDebt,
+    required this.monthlyPayment,
+    required this.payoffMonths,
+    required this.estimatedInterest,
+    required this.monthOverMonthDelta,
+    required this.debtCount,
+  });
+
+  /// 前月より残債が減ったか。前月データが無いときは null。
+  bool? get isImproving {
+    final delta = monthOverMonthDelta;
+    if (delta == null) return null;
+    return delta < 0;
+  }
+
+  /// 完済予定を「◯年◯ヶ月」に整形する。完済しない場合は null。
+  String? get payoffLabel {
+    final months = payoffMonths;
+    if (months == null) return null;
+    if (months < 12) return '$monthsヶ月';
+    final years = months ~/ 12;
+    final rest = months % 12;
+    return rest == 0 ? '$years年' : '$years年$restヶ月';
+  }
+}
+
+/// ワークブックから進捗カードのデータを組み立てる純サービス。
+///
+/// Supabase / 認証 / ネットワークに依存しない。
+class DebtProgressCardService {
+  const DebtProgressCardService();
+
+  /// 投稿の下書き文面を組み立てる。
+  ///
+  /// **草案であって確定文ではない**。投稿前にユーザーが必ず編集できる前提で、
+  /// 界隈の慣習 (残債・今月の返済・完済目標を淡々と report する) に寄せた
+  /// たたき台を返す。
+  ///
+  /// 🔒 ここでも開示境界を守る: [DebtProgressCardData] が持たない情報は
+  /// そもそも参照できないので、文面に年収・口座残高・借入先名は混入しない。
+  String buildDraftText(
+    DebtProgressCardData card, {
+    required DateTime month,
+    List<String> hashtags = const <String>['#借金返済', '#家計簿'],
+  }) {
+    final lines = <String>[
+      '【${month.year}年${month.month}月の返済報告】',
+      '残債 ${_yen(card.totalDebt)}${_deltaSuffix(card.monthOverMonthDelta)}',
+      '今月の返済 ${_yen(card.monthlyPayment)}',
+    ];
+    final payoff = card.payoffLabel;
+    if (payoff != null) {
+      lines.add('このペースで完済まで あと$payoff');
+    } else {
+      // 完済しない見込みを黙って省くと、報告として誠実でなくなる。
+      lines.add('※ 今の返済額だと元金が減りません(要見直し)');
+    }
+    final interest = card.estimatedInterest;
+    if (interest != null) {
+      lines.add('完済までの利息見込み ${_yen(interest)}');
+    }
+    if (hashtags.isNotEmpty) {
+      lines
+        ..add('')
+        ..add(hashtags.join(' '));
+    }
+    return lines.join('\n');
+  }
+
+  String _deltaSuffix(double? delta) {
+    if (delta == null) return '';
+    if (delta == 0) return '(前月比 ±0円)';
+    final sign = delta < 0 ? '-' : '+';
+    return '(前月比 $sign${_yen(delta.abs())})';
+  }
+
+  static String _yen(double value) {
+    final rounded = value.round();
+    final digits = rounded.abs().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+      buffer.write(digits[i]);
+    }
+    return '${rounded < 0 ? '-' : ''}$buffer円';
+  }
+
+  /// 完済月数と利息見込みの算出基準に使う戦略。
+  ///
+  /// 繰り上げ返済なし (extra = 0) の比較なので戦略差はほぼ出ないが、
+  /// **カードの数字が実行ごとにブレないよう固定する**。
+  static const AssetLiabilityRepaymentSimulationStrategy _basisStrategy =
+      AssetLiabilityRepaymentSimulationStrategy.interestRate;
+
+  /// 進捗カードを組み立てる。返済対象の負債が無ければ null。
+  ///
+  /// [priorBalancesByAccountId] は前月の残高スナップショット
+  /// (`AssetAccountBalanceHistoryStore.priorMonthBalances` /
+  /// **accountId -> 利用残高の絶対額 (正の値)**)。空なら前月比は null。
+  DebtProgressCardData? build({
+    required AssetLiabilityWorkbook workbook,
+    Map<String, double> priorBalancesByAccountId = const <String, double>{},
+  }) {
+    const simulation = AssetLiabilityRepaymentSimulationService();
+    // 繰り上げ返済なしの基準プラン = 「今のままだとこうなる」。
+    final result = simulation.buildComparison(workbook: workbook);
+    final basis = result.baselinePlanFor(_basisStrategy);
+    if (basis == null || basis.priorityRows.isEmpty) return null;
+
+    // 🔑 対象集合はシミュレーションが選んだものをそのまま使う。
+    // ここで自前の絞り込み条件を書くと、カードの「残債総額」と
+    // 「完済予定」が別々の集合を指し、合わない数字を公開してしまう。
+    final eligibleIds = <String>{
+      for (final row in basis.priorityRows) row.id,
+    };
+
+    final payoffMonths = basis.estimatedPayoffMonths;
+    // 完済しない場合の利息総額はシミュレーション打ち切り時点の部分和でしかなく、
+    // 「完済までに払う利息」として出すと実際より小さい額を約束することになる。
+    final estimatedInterest =
+        payoffMonths == null ? null : basis.estimatedInterestTotal;
+
+    return DebtProgressCardData(
+      totalDebt: basis.startingBalanceTotal,
+      monthlyPayment: result.baseMonthlyPayment,
+      payoffMonths: payoffMonths,
+      estimatedInterest: estimatedInterest,
+      monthOverMonthDelta: _monthOverMonthDelta(
+        workbook: workbook,
+        eligibleIds: eligibleIds,
+        priorBalancesByAccountId: priorBalancesByAccountId,
+      ),
+      debtCount: basis.priorityRows.length,
+    );
+  }
+
+  /// 前月比を出す。
+  ///
+  /// 🔴 **符号規約が両者で違う**: ワークブックの負債 `balance` は負値、
+  /// 履歴ストアの前月残高は絶対額 (正)。素直に引き算すると符号が反転し、
+  /// 返済が進んでいるのに「増えた」と公開投稿してしまう。両辺とも
+  /// **絶対額に正規化**してから比較する。
+  ///
+  /// 🔑 **前月に記録が無い負債は比較から除外する**。0円として扱うと、
+  /// 記録を始めたばかりの負債が「今月まるごと増えた」ように見える。
+  /// 比較可能な行が1件も無ければ null (= カードに前月比を出さない)。
+  double? _monthOverMonthDelta({
+    required AssetLiabilityWorkbook workbook,
+    required Set<String> eligibleIds,
+    required Map<String, double> priorBalancesByAccountId,
+  }) {
+    if (priorBalancesByAccountId.isEmpty) return null;
+    double current = 0;
+    double prior = 0;
+    var comparable = 0;
+    for (final row in workbook.debtMasterRows) {
+      if (!eligibleIds.contains(row.id)) continue;
+      final priorBalance = priorBalancesByAccountId[row.id];
+      if (priorBalance == null) continue;
+      current += row.balance.abs();
+      prior += priorBalance.abs();
+      comparable += 1;
+    }
+    if (comparable == 0) return null;
+    return current - prior;
+  }
+}

--- a/lib/widgets/debt_progress_card.dart
+++ b/lib/widgets/debt_progress_card.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:my_web_app/services/debt_progress_card_service.dart';
+
+/// 借金返済の月次進捗カード (公開投稿用の画像として書き出される)。
+///
+/// 🔒 描画するのは [DebtProgressCardData] が持つ項目だけ。
+/// 年収・口座残高・借入先名はモデルに存在しないので描画しようがない。
+class DebtProgressCard extends StatelessWidget {
+  final DebtProgressCardData data;
+  final DateTime month;
+
+  /// 画像化したときに読める固定幅。SNS のタイムラインでの視認性を優先する。
+  static const double cardWidth = 480;
+
+  const DebtProgressCard({super.key, required this.data, required this.month});
+
+  @override
+  Widget build(BuildContext context) {
+    final delta = data.monthOverMonthDelta;
+    final improving = data.isImproving;
+    return Container(
+      width: cardWidth,
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: <Color>[Color(0xFF0F172A), Color(0xFF1E293B)],
+        ),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${month.year}年${month.month}月の返済報告',
+            style: const TextStyle(
+              color: Color(0xFF94A3B8),
+              fontSize: 13,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            '残債',
+            style: TextStyle(color: Color(0xFF94A3B8), fontSize: 12),
+          ),
+          const SizedBox(height: 2),
+          // 桁数が伸びても崩れないよう縮小に逃がす (金額は桁が増えるほど
+          // 重要なのに、はみ出して切れると読めなくなる)。
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Flexible(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    _yen(data.totalDebt),
+                    maxLines: 1,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 34,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              if (delta != null) ...[
+                const SizedBox(width: 10),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(
+                    '${delta < 0 ? '−' : '+'}${_yen(delta.abs())}',
+                    maxLines: 1,
+                    style: TextStyle(
+                      // 借金は減る方が良い = 減少を緑にする。増加を緑にすると
+                      // 悪化を好調に見せてしまう。
+                      color: improving == true
+                          ? const Color(0xFF4ADE80)
+                          : const Color(0xFFF87171),
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: 20),
+          _row('今月の返済', _yen(data.monthlyPayment)),
+          const SizedBox(height: 10),
+          _row(
+            '完済まで',
+            data.payoffLabel == null ? '— (要見直し)' : 'あと${data.payoffLabel}',
+            emphasize: data.payoffLabel == null,
+          ),
+          if (data.estimatedInterest != null) ...[
+            const SizedBox(height: 10),
+            _row('利息見込み', _yen(data.estimatedInterest!)),
+          ],
+          const SizedBox(height: 18),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '返済中 ${data.debtCount}件',
+                style: const TextStyle(
+                  color: Color(0xFF64748B),
+                  fontSize: 11,
+                ),
+              ),
+              const Text(
+                '自分株式会社',
+                style: TextStyle(
+                  color: Color(0xFF64748B),
+                  fontSize: 11,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _row(String label, String value, {bool emphasize = false}) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(color: Color(0xFF94A3B8), fontSize: 13),
+        ),
+        Text(
+          value,
+          style: TextStyle(
+            color: emphasize ? const Color(0xFFFBBF24) : Colors.white,
+            fontSize: 17,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  static String _yen(double value) {
+    final rounded = value.round();
+    final digits = rounded.abs().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+      buffer.write(digits[i]);
+    }
+    return '${rounded < 0 ? '-' : ''}$buffer円';
+  }
+}

--- a/lib/widgets/debt_progress_share_dialog.dart
+++ b/lib/widgets/debt_progress_share_dialog.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:my_web_app/services/debt_progress_card_service.dart';
+import 'package:my_web_app/services/note_card_service.dart';
+import 'package:my_web_app/utils/web_image_downloader.dart';
+import 'package:my_web_app/widgets/debt_progress_card.dart';
+
+/// 返済進捗カードの共有ダイアログ。
+///
+/// 🔴 **HITL 厳守**: ここから自動投稿はしない。カード画像と下書き文面を
+/// 用意するだけで、実際に X へ投稿するかどうか・何を書くかは必ず本人が
+/// 決める。公開すると取り消せない個人情報なので、自動化してはいけない。
+class DebtProgressShareDialog extends StatefulWidget {
+  final DebtProgressCardData data;
+  final DateTime month;
+
+  const DebtProgressShareDialog({
+    super.key,
+    required this.data,
+    required this.month,
+  });
+
+  @override
+  State<DebtProgressShareDialog> createState() =>
+      _DebtProgressShareDialogState();
+}
+
+class _DebtProgressShareDialogState extends State<DebtProgressShareDialog> {
+  final GlobalKey _repaintKey = GlobalKey();
+  late final TextEditingController _textController;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    const service = DebtProgressCardService();
+    _textController = TextEditingController(
+      text: service.buildDraftText(widget.data, month: widget.month),
+    );
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('今月の返済報告を作る'),
+      content: SizedBox(
+        width: 520,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '公開前に必ず内容を確認してください。投稿は自動では行いません。',
+                style: TextStyle(fontSize: 12, color: Color(0xFF64748B)),
+              ),
+              const SizedBox(height: 12),
+              Center(
+                child: RepaintBoundary(
+                  key: _repaintKey,
+                  child: DebtProgressCard(
+                    data: widget.data,
+                    month: widget.month,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                '投稿文(編集できます)',
+                style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 6),
+              TextField(
+                controller: _textController,
+                maxLines: 8,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                style: const TextStyle(fontSize: 13),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('閉じる'),
+        ),
+        TextButton.icon(
+          onPressed: _copyText,
+          icon: const Icon(Icons.copy, size: 16),
+          label: const Text('文面をコピー'),
+        ),
+        FilledButton.icon(
+          onPressed: _saving ? null : _downloadCard,
+          icon: _saving
+              ? const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.download, size: 16),
+          label: const Text('カード画像を保存'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _copyText() async {
+    await Clipboard.setData(ClipboardData(text: _textController.text));
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('投稿文をコピーしました')));
+  }
+
+  Future<void> _downloadCard() async {
+    setState(() => _saving = true);
+    try {
+      // 描画完了を待ってからキャプチャする (未確定フレームだと空画像になる)。
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      final bytes = await NoteCardService.captureWidgetSimple(_repaintKey);
+      if (bytes == null) throw Exception('画像の生成に失敗しました');
+      final name = 'debt_progress_${widget.month.year}'
+          '${widget.month.month.toString().padLeft(2, '0')}.png';
+      downloadImageFile(bytes, name);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('カード画像を保存しました。Xに添付して投稿してください')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('保存に失敗しました: $error')));
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+}

--- a/test/services/debt_progress_card_service_test.dart
+++ b/test/services/debt_progress_card_service_test.dart
@@ -1,0 +1,255 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+import 'package:my_web_app/services/debt_progress_card_service.dart';
+
+void main() {
+  const planner = AssetLiabilityPlanningService();
+  const service = DebtProgressCardService();
+  final baseDate = DateTime(2026, 7, 1);
+
+  AssetLiabilityWorkbook workbookWith({
+    required Map<String, double> snapshot,
+    Map<String, double> payments = const <String, double>{},
+  }) {
+    return planner.buildWorkbook(
+      latestSnapshot: snapshot,
+      baseDate: baseDate,
+      monthlyPaymentOverrides: payments,
+    );
+  }
+
+  String debtId(AssetLiabilityWorkbook workbook, String name) {
+    return workbook.debtMasterRows.firstWhere((row) => row.name == name).id;
+  }
+
+  group('DebtProgressCardService.build', () {
+    test('returns null when there is no debt to report', () {
+      final workbook = workbookWith(
+        snapshot: const <String, double>{'bank': 500000},
+      );
+
+      expect(service.build(workbook: workbook), isNull);
+    });
+
+    test('summarises total debt, monthly payment and payoff horizon', () {
+      final workbook = workbookWith(
+        snapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -100000,
+        },
+        payments: const <String, double>{'ファミペイ': 10000},
+      );
+
+      final card = service.build(workbook: workbook);
+
+      expect(card, isNotNull);
+      expect(card!.totalDebt, 100000);
+      expect(card.monthlyPayment, 10000);
+      expect(card.debtCount, 1);
+      expect(card.payoffMonths, isNotNull);
+      // 利息総額は「完済する」ときだけ意味を持つ。
+      expect(card.estimatedInterest, isNotNull);
+      expect(card.estimatedInterest! > 0, isTrue);
+    });
+
+    test(
+      'omits the interest total when the current payment never clears the debt',
+      () {
+        // 月1,000円は初月利息を下回る → 完済しない。
+        final workbook = workbookWith(
+          snapshot: const <String, double>{
+            'bank': 500000,
+            'ファミペイ': -100000,
+          },
+          payments: const <String, double>{'ファミペイ': 1000},
+        );
+
+        final card = service.build(workbook: workbook);
+
+        expect(card, isNotNull);
+        expect(card!.payoffMonths, isNull);
+        // 打ち切り時点の部分和を「完済までに払う利息」として出すと
+        // 実際より小さい額を約束することになるため出さない。
+        expect(card.estimatedInterest, isNull);
+      },
+    );
+  });
+
+  group('DebtProgressCardService month-over-month', () {
+    test('is null when no prior month snapshot exists', () {
+      final workbook = workbookWith(
+        snapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -100000,
+        },
+        payments: const <String, double>{'ファミペイ': 10000},
+      );
+
+      final card = service.build(workbook: workbook);
+
+      expect(card!.monthOverMonthDelta, isNull);
+      expect(card.isImproving, isNull);
+    });
+
+    test('reports a decrease as negative delta and improving', () {
+      final workbook = workbookWith(
+        snapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -90000,
+        },
+        payments: const <String, double>{'ファミペイ': 10000},
+      );
+      final id = debtId(workbook, 'ファミペイ');
+
+      final card = service.build(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{id: 100000},
+      );
+
+      expect(card!.monthOverMonthDelta, -10000);
+      expect(card.isImproving, isTrue);
+    });
+
+    test(
+      'excludes debts with no prior record instead of treating them as zero',
+      () {
+        // 🔑 前月に記録が無い負債を 0 円扱いすると「今月まるごと増えた」と
+        // 出てしまい、実際は返済が進んでいるのに増加と報告する事故になる。
+        final workbook = workbookWith(
+          snapshot: const <String, double>{
+            'bank': 500000,
+            'ファミペイ': -90000,
+            'newcard': -300000,
+          },
+          payments: const <String, double>{
+            'ファミペイ': 10000,
+            'newcard': 20000,
+          },
+        );
+        final trackedId = debtId(workbook, 'ファミペイ');
+
+        final card = service.build(
+          workbook: workbook,
+          priorBalancesByAccountId: <String, double>{trackedId: 100000},
+        );
+
+        // 記録のある1件だけで比較する = -10,000 (新規カードの30万は混ぜない)。
+        expect(card!.monthOverMonthDelta, -10000);
+        expect(card.isImproving, isTrue);
+        // 残債総額そのものは全件の合計であることは変わらない。
+        expect(card.totalDebt, 390000);
+        expect(card.debtCount, 2);
+      },
+    );
+
+    test('is null when none of the current debts have a prior record', () {
+      final workbook = workbookWith(
+        snapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -90000,
+        },
+        payments: const <String, double>{'ファミペイ': 10000},
+      );
+
+      final card = service.build(
+        workbook: workbook,
+        priorBalancesByAccountId: const <String, double>{
+          'unrelated-account': 100000,
+        },
+      );
+
+      expect(card!.monthOverMonthDelta, isNull);
+    });
+  });
+
+  group('DebtProgressCardService.buildDraftText', () {
+    DebtProgressCardData card({
+      int? payoffMonths = 38,
+      double? interest = 234567,
+      double? delta = -50000,
+    }) =>
+        DebtProgressCardData(
+          totalDebt: 1234567,
+          monthlyPayment: 45000,
+          payoffMonths: payoffMonths,
+          estimatedInterest: interest,
+          monthOverMonthDelta: delta,
+          debtCount: 3,
+        );
+
+    test('reports the disclosed figures with a signed month-over-month delta',
+        () {
+      final text = service.buildDraftText(
+        card(),
+        month: DateTime(2026, 7, 1),
+      );
+
+      expect(text, contains('2026年7月の返済報告'));
+      expect(text, contains('残債 1,234,567円'));
+      expect(text, contains('前月比 -50,000円'));
+      expect(text, contains('今月の返済 45,000円'));
+      expect(text, contains('完済まで あと3年2ヶ月'));
+      expect(text, contains('利息見込み 234,567円'));
+      expect(text, contains('#借金返済'));
+    });
+
+    test('omits the delta line entirely when there is no prior month', () {
+      final text = service.buildDraftText(
+        card(delta: null),
+        month: DateTime(2026, 7, 1),
+      );
+
+      expect(text, isNot(contains('前月比')));
+    });
+
+    test('states plainly when the current payment never clears the debt', () {
+      // 完済しない事実を黙って省くと報告として誠実でなくなる。
+      final text = service.buildDraftText(
+        card(payoffMonths: null, interest: null),
+        month: DateTime(2026, 7, 1),
+      );
+
+      expect(text, contains('元金が減りません'));
+      expect(text, isNot(contains('利息見込み')));
+    });
+
+    test('never leaks income, account balances or lender names', () {
+      // 🔒 開示境界の回帰ガード。カード型がこれらを持たない以上、文面にも
+      // 出得ないが、将来フィールドを足したときにここで気付けるようにする。
+      final text = service.buildDraftText(
+        card(),
+        month: DateTime(2026, 7, 1),
+      );
+
+      for (final forbidden in <String>[
+        '年収',
+        '月収',
+        '手取り',
+        '口座残高',
+        '残高照会',
+        '勤務先',
+      ]) {
+        expect(text, isNot(contains(forbidden)), reason: '$forbidden は開示範囲外');
+      }
+    });
+  });
+
+  group('DebtProgressCardData.payoffLabel', () {
+    test('formats months, years and mixed spans', () {
+      DebtProgressCardData card(int? months) => DebtProgressCardData(
+            totalDebt: 1000,
+            monthlyPayment: 100,
+            payoffMonths: months,
+            estimatedInterest: 0,
+            monthOverMonthDelta: null,
+            debtCount: 1,
+          );
+
+      expect(card(11).payoffLabel, '11ヶ月');
+      expect(card(12).payoffLabel, '1年');
+      expect(card(25).payoffLabel, '2年1ヶ月');
+      expect(card(null).payoffLabel, isNull);
+    });
+  });
+}

--- a/test/widgets/debt_progress_card_test.dart
+++ b/test/widgets/debt_progress_card_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/debt_progress_card_service.dart';
+import 'package:my_web_app/widgets/debt_progress_card.dart';
+
+void main() {
+  DebtProgressCardData cardData({
+    int? payoffMonths = 38,
+    double? interest = 234567,
+    double? delta = -50000,
+  }) =>
+      DebtProgressCardData(
+        totalDebt: 1234567,
+        monthlyPayment: 45000,
+        payoffMonths: payoffMonths,
+        estimatedInterest: interest,
+        monthOverMonthDelta: delta,
+        debtCount: 3,
+      );
+
+  Future<void> pump(WidgetTester tester, DebtProgressCardData data) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: DebtProgressCard(data: data, month: DateTime(2026, 7, 1)),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders the disclosed figures', (tester) async {
+    await pump(tester, cardData());
+
+    expect(find.text('2026年7月の返済報告'), findsOneWidget);
+    expect(find.text('1,234,567円'), findsOneWidget);
+    expect(find.text('45,000円'), findsOneWidget);
+    expect(find.text('あと3年2ヶ月'), findsOneWidget);
+    expect(find.text('234,567円'), findsOneWidget);
+    expect(find.text('返済中 3件'), findsOneWidget);
+  });
+
+  testWidgets('shows a decrease in green and an increase in red', (
+    tester,
+  ) async {
+    // 借金は減る方が良い。増加を緑にすると悪化を好調に見せてしまう。
+    await pump(tester, cardData(delta: -50000));
+    final decrease = tester.widget<Text>(find.text('−50,000円'));
+    expect(decrease.style?.color, const Color(0xFF4ADE80));
+
+    await pump(tester, cardData(delta: 30000));
+    final increase = tester.widget<Text>(find.text('+30,000円'));
+    expect(increase.style?.color, const Color(0xFFF87171));
+  });
+
+  testWidgets('flags a non-clearing payment instead of hiding it', (
+    tester,
+  ) async {
+    await pump(tester, cardData(payoffMonths: null, interest: null));
+
+    expect(find.text('— (要見直し)'), findsOneWidget);
+    // 完済しないときに利息見込みを出すと、実際より小さい額を約束してしまう。
+    expect(find.text('利息見込み'), findsNothing);
+  });
+
+  testWidgets('omits the delta chip when there is no prior month', (
+    tester,
+  ) async {
+    await pump(tester, cardData(delta: null));
+
+    expect(find.textContaining('前月比'), findsNothing);
+    expect(find.textContaining('−'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

借金返済コミュニティ向けの**月次返済報告カード**を追加します。/grilling で「収益/成長へ軸足を移す」「ICPを『リボ払い・借金からの生活再建』1つに絞る」「進捗カードを先行出荷する」と合意した第1弾です。

- `DebtProgressCardService` (純関数 / Supabase・認証・ネットワーク非依存)
- `DebtProgressCard` ウィジェット (SNS 投稿用の画像として書き出す)
- `DebtProgressShareDialog` — プレビュー + **編集可能な**下書き文面 + 画像保存
- 家計トラッカーのヘッダーに導線を1つ追加

## 設計判断 (レビュー観点)

**🔒 開示範囲を型で固定した**。カードは当事者として実名で公開の場に投稿されるため、身元特定・与信・就業に波及しうる情報は `DebtProgressCardData` の**フィールドとして持たない**。載せる/載せないの判断を UI 側の書き忘れに依存させると、一度の事故で取り消し不能な開示になる。載せるのは 残債総額 / 今月の返済予定額 / 完済予定 / 利息見込み / 前月比 / 件数 のみ。年収・口座残高・借入先名は型に存在しない。

**🔴 符号規約の不一致を実測で発見して潰した**。ワークブックの負債 `balance` は**負値**、履歴ストアの前月残高は**絶対額(正)**。素直に引き算すると符号が反転し、**返済が進んでいるのに「増えた」と実名で誤報**する。両辺を絶対額に正規化し、実測値 (-10,000) でテスト固定。

**🔑 対象集合をシミュレーションから貰う**。自前の絞り込み条件を書くと「残債総額」と「完済予定」が別々の集合を指し、噛み合わない数字を公開してしまう。`baselinePlanFor().priorityRows` を唯一の真実として使う。

**完済しない場合は利息総額を出さない**。打ち切り時点の部分和を「完済までに払う利息」として提示すると、実際より小さい額を約束することになる。代わりに「元金が減りません(要見直し)」と明示する。

**🔴 HITL 厳守 / 自動投稿しない**。カード画像と下書きを用意するだけで、公開するかは必ず本人が決める。取り消せない個人情報のため自動化しない。

**借金は減る方が良い**ので前月比の減少を緑・増加を赤にした (逆にすると悪化を好調に見せる)。

## 検証

- unit 12件 + widget 4件 = **16件 green**
- ウィジェットテストが**実レイアウトのオーバーフローを検出**したので `FittedBox` で修正済み (画像化したとき金額が切れる実害あり)
- `flutter analyze` No issues / `dart format` clean

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: local-only card rendering and clipboard/download helpers with no network or server state; covered by 16 unit and widget tests including the disclosure-boundary guard

## High-Risk Ultrareview

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: additive pure service plus a preview-only dialog; no migration, no Edge Function, no auto-posting, and the disclosure boundary is enforced at the type level with a regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
