### PR TITLE
fix(watcher): worktrees 配下を除外し捕獲条件を CI guard と同じ述語に揃える

### DIFF
--- a/scripts/watch_protected_files.ps1
+++ b/scripts/watch_protected_files.ps1
@@ -59,6 +59,12 @@ $ErrorActionPreference = 'Stop'
 
 $WatchedRelativeDirs = @('.github\workflows', '.claude')
 
+# .claude/worktrees/ holds entire sibling checkouts of this repository. Watching
+# into them is both wrong and ruinously slow: the first deployment burned its
+# single capture on a tool's temp file inside a worktree, and the burst-window
+# rescan took 54s instead of 10s because it walked six full checkouts.
+$ExcludedPathFragments = @('\.claude\worktrees\', '\node_modules\', '\.dart_tool\', '\build\')
+
 if (-not (Test-Path $LogDir)) {
     New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
 }
@@ -81,14 +87,46 @@ function Write-Log {
     Write-Output $line
 }
 
+function Test-IsExcludedPath {
+    param([string]$Path)
+    foreach ($fragment in $ExcludedPathFragments) {
+        if ($Path -like ('*' + $fragment + '*')) { return $true }
+    }
+    return $false
+}
+
+function Test-IsProtectedTarget {
+    <# Mirrors the CI guard predicate: tracked in git AND non-empty at HEAD.
+
+       An untracked temp file going to 0 bytes is noise, and a tracked file that
+       is *supposed* to be empty (a .gitkeep) is not a regression. Only a file
+       that git says had content is worth spending the capture on.
+    #>
+    param([string]$Path)
+
+    if (Test-IsExcludedPath $Path) { return $false }
+
+    $full = [System.IO.Path]::GetFullPath($Path)
+    $root = [System.IO.Path]::GetFullPath($RepoRoot)
+    if (-not $full.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) { return $false }
+
+    $relative = $full.Substring($root.Length).TrimStart('\', '/').Replace('\', '/')
+    $size = & git -C $RepoRoot cat-file -s ('HEAD:' + $relative) 2>$null
+    if ($LASTEXITCODE -ne 0) { return $false }
+
+    $parsed = 0
+    if (-not [int]::TryParse(($size | Select-Object -First 1), [ref]$parsed)) { return $false }
+    return ($parsed -gt 0)
+}
+
 function Get-ZeroBytePath {
-    <# Every currently-empty file across the watched trees. #>
+    <# Currently-empty files across the watched trees, excluding nested checkouts. #>
     $found = @()
     foreach ($rel in $WatchedRelativeDirs) {
         $dir = Join-Path $RepoRoot $rel
         if (-not (Test-Path $dir)) { continue }
         $found += Get-ChildItem -Path $dir -Recurse -File -ErrorAction SilentlyContinue |
-            Where-Object { $_.Length -eq 0 } |
+            Where-Object { $_.Length -eq 0 -and -not (Test-IsExcludedPath $_.FullName) } |
             ForEach-Object { $_.FullName }
     }
     return $found
@@ -186,6 +224,11 @@ try {
         Remove-Event -EventIdentifier $evt.EventIdentifier -ErrorAction SilentlyContinue
         if (-not $path) { continue }
 
+        # Cheapest filter first, before paying for a process snapshot: nested
+        # checkouts under .claude/worktrees/ produce constant 0-byte churn
+        # (.gitkeep, crash dumps, build artefacts) that is never our target.
+        if (Test-IsExcludedPath $path) { continue }
+
         $isEmpty = $false
         try {
             $item = Get-Item -LiteralPath $path -ErrorAction Stop
@@ -211,6 +254,14 @@ try {
             # Transient 0-byte state from an ordinary write-then-flush. Discard so
             # a normal editor save does not burn the single capture.
             Remove-Item -LiteralPath $dump -Force -ErrorAction SilentlyContinue
+            continue
+        }
+
+        if (-not (Test-IsProtectedTarget $path)) {
+            # Untracked temp file, or a file git says is legitimately empty
+            # (.gitkeep). Not a regression, so keep watching.
+            Remove-Item -LiteralPath $dump -Force -ErrorAction SilentlyContinue
+            Write-Log ("Ignored 0-byte file (not tracked with content at HEAD): {0}" -f $path)
             continue
         }
 


### PR DESCRIPTION
[PR #4371](https://github.com/kanta13jp1/my_web_app/pull/4371) で投入した watcher の**本番不具合の修正**。

## 何が起きたか

本番投入から約 13 時間で watcher が**誤検知して発火し、1 回しかない捕獲枠を使い切って自己終了**していた。捕まえたのは `\.claude\worktrees\gracious-hodgkin-3f2f85\pr_diff.txt` — あるツールが生成した一時ファイルが 0 byte になっただけのもの。

## 原因 (設計ミス)

`.claude/` を `IncludeSubdirectories = $true` で監視しているが、**`.claude/worktrees/` の下には各 worktree のリポジトリ全体が入っている**(実測 6 checkout)。結果として監視対象に以下が含まれてしまっていた:

- `docs/*/.gitkeep` — **正当に空であるべき tracked ファイル**
- `.chrome-profile/Crashpad/reports/*.dmp`
- `.dart_tool/hooks_runner/**/stderr.txt`
- `build/` 配下の成果物

バースト窓のログには 29 件が並び、そのほぼ全てがこの種のノイズだった。加えて `Get-ZeroBytePath` が 6 checkout を再帰走査するため、**10 秒指定のバースト窓が実測 54 秒**かかっていた (10:45:35 → 10:46:29)。

## 修正: 3 段フィルタ

1. **安価な path 除外を snapshot より前に**置く (`worktrees` / `node_modules` / `.dart_tool` / `build`)。プロセススナップショットの費用を払う前に捨てる
2. 既存の 250ms 再チェック (書き込み途中の一過性 0 byte を除外)
3. **CI guard と同じ述語** — `tracked かつ HEAD で非空`。untracked な一時ファイルはノイズであり、元から空であるべき `.gitkeep` は regression ではない

`Get-ZeroBytePath` の再帰スキャンにも同じ除外を適用した。

## 検証 (fixture は本物の git repo)

| 投入したもの | 期待 | 結果 |
|---|---|---|
| `worktrees/` 配下の tracked ファイルを空に | 無視 | ✅ ログにも出ず (snapshot 前に除外) |
| untracked な `pr_diff.txt` (初回を殺した犯人) | 無視 | ✅ capture 0 件 |
| `.gitkeep` を touch (元から空) | 無視 | ✅ `Ignored 0-byte file (not tracked with content at HEAD)` と記録 |
| **tracked かつ HEAD 非空の `.claude/settings.json` を空に** | **捕獲** | ✅ `CAPTURED` |

捕獲時のバースト窓は `.github/workflows/ci.yml` も収集し、所要は **2 秒 (指定どおり)** に戻った。capture ダンプの 0 byte 一覧から worktrees 由来の 29 件も消えている。

## 教訓

初回投入は「計装が動くこと」は実証した (検知 → スナップショット → ログ → 自己停止がすべて期待どおり動いた) が、**スコープが間違っていた**。fixture では `.claude/worktrees/` を作らなかったため、この誤検知源は本番でしか現れなかった — **fixture が本番の構造を再現していないと、動作は検証できてもスコープは検証できない**。

## E2E について

運用スクリプトのみの変更で、アプリのコード・UI・データ経路に一切触れないため `no-e2e-needed`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>`no-e2e-needed` ラベルは PR 作成時の payload に載らないことがあるため、本文編集で再評価させている。</sub>
