### PR TITLE
fix(ci): review .yml and .py — the AI review could not read its own file type

### DIFF
--- a/.github/workflows/claude-agent-review.yml
+++ b/.github/workflows/claude-agent-review.yml
@@ -64,18 +64,32 @@ jobs:
           HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
 
           if [ -n "$BASE_SHA" ]; then
-            git diff "${BASE_SHA}...${HEAD_SHA}" -- \
-              '*.dart' '*.ts' '*.yaml' '*.sql' '*.json' \
-              | head -n 400 > pr_diff.txt
+            RANGE="${BASE_SHA}...${HEAD_SHA}"
           else
-            git diff HEAD~1...HEAD -- \
-              '*.dart' '*.ts' '*.yaml' '*.sql' '*.json' \
-              | head -n 400 > pr_diff.txt
+            RANGE="HEAD~1...HEAD"
           fi
+
+          # These must match the extensions the repo actually uses. The list
+          # previously carried '*.yaml' (4 files) while omitting '*.yml' (124,
+          # including all 117 workflows) and '*.py' (218), so workflow and
+          # script changes were never reviewed — the job just reported
+          # "Diff extracted: 0 lines" and passed.
+          git diff "$RANGE" -- \
+            '*.dart' '*.ts' '*.yml' '*.yaml' '*.sql' '*.json' '*.py' '*.ps1' \
+            | head -n 400 > pr_diff.txt
 
           LINES=$(wc -l < pr_diff.txt | tr -d ' ')
           echo "lines=$LINES" >> $GITHUB_OUTPUT
           echo "Diff extracted: ${LINES} lines"
+
+          # An allowlist drifts silently. If files changed but none matched,
+          # say so and name the extensions, so the next drift is visible
+          # instead of looking like "nothing to review".
+          CHANGED=$(git diff --name-only "$RANGE" | wc -l | tr -d ' ')
+          if [ "$LINES" -eq 0 ] && [ "$CHANGED" -gt 0 ]; then
+            EXTS=$(git diff --name-only "$RANGE" | sed -n 's/.*\.//p' | sort -u | tr '\n' ' ')
+            echo "::warning::AI review skipped: ${CHANGED} changed file(s), none matching the reviewed extensions (saw: ${EXTS})"
+          fi
 
       - name: AI Review (Claude primary / Gemini fallback)
         id: review


### PR DESCRIPTION
## 概要

`review` ジョブ (= "AI Agent Code Review") の diff 抽出 pathspec に **`*.yml` が入っていない**。入っているのは `*.yaml`。

リポジトリの実測:

| パターン | 該当ファイル数 |
|---|---|
| `*.yaml` (pathspec にあった) | **4** |
| `*.yml` (無かった) | **124** (うち 117 が `.github/workflows/`) |
| `*.py` (無かった) | **218** |

結果、**GitHub Actions と Python の変更は一度も AI レビューされていない**。該当 PR では `Diff extracted: 0 lines` → プロバイダ呼び出しをスキップ → **success**。直近 10 run のうち **5 run が 0 lines** だった。

## これは今日マージした 3 本の PR にも起きていた

#4360 / #4366 / #4375 はいずれも `.yml` のみの変更で、`AI Agent Code Review: pass` と表示されていたが**実際には何もレビューしていない**。しかも `.github/workflows/claude-agent-review.yml` は、**同じファイル内の sibling ジョブ (high-risk gate) が high-risk path として分類しているパス**である。

> レビュー用ワークフローが**自分自身のファイル形式を読めない**状態だった。

## 変更内容

- pathspec に `*.yml` `*.py` `*.ps1` を追加(`*.yaml` は無害なので残置)。
- 2 箇所に複製されていた pathspec を `RANGE` 変数 1 つに集約 — 片方だけ直して乖離する事故を防ぐ。
- **allowlist は黙って陳腐化する**ので、「ファイルは変わったが 1 つも一致しなかった」場合に `::warning::` で**実際に見た拡張子を列挙**する。次に同じ乖離が起きたら「レビュー対象が無かった」ではなくメッセージとして現れる。

## 検証 (main 上の実コミットで実測)

| 対象 | 旧 pathspec | 新 pathspec |
|---|---|---|
| PR #4375 の squash コミット (`.yml` のみ) | **0 lines** | **30 lines** ✅ |
| docs のみのコミット | 0 lines (無言) | 0 lines + `::warning::AI review skipped: 1 changed file(s), none matching the reviewed extensions (saw: md )` ✅ |

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ultrareview cannot launch from CI (documented in docs/automation/high-risk-ultrareview-gate.md); verified instead by replaying real commits from main through both the old and new pathspec

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CI workflow definition only (.github/), no application code path; verified by replaying two real commits from main through the diff step and comparing old vs new pathspec output.
