### PR TITLE
feat(x-growth): scope winner selection to the ICP topic cohort

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -37,8 +37,10 @@ import {
 } from "./x_analytics_import.ts";
 import {
   buildArchetypeTopicInteractionLine,
+  buildIcpScopeLine,
   buildTopicLiftLine,
   classifyPostTopic,
+  selectIcpCohort,
 } from "./x_topic_audience.ts";
 import {
   buildSignupSlackPayload,
@@ -1110,13 +1112,29 @@ function buildXPerformanceContextFromLogs(
     right.acquisitionScore - left.acquisitionScore ||
     (right.rankingImpressions ?? -1) - (left.rankingImpressions ?? -1)
   );
-  const winners = acquisitionRanked.slice(0, 5);
-  const underperformers = acquisitionRanked.slice(-5).reverse();
+  // R28: 勝ち exemplar と勝ち型は ICP トピックのコホート内で選ぶ。実測では
+  // URL クリックの 94% が japan_politics の定点観測シリーズから出ており、
+  // 素朴に最大値を取ると学習ループが「政治の集計レポートを再生産せよ」と
+  // 指示する。2026-07-28 の戦略確定で楔は「借金・リボ払いからの生活再建」に
+  // 絞られており、その受け手は楔の客ではない。
+  // コホートが薄いときはグローバルへ落ちず、勝者を宣言しない (落とすと
+  // 政治シリーズが復活し、このスコープの意味が消える)。
+  const icpCohort = selectIcpCohort(
+    acquisitionRanked,
+    (row) => row.topic,
+  );
+  const icpScopeLine = buildIcpScopeLine(icpCohort);
+  const winners = icpCohort.sufficient ? icpCohort.rows.slice(0, 5) : [];
+  const underperformers = icpCohort.sufficient
+    ? icpCohort.rows.slice(-5).reverse()
+    : [];
   const byVariant = new Map<
     string,
     { variant: string; count: number; totalScore: number; maxScore: number }
   >();
-  for (const row of learningRows) {
+  // R28: 勝ち型 (variant) も ICP コホート内で数える。グローバルで数えると
+  // 政治シリーズの variant が「勝ち型」として昇格してしまう。
+  for (const row of (icpCohort.sufficient ? icpCohort.rows : [])) {
     const key = row.variant || "unknown";
     const current = byVariant.get(key) ?? {
       variant: key,
@@ -1354,6 +1372,7 @@ function buildXPerformanceContextFromLogs(
       `(comparable n=${learningRows.length}; total measured n=${rows.length}). ` +
       `Optimize for site visits and replies, not for raw reach.`,
       ...(acquisitionLine ? [acquisitionLine] : []),
+      icpScopeLine,
       ...winners.map((row, index) =>
         `Winner ${
           index + 1

--- a/supabase/functions/growth-hub/x_topic_audience.ts
+++ b/supabase/functions/growth-hub/x_topic_audience.ts
@@ -17,9 +17,15 @@
 export type TopicBucket =
   | "japan_politics"
   | "ai_tech"
+  | "debt_recovery"
   | "household_finance"
   | "product"
   | "general";
+
+/// R28: 楔 (2026-07-28 の戦略確定) の ICP トピック。到達だけを見ると
+/// japan_politics が常に勝つが、その受け手は楔の客ではない。勝ち型の選定は
+/// このコホート内で行う (下の [selectIcpCohort])。
+export const ICP_TARGET_TOPIC: TopicBucket = "debt_recovery";
 
 /// 既存オーディエンスを持つ固有名詞アンカー。ここに載る語が本文にあると、
 /// その語のフォロワー/検索面に乗る (= 自力のフォロワー数を超えて配信される)。
@@ -55,6 +61,24 @@ const AI_TECH_ANCHORS = [
   "supabase",
   "ai",
 ];
+/// 借金・リボ払いからの生活再建 (楔の ICP)。家計一般より狭く、当事者コミュニティ
+/// の語彙に寄せる。分類のみに使う語であり、助言や法律判断には一切用いない
+/// (非弁行為の一線を越えないため、債務整理系の語も「その話題である」ことの
+/// 検出だけに使う)。
+const DEBT_RECOVERY_ANCHORS = [
+  "リボ",
+  "借金",
+  "返済",
+  "完済",
+  "残債",
+  "滞納",
+  "延滞",
+  "多重債務",
+  "自転車操業",
+  "任意整理",
+  "債務整理",
+  "繰り上げ",
+];
 const FINANCE_ANCHORS = [
   "家計",
   "資産",
@@ -81,8 +105,8 @@ function hits(haystack: string, needles: readonly string[]): number {
 export function normalizeTopicBucket(raw: string): TopicBucket {
   const v = (raw ?? "").toLowerCase().trim();
   if (
-    v === "japan_politics" || v === "ai_tech" || v === "household_finance" ||
-    v === "product" || v === "general"
+    v === "japan_politics" || v === "ai_tech" || v === "debt_recovery" ||
+    v === "household_finance" || v === "product" || v === "general"
   ) {
     return v;
   }
@@ -95,10 +119,14 @@ export function normalizeTopicBucket(raw: string): TopicBucket {
 export function classifyPostTopic(text: string): TopicBucket {
   const body = (text ?? "").toLowerCase();
   const politics = hits(text ?? "", POLITICS_ANCHORS);
+  const debt = hits(text ?? "", DEBT_RECOVERY_ANCHORS);
   const finance = hits(text ?? "", FINANCE_ANCHORS);
   const aiTech = hits(body, AI_TECH_ANCHORS);
   const product = hits(body, PRODUCT_ANCHORS);
   if (politics >= 1) return "japan_politics";
+  // 借金・リボは家計一般より狭いので先に判定する (「返済」「残債」を
+  // household_finance に吸わせると ICP コホートが永久に空になる)。
+  if (debt >= 1) return "debt_recovery";
   if (finance >= 1 && finance >= aiTech) return "household_finance";
   if (aiTech >= 1) return "ai_tech";
   if (product >= 1) return "product";
@@ -125,6 +153,7 @@ export function buildTopicLiftLine<T>(
       list.reduce((sum, row) => sum + scoreOf(row), 0) / list.length,
     );
   const order: TopicBucket[] = [
+    "debt_recovery",
     "japan_politics",
     "ai_tech",
     "household_finance",
@@ -191,4 +220,61 @@ export function buildArchetypeTopicInteractionLine<T>(
   return `Archetype x topic interaction: ${described.join("; ")}. ` +
     `The same archetype does not transfer across topics — do not reuse a ` +
     `winning format on a topic where it has not been measured.`;
+}
+
+/// R28: 勝ち型の選定を ICP トピックのコホート内に閉じる。
+///
+/// なぜ必要か: 実測 (2026-04-27〜07-25 / 350 投稿) では URL クリックの 94% が
+/// japan_politics の定点観測シリーズから出ている。到達・獲得ともグローバル最大
+/// なので、素朴に最大値を取ると学習ループは「政治の集計レポートを再生産せよ」と
+/// 指示する。だが 2026-07-28 の戦略確定で楔は「借金・リボ払いからの生活再建」に
+/// 絞られており、その受け手は楔の客ではない。数字が大きいことと、客に届いている
+/// ことは別問題。
+///
+/// 重要: サンプルが足りないとき **グローバル最大へ黙って落ちない**。落ちると
+/// 政治シリーズが勝者として復活し、この関数の意味が消える。足りなければ
+/// `sufficient: false` を返し、呼び出し側は「勝者を宣言しない」を選ぶ。
+export interface IcpCohortSelection<T> {
+  rows: readonly T[];
+  sufficient: boolean;
+  target: TopicBucket;
+  totalCount: number;
+}
+
+/// ICP コホートを切り出す。既定の最小サンプルは 2 (他の lift 行と同じ基準)。
+export function selectIcpCohort<T>(
+  rows: readonly T[],
+  topicOf: (row: T) => string,
+  options: { target?: TopicBucket; minSamples?: number } = {},
+): IcpCohortSelection<T> {
+  const target = options.target ?? ICP_TARGET_TOPIC;
+  const minSamples = options.minSamples ?? 2;
+  const scoped = rows.filter((row) =>
+    normalizeTopicBucket(topicOf(row)) === target
+  );
+  return {
+    rows: scoped,
+    sufficient: scoped.length >= minSamples,
+    target,
+    totalCount: rows.length,
+  };
+}
+
+/// x.performance_context に出す ICP スコープ行。コホートが薄いときは
+/// 「グローバルの勝者を手本にするな」と明示する (沈黙すると、他の行に残る
+/// グローバル最大が事実上の手本になってしまう)。
+export function buildIcpScopeLine<T>(
+  selection: IcpCohortSelection<T>,
+): string {
+  if (selection.sufficient) {
+    return `ICP cohort: winner selection is scoped to topic=${selection.target} ` +
+      `(n=${selection.rows.length} of ${selection.totalCount} measured posts). ` +
+      `Reach from other topics is not evidence for this audience.`;
+  }
+  return `ICP cohort: topic=${selection.target} has only ` +
+    `${selection.rows.length}/${selection.totalCount} measured posts — ` +
+    `not enough to name a winner. Do NOT copy the highest-reach or ` +
+    `highest-acquisition post from another topic: those numbers come from a ` +
+    `different audience and do not transfer. Write for the ICP and collect ` +
+    `measurements first.`;
 }

--- a/supabase/functions/growth-hub/x_topic_audience_test.ts
+++ b/supabase/functions/growth-hub/x_topic_audience_test.ts
@@ -4,9 +4,12 @@ import {
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   buildArchetypeTopicInteractionLine,
+  buildIcpScopeLine,
   buildTopicLiftLine,
   classifyPostTopic,
+  ICP_TARGET_TOPIC,
   normalizeTopicBucket,
+  selectIcpCohort,
 } from "./x_topic_audience.ts";
 
 // 実測 3 コホートの縮約サンプル (同一 data_report 型・topic 違い)。
@@ -103,4 +106,70 @@ Deno.test("buildArchetypeTopicInteractionLine is silent without a split archetyp
     ),
     null,
   );
+});
+
+// R28: 楔 (借金・リボ払い) の ICP コホートへスコープする回帰テスト。
+Deno.test("classifyPostTopic: 借金・リボは household_finance でなく debt_recovery", () => {
+  assertEquals(
+    classifyPostTopic("リボ払いの残債を今月2万円繰り上げ返済しました"),
+    "debt_recovery",
+  );
+  assertEquals(classifyPostTopic("完済まであと18ヶ月"), "debt_recovery");
+  // 借金語が無い一般家計は従来どおり household_finance。
+  assertEquals(
+    classifyPostTopic("今月の家計の支出を見直して節約しました"),
+    "household_finance",
+  );
+  // 政治アンカーは引き続き最優先 (実測でリーチを支配するため)。
+  assertEquals(
+    classifyPostTopic("国民民主党 地方議員集計 返済"),
+    "japan_politics",
+  );
+});
+
+Deno.test("selectIcpCohort: 対象トピックだけを切り出す", () => {
+  const rows = [
+    { topic: "japan_politics" },
+    { topic: "debt_recovery" },
+    { topic: "debt_recovery" },
+    { topic: "ai_tech" },
+  ];
+  const sel = selectIcpCohort(rows, (r) => r.topic);
+  assertEquals(sel.target, ICP_TARGET_TOPIC);
+  assertEquals(sel.rows.length, 2);
+  assertEquals(sel.totalCount, 4);
+  assert(sel.sufficient);
+});
+
+Deno.test("selectIcpCohort: 薄いコホートは sufficient=false (グローバルへ落ちない)", () => {
+  const rows = [
+    { topic: "japan_politics" },
+    { topic: "japan_politics" },
+    { topic: "debt_recovery" },
+  ];
+  const sel = selectIcpCohort(rows, (r) => r.topic);
+  assertEquals(sel.rows.length, 1);
+  assert(!sel.sufficient, "1 件で勝者を名乗ってはいけない");
+  // 空でも同じ (グローバル最大へフォールバックしない)。
+  const empty = selectIcpCohort([{ topic: "japan_politics" }], (r) => r.topic);
+  assertEquals(empty.rows.length, 0);
+  assert(!empty.sufficient);
+});
+
+Deno.test("buildIcpScopeLine: 薄いときは他トピックの勝者を真似るなと明示する", () => {
+  const thin = buildIcpScopeLine(
+    selectIcpCohort([{ topic: "japan_politics" }], (r) => r.topic),
+  );
+  assert(thin.includes("not enough to name a winner"));
+  assert(thin.includes("Do NOT copy"));
+  assert(thin.includes("different audience"));
+
+  const ok = buildIcpScopeLine(
+    selectIcpCohort(
+      [{ topic: "debt_recovery" }, { topic: "debt_recovery" }],
+      (r) => r.topic,
+    ),
+  );
+  assert(ok.includes("scoped to topic=debt_recovery"));
+  assert(!ok.includes("Do NOT copy"));
 });


### PR DESCRIPTION
## なぜ

実測（2026-04-27〜07-25 / 350投稿）では、サイトへの URL クリック 304 件のうち **286 件（94%）が `japan_politics` の定点観測シリーズ**から出ている。到達・獲得ともグローバル最大なので、素朴に最大値を取ると学習ループは「政治の集計レポートを再生産せよ」と AIシェアに指示する。

だが 2026-07-28 の戦略確定（`project_wedge_debt_recovery_icp`）で楔は **「借金・リボ払いからの生活再建」1つ**に絞られ、反応ゼロの真因は **ICP不在** と診断されている。同記録は「成長エンジンが開発者向けに建っていた … 楔に対し資産価値ゼロ」とも書いている。

**数字が大きいことと、客に届いていることは別問題。** [#4355](https://github.com/kanta13jp1/my_web_app/pull/4355) で入れた topic 軸は層別はできるが、**ランキング自体はグローバル最大のまま**で、政治シリーズが勝者に選ばれ続ける。

## 何を変えたか

1. **`debt_recovery` バケットを追加**（リボ / 借金 / 返済 / 完済 / 残債 / 滞納 / 延滞 / 多重債務 / 自転車操業 ほか）。家計一般より**先に**判定する — 「返済」「残債」を `household_finance` に吸わせると ICP コホートが永久に空になる。分類のみに使う語であり、助言や法律判断には一切用いない（非弁行為の一線を越えないため、債務整理系の語も「その話題である」ことの検出だけに使う）。
2. **`selectIcpCohort()` / `buildIcpScopeLine()`** を追加し、勝ち exemplar（winners / underperformers）と勝ち型（variant ランキング）の選定を ICP コホート内に閉じる。
3. **サンプル不足時にグローバル最大へ黙って落ちない。** 落とすと政治シリーズが勝者として復活し、このスコープの意味が消える。代わりに「他トピックの勝者を真似るな。その数字は別の受け手のもので転移しない」と明示する行を `performance_context` に出す。

構造 lift（メディア / リンク位置 / スレッド長）は受け手ではなく形式の話なので、従来どおり全件で測る。

## Minimal E2E Gate

- 検証は **実装詳細に依存しない** 入出力ベース: 投稿本文または topic を持つ行の配列を渡し、返る分類・コホート件数・`sufficient`・警告文の有無だけで判定する。内部の分岐やアンカー配列の構造には触れない。
- **最小限の3ケース**: (1) 借金・リボ文面が `debt_recovery` に落ち、家計一般は `household_finance` のまま（政治アンカーは引き続き最優先） (2) 対象トピックだけが切り出され `sufficient=true` (3) 1件/0件では `sufficient=false` になり、警告文が "Do NOT copy" を含む。
- E2E-Exception: 変更は Deno Edge Function の純ロジックで、Flutter Web のアプリバンドルに入らない。ブラウザ E2E から到達する UI 経路が無いため integration_test / playwright の対象にならない。`deno test` の入出力レベルで固定した。

## 検証

- `x_topic_audience_test.ts`: **11 passed**（新規4）
- growth-hub 純ロジック合計: **37 passed**
- pre-commit fast quality gate: `flutter analyze` No issues found / deno lint 190 files

既知: `x_post_preflight_test.ts` / `x_today_status_test.ts` の 2 件は `--allow-env` 不足で落ちるが、**origin/main でも同一に再現する既存事象**で本変更とは無関係（stash して確認済み）。

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は growth-hub の学習ランキング算出とトピック分類のみで、投稿・課金・認証の経路に触れていない。追加した分類語は自分の投稿の話題判定にのみ使い、ユーザーへの助言や法的判断には用いない。コホート不足時は勝者を宣言しない安全側に倒れる。新規4件を含む37件のテストと全体 analyze / deno lint で回帰を確認済み。

Refs #4355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
