### PR TITLE
feat(web): タブ切替を URL に反映する (?tab=<slug>)

### DIFF
--- a/lib/pages/budget_financial_planner_page.dart
+++ b/lib/pages/budget_financial_planner_page.dart
@@ -7,6 +7,7 @@ import 'asset_management_page.dart';
 import '../models/budget_entry.dart';
 import '../models/kgi_csf_kpi.dart';
 import '../widgets/kgi_csf_kpi_panel.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 予算・財務プランナーページ (MoneyForward / Amazon Rufus 競合)
 /// budget-financial-planner Edge Function + ai-assistant Edge Function と連携
@@ -22,7 +23,19 @@ class BudgetFinancialPlannerPage extends StatefulWidget {
 }
 
 class _BudgetFinancialPlannerPageState extends State<BudgetFinancialPlannerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  // タブ: 概要 / 予算 / AI節約 / シミュレーション
+  @override
+  List<String> get tabUrlSlugs => const <String>[
+        'overview',
+        'budget',
+        'ai-savings',
+        'simulation',
+      ];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabController;
 

--- a/lib/pages/election_management_dashboard.dart
+++ b/lib/pages/election_management_dashboard.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 class ElectionManagementDashboard extends StatefulWidget {
   const ElectionManagementDashboard({super.key});
@@ -12,7 +13,18 @@ class ElectionManagementDashboard extends StatefulWidget {
 
 class _ElectionManagementDashboardState
     extends State<ElectionManagementDashboard>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  // タブ: 月次工程管理 (KPI) / 最新実データ (AI取得) / 選挙スケジュール
+  @override
+  List<String> get tabUrlSlugs => const <String>[
+        'kpi',
+        'live-data',
+        'schedule',
+      ];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   late TabController _tabController;
   bool _isLoading = true;
   List<Map<String, dynamic>> _politicians = [];

--- a/lib/pages/election_strategy_page.dart
+++ b/lib/pages/election_strategy_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 class ElectionStrategyPage extends StatefulWidget {
   const ElectionStrategyPage({super.key});
@@ -13,7 +14,20 @@ class ElectionStrategyPage extends StatefulWidget {
 }
 
 class _ElectionStrategyPageState extends State<ElectionStrategyPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  // タブ: 戦況マップ / 予測 / 地上戦 / 戦略 / 素材
+  @override
+  List<String> get tabUrlSlugs => const <String>[
+        'map',
+        'forecast',
+        'ground-game',
+        'strategy',
+        'assets',
+      ];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   final TextEditingController _strategyController = TextEditingController();
   late TabController _tabController;

--- a/lib/pages/financial_report_page.dart
+++ b/lib/pages/financial_report_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:intl/intl.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 class FinancialReportPage extends StatefulWidget {
   const FinancialReportPage({super.key});
@@ -11,7 +12,14 @@ class FinancialReportPage extends StatefulWidget {
 }
 
 class _FinancialReportPageState extends State<FinancialReportPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  // タブ: 日次 / 週次 / 月次
+  @override
+  List<String> get tabUrlSlugs => const <String>['daily', 'weekly', 'monthly'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   late TabController _tabController;
   Map<String, Map<String, double>> _assetData = {};
   List<String> _sortedDates = [];

--- a/lib/pages/morning_briefing_page.dart
+++ b/lib/pages/morning_briefing_page.dart
@@ -16,6 +16,7 @@ import '../services/gamification_service.dart';
 import '../services/completion_goal_service.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 class MorningBriefingPage extends StatefulWidget {
   const MorningBriefingPage({super.key});
@@ -25,7 +26,19 @@ class MorningBriefingPage extends StatefulWidget {
 }
 
 class _MorningBriefingPageState extends State<MorningBriefingPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  // タブ: タスク / カレンダー / 履歴 / ストック
+  @override
+  List<String> get tabUrlSlugs => const <String>[
+        'tasks',
+        'calendar',
+        'history',
+        'stock',
+      ];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final TextEditingController _todoController = TextEditingController();
   List<Map<String, dynamic>> _todos = [];
   List<Map<String, dynamic>> _subtasks = [];

--- a/lib/pages/recipe_meal_planner_page.dart
+++ b/lib/pages/recipe_meal_planner_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../widgets/meal_nutrition_tracker.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 const _accentOrange = Color(0xFFFF6B35);
 const _accentIndigo = Color(0xFF3D5AFE);
@@ -50,7 +51,20 @@ class RecipeMealPlannerPage extends StatefulWidget {
 }
 
 class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  // タブ: レシピ / 週間プラン / 買い物リスト / 食事ログ / 栄養ログ
+  @override
+  List<String> get tabUrlSlugs => const <String>[
+        'recipes',
+        'weekly-plan',
+        'shopping-list',
+        'meal-log',
+        'nutrition-log',
+      ];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   late final SupabaseClient _supabase;
   late final TabController _tabController;
 

--- a/lib/utils/tab_route_url_sync.dart
+++ b/lib/utils/tab_route_url_sync.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// 同一ページ内のタブ切替を URL (`?tab=<slug>`) に反映するための仕組み。
+///
+/// [route_url_sync.dart](route_url_sync.dart) が「別画面への遷移」で URL を必ず
+/// 変える単一チョークポイントなのに対し、こちらは「画面は同じだがユーザーから
+/// 見える内容が変わる」タブ切替を URL に載せる。共有・リロード・ブックマークで
+/// 同じタブを復元できるようにするのが目的。
+///
+/// **`main.dart` の route 定義は一切増やさない。** 各ページが自分の
+/// `RouteSettings.name` から query を読み書きするので、340 個の route はそのまま。
+///
+/// スラッグ (index ではなく名前) を使うのは、タブを並べ替えたときに既存の共有
+/// リンクが黙って別のタブを開くのを防ぐため。
+
+/// URL の `?tab=` に載せるキー。
+const String tabRouteQueryParam = 'tab';
+
+/// [index] のタブを指す route 名を組み立てる。
+///
+/// 既定タブ (index 0) は query を付けない (`/foo`)。それ以外は `/foo?tab=<slug>`。
+/// 組み立てられない場合 (route 名が無い / index が範囲外) は null を返し、
+/// 呼び出し側は URL 更新を行わない。
+String? tabSyncRouteName({
+  required String? currentRouteName,
+  required List<String> slugs,
+  required int index,
+}) {
+  if (currentRouteName == null) return null;
+  if (index < 0 || index >= slugs.length) return null;
+  final path = Uri.parse(currentRouteName).path;
+  if (path.isEmpty) return null;
+  if (index == 0) return path;
+  return '$path?$tabRouteQueryParam=${Uri.encodeQueryComponent(slugs[index])}';
+}
+
+/// route 名の `?tab=` から復元すべきタブ index を解決する。
+///
+/// query が無い / 未知のスラッグなら null を返す (= 呼び出し側は既定タブのまま)。
+/// 未知スラッグでエラーにしないのは、古い共有リンクを踏んでも画面が壊れず
+/// 既定タブで開けるようにするため。
+int? tabIndexFromRouteName({
+  required String? routeName,
+  required List<String> slugs,
+}) {
+  if (routeName == null) return null;
+  final slug = Uri.parse(routeName).queryParameters[tabRouteQueryParam];
+  if (slug == null || slug.isEmpty) return null;
+  final index = slugs.indexOf(slug);
+  return index < 0 ? null : index;
+}
+
+/// タブ付きページに付けると、タブ切替が URL に反映され、URL からタブが復元される。
+///
+/// 使い方: `with TickerProviderStateMixin, TabRouteUrlSync` を付け、
+/// [tabUrlSlugs] と [tabUrlController] を実装する。`TabController` の生成は
+/// 従来どおり `initState` のままでよい。
+///
+/// 注意: このページで `didChangeDependencies` / `dispose` を override する場合は
+/// 必ず `super` を呼ぶこと (呼ばないと同期が動かない / listener が残る)。
+mixin TabRouteUrlSync<T extends StatefulWidget> on State<T> {
+  /// タブ index → URL スラッグ。**TabBar の並び順と一致させること。**
+  /// 検証は `test/routes/tab_route_url_sync_test.dart` が行う。
+  List<String> get tabUrlSlugs;
+
+  /// URL と同期する `TabController`。
+  TabController get tabUrlController;
+
+  bool _tabUrlBound = false;
+  String? _tabUrlRouteName;
+  int? _lastAnnouncedTabIndex;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_tabUrlBound) return;
+    _tabUrlBound = true;
+
+    _tabUrlRouteName = ModalRoute.of(context)?.settings.name;
+    final initial = tabIndexFromRouteName(
+      routeName: _tabUrlRouteName,
+      slugs: tabUrlSlugs,
+    );
+    if (initial != null && initial != tabUrlController.index) {
+      tabUrlController.index = initial;
+    }
+    _lastAnnouncedTabIndex = tabUrlController.index;
+    tabUrlController.addListener(_announceTabUrl);
+  }
+
+  void _announceTabUrl() {
+    if (!mounted) return;
+    final index = tabUrlController.index;
+    // TabController の listener はアニメーション中に何度も発火するため、
+    // 実際に index が変わった 1 回だけ URL を更新する。
+    if (index == _lastAnnouncedTabIndex) return;
+    // このページが最前面でないときに URL を書くと、上に積まれた別画面の URL を
+    // 奪ってしまう。最前面のときだけ名乗る。
+    if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
+
+    final next = tabSyncRouteName(
+      currentRouteName: _tabUrlRouteName,
+      slugs: tabUrlSlugs,
+      index: index,
+    );
+    if (next == null) return;
+    _lastAnnouncedTabIndex = index;
+    // replace: true = 履歴に積まない。タブを何度切り替えても、戻るキー 1 回で
+    // 前の画面へ戻れるようにする (既存の horse_racing_predictor_page と同じ方針)。
+    SystemNavigator.routeInformationUpdated(
+      uri: Uri.parse(next),
+      replace: true,
+    );
+  }
+
+  @override
+  void dispose() {
+    if (_tabUrlBound) {
+      tabUrlController.removeListener(_announceTabUrl);
+    }
+    super.dispose();
+  }
+}

--- a/test/routes/tab_route_url_sync_test.dart
+++ b/test/routes/tab_route_url_sync_test.dart
@@ -1,0 +1,286 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
+
+/// タブ切替を URL に反映する仕組み ([tab_route_url_sync.dart]) のガード。
+///
+/// (1) URL の組み立て / 解釈を担う純関数を VM 上で直接検証し、
+/// (2) mixin が実際に `SystemNavigator.routeInformationUpdated` を呼ぶことを
+///     ウィジェットテストで検証し、
+/// (3) 適用済みページのスラッグ定義がタブ数と一致しているかを静的に検証する。
+///
+/// アプリ全体を推移的に import するとテストがコンパイルできないため、
+/// (3) は既存の route ガードと同じくソースを静的に検査する。
+void main() {
+  group('tabSyncRouteName (URL の組み立て)', () {
+    const slugs = ['overview', 'budget', 'simulation'];
+
+    test('既定タブ (index 0) は query を付けない', () {
+      expect(
+        tabSyncRouteName(
+          currentRouteName: '/budget-financial-planner',
+          slugs: slugs,
+          index: 0,
+        ),
+        '/budget-financial-planner',
+      );
+    });
+
+    test('index 1 以降は ?tab=<slug> を付ける', () {
+      expect(
+        tabSyncRouteName(
+          currentRouteName: '/budget-financial-planner',
+          slugs: slugs,
+          index: 1,
+        ),
+        '/budget-financial-planner?tab=budget',
+      );
+    });
+
+    test('既存の query は捨てて path だけを土台にする', () {
+      expect(
+        tabSyncRouteName(
+          currentRouteName: '/budget-financial-planner?tab=simulation',
+          slugs: slugs,
+          index: 1,
+        ),
+        '/budget-financial-planner?tab=budget',
+        reason: 'タブを切り替えるたびに query が積み重なってはいけない',
+      );
+    });
+
+    test('route 名が無い / index が範囲外なら null (URL を触らない)', () {
+      expect(
+        tabSyncRouteName(currentRouteName: null, slugs: slugs, index: 1),
+        isNull,
+      );
+      expect(
+        tabSyncRouteName(currentRouteName: '/x', slugs: slugs, index: 9),
+        isNull,
+      );
+      expect(
+        tabSyncRouteName(currentRouteName: '/x', slugs: slugs, index: -1),
+        isNull,
+      );
+    });
+  });
+
+  group('tabIndexFromRouteName (URL の解釈)', () {
+    const slugs = ['daily', 'weekly', 'monthly'];
+
+    test('スラッグから index を復元する', () {
+      expect(
+        tabIndexFromRouteName(
+          routeName: '/financial-report?tab=monthly',
+          slugs: slugs,
+        ),
+        2,
+      );
+    });
+
+    test('query 無しなら null (既定タブのまま)', () {
+      expect(
+        tabIndexFromRouteName(routeName: '/financial-report', slugs: slugs),
+        isNull,
+      );
+    });
+
+    test('未知のスラッグでも例外にせず null (古い共有リンクを壊さない)', () {
+      expect(
+        tabIndexFromRouteName(
+          routeName: '/financial-report?tab=quarterly',
+          slugs: slugs,
+        ),
+        isNull,
+      );
+    });
+
+    test('組み立てと解釈が往復する', () {
+      for (var i = 0; i < slugs.length; i++) {
+        final url = tabSyncRouteName(
+          currentRouteName: '/financial-report',
+          slugs: slugs,
+          index: i,
+        );
+        final back = tabIndexFromRouteName(routeName: url, slugs: slugs);
+        // index 0 は query を付けないので null (= 既定タブ) に戻るのが正しい。
+        expect(back, i == 0 ? isNull : i, reason: 'index $i で往復しない');
+      }
+    });
+  });
+
+  group('TabRouteUrlSync mixin (実ランタイム)', () {
+    late List<String> announced;
+
+    setUp(() {
+      announced = <String>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.navigation, (call) async {
+        if (call.method == 'routeInformationUpdated') {
+          final args = call.arguments as Map<Object?, Object?>;
+          announced.add((args['uri'] ?? args['location']).toString());
+        }
+        return null;
+      });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.navigation, null);
+    });
+
+    Future<void> pump(WidgetTester tester, String routeName) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          initialRoute: routeName,
+          onGenerateRoute: (settings) => MaterialPageRoute<void>(
+            settings: settings,
+            builder: (_) => const _TabProbe(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('タブを切り替えると URL が通知される', (tester) async {
+      await pump(tester, '/probe');
+      announced.clear();
+
+      tester.state<_TabProbeState>(find.byType(_TabProbe)).goTo(2);
+      await tester.pumpAndSettle();
+
+      expect(
+        announced,
+        contains('/probe?tab=third'),
+        reason: 'タブが変わったのにブラウザ URL が更新されていない',
+      );
+    });
+
+    testWidgets('既定タブへ戻すと query の無い URL に戻る', (tester) async {
+      await pump(tester, '/probe');
+      final probe = tester.state<_TabProbeState>(find.byType(_TabProbe));
+
+      probe.goTo(1);
+      await tester.pumpAndSettle();
+      announced.clear();
+
+      probe.goTo(0);
+      await tester.pumpAndSettle();
+
+      expect(announced, contains('/probe'));
+    });
+
+    testWidgets('?tab= 付きで開くとそのタブが復元される', (tester) async {
+      await pump(tester, '/probe?tab=second');
+
+      expect(
+        tester.state<_TabProbeState>(find.byType(_TabProbe)).controller.index,
+        1,
+        reason: '共有リンク/リロードでタブが復元されない',
+      );
+    });
+
+    testWidgets('未知のスラッグなら既定タブで開く (壊れない)', (tester) async {
+      await pump(tester, '/probe?tab=removed-tab');
+
+      expect(
+        tester.state<_TabProbeState>(find.byType(_TabProbe)).controller.index,
+        0,
+      );
+    });
+  });
+
+  // スラッグの数がタブ数とずれると、URL が別のタブを指したり範囲外で
+  // 無視されたりする。適用済みページで一致していることを保証する。
+  test('applied pages: tabUrlSlugs の数が TabController の length と一致する', () {
+    final offenders = <String>[];
+    var checked = 0;
+
+    for (final entity in Directory('lib/pages').listSync()) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final source = entity.readAsStringSync();
+      if (!source.contains('TabRouteUrlSync')) continue;
+
+      final slugMatch = RegExp(
+        r'List<String> get tabUrlSlugs => const <String>\[([\s\S]*?)\];',
+      ).firstMatch(source);
+      final lenMatch = RegExp(
+        r'TabController\(\s*length:\s*(\d+)',
+      ).firstMatch(source);
+
+      if (slugMatch == null || lenMatch == null) {
+        offenders.add('${entity.path}: スラッグ定義か TabController が読めない');
+        continue;
+      }
+      checked++;
+      final slugs = RegExp(
+        r"'([^']+)'",
+      ).allMatches(slugMatch.group(1)!).map((m) => m.group(1)!).toList();
+      final length = int.parse(lenMatch.group(1)!);
+
+      if (slugs.length != length) {
+        offenders.add('${entity.path}: slugs=${slugs.length} vs tabs=$length');
+      }
+      if (slugs.toSet().length != slugs.length) {
+        offenders.add('${entity.path}: スラッグが重複している ($slugs)');
+      }
+      for (final s in slugs) {
+        if (!RegExp(r'^[a-z0-9-]+$').hasMatch(s)) {
+          offenders.add('${entity.path}: URL に使えないスラッグ "$s"');
+        }
+      }
+    }
+
+    expect(checked, greaterThan(0), reason: '適用済みページを 1 つも検出できていない');
+    expect(offenders, isEmpty, reason: 'タブとスラッグの不整合:\n${offenders.join('\n')}');
+  });
+}
+
+class _TabProbe extends StatefulWidget {
+  const _TabProbe();
+
+  @override
+  State<_TabProbe> createState() => _TabProbeState();
+}
+
+class _TabProbeState extends State<_TabProbe>
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  late final TabController controller;
+
+  @override
+  List<String> get tabUrlSlugs => const <String>['first', 'second', 'third'];
+
+  @override
+  TabController get tabUrlController => controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = TabController(length: 3, vsync: this);
+  }
+
+  void goTo(int index) => controller.index = index;
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: TabBarView(
+        controller: controller,
+        children: const [
+          SizedBox.shrink(),
+          SizedBox.shrink(),
+          SizedBox.shrink(),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 何を直すか

「画面が変わったのに URL が変わらない」最後の残りである**同一ページ内のタブ切替**を URL に反映する。

PR #4326 で別画面への遷移は URL が必ず変わるようにしたが、タブは対象外だった。ユーザーから
見える内容が変わっているのに URL が変わらないため、**タブを開いた状態を共有・ブックマーク
できず、リロードすると既定タブに戻る**。

本番実機で #4326 の受け入れ基準は確認済み（`/` → `/import` で URL が変化、戻るキーで復帰）。

## 直し方 — 単一チョークポイント (#4326 と同じ思想)

`lib/utils/tab_route_url_sync.dart` に純関数 2 つ + mixin 1 つを新設する。

- **出口**: タブ変更で `routeInformationUpdated(replace: true)` を呼び URL を `?tab=<slug>` に更新
- **入口**: ページ自身が `ModalRoute.of(context)?.settings.name` の query を読んで初期タブを復元

**`main.dart` の route 定義は 1 つも増やさない**（340 のまま）。ページが自分の `RouteSettings`
を読むだけなので、パス方式で必要になる約 142 case の追加と、それに伴う衝突を避けられる。

### 設計判断

- **index ではなくスラッグ** (`?tab=budget`)。index だとタブを並べ替えた瞬間に既存の共有リンクが
  黙って別のタブを開く。スラッグなら並べ替えに強い。
- **既定タブは query 無し** (`/financial-report`)。URL が不必要に汚れない。
- **履歴には積まない** (`replace: true`)。タブを何度切り替えても戻るキー 1 回で前の画面へ戻れる。
  既存の `horse_racing_predictor_page.dart` と同じ方針で統一。
- **未知のスラッグは既定タブで開く**。古い共有リンクを踏んでも画面が壊れない。

## 適用範囲 (1st PR)

TabController を持つが URL 同期していないページは 51 / タブ総数 142。本 PR は基盤 + カタログ
露出の大きい 6 ページ（22 タブ）に適用し、残り 45 ページは同じ mixin を付けるだけの後続 PR とする。

| ページ | URL | タブ |
|---|---|---|
| 朝のブリーフィング | `/morning-briefing` | tasks / calendar / history / stock |
| 選挙戦略 | `/election-strategy` | map / forecast / ground-game / strategy / assets |
| 選挙ダッシュボード | `/election-dashboard` | kpi / live-data / schedule |
| 決算レポート | `/financial-report` | daily / weekly / monthly |
| コスト・予算管理 | `/budget-financial-planner` | overview / budget / ai-savings / simulation |
| レシピ・献立 | `/recipe-meal-planner` | recipes / weekly-plan / shopping-list / meal-log / nutrition-log |

## 検証

VM で回るガード 13 本を追加 (`test/routes/tab_route_url_sync_test.dart`)。全て CI の
`flutter test` で回る。

- 純関数: 既定タブは query 無し / query の積み重ね防止 / 範囲外は URL を触らない / 往復一致
- mixin 実ランタイム: タブ変更で URL が通知される / 既定タブで query が消える /
  `?tab=` 付きで開くとタブが復元される / 未知スラッグでも壊れない
- 静的: 適用済みページのスラッグ数が `TabController` の length と一致 / 重複なし / URL 安全な文字のみ

ガードが回帰を検出することも確認済み（スラッグを 1 つ減らすと
`slugs=2 vs tabs=3` で FAIL）。既存 `flutter test` も全て緑。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: タブURL同期は VM ガード13本(純関数+mixin実ランタイム+スラッグ整合の静的検証)で担保。ブラウザ E2E はこの環境で起動不可のため非同梱

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
