### PR TITLE
docs: EF secret 監査に「未登録=障害とは限らない」判定基準を追加

### DIFF
--- a/docs/EDGE_FUNCTION_LIST.md
+++ b/docs/EDGE_FUNCTION_LIST.md
@@ -83,6 +83,36 @@ provider 側の応答 (残高不足など) に変われば、キーは到達し�
 「まだ動かない」は「直っていない」を意味しない — 段階の違うブロッカーへ
 進んだだけのことがある。
 
+### 「読まれているが未登録」= 障害とは限らない
+
+上の差分は**候補**であって障害リストではない。**意図的にオフの任意機能**と
+**設定したつもりで壊れている機能**は差分だけでは区別できず、以下 3 点を
+揃えて初めて判定できる (2026-07-29 に認証情報 12 件を判定して確立)。
+
+| # | 確認事項 | 外すとどう間違えるか |
+| --- | --- | --- |
+| (a) | **未設定時の分岐** — 全停止 / 既定値で縮退 / 完全に無害 | 縮退設計済みを障害と誤検知する。`AIRTABLE_API_KEY` 未設定は `configured:false` → Supabase competitors へ自動フォールバック = 無害 |
+| (b) | **その action の呼び出し元が実在するか** | allowlist に名前があるだけで**永久に実行されない** action を「壊れている」と数える。判定は `git grep '<action名>' -- lib scripts .github supabase/migrations` |
+| (c) | **同時に必要な他の env** | ゲートしている変数を見落とす。`VIRAL_VIDEO_PROVIDER_API_KEY` は `VIRAL_VIDEO_PROVIDER_URL` が空の時点で fetch 自体が走らないので単独登録は無意味 |
+
+落とし穴:
+
+- **別名 action に注意**。UI が呼ぶのは `legal-assistant.harvey.complete` なので
+  `legal.harvey` だけを grep すると呼び出し元ゼロと誤判定する。(b) は
+  **EF 側の `case` 全部**を候補に grep する。
+- **語幹が近い = 名前ズレ ではない**。`SLACK_BOT_TOKEN` (Bot OAuth トークン) と
+  登録済 `SLACK_WEBHOOK_URL` (Incoming Webhook URL)、`X_BEARER_TOKEN` (OAuth 2.0) と
+  登録済 `X_API_KEY`/`X_ACCESS_TOKEN` (OAuth 1.0a) は**別の認証方式**で代替不可。
+  ダイジェスト一致 (上の使い方 1) が取れない限り名前ズレと断定しない。
+- **UI 導線の有無まで見る**。資格情報が無いのに UI にボタン/選択肢が実在する場合、
+  鍵を足すのではなく**導線を隠す**のが正しい修正のことがある。
+- **未設定時に 200 を返す経路は latent dead green**。`core-hub:discord.notify` は
+  未設定時 `skipped` かつ HTTP 200 (現状 呼び出し元ゼロで実害なし / 将来 cron から
+  呼ぶと「成功したのに届かない」に化ける)。
+- **鍵を足しても直らないことがある**。`LINE_NOTIFY_TOKEN` が叩く `notify-api.line.me` は
+  **2025-03-31 に LINE Notify 自体がサービス終了**し 2025-04-01 以降 全 API が利用不可
+  ([公式告知](https://notify-bot.line.me/closing-announce) / 代替は Messaging API)。
+
 ## 関連
 
 - [`docs/DIRECTORY_STRUCTURE.md`](DIRECTORY_STRUCTURE.md) — リポジトリ全体構成


### PR DESCRIPTION
## 背景

2026-07-25 の FAL 障害 (コードは `FAL_KEY` を読むが値は `FAL_API_KEY` として登録済 → AIシェアの動画が丸一日欠落 / 投稿自体は成功するため気づけない) の再発点検として、**EF が読んでいるのに EF secret 未登録**の認証情報 12 件を「意図的にオフの任意機能」か「設定したつもりで静かに壊れている機能」かで判定した。

その過程で、既存の「env 名ズレの監査手順」節が示す差分の取り方だけでは**この 2 つを区別できない**ことが分かったため、判定に必要な観点を追記する。

## 変更

`docs/EDGE_FUNCTION_LIST.md` に「読まれているが未登録」= 障害とは限らない小節を追加 (+30 行)。既存節と重複する内容 (FAL の経緯 / `secrets list` の使い方 / ダイジェスト一致 / GHA と EF の別ストア注意) は書かず、差分のみ。

- 判定に必要な 3 点: (a) 未設定時の分岐 (b) その action の呼び出し元の実在 (c) 同時に必要な他の env
- 落とし穴 4 件 (いずれも本調査で実際に踏んだ / 踏みかけたもの)

## 判定結果 (12 件)

**FAL 型の名前ズレは 0 件。** 語幹が近い登録済 secret はあるが、いずれも別の認証方式で代替不可 (`SLACK_BOT_TOKEN` は Bot OAuth トークンで登録済 `SLACK_WEBHOOK_URL` は Incoming Webhook URL / `X_BEARER_TOKEN` は OAuth 2.0 で登録済 `X_API_KEY` 等は OAuth 1.0a)。

| 判定 | 件数 | 内訳 |
| --- | --- | --- |
| UI 導線があるのに恒常 503 | 2 | `HARVEY_API_KEY` (法務ページ) / `MANUS_API_KEY` (チャットのプロバイダ選択) |
| 意図的にオフ + 設計済フォールバック | 1 | `X_BEARER_TOKEN` (有料 tier / RSS へ縮退) |
| 意図的にオフ・呼び出し元ゼロ | 5 | `DISCORD_WEBHOOK_URL` `LINE_NOTIFY_TOKEN` `SLACK_BOT_TOKEN` `NEWS_API_KEY` `ALPHA_VANTAGE_API_KEY` |
| 縮退設計済み・無害 | 3 | `AIRTABLE_API_KEY` / `AIRTABLE_PAT` (Supabase へ自動フォールバック) / `VIRAL_VIDEO_PROVIDER_API_KEY` (URL 未設定で fetch 自体が走らない) |
| 調査対象外 | 1 | `QIITA_ACCESS_TOKEN` (2026-07-12 アカウント停止 / rotate 禁止) |

補足 2 点:

- `DISCORD_WEBHOOK_URL` は当初「設定手順があるのに届いていない」と疑ったが、**誰も Discord 配信を要求していない**のが実態だった。オプトインフラグ `discord_secondary` を立てる呼び出し元がリポジトリ全体に存在せず、UI の Discord ページは env ではなく DB 保存の per-user webhook を使う。仕様通りのオプトイン未使用。
- `LINE_NOTIFY_TOKEN` は **secret を登録しても直らない**。`notify-api.line.me` は 2025-03-31 に LINE Notify 自体がサービス終了済 ([公式告知](https://notify-bot.line.me/closing-announce))。

## secret 登録について

**本 PR では secret を登録していない** (ユーザー操作が必要なため)。`HARVEY_API_KEY` / `MANUS_API_KEY` は「鍵を足す」か「UI 導線を隠す」かの方針判断が先で、未決。

## テスト

docs のみ。pre-commit fast gate (446s) / pre-push full gate (1098s, 581 tests passed) ともに通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
