### PR TITLE
fix(x-growth): let the ICP scope line see imported ICP history

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -40,6 +40,7 @@ import {
   buildIcpScopeLine,
   buildTopicLiftLine,
   classifyPostTopic,
+  normalizeTopicBucket,
   selectIcpCohort,
 } from "./x_topic_audience.ts";
 import {
@@ -1123,7 +1124,16 @@ function buildXPerformanceContextFromLogs(
     acquisitionRanked,
     (row) => row.topic,
   );
-  const icpScopeLine = buildIcpScopeLine(icpCohort);
+  // R28 fix: CSV 取込の行は historical_benchmark として learningRows から
+  // 除外されるため、ICP の実績があっても icpCohort には 1 件も入らない。
+  // 返済報告カードの共有はクリップボードのみで x_post_log に残らないので、
+  // ICP の実績は事実上「取り込んだ履歴」にしか存在しない。件数を数えて
+  // 「1本も無い」と「あるが年齢比較できない」を区別して報告する。
+  const icpHistoricalCount = rows.filter((row) =>
+    row.learningCohort === "historical_benchmark" &&
+    normalizeTopicBucket(row.topic) === icpCohort.target
+  ).length;
+  const icpScopeLine = buildIcpScopeLine(icpCohort, icpHistoricalCount);
   const winners = icpCohort.sufficient ? icpCohort.rows.slice(0, 5) : [];
   const underperformers = icpCohort.sufficient
     ? icpCohort.rows.slice(-5).reverse()

--- a/supabase/functions/growth-hub/x_topic_audience.ts
+++ b/supabase/functions/growth-hub/x_topic_audience.ts
@@ -263,18 +263,37 @@ export function selectIcpCohort<T>(
 /// x.performance_context に出す ICP スコープ行。コホートが薄いときは
 /// 「グローバルの勝者を手本にするな」と明示する (沈黙すると、他の行に残る
 /// グローバル最大が事実上の手本になってしまう)。
+///
+/// R28 fix: 「ICP の投稿が 1 本も無い」と「ICP の投稿はあるが投稿年齢を揃えた
+/// 比較ができない」は別の状態で、必要な次の一手も違う (前者は書け / 後者は
+/// アプリ経由で投稿して計測を貯めろ)。両者を同じ 0 件として報告していた。
+///
+/// 背景: CSV 取込の行は `learning_cohort='historical_benchmark'` になり、
+/// 年齢正規化ランキング (learningRows) から意図的に除外される。一方、返済
+/// 報告カードの共有はクリップボードのみで `x_post_log` に残らない。結果、
+/// ICP の実績は「取り込んだ履歴」にしか存在しえないのに、それが 1 件も
+/// 見えないまま「measurements first」とだけ言い続ける状態になっていた。
 export function buildIcpScopeLine<T>(
   selection: IcpCohortSelection<T>,
+  historicalCount = 0,
 ): string {
   if (selection.sufficient) {
     return `ICP cohort: winner selection is scoped to topic=${selection.target} ` +
       `(n=${selection.rows.length} of ${selection.totalCount} measured posts). ` +
       `Reach from other topics is not evidence for this audience.`;
   }
-  return `ICP cohort: topic=${selection.target} has only ` +
-    `${selection.rows.length}/${selection.totalCount} measured posts — ` +
-    `not enough to name a winner. Do NOT copy the highest-reach or ` +
+  const base = `ICP cohort: topic=${selection.target} has only ` +
+    `${selection.rows.length}/${selection.totalCount} post-age comparable ` +
+    `posts — not enough to name a winner. Do NOT copy the highest-reach or ` +
     `highest-acquisition post from another topic: those numbers come from a ` +
-    `different audience and do not transfer. Write for the ICP and collect ` +
-    `measurements first.`;
+    `different audience and do not transfer.`;
+  if (historicalCount > 0) {
+    return `${base} ${historicalCount} imported historical ICP post(s) exist ` +
+      `but are lifetime-cumulative, so they cannot be ranked against ` +
+      `age-normalized posts. Treat them as audience evidence only. To get a ` +
+      `comparable winner, post ICP content through the app so metrics are ` +
+      `logged from posting time.`;
+  }
+  return `${base} No ICP post has been measured at all yet — write for the ` +
+    `ICP first, then collect measurements.`;
 }

--- a/supabase/functions/growth-hub/x_topic_audience_test.ts
+++ b/supabase/functions/growth-hub/x_topic_audience_test.ts
@@ -173,3 +173,41 @@ Deno.test("buildIcpScopeLine: 薄いときは他トピックの勝者を真似�
   assert(ok.includes("scoped to topic=debt_recovery"));
   assert(!ok.includes("Do NOT copy"));
 });
+
+// R28 fix: 「ICP投稿が1本も無い」と「あるが年齢比較できない」の区別。
+// CSV 取込行は historical_benchmark で learningRows から除外されるため、
+// 前者としてしか報告されず、次の一手を誤らせていた。
+Deno.test("buildIcpScopeLine: 取り込み履歴が無いときは『まず書け』", () => {
+  const line = buildIcpScopeLine(
+    selectIcpCohort([{ topic: "japan_politics" }], (r) => r.topic),
+    0,
+  );
+  assert(line.includes("No ICP post has been measured at all yet"));
+  assert(line.includes("write for the"));
+  assert(!line.includes("imported historical"));
+});
+
+Deno.test("buildIcpScopeLine: 取り込み履歴があるときは別の次の一手を出す", () => {
+  const line = buildIcpScopeLine(
+    selectIcpCohort([{ topic: "japan_politics" }], (r) => r.topic),
+    7,
+  );
+  assert(line.includes("7 imported historical ICP post(s) exist"));
+  // lifetime cumulative なので年齢正規化ランキングには載せられない、と明示。
+  assert(line.includes("lifetime-cumulative"));
+  assert(line.includes("audience evidence only"));
+  // 次の一手は「書け」ではなく「アプリ経由で投稿して計測を貯めろ」。
+  assert(line.includes("post ICP content through the app"));
+  assert(!line.includes("No ICP post has been measured at all yet"));
+});
+
+Deno.test("buildIcpScopeLine: 十分なら履歴件数に関わらずスコープ宣言のまま", () => {
+  const enough = selectIcpCohort(
+    [{ topic: "debt_recovery" }, { topic: "debt_recovery" }],
+    (r) => r.topic,
+  );
+  assert(
+    buildIcpScopeLine(enough, 9).includes("scoped to topic=debt_recovery"),
+  );
+  assert(!buildIcpScopeLine(enough, 9).includes("imported historical"));
+});


### PR DESCRIPTION
## なぜ

[#4374](https://github.com/kanta13jp1/my_web_app/pull/4374) で勝者選定を ICP コホートへスコープしたあと、**そこへ到達する経路が実在するか**を末端まで辿った。結果、チェーンが切れていた。

1. 返済報告カードの共有 (`debt_progress_share_dialog.dart:118`) は **`Clipboard.setData` のみ**で `growth-hub x.post` を呼ばない → `x_post_log` に残らない
2. CSV 取込の行は `learning_cohort='historical_benchmark'` (`x_analytics_import.ts:190`)
3. `index.ts` の `postAgeComparableRows` が `historical_benchmark` を**除外**
4. `icpCohort` はその部分集合

つまり **取り込んでも ICP コホートには 1 件も入らない**。#4374 は投稿を何本重ねても永久に「not enough to name a winner」と言い続ける。

さらに悪いことに、「ICP の投稿が 1 本も無い」と「ICP の投稿はあるが投稿年齢を揃えた比較ができない」を**同じ 0 件として報告**していた。必要な次の一手は前者が「まず ICP 向けに書け」、後者が「アプリ経由で投稿して計測を貯めろ」で、全く違う。

## 何を変えたか

- `buildIcpScopeLine()` に取り込み履歴の件数を渡し、2 つの状態を区別する。履歴があるときは (a) lifetime-cumulative なので年齢正規化ランキングには載せられない (b) audience evidence として扱う (c) 比較可能な勝者が欲しければアプリ経由で投稿する、を明示する。
- `index.ts` で ICP トピックの `historical_benchmark` 行を数えて渡す。

**`historical_benchmark` をランキングへ混ぜる修正はしない。** [#4367](https://github.com/kanta13jp1/my_web_app/pull/4367) で直したばかりの「全項を同じ期間基準で採点する」不変条件を壊すため。ここで直すのは報告の正確さ。

なお、分類器自体は正しく動くことを実文面で確認済み — `debt_progress_card_service.dart` の `buildDraftText()` が生成する2分岐（通常 / 元金減らず）はいずれも `debt_recovery` に分類される。

## Minimal E2E Gate

- 検証は **実装詳細に依存しない** 入出力ベース: コホート選択結果と履歴件数を渡し、返る文言に含まれる語だけで判定する。内部の分岐構造には触れない。
- **最小限の3ケース**: (1) 履歴0件 → 「まず書け」 (2) 履歴あり → 「lifetime-cumulative / audience evidence only / アプリ経由で投稿」 (3) コホート十分 → 履歴件数に関わらずスコープ宣言のまま。
- E2E-Exception: 変更は Deno Edge Function の純ロジックで、Flutter Web のアプリバンドルに入らない。ブラウザ E2E から到達する UI 経路が無いため integration_test / playwright の対象にならない。`deno test` の入出力レベルで固定した。

## 検証

- `x_topic_audience_test.ts`: **14 passed**（新規3）
- 併せて `x_acquisition_score_test.ts` と合計 **24 passed**
- pre-commit fast quality gate: `flutter analyze` No issues found / deno lint 192 files

## 残る設計上の論点（本PRでは触れない）

返済報告カードがクリップボード専用である限り、ICP 投稿は `x_post_log` に入らず、**年齢正規化された勝者は永久に立たない**。CSV 取込は audience evidence にはなるが順位付けには使えない。カードに「Xへ投稿」経路を足すかどうかは #4373 の担当領域なので、ここでは報告の正確さだけを直し、判断材料を prompt に出すに留めた。

Refs #4374, #4373

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は performance_context に出す説明文の分岐と、その入力となる件数カウントのみ。ランキング・スコア計算・投稿経路のいずれにも触れておらず、既存の除外ルールもそのまま維持している。新規3件を含む24件のテストと全体 analyze / deno lint で回帰を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
