### PR TITLE
docs: record that ultrareview cannot run in CI, with the evidence

### DIFF
--- a/docs/automation/high-risk-ultrareview-gate.md
+++ b/docs/automation/high-risk-ultrareview-gate.md
@@ -76,6 +76,60 @@ Do not paste the evidence block unless a real `/ultrareview` run happened;
 claiming review evidence that was not produced defeats the gate. When in doubt,
 use the exception route and name the follow-up plan.
 
+## Ultrareview cannot run in CI — run it locally
+
+Do not spend time trying to make the `Claude ultrareview (opt-in)` job in
+`.github/workflows/claude-agent-review.yml` produce evidence. It has been
+investigated to exhaustion (2026-07-27/28) and the launch is refused from the
+GitHub Actions runner:
+
+```
+Ultrareview could not launch: Ultrareview is currently unavailable.
+```
+
+Every competing explanation was eliminated by measurement, so **the evidence
+route is satisfied by running ultrareview locally, not by CI**:
+
+| Hypothesis | Verdict | Evidence |
+| --- | --- | --- |
+| Credential tier too low (API key) | Refuted | A subscription `CLAUDE_CODE_OAUTH_TOKEN` reproduces it exactly |
+| Stored token invalid/revoked | Refuted | The pre-flight probe passes in CI, where there is no keychain to fall back to |
+| Organization policy | Refuted | That case has its own message ("Cloud sessions are disabled by your organization's policy") and is not what we get |
+| Overage / quota block | Refuted | Those have their own `blocked` / `needs-confirm` paths |
+| Service-wide outage | Refuted | The same command succeeds locally |
+| **GitHub Actions runner environment** | **Remaining** | Local succeeds, CI fails, with the same valid credential |
+
+The job is still wired correctly and is left in place: if cloud sessions ever
+become launchable from CI it will work unchanged. It fails loudly and never
+posts a comment unless a review actually ran.
+
+### Reading the job's failure
+
+The job distinguishes three outcomes, so a red run should not be re-diagnosed
+from scratch:
+
+- **Credential check fails** — the configured secret is bad; re-issue with
+  `claude setup-token` and update `CLAUDE_CODE_OAUTH_TOKEN`.
+- **Credential check passes, ultrareview will not launch** — the known
+  environment limitation above. Run it locally instead.
+- **Both pass** — findings are posted to the PR.
+
+Note `claude auth status` is *not* a credential check: it reports
+`"loggedIn": true` even for a completely invalid token. Nor is a local
+`claude -p` call, which silently falls back to the keychain session when the
+configured token is bad. Only the CI-side probe isolates the credential.
+
+### Producing evidence for a high-risk PR
+
+```bash
+claude ultrareview <PR#>
+```
+
+Runs in the cloud, takes about 5-10 minutes, and prints the findings. **The free
+tier is limited (the CLI prints e.g. `Free ultrareview 2 of 3`)**, which is a
+further reason the gate is manual rather than fired on every high-risk PR. Only
+after a real run, record it with `--emit-evidence`.
+
 ## Local Verification
 
 ```powershell


### PR DESCRIPTION
## 概要

CI の ultrareview は 4 回の dispatch(約 24 時間)で `Ultrareview is currently unavailable.` しか返さない一方、**同じコマンドがローカルでは成功する**。競合仮説を実測で 1 つずつ潰した結果、残ったのは **GitHub Actions ランナー環境固有** という結論。

同じ調査を次の担当者(あるいは次の AI セッション)が繰り返さないよう、**何を・どうやって否定したか**を docs に残す。docs のみの変更。

## 消去された仮説 (すべて実測)

| 仮説 | 判定 | 根拠 |
|---|---|---|
| 資格情報のティア不足(API キー) | 否定 | 購読 `CLAUDE_CODE_OAUTH_TOKEN` でも完全に同一の失敗 |
| secret のトークンが無効・revoke 済み | 否定 | CI 側 pre-flight probe が **成功** ([run 30409293156](https://github.com/kanta13jp1/my_web_app/actions/runs/30409293156)) — ランナーには keychain フォールバックが無いので、これは資格情報が有効であることの証明 |
| 組織ポリシーによる禁止 | 否定 | その場合は専用メッセージ "Cloud sessions are disabled by your organization's policy" が出る |
| overage / 課金上限 | 否定 | 専用の `blocked` / `needs-confirm` 経路を通っていない |
| サービス全体の停止 | 否定 | ローカルでは成功(`Free ultrareview 2 of 3` → 完走) |
| **ランナー環境固有** | **残存** | 同一の有効な資格情報でローカル成功・CI 失敗 |

## 途中で見つかった 2 つの罠 (docs に明記)

**① `claude auth status` は認証の証明にならない** — でたらめなトークンでも `"loggedIn": true` を返す(ローカル設定を読むだけでサーバ検証をしない)。

**② ローカルの `claude -p` も証明にならない** — 無効なトークンを設定しても CLI が**黙って keychain セッションにフォールバック**して成功する。**CI 側の probe だけ**が資格情報を切り分けられる(ランナーにはフォールバック先が無いため)。

## 記載内容

- ultrareview は CI で起動できないので、**evidence 経路はローカル実行で満たす**こと。
- ジョブは配線としては正しく、そのまま残す。将来 CI から cloud session が起動可能になれば無変更で動く。未実行ならコメントを投稿しない性質も維持。
- ジョブの赤を再診断しないための**3 分岐の読み方**(資格情報が悪い / ultrareview が起動しない / 成功)。
- **無料枠は有限**(CLI が `Free ultrareview 2 of 3` と表示)。high-risk PR ごとの自動実行ではなく手動運用が妥当である理由として明記。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: documentation-only change recording why ultrareview cannot run in CI; no executable path is modified

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: documentation-only change under docs/, no application code or workflow logic is touched.
