### PR TITLE
feat(iq): 10仮説の実測検証にもとづくIQテスト改善 (9件修正 / 1件反証)

### DIFF
--- a/lib/data/iq_question_bank.dart
+++ b/lib/data/iq_question_bank.dart
@@ -8,6 +8,7 @@
 import 'dart:math' as math;
 
 import '../models/iq_test.dart';
+import 'iq_question_bank_alternates.dart';
 
 class IqQuestionBank {
   const IqQuestionBank._();
@@ -21,34 +22,46 @@ class IqQuestionBank {
   static int get totalQuestions =>
       IqCategory.values.length * questionsPerCategory;
 
+  /// 全問題プール (既定フォーム + 代替フォーム)。
+  static List<IqQuestion> get allQuestions =>
+      List.unmodifiable([..._all, ..._alternates]);
+
+  /// (領域, 難易度) ごとの候補。各セルに2問ずつある。
+  static Map<String, List<IqQuestion>> _pool() {
+    final pool = <String, List<IqQuestion>>{};
+    for (final q in [..._all, ..._alternates]) {
+      pool.putIfAbsent('${q.category.key}-${q.difficulty}', () => []).add(q);
+    }
+    return pool;
+  }
+
   /// 標準テストの25問を返す。
   ///
-  /// [seed] を渡すと選択肢の並びをシャッフルする (正解位置の丸暗記対策)。
+  /// [seed] を渡すと **各セルからどの問題を出すかと選択肢の並びの両方** が変わる。
+  /// 以前は seed が選択肢順しか変えず、再受験すると毎回まったく同じ25問が出て
+  /// いた (= 練習効果でスコアが上がり、推移が能力変化を表さない)。
   /// 問題の並びは領域が偏らないようラウンドロビンで交互に出す。
   static List<IqQuestion> standardTest({int? seed}) {
-    final byCategory = <IqCategory, List<IqQuestion>>{};
-    for (final q in _all) {
-      byCategory.putIfAbsent(q.category, () => []).add(q);
-    }
-    for (final list in byCategory.values) {
-      list.sort((a, b) => a.difficulty.compareTo(b.difficulty));
-    }
+    final pool = _pool();
+    final random = seed == null ? null : math.Random(seed);
 
     // ラウンドロビン: 難易度1を全領域 → 難易度2を全領域 … と並べる。
     // 序盤で難問が固まって離脱するのを防ぐ。
     final ordered = <IqQuestion>[];
-    for (var i = 0; i < questionsPerCategory; i++) {
+    for (var difficulty = 1; difficulty <= questionsPerCategory; difficulty++) {
       for (final category in IqCategory.values) {
-        final list = byCategory[category];
-        if (list != null && i < list.length) {
-          ordered.add(list[i]);
-        }
+        final candidates = pool['${category.key}-$difficulty'];
+        if (candidates == null || candidates.isEmpty) continue;
+
+        // seed 無しは常に先頭 (既定フォーム) = 決定的なので参照用に使える。
+        final picked = random == null
+            ? candidates.first
+            : candidates[random.nextInt(candidates.length)];
+        ordered.add(picked);
       }
     }
 
-    if (seed == null) return ordered;
-
-    final random = math.Random(seed);
+    if (random == null) return ordered;
     return ordered.map((q) => shuffleOptions(q, random)).toList();
   }
 
@@ -72,6 +85,9 @@ class IqQuestionBank {
       monospacePrompt: question.monospacePrompt,
     );
   }
+
+  /// 代替フォーム。各 (領域, 難易度) セルの2問目。
+  static const List<IqQuestion> _alternates = kIqAlternateQuestions;
 
   static const List<IqQuestion> _all = [
     // ---------------------------------------------------------------- 論理推論

--- a/lib/data/iq_question_bank_alternates.dart
+++ b/lib/data/iq_question_bank_alternates.dart
@@ -1,0 +1,339 @@
+// 代替フォームの25問 (5領域 × 難易度1..5)。
+//
+// 仮説検証 H1 への対応: 既定フォームだけだと再受験で毎回まったく同じ25問が出て、
+// 練習効果でスコアが上がる。推移グラフが能力変化を表さなくなるため、
+// 各 (領域, 難易度) セルに 2 問目を用意し seed で選ばせる。
+//
+// 難易度は既定フォームの同セルと揃えてある (重み構成が変わると領域間比較が崩れる)。
+
+import '../models/iq_test.dart';
+
+/// 代替フォーム。キーは既定フォームと衝突しないよう `-b` を付ける。
+const List<IqQuestion> kIqAlternateQuestions = [
+  // ---------------------------------------------------------------- 論理推論
+  IqQuestion(
+    key: 'logic-01b',
+    category: IqCategory.logic,
+    difficulty: 1,
+    prompt: 'すべての鳥は卵を生む。ハトは鳥である。\n'
+        'このとき確実に言えるのはどれか。',
+    options: [
+      'ハトは卵を生む',
+      '卵を生むものはすべて鳥である',
+      'ハトは卵を生まない',
+      '鳥の多くはハトである',
+    ],
+    correctIndex: 0,
+    explanation: '三段論法。「すべてのAはB」「xはA」から「xはB」。'
+        '逆 (卵を生む→鳥) は成り立たない。',
+  ),
+  IqQuestion(
+    key: 'logic-02b',
+    category: IqCategory.logic,
+    difficulty: 2,
+    prompt: 'PはQより速い。RはPより速い。SはQより遅い。\n'
+        '最も速いのは誰か。',
+    options: ['P', 'Q', 'R', 'S'],
+    correctIndex: 2,
+    explanation: '不等号でつなぐと R > P > Q > S。'
+        'バラバラの関係文を1本の並びに統合してから読む。',
+  ),
+  IqQuestion(
+    key: 'logic-03b',
+    category: IqCategory.logic,
+    difficulty: 3,
+    prompt: '「準備をすれば合格する」が正しいとき、\n'
+        '確実に言えるのはどれか。',
+    options: [
+      '合格したなら、準備をした',
+      '合格しなかったなら、準備をしていない',
+      '準備をしなければ、合格しない',
+      '合格したなら、準備をしていない',
+    ],
+    correctIndex: 1,
+    explanation: '確実に言えるのは対偶のみ。「準備→合格」の対偶は'
+        '「合格でない→準備でない」。逆も裏も導けない。',
+  ),
+  IqQuestion(
+    key: 'logic-04b',
+    category: IqCategory.logic,
+    difficulty: 4,
+    prompt: 'A・B・Cの3人のうち、嘘つきはちょうど1人である。\n'
+        'A「Bは正直者だ」\n'
+        'B「Cは嘘つきだ」\n'
+        'C「私は正直者だ」\n'
+        '嘘つきは誰か。',
+    options: ['A', 'B', 'C', '特定できない'],
+    correctIndex: 2,
+    explanation: 'Aが嘘つき→Bも嘘つきとなり2人で矛盾。'
+        'Bが嘘つき→Cは正直、Aは正直なのでBは正直となり矛盾。'
+        'Cが嘘つきのときだけ全発言が整合する。',
+  ),
+  IqQuestion(
+    key: 'logic-05b',
+    category: IqCategory.logic,
+    difficulty: 5,
+    prompt: '次の3つがすべて正しいとする。\n'
+        '① AならばB\n'
+        '② BでないならばC\n'
+        '③ Cではない\n'
+        'このとき確実に言えるのはどれか。',
+    options: [
+      'Aである',
+      'Bである',
+      'AでもBでもない',
+      'これだけでは判定できない',
+    ],
+    correctIndex: 1,
+    explanation: '③よりCでない。②の対偶「CでないならばB」よりBが成り立つ。'
+        '①はAについて何も決めないので、Aは不明のまま。'
+        '「全部決まる」と思い込まないことが要点。',
+  ),
+
+  // ---------------------------------------------------------------- 数的処理
+  IqQuestion(
+    key: 'num-01b',
+    category: IqCategory.numerical,
+    difficulty: 1,
+    prompt: '次の数列の「?」に入る数はどれか。\n\n5, 10, 15, 20, ?',
+    options: ['22', '25', '30', '24'],
+    correctIndex: 1,
+    explanation: '公差5の等差数列。まず隣同士の差を取る。',
+  ),
+  IqQuestion(
+    key: 'num-02b',
+    category: IqCategory.numerical,
+    difficulty: 2,
+    prompt: '次の数列の「?」に入る数はどれか。\n\n1, 8, 27, 64, ?',
+    options: ['100', '121', '125', '144'],
+    correctIndex: 2,
+    explanation: '立方数の列 (1³, 2³, 3³, 4³, 5³)。'
+        '増え方が急なら累乗を疑う。',
+  ),
+  IqQuestion(
+    key: 'num-03b',
+    category: IqCategory.numerical,
+    difficulty: 3,
+    prompt: '次の数列の「?」に入る数はどれか。\n\n1, 3, 4, 7, 11, ?',
+    options: ['15', '16', '18', '22'],
+    correctIndex: 2,
+    explanation: '直前2項の和 (1+3=4, 3+4=7, 4+7=11, 7+11=18)。'
+        '差が一定でないときは前の項との関係を疑う。',
+  ),
+  IqQuestion(
+    key: 'num-04b',
+    category: IqCategory.numerical,
+    difficulty: 4,
+    prompt: '次の数列の「?」に入る数はどれか。\n\n2, 6, 12, 20, 30, ?',
+    options: ['40', '42', '44', '36'],
+    correctIndex: 1,
+    explanation: '差が 4, 6, 8, 10 と2ずつ増える階差数列。次の差は12で 30+12=42。'
+        'n×(n+1) の形 (1·2, 2·3, 3·4 …) と見ても同じ。',
+  ),
+  IqQuestion(
+    key: 'num-05b',
+    category: IqCategory.numerical,
+    difficulty: 5,
+    prompt: '次の数列の「?」に入る数はどれか。\n\n1, 2, 5, 14, 41, ?',
+    options: ['118', '120', '122', '125'],
+    correctIndex: 2,
+    explanation: '規則は「×3して1を引く」: 1×3-1=2, 2×3-1=5, 5×3-1=14, '
+        '14×3-1=41、よって 41×3-1=122。倍率と加減が同時に動く複合型。',
+  ),
+
+  // ---------------------------------------------------------------- 空間認識
+  IqQuestion(
+    key: 'spa-01b',
+    category: IqCategory.spatial,
+    difficulty: 1,
+    prompt: '次の図形を時計回りに90度回転させた結果はどれか。\n\n'
+        '□ ■\n'
+        '□ □',
+    monospacePrompt: true,
+    options: [
+      '□ □\n□ ■',
+      '■ □\n□ □',
+      '□ ■\n□ □',
+      '□ □\n■ □',
+    ],
+    correctIndex: 0,
+    explanation: '時計回り90度で右上は右下へ移る。'
+        '基準点 (■) を1つだけ追うのがコツ。',
+  ),
+  IqQuestion(
+    key: 'spa-02b',
+    category: IqCategory.spatial,
+    difficulty: 2,
+    prompt: '次は立方体の展開図である。面Cの向かい側にくる面はどれか。\n\n'
+        '　　[A]\n'
+        '[B][C][D]\n'
+        '　　[E]\n'
+        '　　[F]',
+    monospacePrompt: true,
+    options: ['A', 'B', 'E', 'F'],
+    correctIndex: 3,
+    explanation: '縦一列に4面 (A・C・E・F) が並ぶとき、1つ飛ばしが向かい合う。'
+        'よって A↔E、C↔F。',
+  ),
+  IqQuestion(
+    key: 'spa-03b',
+    category: IqCategory.spatial,
+    difficulty: 3,
+    prompt: '次のパターンの「?」に入る図形はどれか。\n\n'
+        '●　○　◐\n'
+        '○　◐　●\n'
+        '◐　●　?',
+    monospacePrompt: true,
+    options: ['●', '○', '◐', '□'],
+    correctIndex: 1,
+    explanation: '各行が1つずつ左へずれている。'
+        '3行目は ◐→● と来ているので次は○。列方向で見ても同じ並びになる。',
+  ),
+  IqQuestion(
+    key: 'spa-04b',
+    category: IqCategory.spatial,
+    difficulty: 4,
+    prompt: '正方形の紙を対角線で半分に折り、さらにもう一度半分に折った。\n'
+        'その状態で1つ穴を開けて紙を広げると、穴はいくつあるか。',
+    options: ['2', '3', '4', '8'],
+    correctIndex: 2,
+    explanation: '2回折ると紙は4枚重なる。1回の穴あけが4枚を貫くので穴は4つ。'
+        '折り目1回につき重なりが2倍になる。',
+  ),
+  IqQuestion(
+    key: 'spa-05b',
+    category: IqCategory.spatial,
+    difficulty: 5,
+    prompt: '次の図を上下反転させ、さらに時計回りに90度回転させた結果はどれか。\n\n'
+        '■ □ □\n'
+        '■ □ □\n'
+        '■ ■ ■',
+    monospacePrompt: true,
+    options: [
+      '■ ■ ■\n□ □ ■\n□ □ ■',
+      '■ □ □\n■ □ □\n■ ■ ■',
+      '□ □ ■\n□ □ ■\n■ ■ ■',
+      '■ ■ ■\n■ □ □\n■ □ □',
+    ],
+    correctIndex: 0,
+    explanation: '上下反転で L 字が上下逆になり、時計回り90度で横棒が上へ来る。'
+        '合成変換は必ず指示された順に1つずつ適用する。',
+  ),
+
+  // -------------------------------------------------------- ワーキングメモリ
+  IqQuestion(
+    key: 'mem-01b',
+    category: IqCategory.memory,
+    difficulty: 1,
+    memoryStimulus: '4　8　2　7　5',
+    revealSeconds: 5,
+    prompt: '先ほど表示された数字のうち、最後の数字はどれか。',
+    options: ['4', '7', '5', '2'],
+    correctIndex: 2,
+    explanation: '末尾は直前に見た分なので保持しやすい (新近効果)。'
+        '中央付近がいちばん落ちやすい。',
+  ),
+  IqQuestion(
+    key: 'mem-02b',
+    category: IqCategory.memory,
+    difficulty: 2,
+    memoryStimulus: 'そら　うみ　やま　かわ　もり',
+    revealSeconds: 6,
+    prompt: '先ほど表示された単語に「含まれていなかった」ものはどれか。',
+    options: ['うみ', 'ほし', 'かわ', 'もり'],
+    correctIndex: 1,
+    explanation: '再認課題。5語を1つの風景として結びつけると保持が安定する。',
+  ),
+  IqQuestion(
+    key: 'mem-03b',
+    category: IqCategory.memory,
+    difficulty: 3,
+    memoryStimulus: '9　1　6　3　8　2　7',
+    revealSeconds: 7,
+    prompt: '先ほどの数字列を「逆から」読んだとき、最初の3つはどれか。',
+    options: ['8 2 7', '7 2 8', '2 7 8', '7 8 2'],
+    correctIndex: 1,
+    explanation: '元の列は 9 1 6 3 8 2 7。逆順の先頭3つは 7 2 8。'
+        '逆唱は保持しながら操作する課題で負荷が高い。',
+  ),
+  IqQuestion(
+    key: 'mem-04b',
+    category: IqCategory.memory,
+    difficulty: 4,
+    memoryStimulus: '春 → 桜\n夏 → 海\n秋 → 月\n冬 → 雪',
+    revealSeconds: 8,
+    prompt: '「秋」と対になっていたのはどれか。',
+    options: ['桜', '海', '月', '雪'],
+    correctIndex: 2,
+    explanation: '対連合学習。「秋の月」のように意味でつなぐと想起が速い。',
+  ),
+  IqQuestion(
+    key: 'mem-05b',
+    category: IqCategory.memory,
+    difficulty: 5,
+    memoryStimulus: 'B2　D1　A3　C4　B1　D3',
+    revealSeconds: 9,
+    prompt: '「D」で始まる組み合わせの数字を、出てきた順に並べるとどれか。',
+    options: ['3 1', '1 3', '1 1', '3 3'],
+    correctIndex: 1,
+    explanation: 'D1 が先、D3 が後なので「1 3」。'
+        '全体を覚えず、条件に合うものだけを選んで保持する選択的更新が要点。',
+  ),
+
+  // ---------------------------------------------------------------- 言語理解
+  IqQuestion(
+    key: 'ver-01b',
+    category: IqCategory.verbal,
+    difficulty: 1,
+    prompt: '「著名」に最も意味が近い語はどれか。',
+    options: ['高名', '無名', '奇妙', '平凡'],
+    correctIndex: 0,
+    explanation: 'どちらも世に広く知られていること。「無名」は対義。',
+  ),
+  IqQuestion(
+    key: 'ver-02b',
+    category: IqCategory.verbal,
+    difficulty: 2,
+    prompt: '「軽率」の対義語はどれか。',
+    options: ['軽薄', '慎重', '率直', '敏速'],
+    correctIndex: 1,
+    explanation: '深く考えずに行う「軽率」に対し、よく考えて行う「慎重」が対。'
+        '同じ漢字を含む「軽薄」「率直」に引かれないこと。',
+  ),
+  IqQuestion(
+    key: 'ver-03b',
+    category: IqCategory.verbal,
+    difficulty: 3,
+    prompt: '「画家 : 絵筆」と同じ関係になるのはどれか。\n\n彫刻家 : ?',
+    options: ['粘土', 'のみ', '石材', '工房'],
+    correctIndex: 1,
+    explanation: '「職業 : その職業が使う道具」の関係。'
+        '粘土や石材は材料、工房は場所なので関係が異なる。',
+  ),
+  IqQuestion(
+    key: 'ver-04b',
+    category: IqCategory.verbal,
+    difficulty: 4,
+    prompt: '次のうち、他と性質が異なるものはどれか。\n\nイルカ / サメ / クジラ / シャチ',
+    options: ['イルカ', 'サメ', 'クジラ', 'シャチ'],
+    correctIndex: 1,
+    explanation: 'イルカ・クジラ・シャチは哺乳類だが、サメは魚類。'
+        '「海の生き物」で止めず、もう一段細かい軸を探す。',
+  ),
+  IqQuestion(
+    key: 'ver-05b',
+    category: IqCategory.verbal,
+    difficulty: 5,
+    prompt: '「彼は謙虚だが、仕事の質には一切妥協しない」\n'
+        'この文と最も近い構造を持つのはどれか。',
+    options: [
+      '彼は明るく、誰とでもすぐ打ち解ける',
+      '彼は温厚だが、不正には決して目をつぶらない',
+      '彼は寝坊したので、会議に遅れた',
+      '彼は教師であり、詩人でもある',
+    ],
+    correctIndex: 1,
+    explanation: '「穏やかな印象」と「譲らない一面」を逆接で対比する構造。'
+        '他は並列 (1・4) と因果 (3)。',
+  ),
+];

--- a/lib/data/iq_training_drills.dart
+++ b/lib/data/iq_training_drills.dart
@@ -26,6 +26,7 @@ class IqDrillGenerator {
     final random = math.Random(seed);
     final clampedLevel = level.clamp(1, 5);
     final questions = <IqQuestion>[];
+    final session = _SessionDraw(random);
 
     for (var i = 0; i < count; i++) {
       questions.add(
@@ -34,6 +35,7 @@ class IqDrillGenerator {
           level: clampedLevel,
           index: i,
           random: random,
+          session: session,
         ),
       );
     }
@@ -45,18 +47,19 @@ class IqDrillGenerator {
     required int level,
     required int index,
     required math.Random random,
+    required _SessionDraw session,
   }) {
     switch (category) {
       case IqCategory.numerical:
         return _numerical(level, index, random);
       case IqCategory.logic:
-        return _logic(level, index, random);
+        return _logic(level, index, random, session);
       case IqCategory.spatial:
         return _spatial(level, index, random);
       case IqCategory.memory:
         return _memory(level, index, random);
       case IqCategory.verbal:
-        return _verbal(level, index, random);
+        return _verbal(level, index, random, session);
     }
   }
 
@@ -203,6 +206,8 @@ class IqDrillGenerator {
     ['りんご', '果物', '食べ物'],
     ['正方形', '四角形', '図形'],
     ['ピアノ', '楽器', '道具'],
+    ['カブトムシ', '昆虫', '動物'],
+    ['ひまわり', '植物', '生物'],
   ];
 
   static const List<String> _logicNames = [
@@ -213,14 +218,19 @@ class IqDrillGenerator {
     'E',
   ];
 
-  static IqQuestion _logic(int level, int index, math.Random random) {
+  static IqQuestion _logic(
+    int level,
+    int index,
+    math.Random random,
+    _SessionDraw session,
+  ) {
     switch (level) {
       case 1:
-        return _logicSyllogism(level, index, random);
+        return _logicSyllogism(level, index, random, session);
       case 2:
         return _logicOrdering(level, index, random, itemCount: 3);
       case 3:
-        return _logicContrapositive(level, index, random);
+        return _logicContrapositive(level, index, random, session);
       case 4:
         return _logicOrdering(level, index, random, itemCount: 4);
       default:
@@ -228,8 +238,16 @@ class IqDrillGenerator {
     }
   }
 
-  static IqQuestion _logicSyllogism(int level, int index, math.Random random) {
-    final triple = _logicCategories[random.nextInt(_logicCategories.length)];
+  static IqQuestion _logicSyllogism(
+    int level,
+    int index,
+    math.Random random,
+    _SessionDraw session,
+  ) {
+    final triple = _logicCategories[session.next(
+      'logicCategories',
+      _logicCategories.length,
+    )];
     final specific = triple[0];
     final middle = triple[1];
     final broad = triple[2];
@@ -291,14 +309,19 @@ class IqDrillGenerator {
     int level,
     int index,
     math.Random random,
+    _SessionDraw session,
   ) {
     const pairs = [
       ['雨が降る', '試合は中止になる'],
       ['電源が入っている', 'ランプが点く'],
       ['会員である', '割引が受けられる'],
       ['締切に間に合う', 'ボーナスが出る'],
+      ['試験に合格する', '資格が取れる'],
+      ['気温が下がる', '水が凍る'],
+      ['鍵をかける', '安全になる'],
+      ['雨が続く', '川が増水する'],
     ];
-    final pair = pairs[random.nextInt(pairs.length)];
+    final pair = pairs[session.next('logicConditionals', pairs.length)];
     final p = pair[0];
     final q = pair[1];
 
@@ -699,6 +722,8 @@ class IqDrillGenerator {
     ['具体', '抽象', '実体', '具現', '個別'],
     ['集中', '分散', '凝縮', '密集', '専念'],
     ['促進', '抑制', '推進', '助長', '加速'],
+    ['拡大', '縮小', '拡張', '増大', '巨大'],
+    ['原因', '結果', '要因', '起因', '動機'],
   ];
 
   /// [A, B, C, 正解, 誤答1, 誤答2, 誤答3, 関係の説明]
@@ -709,6 +734,8 @@ class IqDrillGenerator {
     ['寒い', '暖房', '暗い', '照明', '電気', '夜', '眠気', '状態とそれを解消する手段'],
     ['種', '花', '卵', 'ひな', '鳥', '巣', '殻', '初期状態とそこから育つもの'],
     ['温度計', '温度', '時計', '時刻', '針', '数字', '時間割', '計測器とそれが測る量'],
+    ['画家', '絵筆', '大工', 'のこぎり', '木材', '家', '設計図', '職業とその職業が使う道具'],
+    ['雨', '傘', '日差し', '帽子', '夏', '日焼け', '雲', '事象とそれを防ぐ道具'],
   ];
 
   /// [仲間はずれ, 同種1, 同種2, 同種3, 理由]
@@ -718,33 +745,146 @@ class IqDrillGenerator {
     ['トマト', 'にんじん', 'だいこん', 'ごぼう', 'トマトだけが果菜で、他は根菜'],
     ['銅', '木材', '鉄', 'アルミ', '木材だけが金属でない'],
     ['ピアノ', 'バイオリン', 'チェロ', 'ギター', 'ピアノだけが弦を指で弾かない (打弦楽器)'],
+    ['コウモリ', 'ワシ', 'ハト', 'ツバメ', 'コウモリだけが哺乳類で、他は鳥類'],
+    ['砂', '金', '銀', '銅', '砂だけが金属でない'],
+    ['トランペット', 'バイオリン', 'チェロ', 'ビオラ', 'トランペットだけが金管楽器で、他は弦楽器'],
   ];
 
-  static IqQuestion _verbal(int level, int index, math.Random random) {
+  static IqQuestion _verbal(
+    int level,
+    int index,
+    math.Random random,
+    _SessionDraw session,
+  ) {
     switch (level) {
       case 1:
-        return _verbalSynonym(level, index, random, pool: _synonymPool);
+        return _verbalSynonym(
+          level,
+          index,
+          random,
+          session,
+          pool: _synonymPool,
+        );
       case 2:
-        return _verbalAntonym(level, index, random);
+        return _verbalAntonym(level, index, random, session);
       case 3:
-        return _verbalAnalogy(level, index, random);
+        return _verbalAnalogy(level, index, random, session);
       case 4:
-        return _verbalOddOneOut(level, index, random);
+        return _verbalOddOneOut(level, index, random, session);
       default:
-        // レベル5は類推と仲間はずれを混ぜ、関係の抽象度が高いものを出す。
-        return random.nextBool()
-            ? _verbalAnalogy(level, index, random)
-            : _verbalOddOneOut(level, index, random);
+        // レベル5は「文の構造どうしを対応させる」課題。
+        // 以前は L3/L4 の生成器を混ぜていただけで、difficulty ラベルが 5 に
+        // なるだけで実際には難しくなっていなかった (第3ラウンド T3 で実測)。
+        return _verbalSentenceRelation(level, index, random, session);
     }
+  }
+
+  /// [文, 構造, 同構造の文, 別構造1, 別構造2, 別構造3]
+  ///
+  /// L5 専用。語と語ではなく **文と文の論理構造** を対応させる課題で、
+  /// L3 (類推) / L4 (仲間はずれ) より一段抽象度が高い。
+  static const List<List<String>> _sentenceRelationPool = [
+    [
+      '彼は寡黙だが、いざという時には誰よりも雄弁だ',
+      '逆接による対比',
+      '彼は小柄だが、力は誰にも負けない',
+      '彼は勤勉で、成績も良い',
+      '彼は疲れたので、早く寝た',
+      '彼は医者であり、作家でもある',
+    ],
+    [
+      '雨が降ったので、試合は中止になった',
+      '原因と結果',
+      '寝坊したので、電車に乗り遅れた',
+      '彼は静かだが、芯は強い',
+      '彼は教師でもあり、詩人でもある',
+      '早く行けば、席が取れる',
+    ],
+    [
+      '練習を続ければ、必ず上達する',
+      '条件と帰結',
+      '早起きすれば、朝日が見られる',
+      '彼女は優しく、そして厳しい',
+      '道が混んだので、遅刻した',
+      '彼は無口だが、よく笑う',
+    ],
+    [
+      '彼女は歌も上手いし、踊りも上手い',
+      '並列の列挙',
+      'この店は安いし、味も良い',
+      '彼は若いが、経験は豊富だ',
+      '風が強いので、電車が止まった',
+      '準備すれば、失敗は減る',
+    ],
+    [
+      '小さな店だが、味は一流だ',
+      '逆接による対比',
+      '古い家だが、住み心地は良い',
+      '雪が降ったので、道が凍った',
+      '彼は速く走り、高く跳ぶ',
+      '練習すれば、上達する',
+    ],
+    [
+      '道が凍ったので、転んでしまった',
+      '原因と結果',
+      '風邪をひいたので、仕事を休んだ',
+      '安いけれど、質は高い',
+      '彼は歌い、そして踊る',
+      '走れば、間に合う',
+    ],
+    [
+      'よく眠れば、頭が冴える',
+      '条件と帰結',
+      '毎日書けば、文章は上達する',
+      '彼は寡黙だが、優しい',
+      '雨なので、試合は中止だ',
+      '彼は速く、そして正確だ',
+    ],
+    [
+      'この本は面白いし、ためになる',
+      '並列の列挙',
+      'あの人は明るいし、頼りになる',
+      '静かだが、存在感がある',
+      '遅れたので、謝った',
+      '努力すれば、報われる',
+    ],
+  ];
+
+  static IqQuestion _verbalSentenceRelation(
+    int level,
+    int index,
+    math.Random random,
+    _SessionDraw session,
+  ) {
+    final row = _sentenceRelationPool[session.next(
+      'sentenceRelation',
+      _sentenceRelationPool.length,
+    )];
+    final source = row[0];
+    final relation = row[1];
+    final answer = row[2];
+    final options = row.sublist(2).toList()..shuffle(random);
+
+    return IqQuestion(
+      key: _key(IqCategory.verbal, level, index),
+      category: IqCategory.verbal,
+      difficulty: level,
+      prompt: '「$source」\nこの文と最も近い構造を持つのはどれか。',
+      options: options,
+      correctIndex: options.indexOf(answer),
+      explanation: '元の文の構造は「$relation」。正解は「$answer」。'
+          '語の意味ではなく、節と節のつながり方を見る。',
+    );
   }
 
   static IqQuestion _verbalSynonym(
     int level,
     int index,
-    math.Random random, {
+    math.Random random,
+    _SessionDraw session, {
     required List<List<String>> pool,
   }) {
-    final row = pool[random.nextInt(pool.length)];
+    final row = pool[session.next('synonym', pool.length)];
     final word = row[0];
     final answer = row[1];
     final options = row.sublist(1).toList()..shuffle(random);
@@ -761,8 +901,13 @@ class IqDrillGenerator {
     );
   }
 
-  static IqQuestion _verbalAntonym(int level, int index, math.Random random) {
-    final row = _antonymPool[random.nextInt(_antonymPool.length)];
+  static IqQuestion _verbalAntonym(
+    int level,
+    int index,
+    math.Random random,
+    _SessionDraw session,
+  ) {
+    final row = _antonymPool[session.next('antonym', _antonymPool.length)];
     final word = row[0];
     final answer = row[1];
     final options = row.sublist(1).toList()..shuffle(random);
@@ -779,8 +924,13 @@ class IqDrillGenerator {
     );
   }
 
-  static IqQuestion _verbalAnalogy(int level, int index, math.Random random) {
-    final row = _analogyPool[random.nextInt(_analogyPool.length)];
+  static IqQuestion _verbalAnalogy(
+    int level,
+    int index,
+    math.Random random,
+    _SessionDraw session,
+  ) {
+    final row = _analogyPool[session.next('analogy', _analogyPool.length)];
     final a = row[0];
     final b = row[1];
     final c = row[2];
@@ -804,8 +954,10 @@ class IqDrillGenerator {
     int level,
     int index,
     math.Random random,
+    _SessionDraw session,
   ) {
-    final row = _oddOneOutPool[random.nextInt(_oddOneOutPool.length)];
+    final row =
+        _oddOneOutPool[session.next('oddOneOut', _oddOneOutPool.length)];
     final answer = row[0];
     final reason = row[4];
     final options = row.sublist(0, 4).toList()..shuffle(random);
@@ -820,5 +972,35 @@ class IqDrillGenerator {
       explanation: '正解は「$answer」。$reason。'
           '共通点で止めず、もう一段細かい軸を探すのが仲間はずれ問題のコツ。',
     );
+  }
+}
+
+/// 1セッション内で同じ出題プール行を使い回さないための抽選器。
+///
+/// 出題プールは 5〜8 行しかないのに 1 セッションは 8 問あるため、
+/// 毎回 `random.nextInt(pool.length)` を引くと同一セッション内で同じ問題が
+/// 何度も出る (実測: 語彙L1 は 30/30 セッションで重複し、最大 4 問が重複)。
+/// 同じ問題を続けて解かされるのは学習としても測定としても無意味なので、
+/// プールごとに順列を作って先頭から配り、尽きたら並べ替えて配り直す。
+class _SessionDraw {
+  final math.Random _random;
+
+  /// プール識別子 -> まだ配っていない添字の並び。
+  final Map<String, List<int>> _remaining = {};
+
+  _SessionDraw(this._random);
+
+  /// [poolSize] 件のプールから、セッション内で重複しない添字を1つ返す。
+  ///
+  /// プールを配り切った場合のみ最初から配り直す (8問 > プール件数のとき)。
+  int next(String poolId, int poolSize) {
+    if (poolSize <= 0) return 0;
+
+    var queue = _remaining[poolId];
+    if (queue == null || queue.isEmpty) {
+      queue = List<int>.generate(poolSize, (i) => i)..shuffle(_random);
+      _remaining[poolId] = queue;
+    }
+    return queue.removeLast();
   }
 }

--- a/lib/models/iq_test.dart
+++ b/lib/models/iq_test.dart
@@ -266,9 +266,61 @@ class IqCategoryScore {
     required this.standardError,
   });
 
+  /// 判定に使う標準誤差。
+  ///
+  /// [standardError] は列欠損時に 0 が入る。0 をそのまま弱点判定の閾値に使うと
+  /// 「総合を1ポイントでも下回れば弱点」に退化し、固定閾値だった頃より
+  /// 過検出がひどくなる。実際には5問の測定で誤差が 0 になることはないので、
+  /// 下限を設けて 0 を弾く。
+  static const double minimumStandardError = 3.0;
+
+  double get effectiveStandardError => standardError < minimumStandardError
+      ? minimumStandardError
+      : standardError;
+
   /// 95% 信頼区間の下限 / 上限。UI では必ず幅つきで見せる。
-  int get iqLower => (iq - 1.96 * standardError).round();
-  int get iqUpper => (iq + 1.96 * standardError).round();
+  int get iqLower => (iq - 1.96 * effectiveStandardError).round();
+  int get iqUpper => (iq + 1.96 * effectiveStandardError).round();
+
+  /// 弱点判定の唯一の実装。
+  ///
+  /// **測定誤差を上回る差だけ**を弱点とする。5問しかない領域スコアの標準誤差は
+  /// 約 18 IQ あり、固定閾値 5 は誤差の 0.27 SE にすぎなかった
+  /// (= ノイズを弱点と呼んでいた)。全領域が誤差内なら空リストを返し、
+  /// 「差が無い」ではなく「差を判別できない」ことを呼び出し側で表現する。
+  ///
+  /// 同じ式を複数のクラスに写すと片側だけ直したときに静かに乖離するため、
+  /// ここを唯一の真実として全呼び出し元がこれを使う。
+  static List<IqCategoryScore> selectWeak(
+    List<IqCategoryScore> scores,
+    int referenceIq, {
+    double sigmaThreshold = 1.0,
+  }) {
+    final weak = scores
+        .where(
+          (s) =>
+              (referenceIq - s.iq) > sigmaThreshold * s.effectiveStandardError,
+        )
+        .toList()
+      ..sort((a, b) => a.iq.compareTo(b.iq));
+    return weak;
+  }
+
+  /// [selectWeak] と対称の強み判定。
+  static List<IqCategoryScore> selectStrong(
+    List<IqCategoryScore> scores,
+    int referenceIq, {
+    double sigmaThreshold = 1.0,
+  }) {
+    final strong = scores
+        .where(
+          (s) =>
+              (s.iq - referenceIq) > sigmaThreshold * s.effectiveStandardError,
+        )
+        .toList()
+      ..sort((a, b) => b.iq.compareTo(a.iq));
+    return strong;
+  }
 
   Map<String, dynamic> toJson() => {
         'category': category.key,
@@ -347,27 +399,21 @@ class IqTestResult {
   }
 
   /// 総合値より明確に低い領域 = トレーニング対象。
-  ///
-  /// **測定誤差を上回る差だけ**を弱点とする。5問しかない領域スコアの標準誤差は
-  /// 約 18 IQ あり、旧実装の固定閾値 5 は誤差の 0.27 SE にすぎなかった
-  /// (= ノイズを弱点と呼んでいた)。全領域が誤差内なら空リストを返し、
-  /// 「差が無い」ではなく「差を判別できない」ことを呼び出し側で表現する。
-  List<IqCategoryScore> weakAreas({double sigmaThreshold = 1.0}) {
-    final weak = categoryScores
-        .where((s) => (totalIq - s.iq) > sigmaThreshold * s.standardError)
-        .toList()
-      ..sort((a, b) => a.iq.compareTo(b.iq));
-    return weak;
-  }
+  /// 判定の実体は [IqCategoryScore.selectWeak] に一本化してある。
+  List<IqCategoryScore> weakAreas({double sigmaThreshold = 1.0}) =>
+      IqCategoryScore.selectWeak(
+        categoryScores,
+        totalIq,
+        sigmaThreshold: sigmaThreshold,
+      );
 
   /// 相対的に強い領域。判定基準は [weakAreas] と対称。
-  List<IqCategoryScore> strongAreas({double sigmaThreshold = 1.0}) {
-    final strong = categoryScores
-        .where((s) => (s.iq - totalIq) > sigmaThreshold * s.standardError)
-        .toList()
-      ..sort((a, b) => b.iq.compareTo(a.iq));
-    return strong;
-  }
+  List<IqCategoryScore> strongAreas({double sigmaThreshold = 1.0}) =>
+      IqCategoryScore.selectStrong(
+        categoryScores,
+        totalIq,
+        sigmaThreshold: sigmaThreshold,
+      );
 
   /// 完答率 0.0..1.0。不明な場合は 1.0 とみなす (旧データ互換)。
   double get completionRate {
@@ -376,7 +422,13 @@ class IqTestResult {
   }
 
   /// スコアを額面どおり読んでよいか。
-  bool get isReliable => completionRate >= 0.9;
+  ///
+  /// 閾値 0.8 = 25問中5問までの未着手は許容する。
+  /// 0.9 だと3問スキップで「測れていない」と出てしまい、警告が日常化して
+  /// 本当に測れていない回 (半分以上未着手など) を見落とす。
+  bool get isReliable => completionRate >= reliableCompletionRate;
+
+  static const double reliableCompletionRate = 0.8;
 
   factory IqTestResult.fromJson(
     Map<String, dynamic> json, {

--- a/lib/models/iq_test.dart
+++ b/lib/models/iq_test.dart
@@ -157,6 +157,48 @@ class IqQuestion {
   bool get hasMemoryPhase => memoryStimulus != null && revealSeconds != null;
 
   bool isCorrect(int selectedIndex) => selectedIndex == correctIndex;
+
+  /// 読み上げ用の問題文。図形は言葉に開く。
+  String get semanticPrompt =>
+      monospacePrompt ? describeGridText(prompt) : prompt;
+
+  /// 読み上げ用の選択肢。
+  String semanticOption(int index) =>
+      monospacePrompt ? describeGridText(options[index]) : options[index];
+}
+
+/// 等幅グリッド (■ / □) を含むテキストを読み上げ可能な説明へ開く。
+///
+/// スクリーンリーダーは ■ を「黒い四角」等としか読まないため、
+/// 空間問題は音声だけでは配置が復元できず解答不能になる。
+/// グリッド行だけを検出し「1行目: 塗り、空」の形に置き換える。
+/// グリッド以外の行はそのまま残す。
+String describeGridText(String text) {
+  final lines = text.split('\n');
+  final out = <String>[];
+  var rowNumber = 0;
+
+  for (final line in lines) {
+    final trimmed = line.trim();
+    final isGridRow =
+        trimmed.isNotEmpty && RegExp(r'^[■□\s]+$').hasMatch(trimmed);
+
+    if (!isGridRow) {
+      rowNumber = 0;
+      out.add(line);
+      continue;
+    }
+
+    rowNumber++;
+    final cells = trimmed
+        .split(RegExp(r'\s+'))
+        .where((c) => c.isNotEmpty)
+        .map((c) => c == '■' ? '塗り' : '空')
+        .join('、');
+    out.add('$rowNumber行目: $cells');
+  }
+
+  return out.join('\n');
 }
 
 /// 1問への回答。
@@ -266,7 +308,18 @@ class IqTestResult {
   final double weightedAccuracy;
   final int correctCount;
   final int questionCount;
+
+  /// 実際に着手した問題数 (未回答を除く)。
+  ///
+  /// [questionCount] だけでは「3問解いて時間切れ」と「25問解いて低得点」を
+  /// 区別できない。列を持たない古い結果では null になり [questionCount] に
+  /// フォールバックする。
+  final int? attemptedCount;
   final int durationSeconds;
+
+  /// 出題時の選択肢シャッフルに使ったシード。
+  /// これがあれば結果画面で当時と同一の問題・選択肢順を再構成できる。
+  final int? questionSeed;
   final List<IqCategoryScore> categoryScores;
 
   const IqTestResult({
@@ -282,6 +335,8 @@ class IqTestResult {
     required this.questionCount,
     required this.durationSeconds,
     required this.categoryScores,
+    this.attemptedCount,
+    this.questionSeed,
   });
 
   IqCategoryScore? scoreFor(IqCategory category) {
@@ -293,24 +348,35 @@ class IqTestResult {
 
   /// 総合値より明確に低い領域 = トレーニング対象。
   ///
-  /// 「最低の1つ」ではなく「総合を [gapThreshold] 以上下回るもの全部」を返す。
-  /// 全領域が均等なら空リスト = 弱点なし、を正しく表現できる。
-  List<IqCategoryScore> weakAreas({int gapThreshold = 5}) {
+  /// **測定誤差を上回る差だけ**を弱点とする。5問しかない領域スコアの標準誤差は
+  /// 約 18 IQ あり、旧実装の固定閾値 5 は誤差の 0.27 SE にすぎなかった
+  /// (= ノイズを弱点と呼んでいた)。全領域が誤差内なら空リストを返し、
+  /// 「差が無い」ではなく「差を判別できない」ことを呼び出し側で表現する。
+  List<IqCategoryScore> weakAreas({double sigmaThreshold = 1.0}) {
     final weak = categoryScores
-        .where((s) => s.iq <= totalIq - gapThreshold)
+        .where((s) => (totalIq - s.iq) > sigmaThreshold * s.standardError)
         .toList()
       ..sort((a, b) => a.iq.compareTo(b.iq));
     return weak;
   }
 
-  /// 相対的に強い領域。
-  List<IqCategoryScore> strongAreas({int gapThreshold = 5}) {
+  /// 相対的に強い領域。判定基準は [weakAreas] と対称。
+  List<IqCategoryScore> strongAreas({double sigmaThreshold = 1.0}) {
     final strong = categoryScores
-        .where((s) => s.iq >= totalIq + gapThreshold)
+        .where((s) => (s.iq - totalIq) > sigmaThreshold * s.standardError)
         .toList()
       ..sort((a, b) => b.iq.compareTo(a.iq));
     return strong;
   }
+
+  /// 完答率 0.0..1.0。不明な場合は 1.0 とみなす (旧データ互換)。
+  double get completionRate {
+    if (questionCount == 0) return 0;
+    return (attemptedCount ?? questionCount) / questionCount;
+  }
+
+  /// スコアを額面どおり読んでよいか。
+  bool get isReliable => completionRate >= 0.9;
 
   factory IqTestResult.fromJson(
     Map<String, dynamic> json, {
@@ -329,6 +395,8 @@ class IqTestResult {
       weightedAccuracy: (json['weighted_accuracy'] as num?)?.toDouble() ?? 0,
       correctCount: json['correct_count'] as int? ?? 0,
       questionCount: json['question_count'] as int? ?? 0,
+      attemptedCount: json['attempted_count'] as int?,
+      questionSeed: json['question_seed'] as int?,
       durationSeconds: json['duration_seconds'] as int? ?? 0,
       categoryScores: categoryScores,
     );

--- a/lib/pages/iq_test_questions_page.dart
+++ b/lib/pages/iq_test_questions_page.dart
@@ -26,7 +26,8 @@ class IqTestQuestionsPage extends StatefulWidget {
   State<IqTestQuestionsPage> createState() => _IqTestQuestionsPageState();
 }
 
-class _IqTestQuestionsPageState extends State<IqTestQuestionsPage> {
+class _IqTestQuestionsPageState extends State<IqTestQuestionsPage>
+    with WidgetsBindingObserver {
   final IqTestService _service = IqTestService();
 
   late final List<IqQuestion> _questions;
@@ -55,12 +56,31 @@ class _IqTestQuestionsPageState extends State<IqTestQuestionsPage> {
     _remainingSeconds = IqQuestionBank.timeLimit.inSeconds;
     _testStartedAt = DateTime.now();
     _questionStartedAt = DateTime.now();
+    WidgetsBinding.instance.addObserver(this);
     _startGlobalTimer();
     _prepareQuestion();
   }
 
+  /// アプリが背面に回ったら記憶課題の提示を止める。
+  ///
+  /// 提示タイマーは実時間で進むため、タブを隠している間もカウントが進み、
+  /// 戻ってきたときには刺激が消えている = 見ていないのに解答を迫られる。
+  /// 背面では一時停止し、復帰時に残り時間から再開する。
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (!_isRevealing) return;
+
+    if (state == AppLifecycleState.resumed) {
+      _resumeRevealCountdown();
+    } else {
+      _revealTimer?.cancel();
+    }
+  }
+
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _revealTimer?.cancel();
     _globalTimer?.cancel();
     super.dispose();
@@ -94,6 +114,15 @@ class _IqTestQuestionsPageState extends State<IqTestQuestionsPage> {
       _revealRemaining = _current.revealSeconds!;
     });
 
+    _resumeRevealCountdown();
+  }
+
+  /// 残り [_revealRemaining] 秒からカウントダウンを（再）開始する。
+  ///
+  /// 初回開始と背面復帰の両方から呼ぶ。残り時間を状態に持たせているので、
+  /// 中断しても見せていない分は減らない。
+  void _resumeRevealCountdown() {
+    _revealTimer?.cancel();
     _revealTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
       if (!mounted) return;
       setState(() => _revealRemaining--);
@@ -405,8 +434,11 @@ class _IqTestQuestionsPageState extends State<IqTestQuestionsPage> {
               borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
               border: Border.all(color: DesignTokens.divider),
             ),
+            // 図形問題は ■□ のままでは読み上げで配置が伝わらないため、
+            // 音声には言葉へ開いた説明を渡す。
             child: Text(
               question.prompt,
+              semanticsLabel: question.semanticPrompt,
               style: TextStyle(
                 color: DesignTokens.textOnDark,
                 fontSize: 16,
@@ -422,6 +454,7 @@ class _IqTestQuestionsPageState extends State<IqTestQuestionsPage> {
               child: _OptionButton(
                 label: String.fromCharCode(65 + i),
                 text: question.options[i],
+                semanticText: question.semanticOption(i),
                 monospace: question.monospacePrompt,
                 enabled: !_isSubmitting,
                 onTap: () => _answer(i),
@@ -488,6 +521,9 @@ class _DifficultyChip extends StatelessWidget {
 class _OptionButton extends StatelessWidget {
   final String label;
   final String text;
+
+  /// 読み上げ用の代替テキスト。図形選択肢を言葉に開いたもの。
+  final String semanticText;
   final bool monospace;
   final bool enabled;
   final VoidCallback onTap;
@@ -495,6 +531,7 @@ class _OptionButton extends StatelessWidget {
   const _OptionButton({
     required this.label,
     required this.text,
+    required this.semanticText,
     required this.monospace,
     required this.enabled,
     required this.onTap,
@@ -539,6 +576,7 @@ class _OptionButton extends StatelessWidget {
               Expanded(
                 child: Text(
                   text,
+                  semanticsLabel: semanticText,
                   style: TextStyle(
                     color: DesignTokens.textPrimary,
                     fontSize: 15,

--- a/lib/pages/iq_test_result_page.dart
+++ b/lib/pages/iq_test_result_page.dart
@@ -5,11 +5,13 @@
 
 import 'package:flutter/material.dart';
 
+import '../data/iq_question_bank.dart';
 import '../models/iq_test.dart';
 import '../services/iq_scoring.dart';
 import '../services/iq_test_service.dart';
 import '../services/iq_training_service.dart';
 import '../theme/design_tokens.dart';
+import '../widgets/iq_review_list.dart';
 import '../widgets/iq_score_widgets.dart';
 import 'iq_training_page.dart';
 
@@ -40,6 +42,11 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
   bool _isCreatingPlan = false;
   String? _error;
 
+  /// 振り返り用: 保存済み回答と、seed から復元した当時の問題。
+  List<IqAnswerRecord> _answers = const [];
+  Map<String, IqQuestion> _questionsByKey = const {};
+  bool _isLoadingReview = true;
+
   @override
   void initState() {
     super.initState();
@@ -49,6 +56,7 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
     } else {
       _load();
     }
+    _loadReview();
   }
 
   Future<void> _load() async {
@@ -66,6 +74,34 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
         _isLoading = false;
         _error = '結果の読み込みに失敗しました: $e';
       });
+    }
+  }
+
+  /// 振り返り用データを読み込む。
+  ///
+  /// 問題本体は DB に無いため、保存済みの question_seed で当時の出題を
+  /// 再構成して回答と突き合わせる。seed が無い古い記録では復元できないので
+  /// 振り返りセクション自体を出さない。
+  Future<void> _loadReview() async {
+    try {
+      final answers = await _testService.getAnswers(widget.testId);
+      final seed = _result?.questionSeed ??
+          (await _testService.getTestResult(widget.testId))?.questionSeed;
+
+      final questions = seed == null
+          ? <IqQuestion>[]
+          : IqQuestionBank.standardTest(seed: seed);
+
+      if (!mounted) return;
+      setState(() {
+        _answers = answers;
+        _questionsByKey = {for (final q in questions) q.key: q};
+        _isLoadingReview = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      // 振り返りが出せなくてもスコア表示は妨げない
+      setState(() => _isLoadingReview = false);
     }
   }
 
@@ -161,6 +197,33 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
                 style: TextStyle(color: DesignTokens.amber, fontSize: 12),
               ),
             ),
+          // H4: 未回答が多い回は「実力が低い」のではなく「測れていない」。
+          // 同じ見た目で数値だけ出すと利用者が判断を誤る。
+          if (!result.isReliable)
+            Container(
+              width: double.infinity,
+              margin: const EdgeInsets.only(bottom: DesignTokens.space16),
+              padding: const EdgeInsets.all(DesignTokens.space12),
+              decoration: BoxDecoration(
+                color: DesignTokens.red.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+                border: Border.all(
+                  color: DesignTokens.red.withValues(alpha: 0.4),
+                ),
+              ),
+              child: Text(
+                '着手できたのは ${result.attemptedCount ?? 0} / '
+                '${result.questionCount} 問 '
+                '(完答率 ${(result.completionRate * 100).round()}%) です。'
+                'この回のスコアは実力ではなく「測れていない」ことを表しています。'
+                '最後まで解ける状態で受け直してください。',
+                style: const TextStyle(
+                  color: DesignTokens.red,
+                  fontSize: 12,
+                  height: 1.6,
+                ),
+              ),
+            ),
           IqScoreDial(
             iq: result.totalIq,
             percentile: result.percentile,
@@ -197,6 +260,20 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
             onPressed: _createPlanAndGo,
           ),
           const SizedBox(height: DesignTokens.space24),
+
+          if (!_isLoadingReview && _questionsByKey.isNotEmpty) ...[
+            const _SectionTitle(
+              title: '問題ごとの振り返り',
+              subtitle: '間違えた問題こそ伸びしろです。解説を読んでから学習に進んでください。',
+            ),
+            const SizedBox(height: DesignTokens.space12),
+            IqReviewList(
+              answers: _answers,
+              questionsByKey: _questionsByKey,
+            ),
+            const SizedBox(height: DesignTokens.space24),
+          ],
+
           const IqDisclaimerCard(),
           const SizedBox(height: DesignTokens.space32),
         ],

--- a/lib/pages/iq_test_result_page.dart
+++ b/lib/pages/iq_test_result_page.dart
@@ -45,6 +45,10 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
   /// 振り返り用: 保存済み回答と、seed から復元した当時の問題。
   List<IqAnswerRecord> _answers = const [];
   Map<String, IqQuestion> _questionsByKey = const {};
+
+  /// 復元した選択肢の並びが当時と一致しているか。
+  /// false のときは selectedIndex から「選んだ選択肢」を復元できない。
+  bool _optionOrderIsTrustworthy = true;
   bool _isLoadingReview = true;
 
   @override
@@ -53,10 +57,15 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
     if (widget.initialResult != null) {
       _result = widget.initialResult;
       _isLoading = false;
+      _loadReview();
     } else {
-      _load();
+      // 結果の取得を待ってから振り返りを読む。
+      // 並行に走らせると _loadReview 側で _result がまだ null になり、
+      // 同じ行をもう一度取りに行っていた (毎回2回フェッチ)。
+      _load().then((_) {
+        if (mounted) _loadReview();
+      });
     }
-    _loadReview();
   }
 
   Future<void> _load() async {
@@ -85,17 +94,36 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
   Future<void> _loadReview() async {
     try {
       final answers = await _testService.getAnswers(widget.testId);
-      final seed = _result?.questionSeed ??
-          (await _testService.getTestResult(widget.testId))?.questionSeed;
+      final seed = _result?.questionSeed;
 
-      final questions = seed == null
+      // seed から当時の出題を復元する。選択肢の並びまで一致して初めて
+      // 「あなたが選んだ選択肢」を index から復元できる。
+      final reconstructed = seed == null
           ? <IqQuestion>[]
           : IqQuestionBank.standardTest(seed: seed);
+      final byKey = {for (final q in reconstructed) q.key: q};
+
+      // 復元集合が回答キーを網羅しているか。
+      // seed の意味を変えた修正 (出題そのものも seed で選ぶ) の前に受けた回は
+      // 復元が一致しないため、放置すると該当問題が振り返りから静かに消える。
+      final answeredKeys = answers.map((a) => a.questionKey).toSet();
+      final reconstructionMatches =
+          answeredKeys.isNotEmpty && answeredKeys.every(byKey.containsKey);
+
+      // 一致しない場合は正本 (全プール) から引いて問題自体は必ず表示する。
+      // ただし選択肢の並びは復元できないので index 由来の表示は使わせない。
+      final resolved = reconstructionMatches
+          ? byKey
+          : {
+              for (final q in IqQuestionBank.allQuestions)
+                if (answeredKeys.contains(q.key)) q.key: q,
+            };
 
       if (!mounted) return;
       setState(() {
         _answers = answers;
-        _questionsByKey = {for (final q in questions) q.key: q};
+        _questionsByKey = resolved;
+        _optionOrderIsTrustworthy = reconstructionMatches;
         _isLoadingReview = false;
       });
     } catch (e) {
@@ -270,6 +298,7 @@ class _IqTestResultPageState extends State<IqTestResultPage> {
             IqReviewList(
               answers: _answers,
               questionsByKey: _questionsByKey,
+              optionOrderIsTrustworthy: _optionOrderIsTrustworthy,
             ),
             const SizedBox(height: DesignTokens.space24),
           ],

--- a/lib/pages/iq_training_drill_page.dart
+++ b/lib/pages/iq_training_drill_page.dart
@@ -33,7 +33,8 @@ class IqTrainingDrillPage extends StatefulWidget {
   State<IqTrainingDrillPage> createState() => _IqTrainingDrillPageState();
 }
 
-class _IqTrainingDrillPageState extends State<IqTrainingDrillPage> {
+class _IqTrainingDrillPageState extends State<IqTrainingDrillPage>
+    with WidgetsBindingObserver {
   final IqTrainingService _service = IqTrainingService();
 
   late final List<IqQuestion> _questions;
@@ -60,11 +61,25 @@ class _IqTrainingDrillPageState extends State<IqTrainingDrillPage> {
       seed: widget.seed ?? math.Random().nextInt(1 << 31),
     );
     _startedAt = DateTime.now();
+    WidgetsBinding.instance.addObserver(this);
     _prepareQuestion();
+  }
+
+  /// 背面では刺激の提示カウントを止める (テスト側と同じ理由)。
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (!_isRevealing) return;
+    if (state == AppLifecycleState.resumed) {
+      _resumeRevealCountdown();
+    } else {
+      _revealTimer?.cancel();
+    }
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _revealTimer?.cancel();
     super.dispose();
   }
@@ -85,6 +100,12 @@ class _IqTrainingDrillPageState extends State<IqTrainingDrillPage> {
       _revealRemaining = _current.revealSeconds!;
     });
 
+    _resumeRevealCountdown();
+  }
+
+  /// 残り時間からカウントダウンを（再）開始する。
+  void _resumeRevealCountdown() {
+    _revealTimer?.cancel();
     _revealTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
       if (!mounted) return;
       setState(() => _revealRemaining--);
@@ -259,8 +280,10 @@ class _IqTrainingDrillPageState extends State<IqTrainingDrillPage> {
               borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
               border: Border.all(color: DesignTokens.divider),
             ),
+            // 図形問題は読み上げ用に言葉へ開いた説明を渡す。
             child: Text(
               question.prompt,
+              semanticsLabel: question.semanticPrompt,
               style: TextStyle(
                 color: DesignTokens.textOnDark,
                 fontSize: 16,
@@ -276,6 +299,7 @@ class _IqTrainingDrillPageState extends State<IqTrainingDrillPage> {
               child: _DrillOption(
                 label: String.fromCharCode(65 + i),
                 text: question.options[i],
+                semanticText: question.semanticOption(i),
                 monospace: question.monospacePrompt,
                 state: _optionState(i),
                 onTap: () => _answer(i),
@@ -445,6 +469,9 @@ enum _OptionState { idle, correct, wrong, dimmed }
 class _DrillOption extends StatelessWidget {
   final String label;
   final String text;
+
+  /// 読み上げ用の代替テキスト。
+  final String semanticText;
   final bool monospace;
   final _OptionState state;
   final VoidCallback onTap;
@@ -452,6 +479,7 @@ class _DrillOption extends StatelessWidget {
   const _DrillOption({
     required this.label,
     required this.text,
+    required this.semanticText,
     required this.monospace,
     required this.state,
     required this.onTap,
@@ -521,6 +549,7 @@ class _DrillOption extends StatelessWidget {
               Expanded(
                 child: Text(
                   text,
+                  semanticsLabel: semanticText,
                   style: TextStyle(
                     color: _textColor,
                     fontSize: 15,

--- a/lib/pages/iq_training_page.dart
+++ b/lib/pages/iq_training_page.dart
@@ -26,6 +26,10 @@ class _IqTrainingPageState extends State<IqTrainingPage> {
 
   IqTrainingPlan? _plan;
   List<IqTrainingSession> _sessions = [];
+
+  /// 最新の完了テストID。プランの元になったテストより新しければ、
+  /// プランは古い測定値に基づいたままなので作り直しを促す。
+  int? _latestTestId;
   bool _isLoading = true;
   String? _error;
 
@@ -54,10 +58,15 @@ class _IqTrainingPageState extends State<IqTrainingPage> {
       }
 
       final sessions = await _service.getSessions(plan.id);
+      // プランが最新の測定に追随しているかを判定するため、
+      // 最新テストの ID も取る。ここを見ないと、再テストで弱点が変わっても
+      // 古い領域を鍛え続けていることにユーザーが気づけない。
+      final latest = await _testService.getLatestResult();
       if (!mounted) return;
       setState(() {
         _plan = plan;
         _sessions = sessions;
+        _latestTestId = latest?.id;
         _isLoading = false;
       });
     } catch (e) {
@@ -255,6 +264,9 @@ class _IqTrainingPageState extends State<IqTrainingPage> {
             totalSessions: totalSessions,
             readyForRetest: readyForRetest,
             remainingForRetest: remaining,
+            isStale:
+                _latestTestId != null && _latestTestId! > plan.sourceTestId,
+            onRegenerate: _regenerateFromLatestTest,
           ),
           const SizedBox(height: DesignTokens.space24),
           const Text(
@@ -307,11 +319,17 @@ class _PlanHeader extends StatelessWidget {
   final bool readyForRetest;
   final int remainingForRetest;
 
+  /// プランより新しいテスト結果が存在するか。
+  final bool isStale;
+  final VoidCallback onRegenerate;
+
   const _PlanHeader({
     required this.plan,
     required this.totalSessions,
     required this.readyForRetest,
     required this.remainingForRetest,
+    required this.isStale,
+    required this.onRegenerate,
   });
 
   @override
@@ -398,6 +416,66 @@ class _PlanHeader extends StatelessWidget {
               ],
             ),
           ),
+          // このプランより新しいテスト結果があるなら、鍛えている領域が
+          // 現在の弱点と食い違っている可能性がある。黙って古い配分を
+          // 続けさせず、作り直しの導線をその場に出す。
+          if (isStale) ...[
+            const SizedBox(height: DesignTokens.space12),
+            Container(
+              padding: const EdgeInsets.all(DesignTokens.space12),
+              decoration: BoxDecoration(
+                color: DesignTokens.amber.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+                border: Border.all(
+                  color: DesignTokens.amber.withValues(alpha: 0.4),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Row(
+                    children: [
+                      Icon(
+                        Icons.update,
+                        size: 16,
+                        color: DesignTokens.amber,
+                      ),
+                      SizedBox(width: DesignTokens.space8),
+                      Expanded(
+                        child: Text(
+                          'このプランより新しいテスト結果があります。'
+                          '弱点が変わっている場合、今の配分は最新の測定と'
+                          'ずれています。',
+                          style: TextStyle(
+                            color: DesignTokens.amber,
+                            fontSize: 11,
+                            height: 1.5,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: DesignTokens.space8),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton(
+                      onPressed: onRegenerate,
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: DesignTokens.amber,
+                        side: BorderSide(
+                          color: DesignTokens.amber.withValues(alpha: 0.5),
+                        ),
+                        padding: const EdgeInsets.symmetric(
+                          vertical: DesignTokens.space8,
+                        ),
+                      ),
+                      child: const Text('最新の結果でプランを作り直す'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/services/iq_scoring.dart
+++ b/lib/services/iq_scoring.dart
@@ -165,6 +165,10 @@ class IqScoring {
       weightedAccuracy: ability,
       correctCount: answers.where((a) => a.isCorrect).length,
       questionCount: answers.length,
+      // 未回答 (selectedIndex == null) を除いた実際に着手した問題数。
+      // これを持たないと「3問だけ解いて時間切れ」と「25問解いて低得点」が
+      // 結果上まったく区別できない。
+      attemptedCount: answers.where((a) => a.selectedIndex != null).length,
       standardError: standardError(ability, answers.length),
       categoryScores: categoryScores(answers),
     );
@@ -178,6 +182,9 @@ class IqScoreSummary {
   final double weightedAccuracy;
   final int correctCount;
   final int questionCount;
+
+  /// 実際に着手した問題数。[questionCount] との差が未回答数。
+  final int attemptedCount;
   final double standardError;
   final List<IqCategoryScore> categoryScores;
 
@@ -187,6 +194,7 @@ class IqScoreSummary {
     required this.weightedAccuracy,
     required this.correctCount,
     required this.questionCount,
+    required this.attemptedCount,
     required this.standardError,
     required this.categoryScores,
   });
@@ -194,10 +202,24 @@ class IqScoreSummary {
   int get iqLower => (totalIq - 1.96 * standardError).round();
   int get iqUpper => (totalIq + 1.96 * standardError).round();
 
-  /// 総合を [gapThreshold] 以上下回る領域 = 学習対象。
-  List<IqCategoryScore> weakAreas({int gapThreshold = 5}) {
+  /// 完答率 0.0..1.0。
+  double get completionRate =>
+      questionCount == 0 ? 0 : attemptedCount / questionCount;
+
+  /// スコアを額面どおり読んでよいか。
+  ///
+  /// 未着手が多い回は「実力が低い」のではなく「測れていない」。
+  /// 両者を同じ数値として提示すると利用者は判断を誤る。
+  bool get isReliable => completionRate >= 0.9;
+
+  /// 弱点と呼べる領域。
+  ///
+  /// 固定値ではなく **その領域自身の測定誤差を上回る差** だけを弱点とする。
+  /// 5問しかない領域スコアの標準誤差は約 18 IQ あり、旧実装の固定閾値 5 は
+  /// 誤差の 0.27 SE にすぎなかった (= ほぼノイズを弱点と呼んでいた)。
+  List<IqCategoryScore> weakAreas({double sigmaThreshold = 1.0}) {
     final weak = categoryScores
-        .where((s) => s.iq <= totalIq - gapThreshold)
+        .where((s) => (totalIq - s.iq) > sigmaThreshold * s.standardError)
         .toList()
       ..sort((a, b) => a.iq.compareTo(b.iq));
     return weak;

--- a/lib/services/iq_test_service.dart
+++ b/lib/services/iq_test_service.dart
@@ -85,6 +85,7 @@ class IqTestService {
             'weighted_accuracy': summary.weightedAccuracy,
             'correct_count': summary.correctCount,
             'question_count': summary.questionCount,
+            'attempted_count': summary.attemptedCount,
             'duration_seconds': durationSeconds,
             'updated_at': completedAt.toIso8601String(),
           })
@@ -135,6 +136,29 @@ class IqTestService {
       );
     } catch (e) {
       debugPrint('Error fetching IQ test result: $e');
+      rethrow;
+    }
+  }
+
+  /// テストの全回答を取得する。結果画面の振り返り表示に使う。
+  ///
+  /// 問題本体は DB に無いので、呼び出し側で question_seed から
+  /// [IqQuestionBank.standardTest] を再構成して突き合わせる。
+  Future<List<IqAnswerRecord>> getAnswers(int testId) async {
+    try {
+      final rows = await _supabase
+          .from('iq_answers')
+          .select()
+          .eq('test_id', testId)
+          // 一意な id をタイエブレーカにして並びを安定させる
+          .order('id', ascending: true)
+          .limit(200);
+
+      return (rows as List)
+          .map((e) => IqAnswerRecord.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      debugPrint('Error fetching IQ answers: $e');
       rethrow;
     }
   }

--- a/lib/services/iq_training_service.dart
+++ b/lib/services/iq_training_service.dart
@@ -174,13 +174,18 @@ class IqTrainingService {
 
     if (relevant.isEmpty) return target.startLevel;
 
-    final recent = relevant.length > window
-        ? relevant.sublist(relevant.length - window)
-        : relevant;
-
     // 直近ウィンドウで実際に出題されたレベルを基準にする。
     // 開始レベルを毎回の起点にすると、実績で上げた分が次回リセットされる。
-    final baseLevel = recent.last.level;
+    final baseLevel = relevant.last.level;
+
+    // **同じレベルで解いた試行だけを合算する。**
+    // レベル1の満点とレベル5の全滅を平均すると 0.5 になり、
+    // 「どちらの難易度も適正」という誤った結論が出る (実際はどちらも不適正)。
+    // 難易度が違う試行は別の母集団なので混ぜてはいけない。
+    final sameLevel = relevant.where((s) => s.level == baseLevel).toList();
+    final recent = sameLevel.length > window
+        ? sameLevel.sublist(sameLevel.length - window)
+        : sameLevel;
 
     var correct = 0;
     var total = 0;
@@ -188,23 +193,33 @@ class IqTrainingService {
       correct += session.correctCount;
       total += session.questionCount;
     }
-    if (total == 0) return target.startLevel;
+
+    // **標本が足りないうちはレベルを動かさない。**
+    // 合算方式の狙いは標本を増やすことなのに、最小標本を課さないと
+    // 1セッション8問で昇格してしまい、逐次適用と同じノイズに戻る。
+    if (total < minQuestionsForLevelChange) return baseLevel;
 
     return nextLevel(baseLevel, correct / total);
   }
 
+  /// レベルを動かすのに必要な最小試行数 (同一レベルでの合算)。
+  ///
+  /// 8問 × 3セッション。真の実力 0.70 での誤判定率が実用域に収まる下限。
+  static const int minQuestionsForLevelChange = 24;
+
   /// 判定に使えるだけの試行数が溜まっているか。
   ///
-  /// 合算してもなお標本が少ないうちは、レベルを動かす根拠が弱い。
+  /// UI が「あと何回で難度が見直されるか」を出すために使う。
   static bool hasEnoughEvidenceForLevelChange(
     List<IqTrainingSession> sessions,
     IqCategory category, {
-    int minQuestions = 24,
+    int? minQuestions,
   }) {
+    final threshold = minQuestions ?? minQuestionsForLevelChange;
     final total = sessions
         .where((s) => s.category == category)
         .fold<int>(0, (sum, s) => sum + s.questionCount);
-    return total >= minQuestions;
+    return total >= threshold;
   }
 
   // =====================================================================

--- a/lib/services/iq_training_service.dart
+++ b/lib/services/iq_training_service.dart
@@ -18,11 +18,18 @@ import '../models/iq_test.dart';
 /// 「弱点あり」と「弱点なし (均等)」を同じ空リストで表現すると
 /// 未評価と区別できなくなるため、理由を明示的に持たせる。
 enum IqPlanBasis {
-  /// 総合スコアを明確に下回る領域が見つかった。
+  /// 総合スコアを測定誤差を超えて下回る領域が見つかった。
   weakAreaDetected,
 
-  /// 領域差が小さく、弱点と言える領域がない。相対的な下位を底上げ対象にする。
-  balancedProfile,
+  /// 領域差が測定誤差の範囲内で、弱点を**判別できない**。
+  ///
+  /// 「差が無い」ではない。5問しかない領域スコアの標準誤差は約 18 IQ あるため、
+  /// 見かけの凸凹の多くはノイズで説明がつく。ここを「弱点あり」と言い切ると
+  /// 存在しない差に学習時間を割かせることになる。
+  withinMeasurementNoise,
+
+  /// 完答率が低く、そもそもスコアを信頼できない。
+  lowCompletion,
 }
 
 /// DB へ書く前の計画案。
@@ -40,13 +47,22 @@ class IqTrainingPlanDraft {
   String get basisMessageJa {
     switch (basis) {
       case IqPlanBasis.weakAreaDetected:
-        return '総合スコアを明確に下回る領域が見つかりました。'
+        return '総合スコアを測定誤差より大きく下回る領域が見つかりました。'
             'そこを重点的に鍛えるのが最も伸びしろが大きい配分です。';
-      case IqPlanBasis.balancedProfile:
-        return '領域ごとの差が小さく、はっきりした弱点はありません。'
-            '相対的に低い領域を底上げしつつ、全体の難度を上げていきます。';
+      case IqPlanBasis.withinMeasurementNoise:
+        return '領域ごとの差は測定誤差 (1領域あたり5問・誤差およそ±18) の範囲内で、'
+            'どこが弱点かを判別できません。'
+            '見かけ上いちばん低い領域から始めますが、これは暫定です。'
+            'トレーニングを重ねるほど実際の得意不得意がはっきりします。';
+      case IqPlanBasis.lowCompletion:
+        return '未回答が多く、スコアそのものを信頼できません。'
+            'まずは最後まで解ける状態で受け直すことをおすすめします。'
+            '暫定として見かけ上低い領域を対象にしています。';
     }
   }
+
+  /// この計画が確かな測定にもとづくか。UI は暫定であることを隠さない。
+  bool get isProvisional => basis != IqPlanBasis.weakAreaDetected;
 }
 
 class IqTrainingService {
@@ -102,12 +118,19 @@ class IqTrainingService {
     int maxTargets = 3,
   }) {
     final weak = result.weakAreas();
-    final basis = weak.isNotEmpty
-        ? IqPlanBasis.weakAreaDetected
-        : IqPlanBasis.balancedProfile;
+    final IqPlanBasis basis;
+    if (!result.isReliable) {
+      // 完答率が低い回は、弱点らしき差が出ていてもそれは未回答の影。
+      basis = IqPlanBasis.lowCompletion;
+    } else if (weak.isNotEmpty) {
+      basis = IqPlanBasis.weakAreaDetected;
+    } else {
+      basis = IqPlanBasis.withinMeasurementNoise;
+    }
 
-    // 弱点がない場合も学習対象は出す (相対的に低い順)。
-    final selected = weak.isNotEmpty
+    // 弱点を判別できない場合も学習対象は出す (見かけ上低い順)。
+    // ただし basis が weakAreaDetected でないことで暫定だと分かるようにする。
+    final selected = basis == IqPlanBasis.weakAreaDetected
         ? weak.take(maxTargets).toList()
         : (List<IqCategoryScore>.from(result.categoryScores)
               ..sort((a, b) => a.iq.compareTo(b.iq)))
@@ -132,8 +155,13 @@ class IqTrainingService {
 
   /// 直近セッションの実績から、その領域の現在レベルを求める。
   ///
-  /// 計画の開始レベルを起点に、セッションを古い順に適用していく。
-  /// 1回のブレで大きく振れないよう、直近 [window] 件だけを見る。
+  /// **直近 [window] 件を合算した正答率で1回だけ判定する。**
+  /// 旧実装はセッションごとに [nextLevel] を逐次適用しており、8問しかない
+  /// 1セッションのばらつきがそのままレベルの上下に化けていた
+  /// (真の実力 0.70 でも 44.9% の確率で誤ってレベルが動く実測)。
+  /// 合算すれば標本数が window 倍になり、同じ実力での誤判定が大きく減る。
+  ///
+  /// レベルが変わるのは1段ずつ。合算値が大きく外れていても一気に飛ばさない。
   static int currentLevelFor({
     required IqTrainingTarget target,
     required List<IqTrainingSession> sessions,
@@ -150,11 +178,33 @@ class IqTrainingService {
         ? relevant.sublist(relevant.length - window)
         : relevant;
 
-    var level = target.startLevel;
+    // 直近ウィンドウで実際に出題されたレベルを基準にする。
+    // 開始レベルを毎回の起点にすると、実績で上げた分が次回リセットされる。
+    final baseLevel = recent.last.level;
+
+    var correct = 0;
+    var total = 0;
     for (final session in recent) {
-      level = nextLevel(level, session.accuracy);
+      correct += session.correctCount;
+      total += session.questionCount;
     }
-    return level;
+    if (total == 0) return target.startLevel;
+
+    return nextLevel(baseLevel, correct / total);
+  }
+
+  /// 判定に使えるだけの試行数が溜まっているか。
+  ///
+  /// 合算してもなお標本が少ないうちは、レベルを動かす根拠が弱い。
+  static bool hasEnoughEvidenceForLevelChange(
+    List<IqTrainingSession> sessions,
+    IqCategory category, {
+    int minQuestions = 24,
+  }) {
+    final total = sessions
+        .where((s) => s.category == category)
+        .fold<int>(0, (sum, s) => sum + s.questionCount);
+    return total >= minQuestions;
   }
 
   // =====================================================================

--- a/lib/widgets/iq_review_list.dart
+++ b/lib/widgets/iq_review_list.dart
@@ -13,10 +13,16 @@ class IqReviewList extends StatefulWidget {
   final List<IqAnswerRecord> answers;
   final Map<String, IqQuestion> questionsByKey;
 
+  /// 復元した選択肢の並びが受験時と一致しているか。
+  /// false のときは「あなたが選んだ選択肢」を出さない
+  /// (index の指す先が当時と違うため、誤った選択肢を提示してしまう)。
+  final bool optionOrderIsTrustworthy;
+
   const IqReviewList({
     super.key,
     required this.answers,
     required this.questionsByKey,
+    this.optionOrderIsTrustworthy = true,
   });
 
   @override
@@ -81,6 +87,7 @@ class _IqReviewListState extends State<IqReviewList> {
               child: _ReviewCard(
                 question: widget.questionsByKey[a.questionKey]!,
                 answer: a,
+                showSelectedOption: widget.optionOrderIsTrustworthy,
               ),
             ),
           ),
@@ -92,8 +99,13 @@ class _IqReviewListState extends State<IqReviewList> {
 class _ReviewCard extends StatelessWidget {
   final IqQuestion question;
   final IqAnswerRecord answer;
+  final bool showSelectedOption;
 
-  const _ReviewCard({required this.question, required this.answer});
+  const _ReviewCard({
+    required this.question,
+    required this.answer,
+    required this.showSelectedOption,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -179,7 +191,7 @@ class _ReviewCard extends StatelessWidget {
             color: DesignTokens.green,
             monospace: question.monospacePrompt,
           ),
-          if (!answer.isCorrect && !unanswered) ...[
+          if (!answer.isCorrect && !unanswered && showSelectedOption) ...[
             const SizedBox(height: DesignTokens.space4),
             _AnswerRow(
               label: 'あなた',

--- a/lib/widgets/iq_review_list.dart
+++ b/lib/widgets/iq_review_list.dart
@@ -1,0 +1,272 @@
+// テスト結果の「問題ごとの振り返り」。
+//
+// 仮説検証 H6: 結果画面はスコアしか出しておらず、どの問題をなぜ間違えたかを
+// 一切見られなかった。学習を目的にした機能でそれは致命的なので、
+// 選んだ選択肢・正解・解説をここで返す。
+
+import 'package:flutter/material.dart';
+
+import '../models/iq_test.dart';
+import '../theme/design_tokens.dart';
+
+class IqReviewList extends StatefulWidget {
+  final List<IqAnswerRecord> answers;
+  final Map<String, IqQuestion> questionsByKey;
+
+  const IqReviewList({
+    super.key,
+    required this.answers,
+    required this.questionsByKey,
+  });
+
+  @override
+  State<IqReviewList> createState() => _IqReviewListState();
+}
+
+class _IqReviewListState extends State<IqReviewList> {
+  /// 既定は誤答のみ。全問見たい人向けにトグルを出す。
+  bool _wrongOnly = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final known = widget.answers
+        .where((a) => widget.questionsByKey.containsKey(a.questionKey))
+        .toList();
+    final items = known.where((a) => !_wrongOnly || !a.isCorrect).toList();
+    final wrongCount = known.where((a) => !a.isCorrect).length;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              _wrongOnly ? '間違えた $wrongCount 問' : '全 ${known.length} 問',
+              style: const TextStyle(
+                color: DesignTokens.textSecondary,
+                fontSize: 13,
+              ),
+            ),
+            const Spacer(),
+            TextButton(
+              onPressed: () => setState(() => _wrongOnly = !_wrongOnly),
+              child: Text(
+                _wrongOnly ? 'すべて表示' : '誤答のみ',
+                style: const TextStyle(color: DesignTokens.orange),
+              ),
+            ),
+          ],
+        ),
+        if (items.isEmpty)
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(DesignTokens.space16),
+            decoration: BoxDecoration(
+              color: DesignTokens.surface1,
+              borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+              border: Border.all(color: DesignTokens.divider),
+            ),
+            child: Text(
+              _wrongOnly ? '全問正解でした。' : '表示できる問題がありません。',
+              style: const TextStyle(
+                color: DesignTokens.textSecondary,
+                fontSize: 13,
+              ),
+            ),
+          )
+        else
+          ...items.map(
+            (a) => Padding(
+              padding: const EdgeInsets.only(bottom: DesignTokens.space12),
+              child: _ReviewCard(
+                question: widget.questionsByKey[a.questionKey]!,
+                answer: a,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ReviewCard extends StatelessWidget {
+  final IqQuestion question;
+  final IqAnswerRecord answer;
+
+  const _ReviewCard({required this.question, required this.answer});
+
+  @override
+  Widget build(BuildContext context) {
+    final unanswered = answer.selectedIndex == null;
+    final color = answer.isCorrect
+        ? DesignTokens.green
+        : unanswered
+            ? DesignTokens.textTertiary
+            : DesignTokens.red;
+    final statusLabel = answer.isCorrect
+        ? '正解'
+        : unanswered
+            ? '未回答'
+            : '不正解';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(DesignTokens.space16),
+      decoration: BoxDecoration(
+        color: DesignTokens.surface1,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+        border: Border.all(color: DesignTokens.divider),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                answer.isCorrect
+                    ? Icons.check_circle_outline
+                    : unanswered
+                        ? Icons.remove_circle_outline
+                        : Icons.cancel_outlined,
+                size: 16,
+                color: color,
+              ),
+              const SizedBox(width: DesignTokens.space8),
+              Text(
+                statusLabel,
+                style: TextStyle(
+                  color: color,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '${question.category.labelJa}・難易度${question.difficulty}',
+                style: const TextStyle(
+                  color: DesignTokens.textTertiary,
+                  fontSize: 11,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: DesignTokens.space12),
+          if (question.hasMemoryPhase) ...[
+            Text(
+              '提示された内容: ${question.memoryStimulus}',
+              style: const TextStyle(
+                color: DesignTokens.textSecondary,
+                fontSize: 12,
+              ),
+            ),
+            const SizedBox(height: DesignTokens.space8),
+          ],
+          Text(
+            question.prompt,
+            semanticsLabel: question.semanticPrompt,
+            style: TextStyle(
+              color: DesignTokens.textOnDark,
+              fontSize: 14,
+              height: question.monospacePrompt ? 1.8 : 1.6,
+              fontFamily: question.monospacePrompt ? 'monospace' : null,
+            ),
+          ),
+          const SizedBox(height: DesignTokens.space12),
+          _AnswerRow(
+            label: '正解',
+            text: question.options[question.correctIndex],
+            semanticText: question.semanticOption(question.correctIndex),
+            color: DesignTokens.green,
+            monospace: question.monospacePrompt,
+          ),
+          if (!answer.isCorrect && !unanswered) ...[
+            const SizedBox(height: DesignTokens.space4),
+            _AnswerRow(
+              label: 'あなた',
+              text: question.options[answer.selectedIndex!],
+              semanticText: question.semanticOption(answer.selectedIndex!),
+              color: DesignTokens.red,
+              monospace: question.monospacePrompt,
+            ),
+          ],
+          const SizedBox(height: DesignTokens.space12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(DesignTokens.space12),
+            decoration: BoxDecoration(
+              color: DesignTokens.surface2,
+              borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+            ),
+            child: Text(
+              question.explanation,
+              style: const TextStyle(
+                color: DesignTokens.textSecondary,
+                fontSize: 12,
+                height: 1.7,
+              ),
+            ),
+          ),
+          // H5: 記録だけして使っていなかった応答時間をここで返す。
+          if (answer.responseMs > 0) ...[
+            const SizedBox(height: DesignTokens.space8),
+            Text(
+              '解答時間 ${(answer.responseMs / 1000).toStringAsFixed(1)} 秒',
+              style: const TextStyle(
+                color: DesignTokens.textTertiary,
+                fontSize: 11,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _AnswerRow extends StatelessWidget {
+  final String label;
+  final String text;
+  final String semanticText;
+  final Color color;
+  final bool monospace;
+
+  const _AnswerRow({
+    required this.label,
+    required this.text,
+    required this.semanticText,
+    required this.color,
+    required this.monospace,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 48,
+          child: Text(
+            label,
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            text,
+            semanticsLabel: semanticText,
+            style: TextStyle(
+              color: DesignTokens.textOnDark,
+              fontSize: 13,
+              height: monospace ? 1.7 : 1.4,
+              fontFamily: monospace ? 'monospace' : null,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/iq_score_widgets.dart
+++ b/lib/widgets/iq_score_widgets.dart
@@ -79,8 +79,10 @@ class IqScoreDial extends StatelessWidget {
               color: DesignTokens.indigo.withValues(alpha: 0.2),
               borderRadius: BorderRadius.circular(DesignTokens.radiusCircle),
             ),
+            // 実在の規準集団と比べた順位ではなく、仮定した正規分布上の位置。
+            // 「上位X%」と言い切ると存在しない比較対象を含意してしまう。
             child: Text(
-              '上位 ${(100 - percentile).toStringAsFixed(1)}%',
+              '仮定分布上では上位 ${(100 - percentile).toStringAsFixed(1)}% 相当',
               style: const TextStyle(
                 color: DesignTokens.indigoLight,
                 fontSize: 13,

--- a/lib/widgets/iq_score_widgets.dart
+++ b/lib/widgets/iq_score_widgets.dart
@@ -81,8 +81,11 @@ class IqScoreDial extends StatelessWidget {
             ),
             // 実在の規準集団と比べた順位ではなく、仮定した正規分布上の位置。
             // 「上位X%」と言い切ると存在しない比較対象を含意してしまう。
+            // さらに信頼区間の幅を考えると小数第1位に意味は無い
+            // (IQ110 の CI 内でパーセンタイルは 4%〜66% まで動く) ため
+            // 整数の概数で示す。
             child: Text(
-              '仮定分布上では上位 ${(100 - percentile).toStringAsFixed(1)}% 相当',
+              '仮定分布上では上位 ${(100 - percentile).round()}% 前後',
               style: const TextStyle(
                 color: DesignTokens.indigoLight,
                 fontSize: 13,

--- a/supabase/migrations/20260729120000_add_iq_attempted_count.sql
+++ b/supabase/migrations/20260729120000_add_iq_attempted_count.sql
@@ -1,0 +1,25 @@
+-- IQテスト: 着手した問題数を記録する
+-- 作成日: 2026年7月29日
+--
+-- 背景 (仮説検証 H4):
+--   従来は question_count (=常に25) しか持たず、
+--   「3問だけ解いて時間切れ」と「25問解いて低得点」が結果上まったく区別できなかった。
+--   実測では前者でも IQ 61 が算出され、低実力と判別不能になる。
+--   スコアを額面どおり読んでよいかを利用者が判断できるよう、完答率の分子を持たせる。
+
+ALTER TABLE iq_tests
+  ADD COLUMN IF NOT EXISTS attempted_count INTEGER;
+
+COMMENT ON COLUMN iq_tests.attempted_count IS
+  '実際に着手した問題数。question_count との差が未回答数。NULL は列追加前の古い記録';
+
+-- 未回答を許すため 0 も正当な値。上限だけ質問数で押さえる。
+ALTER TABLE iq_tests
+  DROP CONSTRAINT IF EXISTS iq_tests_attempted_count_range;
+
+ALTER TABLE iq_tests
+  ADD CONSTRAINT iq_tests_attempted_count_range
+  CHECK (
+    attempted_count IS NULL
+    OR (attempted_count >= 0 AND attempted_count <= question_count)
+  );

--- a/test/data/iq_hypothesis_round3_test.dart
+++ b/test/data/iq_hypothesis_round3_test.dart
@@ -1,0 +1,265 @@
+// IQテスト機能 改善 第3ラウンドの 10 仮説検証。
+//
+// 第1・2ラウンドは採点とレベル調整 (スコアの意味) を見た。
+// 第3ラウンドは **出題の中身そのもの** を見る。ここは両ラウンドとも
+// 「生成できている / 4択が壊れていない」までしか確認していない。
+//
+// 実行: flutter test test/data/iq_hypothesis_round3_test.dart
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/data/iq_training_drills.dart';
+import 'package:my_web_app/models/iq_test.dart';
+
+void main() {
+  group('T1: 1セッション内で同じ問題が重複出題される', () {
+    test('語彙ドリルは8問中に同一問題が複数回出る', () {
+      // 語彙の出題プールは 5〜8 件しかない。1セッション8問なので
+      // 鳩の巣原理で必ず重複する。同じ問題を続けて解かされるのは
+      // 学習としても測定としても無意味。
+      var sessionsWithDuplicates = 0;
+      var worstDuplicateCount = 0;
+
+      for (var seed = 0; seed < 30; seed++) {
+        final drills = IqDrillGenerator.generate(
+          category: IqCategory.verbal,
+          level: 1,
+          seed: seed,
+        );
+        final prompts = drills.map((q) => q.prompt).toList();
+        final unique = prompts.toSet();
+        if (unique.length < prompts.length) {
+          sessionsWithDuplicates++;
+          final dup = prompts.length - unique.length;
+          if (dup > worstDuplicateCount) worstDuplicateCount = dup;
+        }
+      }
+
+      // ignore: avoid_print
+      print('T1 FIXED: 語彙L1 30セッション中 $sessionsWithDuplicates 回で重複 '
+          '(最大 $worstDuplicateCount 問)');
+
+      expect(
+        sessionsWithDuplicates,
+        0,
+        reason: 'プールを配り切るまで同じ問題を出さない',
+      );
+    });
+
+    test('論理L1・語彙L4 でも同様に重複する', () {
+      for (final spec in [
+        (IqCategory.logic, 1),
+        (IqCategory.verbal, 4),
+      ]) {
+        var dupSessions = 0;
+        for (var seed = 0; seed < 20; seed++) {
+          final drills = IqDrillGenerator.generate(
+            category: spec.$1,
+            level: spec.$2,
+            seed: seed,
+          );
+          final prompts = drills.map((q) => q.prompt).toList();
+          if (prompts.toSet().length < prompts.length) dupSessions++;
+        }
+        // ignore: avoid_print
+        print('T1 FIXED: ${spec.$1.key} L${spec.$2} → 20セッション中 '
+            '$dupSessions 回で重複');
+        expect(dupSessions, 0);
+      }
+    });
+  });
+
+  group('T3: 生成ドリルのレベルが実際の難易度と対応していない', () {
+    test('語彙レベル5はレベル3・4と同じ生成器を使っている', () {
+      // レベル5は analogy / oddOneOut をランダムに選ぶだけで、
+      // レベル3 (analogy) とレベル4 (oddOneOut) の問題そのもの。
+      // difficulty ラベルだけが 5 になっている。
+      final l3 = <String>{};
+      final l4 = <String>{};
+      final l5 = <String>{};
+      for (var seed = 0; seed < 40; seed++) {
+        l3.addAll(
+          IqDrillGenerator.generate(
+            category: IqCategory.verbal,
+            level: 3,
+            seed: seed,
+          ).map((q) => q.prompt),
+        );
+        l4.addAll(
+          IqDrillGenerator.generate(
+            category: IqCategory.verbal,
+            level: 4,
+            seed: seed,
+          ).map((q) => q.prompt),
+        );
+        l5.addAll(
+          IqDrillGenerator.generate(
+            category: IqCategory.verbal,
+            level: 5,
+            seed: seed,
+          ).map((q) => q.prompt),
+        );
+      }
+
+      // 選択肢の並びが違うだけで prompt 文字列は変わるため、
+      // 「どの生成器から出たか」で比べる (シャッフル非依存)。
+      String kind(String prompt) => prompt.contains('同じ関係になる')
+          ? 'analogy'
+          : prompt.contains('性質が異なる')
+              ? 'oddOneOut'
+              : prompt.contains('近い構造')
+                  ? 'sentenceRelation'
+                  : 'other';
+
+      final l5Kinds = l5.map(kind).toSet();
+      final lowerKinds = {...l3.map(kind), ...l4.map(kind)};
+
+      // ignore: avoid_print
+      print('T3: 語彙L5 の生成器 = $l5Kinds / L3+L4 の生成器 = $lowerKinds');
+
+      expect(
+        l5Kinds.difference(lowerKinds),
+        isNotEmpty,
+        reason: 'L5 固有の生成器が無ければ難易度は上がっていない',
+      );
+      // ignore: avoid_print
+      print('T3 FIXED: 語彙L5 に固有の生成器 '
+          '${l5Kinds.difference(lowerKinds)} が入った');
+    });
+
+    test('記憶ドリルは正しくレベルとともに負荷が上がる (対照)', () {
+      // 対照実験: 記憶は span が 4+level で単調に伸びる。
+      // つまり「レベル設計ができない」のではなく語彙だけが欠けている。
+      var previousSpan = 0;
+      for (var level = 1; level <= 5; level++) {
+        final q = IqDrillGenerator.generate(
+          category: IqCategory.memory,
+          level: level,
+          seed: 7,
+        ).first;
+        final span = q.memoryStimulus!.split('　').length;
+        expect(span, greaterThan(previousSpan));
+        previousSpan = span;
+      }
+      // ignore: avoid_print
+      print('T3: 記憶ドリルは span が単調増加 (対照として正常)');
+    });
+  });
+
+  group('T8: 順序推論の答えが一意に決まるか', () {
+    test('提示された関係文から順序が一意に定まる', () {
+      // 生成器は真の並びから連続ペアだけを提示している。
+      // A>B, B>C, C>D が揃えば全順序は一意。
+      // 「一意でない問題が混ざる」という仮説を反証しにいく。
+      for (var seed = 0; seed < 40; seed++) {
+        final drills = IqDrillGenerator.generate(
+          category: IqCategory.logic,
+          level: 4,
+          seed: seed,
+        );
+        for (final q in drills) {
+          // 提示文の数 = 人数-1 なら連鎖が一本に繋がる
+          final statements =
+              q.prompt.split('\n').where((l) => l.contains('より背が高い')).length;
+          final names = RegExp('[A-E]')
+              .allMatches(q.prompt)
+              .map((m) => m.group(0)!)
+              .toSet();
+          expect(
+            statements,
+            names.length - 1,
+            reason: '関係文が n-1 本なら全順序が一意に決まる',
+          );
+        }
+      }
+      // ignore: avoid_print
+      print('T8 REFUTED: 順序推論は常に一意に決まる (n-1 本の連鎖)');
+    });
+  });
+
+  group('T9: 同一プール行が1セッションに複数回現れる', () {
+    test('類推ドリルは同じ関係を繰り返し出す', () {
+      final drills = IqDrillGenerator.generate(
+        category: IqCategory.verbal,
+        level: 3,
+        seed: 3,
+      );
+      final relations =
+          drills.map((q) => q.explanation.split('。').first).toList();
+      final unique = relations.toSet();
+      // ignore: avoid_print
+      print('T9: 8問中の関係の種類 = ${unique.length} 種');
+
+      // プール6件に対し8問なので、配り切るまでは重複しない = 6種以上
+      expect(
+        unique.length,
+        greaterThanOrEqualTo(6),
+        reason: 'プールを配り切るまで同じ関係を繰り返さない',
+      );
+      // ignore: avoid_print
+      print('T9 FIXED: 8問中 ${unique.length} 種 '
+          '(プール6件を配り切ってから再利用)');
+    });
+  });
+
+  group('T6: 数列ドリルの誤答が正解と紛らわしすぎないか', () {
+    test('誤答は正解と異なる値で、かつ極端に離れていない', () {
+      var tooFar = 0;
+      var total = 0;
+
+      for (var level = 1; level <= 5; level++) {
+        for (var seed = 0; seed < 20; seed++) {
+          final drills = IqDrillGenerator.generate(
+            category: IqCategory.numerical,
+            level: level,
+            seed: seed,
+          );
+          for (final q in drills) {
+            final answer = int.parse(q.options[q.correctIndex]);
+            for (var i = 0; i < q.options.length; i++) {
+              if (i == q.correctIndex) continue;
+              final wrong = int.parse(q.options[i]);
+              expect(wrong, isNot(answer));
+              total++;
+              // 桁が違うほど離れていると消去法で当たる
+              if (answer > 0 && (wrong / answer > 3 || wrong / answer < 0.33)) {
+                tooFar++;
+              }
+            }
+          }
+        }
+      }
+
+      // ignore: avoid_print
+      print('T6: 誤答 $total 件中 $tooFar 件が正解の1/3未満または3倍超');
+      expect(
+        tooFar / total,
+        lessThan(0.05),
+        reason: '桁違いの誤答が多いと消去法で当たってしまう',
+      );
+      // ignore: avoid_print
+      print('T6 REFUTED: 誤答は正解の近傍に収まっている');
+    });
+  });
+
+  group('T5: 記憶課題の提示時間が制限時間を圧迫する', () {
+    test('記憶5問の提示時間だけで35秒が消費される', () {
+      // テスト本体の記憶課題は revealSeconds 5..9。
+      // この間ユーザーは選択肢を見られないのに、全体の20分は減り続ける。
+      const revealSeconds = [5, 6, 7, 8, 9];
+      final total = revealSeconds.reduce((a, b) => a + b);
+      // ignore: avoid_print
+      print('T5: 記憶課題の提示時間合計 = $total 秒 '
+          '(制限時間 1200 秒の ${(total / 1200 * 100).toStringAsFixed(1)}%)');
+
+      expect(total, 35);
+      // 影響は約3% と小さい。過大評価しないための実測。
+      expect(
+        total / 1200,
+        lessThan(0.05),
+        reason: '5%未満なら実務上の影響は小さい',
+      );
+      // ignore: avoid_print
+      print('T5 REFUTED: 影響は 2.9% で、制限時間を実質的に圧迫しない');
+    });
+  });
+}

--- a/test/data/iq_question_bank_test.dart
+++ b/test/data/iq_question_bank_test.dart
@@ -49,9 +49,9 @@ void main() {
     });
   });
 
-  group('問題そのものの整合性', () {
+  group('問題そのものの整合性 (代替フォーム含む全50問)', () {
     test('全問が選択肢を持ち、正解インデックスが範囲内', () {
-      for (final q in IqQuestionBank.standardTest()) {
+      for (final q in IqQuestionBank.allQuestions) {
         expect(q.options.length, greaterThanOrEqualTo(2), reason: q.key);
         expect(q.correctIndex, greaterThanOrEqualTo(0), reason: q.key);
         expect(q.correctIndex, lessThan(q.options.length), reason: q.key);
@@ -59,7 +59,7 @@ void main() {
     });
 
     test('選択肢に重複がない (正解が複数存在しない)', () {
-      for (final q in IqQuestionBank.standardTest()) {
+      for (final q in IqQuestionBank.allQuestions) {
         expect(
           q.options.toSet().length,
           q.options.length,
@@ -69,14 +69,14 @@ void main() {
     });
 
     test('全問に空でない問題文と解説がある', () {
-      for (final q in IqQuestionBank.standardTest()) {
+      for (final q in IqQuestionBank.allQuestions) {
         expect(q.prompt.trim(), isNotEmpty, reason: q.key);
         expect(q.explanation.trim(), isNotEmpty, reason: q.key);
       }
     });
 
     test('記憶課題は刺激と提示時間の両方を持つ', () {
-      final memory = IqQuestionBank.standardTest()
+      final memory = IqQuestionBank.allQuestions
           .where((q) => q.category == IqCategory.memory);
 
       expect(memory, isNotEmpty);
@@ -88,7 +88,7 @@ void main() {
     });
 
     test('記憶課題以外は刺激提示フェーズを持たない', () {
-      final others = IqQuestionBank.standardTest()
+      final others = IqQuestionBank.allQuestions
           .where((q) => q.category != IqCategory.memory);
 
       for (final q in others) {
@@ -97,21 +97,48 @@ void main() {
     });
   });
 
+  group('出題プールの構成', () {
+    test('全問のキーが一意', () {
+      final keys = IqQuestionBank.allQuestions.map((q) => q.key).toSet();
+      expect(keys.length, IqQuestionBank.allQuestions.length);
+    });
+
+    test('各 (領域, 難易度) セルにちょうど2問ある', () {
+      final counts = <String, int>{};
+      for (final q in IqQuestionBank.allQuestions) {
+        final cell = '${q.category.key}-${q.difficulty}';
+        counts[cell] = (counts[cell] ?? 0) + 1;
+      }
+
+      expect(counts.length, 25, reason: 'セル数が 5領域 × 5難易度 でない');
+      for (final entry in counts.entries) {
+        expect(
+          entry.value,
+          2,
+          reason: '${entry.key} の候補が ${entry.value} 問 (2問でない)',
+        );
+      }
+    });
+  });
+
   group('選択肢シャッフル', () {
     test('シャッフルしても正解の中身は変わらない', () {
-      final plain = IqQuestionBank.standardTest();
+      // seed は「どの問題を出すか」も変えるため、index 同士では比較できない。
+      // キーで正本を引いて突き合わせる。
+      final canonical = {
+        for (final q in IqQuestionBank.allQuestions) q.key: q,
+      };
       final shuffled = IqQuestionBank.standardTest(seed: 42);
 
-      expect(shuffled.length, plain.length);
-      for (var i = 0; i < plain.length; i++) {
-        final original = plain[i];
-        final variant = shuffled[i];
+      expect(shuffled.length, 25);
+      for (final variant in shuffled) {
+        final original = canonical[variant.key];
+        expect(original, isNotNull, reason: '${variant.key} が正本に無い');
 
-        expect(variant.key, original.key);
         expect(
           variant.options[variant.correctIndex],
-          original.options[original.correctIndex],
-          reason: '${original.key} の正解がシャッフルで入れ替わっている',
+          original!.options[original.correctIndex],
+          reason: '${variant.key} の正解がシャッフルで入れ替わっている',
         );
         expect(variant.options.toSet(), original.options.toSet());
       }
@@ -127,13 +154,16 @@ void main() {
     });
 
     test('多数の seed を通しても正解が保たれる', () {
-      final plain = IqQuestionBank.standardTest();
+      final canonical = {
+        for (final q in IqQuestionBank.allQuestions) q.key: q,
+      };
       for (var seed = 0; seed < 50; seed++) {
-        final shuffled = IqQuestionBank.standardTest(seed: seed);
-        for (var i = 0; i < plain.length; i++) {
+        for (final variant in IqQuestionBank.standardTest(seed: seed)) {
+          final original = canonical[variant.key]!;
           expect(
-            shuffled[i].options[shuffled[i].correctIndex],
-            plain[i].options[plain[i].correctIndex],
+            variant.options[variant.correctIndex],
+            original.options[original.correctIndex],
+            reason: 'seed=$seed / ${variant.key}',
           );
         }
       }

--- a/test/services/iq_hypothesis_round2_test.dart
+++ b/test/services/iq_hypothesis_round2_test.dart
@@ -1,0 +1,388 @@
+// IQテスト機能 改善 第2ラウンドの 10 仮説検証。
+//
+// 第1ラウンド (PR #4385) で入れた修正そのものを敵対的に検証する。
+// 自分が直したばかりのコードは、直したという安心感で検査が甘くなる。
+//
+// 実行: flutter test test/services/iq_hypothesis_round2_test.dart
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/data/iq_question_bank.dart';
+import 'package:my_web_app/models/iq_test.dart';
+import 'package:my_web_app/services/iq_scoring.dart';
+import 'package:my_web_app/services/iq_training_service.dart';
+
+IqCategoryScore _score(
+  IqCategory category,
+  int iq, {
+  double standardError = 18.5,
+}) =>
+    IqCategoryScore(
+      category: category,
+      correctCount: 3,
+      questionCount: 5,
+      weightedAccuracy: 0.55,
+      iq: iq,
+      standardError: standardError,
+    );
+
+IqTestResult _result({
+  required int totalIq,
+  required List<IqCategoryScore> scores,
+  int questionCount = 25,
+  int? attemptedCount,
+}) =>
+    IqTestResult(
+      id: 1,
+      userId: 'u',
+      startedAt: DateTime(2026, 7, 29, 10),
+      completedAt: DateTime(2026, 7, 29, 10, 20),
+      isCompleted: true,
+      totalIq: totalIq,
+      percentile: 50,
+      weightedAccuracy: 0.55,
+      correctCount: 14,
+      questionCount: questionCount,
+      attemptedCount: attemptedCount,
+      durationSeconds: 1200,
+      categoryScores: scores,
+    );
+
+IqTrainingSession _session({
+  required IqCategory category,
+  required int level,
+  required int correct,
+  required int total,
+  required DateTime at,
+}) =>
+    IqTrainingSession(
+      id: 1,
+      planId: 1,
+      userId: 'u',
+      category: category,
+      level: level,
+      correctCount: correct,
+      questionCount: total,
+      durationSeconds: 300,
+      completedAt: at,
+    );
+
+void main() {
+  group('R1: standardError が 0 だと弱点判定が全通しになる', () {
+    test('SE=0 では 1 ポイント差でも弱点と判定される', () {
+      // fromJson は standard_error 欠損時に 0 を入れる。
+      // 新しい判定式は gap > 1.0 * SE なので、SE=0 だと
+      // 「総合を少しでも下回れば弱点」に退化する。
+      final result = _result(
+        totalIq: 100,
+        scores: [
+          _score(IqCategory.logic, 99, standardError: 0),
+          _score(IqCategory.spatial, 100, standardError: 0),
+        ],
+      );
+
+      final weak = result.weakAreas();
+      // ignore: avoid_print
+      print('R1 FIXED: SE=0 でも 1 ポイント差は弱点にならない '
+          '(検出 ${weak.length} 件)');
+
+      expect(
+        weak,
+        isEmpty,
+        reason: 'SE に下限を課したので、誤差ゼロ扱いのデータでも過検出しない',
+      );
+    });
+
+    test('fromJson は standard_error 欠損時に 0 を入れる', () {
+      final score = IqCategoryScore.fromJson({
+        'category': 'logic',
+        'correct_count': 3,
+        'question_count': 5,
+        'weighted_accuracy': 0.55,
+        'category_iq': 100,
+        // standard_error なし
+      });
+      // 生の値は 0 のままだが、判定に使う実効値は下限で守られる
+      expect(score.standardError, 0);
+      expect(
+        score.effectiveStandardError,
+        IqCategoryScore.minimumStandardError,
+      );
+      // ignore: avoid_print
+      print('R1 FIXED: 生値 0 / 実効値 '
+          '${score.effectiveStandardError} で判定式を保護');
+    });
+  });
+
+  group('R2: 修正前のテストは振り返りを復元できない', () {
+    test('同じ seed でも修正後は別の問題セットになりうる', () {
+      // 修正前: seed は選択肢順だけを変えた → 出題は常に既定フォーム。
+      // 修正後: seed が出題そのものも選ぶ。
+      // つまり修正前に seed=X で受けた人の回答キーは既定フォーム側なのに、
+      // 復元は代替フォームを混ぜた集合を返す。
+      const seed = 42;
+      final reconstructed =
+          IqQuestionBank.standardTest(seed: seed).map((q) => q.key).toSet();
+      final legacyForm =
+          IqQuestionBank.standardTest().map((q) => q.key).toSet();
+
+      final missing = legacyForm.difference(reconstructed);
+      // ignore: avoid_print
+      print('R2: 修正前フォームのうち復元集合に無いキー = ${missing.length} 件');
+
+      expect(
+        missing,
+        isNotEmpty,
+        reason: '一致するなら復元は壊れていない',
+      );
+      // ignore: avoid_print
+      print('R2 CONFIRMED: 修正前の回答は振り返りから静かに脱落する');
+    });
+  });
+
+  group('R3: 追加したのに呼ばれていない関数がある', () {
+    test('hasEnoughEvidenceForLevelChange は動くが誰も使っていない', () {
+      // 関数自体は正しく動く
+      final sessions = [
+        _session(
+          category: IqCategory.logic,
+          level: 3,
+          correct: 6,
+          total: 8,
+          at: DateTime(2026, 7, 20),
+        ),
+      ];
+      expect(
+        IqTrainingService.hasEnoughEvidenceForLevelChange(
+          sessions,
+          IqCategory.logic,
+        ),
+        isFalse,
+      );
+      // ignore: avoid_print
+      print('R3 FIXED: 最小標本の判定が currentLevelFor に組み込まれた');
+    });
+
+    test('試行数が1セッションでもレベルが動いてしまう', () {
+      const target = IqTrainingTarget(
+        category: IqCategory.logic,
+        baselineIq: 100,
+        startLevel: 3,
+        weeklySessions: 3,
+      );
+      // たった8問の1セッションで昇格が起きる
+      final level = IqTrainingService.currentLevelFor(
+        target: target,
+        sessions: [
+          _session(
+            category: IqCategory.logic,
+            level: 3,
+            correct: 8,
+            total: 8,
+            at: DateTime(2026, 7, 20),
+          ),
+        ],
+      );
+      expect(
+        level,
+        3,
+        reason: '8問 (最小標本24問未満) ではレベルを動かさない',
+      );
+      // ignore: avoid_print
+      print('R3 FIXED: 8問だけではレベルが動かない '
+          '(最小 ${IqTrainingService.minQuestionsForLevelChange} 問)');
+    });
+  });
+
+  group('R4: 異なるレベルのセッションを混ぜて合算している', () {
+    test('レベル1とレベル5の試行が1つの正答率に合算される', () {
+      const target = IqTrainingTarget(
+        category: IqCategory.logic,
+        baselineIq: 100,
+        startLevel: 3,
+        weeklySessions: 3,
+      );
+
+      // レベル1で満点、レベル5で全滅 → 難易度がまるで違う試行を平均している
+      final sessions = [
+        _session(
+          category: IqCategory.logic,
+          level: 1,
+          correct: 8,
+          total: 8,
+          at: DateTime(2026, 7, 20),
+        ),
+        _session(
+          category: IqCategory.logic,
+          level: 5,
+          correct: 0,
+          total: 8,
+          at: DateTime(2026, 7, 21),
+        ),
+      ];
+
+      final level = IqTrainingService.currentLevelFor(
+        target: target,
+        sessions: sessions,
+      );
+      // 直近レベル(5)の試行だけを見る。8問しかないので最小標本に届かず据置。
+      // ignore: avoid_print
+      print('R4 FIXED: レベル1満点は合算されず、直近レベル5の判定結果 = '
+          'レベル$level');
+
+      expect(
+        level,
+        5,
+        reason: '直近レベルの試行だけで判定し、標本不足なら据え置く',
+      );
+    });
+  });
+
+  group('R5: 完答率の閾値', () {
+    test('3問スキップは許容し、半分未着手は警告する', () {
+      final mild = _result(
+        totalIq: 100,
+        scores: [_score(IqCategory.logic, 100)],
+        attemptedCount: 22,
+      );
+      final severe = _result(
+        totalIq: 100,
+        scores: [_score(IqCategory.logic, 100)],
+        attemptedCount: 10,
+      );
+
+      // ignore: avoid_print
+      print('R5 FIXED: 22/25 (${(mild.completionRate * 100).round()}%) '
+          '→ reliable=${mild.isReliable} / '
+          '10/25 (${(severe.completionRate * 100).round()}%) '
+          '→ reliable=${severe.isReliable}');
+
+      // 閾値 0.9 では3問スキップで警告が出て日常化し、
+      // 本当に測れていない回を見落とす。0.8 に緩めた。
+      expect(mild.isReliable, isTrue);
+      expect(severe.isReliable, isFalse);
+    });
+
+    test('旧データ (attemptedCount 欠損) は信頼できる扱いになる', () {
+      final legacy = _result(
+        totalIq: 100,
+        scores: [_score(IqCategory.logic, 100)],
+        // attemptedCount なし
+      );
+      expect(legacy.completionRate, 1.0);
+      expect(legacy.isReliable, isTrue);
+      // ignore: avoid_print
+      print('R5: 旧データは完答扱いにフォールバック (意図どおり)');
+    });
+  });
+
+  group('R6: 弱点判定ロジックが2箇所に重複している', () {
+    test('IqScoreSummary と IqTestResult が同じ計算を別々に持つ', () {
+      final answers = [
+        for (final c in IqCategory.values)
+          for (var d = 1; d <= 5; d++)
+            IqAnswerRecord(
+              questionKey: '${c.key}-$d',
+              category: c,
+              difficulty: d,
+              selectedIndex: 0,
+              isCorrect: c != IqCategory.spatial,
+              responseMs: 1000,
+            ),
+      ];
+
+      final summary = IqScoring.summarize(answers);
+      final result = _result(
+        totalIq: summary.totalIq,
+        scores: summary.categoryScores,
+      );
+
+      final fromSummary = summary.weakAreas().map((s) => s.category).toSet();
+      final fromResult = result.weakAreas().map((s) => s.category).toSet();
+
+      expect(fromSummary, fromResult);
+
+      // 判定の実体を IqCategoryScore.selectWeak に一本化したので、
+      // 両クラスは同じ関数を呼ぶだけになり乖離しえない。
+      final direct = IqCategoryScore.selectWeak(
+        summary.categoryScores,
+        summary.totalIq,
+      ).map((s) => s.category).toSet();
+      expect(direct, fromSummary);
+      expect(direct, fromResult);
+      // ignore: avoid_print
+      print('R6 FIXED: 両クラスとも selectWeak に委譲 (実装は1箇所)');
+    });
+  });
+
+  group('R7: パーセンタイル表示の精度', () {
+    test('信頼区間 ±36 に対し 0.1% 刻みで提示している', () {
+      final se = IqScoring.standardError(0.55, 25);
+      const iq = 110;
+      final p = IqScoring.percentileForIq(iq);
+      final pLow = IqScoring.percentileForIq((iq - 1.96 * se).round());
+      final pHigh = IqScoring.percentileForIq((iq + 1.96 * se).round());
+
+      // ignore: avoid_print
+      print('R7: IQ$iq → 上位 ${(100 - p).toStringAsFixed(1)}% / '
+          'CI 内では 上位 ${(100 - pHigh).toStringAsFixed(1)}% 〜 '
+          '${(100 - pLow).toStringAsFixed(1)}%');
+
+      expect(
+        (pHigh - pLow).abs(),
+        greaterThan(10),
+        reason: 'CI 内でパーセンタイルが十分動くなら 0.1% 刻みは過剰精度',
+      );
+      // ignore: avoid_print
+      print('R7 CONFIRMED (表示側で緩和): 小数第1位は根拠が無いため'
+          '整数の概数表示へ変更。基礎的な不確かさ自体は残る');
+    });
+  });
+
+  group('R9: 代替フォームの難易度が同等である保証', () {
+    test('同一セルの2問は難易度ラベルだけが一致し中身は未検証', () {
+      final byCell = <String, List<IqQuestion>>{};
+      for (final q in IqQuestionBank.allQuestions) {
+        byCell
+            .putIfAbsent('${q.category.key}-${q.difficulty}', () => [])
+            .add(q);
+      }
+
+      for (final entry in byCell.entries) {
+        expect(entry.value.length, 2, reason: entry.key);
+        // 揃っているのは difficulty (= 得点の重み) だけ
+        expect(
+          entry.value.map((q) => q.difficulty).toSet().length,
+          1,
+          reason: entry.key,
+        );
+      }
+      // ignore: avoid_print
+      print('R9 CONFIRMED: 重み構成は保証されるが、'
+          '実際の正答率が同等かは受験データがないと検証不能');
+    });
+  });
+
+  group('R10: グリッド説明の頑健性', () {
+    test('全角スペース区切りのグリッドは説明に変換されない', () {
+      // 記憶課題の刺激は全角スペース区切り。空間問題は半角。
+      // 将来どちらかが混ざると説明が作れず ■□ が読み上げられる。
+      const halfWidth = '■ □\n□ □';
+      const fullWidth = '■　□\n□　□';
+
+      final a = describeGridText(halfWidth);
+      final b = describeGridText(fullWidth);
+
+      // ignore: avoid_print
+      print('R10: 半角区切り → ${a.replaceAll("\\n", " / ")}');
+      // ignore: avoid_print
+      print('R10: 全角区切り → ${b.replaceAll("\\n", " / ")}');
+
+      expect(a, contains('塗り'));
+      expect(
+        b,
+        contains('塗り'),
+        reason: '全角区切りでも説明に変換できるべき',
+      );
+    });
+  });
+}

--- a/test/services/iq_hypothesis_verification_test.dart
+++ b/test/services/iq_hypothesis_verification_test.dart
@@ -1,0 +1,328 @@
+// IQテスト機能の改善に向けた 10 仮説の検証ハーネス。
+//
+// 目的は「意見」ではなく「実測」で各仮説の真偽を決めること。
+// ここでは *現状の* 振る舞いを表明する。修正が入ればこのファイルの
+// 該当テストは落ちるので、そのとき初めて仮説が解消されたと言える。
+//
+// 実行: flutter test test/services/iq_hypothesis_verification_test.dart
+
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/data/iq_question_bank.dart';
+import 'package:my_web_app/data/iq_training_drills.dart';
+import 'package:my_web_app/models/iq_test.dart';
+import 'package:my_web_app/services/iq_scoring.dart';
+import 'package:my_web_app/services/iq_training_service.dart';
+
+IqAnswerRecord _a({
+  required IqCategory category,
+  required int difficulty,
+  required bool correct,
+}) =>
+    IqAnswerRecord(
+      questionKey: '${category.key}-$difficulty',
+      category: category,
+      difficulty: difficulty,
+      selectedIndex: correct ? 0 : 1,
+      isCorrect: correct,
+      responseMs: 1000,
+    );
+
+void main() {
+  group('H1 (修正後): 再受験で出題が入れ替わる', () {
+    test('seed が違えば出題される問題キーが変わる', () {
+      final sets = <Set<String>>[
+        for (final seed in [1, 7, 42, 999, 12345])
+          IqQuestionBank.standardTest(seed: seed).map((q) => q.key).toSet(),
+      ];
+
+      // すべて同一なら練習効果の問題が残っている
+      final allIdentical = sets.every((s) => s.difference(sets.first).isEmpty);
+      expect(
+        allIdentical,
+        isFalse,
+        reason: 'seed を変えても同じ25問なら再受験対策になっていない',
+      );
+
+      final distinct = sets.map((s) => s.join('|')).toSet().length;
+      // ignore: avoid_print
+      print('H1 FIXED: 5通りの seed で $distinct 種類の出題セット');
+    });
+
+    test('どの seed でも 5領域 × 難易度1..5 の構成は保たれる', () {
+      for (final seed in [0, 3, 77, 2024]) {
+        final questions = IqQuestionBank.standardTest(seed: seed);
+        expect(questions.length, 25, reason: 'seed=$seed');
+        expect(
+          questions.map((q) => q.key).toSet().length,
+          25,
+          reason: 'seed=$seed で問題が重複している',
+        );
+
+        for (final category in IqCategory.values) {
+          final diffs = questions
+              .where((q) => q.category == category)
+              .map((q) => q.difficulty)
+              .toList()
+            ..sort();
+          expect(
+            diffs,
+            [1, 2, 3, 4, 5],
+            reason: 'seed=$seed の ${category.key} で重み構成が崩れている',
+          );
+        }
+      }
+      // ignore: avoid_print
+      print('H1 FIXED: 出題が変わっても領域×難易度の構成は不変');
+    });
+
+    test('代替フォームを含めプールが出題数の2倍ある', () {
+      expect(
+        IqQuestionBank.allQuestions.length,
+        IqQuestionBank.totalQuestions * 2,
+      );
+      // ignore: avoid_print
+      print('H1 FIXED: プール ${IqQuestionBank.allQuestions.length} 問 '
+          '(出題 ${IqQuestionBank.totalQuestions} 問)');
+    });
+  });
+
+  group('H2: 領域別スコアの誤差が弱点判定の閾値より大きい', () {
+    test('5問カテゴリの標準誤差は弱点閾値(5 IQ)を大きく上回る', () {
+      // 平均的な受験者 (ability 0.55) を想定
+      final se = IqScoring.standardError(0.55, 5);
+      const weakGapThreshold = 5; // IqTestResult.weakAreas の既定値
+
+      // ignore: avoid_print
+      print('H2: 5問時の標準誤差 = ${se.toStringAsFixed(1)} IQ '
+          '/ 95%CI幅 = ±${(1.96 * se).toStringAsFixed(1)} '
+          '/ 弱点判定の閾値 = $weakGapThreshold');
+
+      expect(
+        se,
+        greaterThan(weakGapThreshold.toDouble()),
+        reason: '誤差が閾値より小さければ弱点判定は意味を持つ',
+      );
+      // ignore: avoid_print
+      print('H2 CONFIRMED: 閾値は誤差の '
+          '${(weakGapThreshold / se).toStringAsFixed(2)} SE しかない');
+    });
+
+    test('全問正解と全問不正解の間でも領域IQはクランプで潰れる', () {
+      // 5問しかないと ability の刻みが粗く、IQ の解像度が低い
+      final observed = <int>{};
+      for (var correct = 0; correct <= 5; correct++) {
+        final answers = [
+          for (var d = 1; d <= 5; d++)
+            _a(
+              category: IqCategory.logic,
+              difficulty: d,
+              correct: d <= correct,
+            ),
+        ];
+        observed.add(IqScoring.categoryScores(answers).single.iq);
+      }
+      // ignore: avoid_print
+      print('H2: 正答数0..5 に対する領域IQ = ${observed.toList()..sort()}');
+      expect(observed.length, lessThanOrEqualTo(6));
+    });
+  });
+
+  group('H4: 時間切れで未着手が全て不正解になり下限に張り付く', () {
+    test('25問中3問だけ解いて時間切れ → IQ は下限に張り付く', () {
+      final answers = <IqAnswerRecord>[
+        // 解いた3問はすべて正解
+        for (var d = 1; d <= 3; d++)
+          _a(category: IqCategory.logic, difficulty: d, correct: true),
+        // 残り22問は未着手 = 不正解として計上される
+        for (final c in IqCategory.values)
+          for (var d = 1; d <= 5; d++)
+            if (!(c == IqCategory.logic && d <= 3))
+              _a(category: c, difficulty: d, correct: false),
+      ];
+      expect(answers.length, 25);
+
+      final summary = IqScoring.summarize(answers);
+      // ignore: avoid_print
+      print('H4: 3問正解+22問未着手 → IQ ${summary.totalIq} '
+          '(下限 ${IqCalibration.minIq})');
+
+      // 当初の予測「下限に張り付く」は外れ (実測 61)。ただし本質は変わらず、
+      // 解いた3問が全問正解でも「かなり低い実力」と区別がつかない値になる。
+      expect(
+        summary.totalIq,
+        greaterThan(IqCalibration.minIq),
+        reason: '実測では下限には達しない',
+      );
+      expect(
+        summary.totalIq,
+        lessThan(70),
+        reason: '解いた分は全問正解なのに著しく低い値になる',
+      );
+      // ignore: avoid_print
+      print('H4 REVISED: 下限張り付きではないが、解答分が全問正解でも '
+          'IQ ${summary.totalIq} = 低実力と判別不能');
+    });
+
+    test('完答率が結果に一切表示されない (信頼できるかを利用者が判断できない)', () {
+      // 3問しか解いていない結果と25問解いた結果が、同じ形式で提示される
+      final partial = IqScoring.summarize([
+        for (var d = 1; d <= 3; d++)
+          _a(category: IqCategory.logic, difficulty: d, correct: true),
+        for (final c in IqCategory.values)
+          for (var d = 1; d <= 5; d++)
+            if (!(c == IqCategory.logic && d <= 3))
+              _a(category: c, difficulty: d, correct: false),
+      ]);
+      // questionCount は 25 と報告される = 未着手22問が「解答済み」に混ざる
+      expect(partial.questionCount, 25);
+      // ignore: avoid_print
+      print('H4 CONFIRMED (別側面): questionCount=${partial.questionCount} '
+          'と報告され、実際に着手した3問との区別が結果に残らない');
+    });
+  });
+
+  group('H7: 1セッション8問では正答率がノイズでレベルが振れる', () {
+    test('真の実力0.70でも1セッションで昇格/降格が両方起こりうる', () {
+      const trueAbility = 0.70;
+      const n = IqDrillGenerator.defaultSessionSize; // 8
+      expect(n, 8);
+
+      // 二項分布で各正答数の確率を出す
+      double binom(int k) {
+        var c = 1.0;
+        for (var i = 0; i < k; i++) {
+          c = c * (n - i) / (i + 1);
+        }
+        return c * math.pow(trueAbility, k) * math.pow(1 - trueAbility, n - k);
+      }
+
+      var pUp = 0.0;
+      var pDown = 0.0;
+      var pStay = 0.0;
+      for (var k = 0; k <= n; k++) {
+        final acc = k / n;
+        final next = IqTrainingService.nextLevel(3, acc);
+        final p = binom(k);
+        if (next > 3) {
+          pUp += p;
+        } else if (next < 3) {
+          pDown += p;
+        } else {
+          pStay += p;
+        }
+      }
+
+      // ignore: avoid_print
+      print('H7: 真の実力 $trueAbility / 1セッション$n問 → '
+          '昇格 ${(pUp * 100).toStringAsFixed(1)}% '
+          '据置 ${(pStay * 100).toStringAsFixed(1)}% '
+          '降格 ${(pDown * 100).toStringAsFixed(1)}%');
+
+      // 適正帯にいるのに、かなりの確率で誤って動く
+      expect(
+        pUp + pDown,
+        greaterThan(0.30),
+        reason: '誤判定が3割を超えるならレベルはノイズで振れている',
+      );
+      // ignore: avoid_print
+      print('H7 CONFIRMED: 誤ってレベルが動く確率 '
+          '${((pUp + pDown) * 100).toStringAsFixed(1)}%');
+    });
+
+    test('修正後: 直近5セッションを合算すると誤判定が激減する', () {
+      const trueAbility = 0.70;
+      const n = IqDrillGenerator.defaultSessionSize * 5; // 8問 × 5セッション = 40
+
+      double binom(int k) {
+        var c = 1.0;
+        for (var i = 0; i < k; i++) {
+          c = c * (n - i) / (i + 1);
+        }
+        return c * math.pow(trueAbility, k) * math.pow(1 - trueAbility, n - k);
+      }
+
+      var pMove = 0.0;
+      for (var k = 0; k <= n; k++) {
+        if (IqTrainingService.nextLevel(3, k / n) != 3) pMove += binom(k);
+      }
+
+      // ignore: avoid_print
+      print('H7 FIXED: 合算$n問での誤判定率 '
+          '${(pMove * 100).toStringAsFixed(1)}% (1セッション8問では 44.9%)');
+
+      expect(
+        pMove,
+        lessThan(0.10),
+        reason: '合算しても誤判定が1割を超えるなら改善になっていない',
+      );
+    });
+
+    test('正答率の刻みは 1/8 = 12.5% しかない', () {
+      final steps = <double>{};
+      for (var k = 0; k <= 8; k++) {
+        steps.add(k / 8);
+      }
+      expect(steps.length, 9);
+      // 6問正解(0.75)は据置、7問正解(0.875)は昇格 = 1問差で結論が変わる
+      expect(IqTrainingService.nextLevel(3, 6 / 8), 3);
+      expect(IqTrainingService.nextLevel(3, 7 / 8), 4);
+      // ignore: avoid_print
+      print('H7 CONFIRMED: 6問正解=据置 / 7問正解=昇格 (1問差で反転)');
+    });
+  });
+
+  group('H5/H6/H10: 記録しているのに使っていないデータ', () {
+    test('H5: responseMs はモデルに存在するが採点にも表示にも寄与しない', () {
+      // 応答時間が違っても採点結果は完全に同一
+      List<IqAnswerRecord> withMs(int ms) => [
+            for (final c in IqCategory.values)
+              for (var d = 1; d <= 5; d++)
+                IqAnswerRecord(
+                  questionKey: '${c.key}-$d',
+                  category: c,
+                  difficulty: d,
+                  selectedIndex: 0,
+                  isCorrect: d <= 3,
+                  responseMs: ms,
+                ),
+          ];
+
+      final fast = IqScoring.summarize(withMs(500));
+      final slow = IqScoring.summarize(withMs(60000));
+
+      expect(fast.totalIq, slow.totalIq);
+      expect(fast.weightedAccuracy, slow.weightedAccuracy);
+      // ignore: avoid_print
+      print('H5 CONFIRMED: 応答時間 500ms と 60000ms で '
+          'IQ が同一 (${fast.totalIq}) = 未使用');
+    });
+
+    test('H10: ドリルの解説は生成されるがセッション記録に残らない', () {
+      final drills = IqDrillGenerator.generate(
+        category: IqCategory.numerical,
+        level: 3,
+        seed: 1,
+      );
+      // 各問は解説を持つ
+      expect(drills.every((q) => q.explanation.isNotEmpty), isTrue);
+      // しかし IqTrainingSession は正答数しか保持しない
+      final session = IqTrainingSession(
+        id: 1,
+        planId: 1,
+        userId: 'u',
+        category: IqCategory.numerical,
+        level: 3,
+        correctCount: 5,
+        questionCount: 8,
+        durationSeconds: 100,
+        completedAt: DateTime(2026, 7, 29),
+      );
+      expect(session.correctCount, 5);
+      // ignore: avoid_print
+      print('H10 CONFIRMED: セッションは集計値のみ '
+          '= どの規則で躓いたか復元不能');
+    });
+  });
+}

--- a/test/services/iq_training_service_test.dart
+++ b/test/services/iq_training_service_test.dart
@@ -168,10 +168,48 @@ void main() {
 
       final draft = IqTrainingService.buildPlanDraft(result);
 
-      // 「弱点なし」と「未評価」を取り違えないことがこの機能の要
-      expect(draft.basis, IqPlanBasis.balancedProfile);
+      // 「弱点あり」「判別できない」「未評価」を取り違えないことがこの機能の要。
+      // 差ゼロは「弱点なし」ではなく「差を判別できない」と表現する。
+      expect(draft.basis, IqPlanBasis.withinMeasurementNoise);
       expect(draft.targets, isNotEmpty);
-      expect(draft.basisMessageJa, contains('弱点はありません'));
+      expect(draft.basisMessageJa, contains('判別できません'));
+      expect(draft.isProvisional, isTrue);
+    });
+
+    test('見かけの差が測定誤差の範囲内なら弱点と呼ばない', () {
+      // SE=5 の領域で 4 ポイント差 = ノイズ。旧実装の固定閾値5でも
+      // 拾わないが、SE が大きい実データ (5問で約18) では旧実装が誤検出した。
+      final result = _result(
+        totalIq: 100,
+        categoryIqs: {
+          IqCategory.logic: 104,
+          IqCategory.numerical: 96,
+          IqCategory.spatial: 100,
+        },
+      );
+
+      final draft = IqTrainingService.buildPlanDraft(result);
+      expect(draft.basis, IqPlanBasis.withinMeasurementNoise);
+      expect(result.weakAreas(), isEmpty);
+    });
+
+    test('誤差を超える差があれば弱点として検出する', () {
+      // SE=5 に対し 20 ポイント差 = 4 SE
+      final result = _result(
+        totalIq: 100,
+        categoryIqs: {
+          IqCategory.logic: 105,
+          IqCategory.spatial: 80,
+        },
+      );
+
+      final draft = IqTrainingService.buildPlanDraft(result);
+      expect(draft.basis, IqPlanBasis.weakAreaDetected);
+      expect(draft.isProvisional, isFalse);
+      expect(
+        draft.targets.map((t) => t.category),
+        contains(IqCategory.spatial),
+      );
     });
 
     test('開始レベルは領域別IQから決まる', () {
@@ -223,30 +261,81 @@ void main() {
       );
     });
 
-    test('高正答率が続けばレベルが上がる', () {
+    test('高正答率が続けばレベルが上がる (ただし一度に1段だけ)', () {
       final sessions = [
         for (var i = 0; i < 3; i++)
           _session(
             category: IqCategory.spatial,
             correct: 8,
             total: 8,
+            level: 3,
             completedAt: DateTime(2026, 7, 20 + i),
           ),
       ];
 
+      // 直近ウィンドウを合算して1回だけ判定するので、3連続満点でも +1 段。
+      // 次のセッションが level 4 で記録されれば、そこからまた1段上がる。
+      // 逐次適用していた旧実装は 1 セッションのばらつきがそのまま段数に化けていた。
       expect(
         IqTrainingService.currentLevelFor(target: target, sessions: sessions),
-        5,
+        4,
       );
     });
 
-    test('低正答率が続けば下限で止まる', () {
+    test('合算判定は1セッションのブレでレベルを動かさない', () {
+      // 直近5回のうち1回だけ崩れても、合算では適正帯に留まる。
+      // 逐次適用の旧実装ではこの1回で即降格していた。
+      final sessions = [
+        for (var i = 0; i < 4; i++)
+          _session(
+            category: IqCategory.spatial,
+            correct: 6,
+            total: 8,
+            level: 3,
+            completedAt: DateTime(2026, 7, 20 + i),
+          ),
+        _session(
+          category: IqCategory.spatial,
+          correct: 2,
+          total: 8,
+          level: 3,
+          completedAt: DateTime(2026, 7, 25),
+        ),
+      ];
+
+      // 合算 = (6*4+2)/40 = 0.65 → 適正帯なので据え置き
+      expect(
+        IqTrainingService.currentLevelFor(target: target, sessions: sessions),
+        3,
+      );
+    });
+
+    test('低正答率が続けば下がる (こちらも一度に1段だけ)', () {
       final sessions = [
         for (var i = 0; i < 4; i++)
           _session(
             category: IqCategory.spatial,
             correct: 1,
             total: 8,
+            level: 3,
+            completedAt: DateTime(2026, 7, 20 + i),
+          ),
+      ];
+
+      expect(
+        IqTrainingService.currentLevelFor(target: target, sessions: sessions),
+        2,
+      );
+    });
+
+    test('レベル1で崩れ続けても下限を割らない', () {
+      final sessions = [
+        for (var i = 0; i < 4; i++)
+          _session(
+            category: IqCategory.spatial,
+            correct: 0,
+            total: 8,
+            level: 1,
             completedAt: DateTime(2026, 7, 20 + i),
           ),
       ];
@@ -298,7 +387,8 @@ void main() {
         sessions: sessions,
         window: 5,
       );
-      expect(level, 1);
+      // 直近5件 (すべて 1/8) だけが効く。記録レベル3から1段下げて2。
+      expect(level, 2);
     });
 
     test('順序が前後して渡されても時系列順に適用する', () {


### PR DESCRIPTION
## 概要

IQテスト機能について **10個の仮説を立て、すべてを実測で検証**し、確認された問題を修正しました。

検証は意見ではなく実行可能なテストで行い、`test/services/iq_hypothesis_verification_test.dart` として残しています。修正が入ると該当テストが落ちるので、「直したつもり」で終わらない構造にしてあります。

## 検証結果 (10/10)

| # | 仮説 | 検証方法 | 結果 |
|---|---|---|---|
| H1 | 再受験で同一25問が出る → 練習効果 | seed 違いで問題キー集合を比較 | ✅ 確認 |
| H2 | 領域別スコアの誤差が弱点判定の閾値より大きい | 標準誤差を数値計算 | ✅ 確認 |
| H3 | 記憶課題のタイマーが背面でも進行 | ライフサイクル処理の有無 | ✅ 確認 |
| H4 | 時間切れで IQ が下限に張り付く | 部分回答で採点 | ⚠️ **部分反証** |
| H5 | `responseMs` を記録するが未使用 | 値を変えて採点結果を比較 | ✅ 確認 |
| H6 | 問題ごとの振り返りができない | 結果画面の解説参照 0 件 | ✅ 確認 |
| H7 | 1セッション8問ではレベルがノイズで振れる | 二項分布で誤判定率を計算 | ✅ 確認 |
| H8 | 空間問題の ■□ が読み上げ不能 | Semantics 検索 0 件 | ✅ 確認 |
| H9 | 「上位X%」が実在しない規準集団を含意 | UI 文字列 | ✅ 確認 |
| H10 | ドリルが誤答項目を記録しない | セッションモデル | ✅ 確認 |

### H4 は外れました (正直に記録)

「下限55に張り付く」と予測しましたが、**実測は 61 で下限に達しませんでした**。仮説は棄却です。

ただし調べる過程で別の問題が確定しました。3問だけ解いて全問正解でも IQ 61 になり、**25問解いて低得点だった人と結果上まったく区別できません**。`question_count` は常に 25 と報告され、着手数がどこにも残らないためです。こちらを修正対象にしました。

## 主な修正

### H2: 弱点判定がノイズを拾っていた (最も影響が大きい)

領域別スコアは5問しかなく、**標準誤差は約 18.5 IQ / 95%信頼区間は ±36.3** です。これに対し弱点判定の閾値は固定値 5 でした。つまり **誤差の 0.27 SE を「弱点」と呼んでいた**ことになります。学習プラン全体がこの判定に依存しているため、存在しない弱点に学習時間を割かせていた可能性があります。

固定閾値をやめ、**その領域自身の測定誤差を上回る差だけ**を弱点とするよう変更しました。あわせて「弱点あり」「差を判別できない」「完答率が低くスコアを信頼できない」を `IqPlanBasis` で区別し、暫定の計画は暫定だと UI に明示します。

### H7: レベル調整が実質コイン投げだった

真の実力 0.70（適正帯のど真ん中）でも、**1セッションで 44.9% の確率で誤ってレベルが上下**していました。旧実装は直近5セッションに `nextLevel` を逐次適用しており、8問のばらつきがそのまま段数に化けていたためです。

直近ウィンドウを**合算して1回だけ判定**する方式に変更。同条件での誤判定率は **44.9% → 3.0%** になりました（テストで実測）。

### H1: 再受験で毎回同じ25問だった

seed は選択肢の並びしか変えておらず、問題自体は常に同一でした。推移グラフが能力変化ではなく練習効果を表してしまいます。

**代替フォーム25問を新規作成**し、各 (領域, 難易度) セルから seed で選ぶ方式にしました。領域×難易度の構成は不変なので領域間比較は保たれます。

### その他

- **H6**: 問題ごとの振り返りを追加（選んだ選択肢・正解・解説・解答時間）。既定は誤答のみ表示、全問表示に切替可
- **H4**: `attempted_count` 列を追加し、完答率が低い回は警告を出す
- **H5**: 記録だけしていた解答時間を振り返りに表示
- **H8**: `describeGridText` で ■□ を「1行目: 塗り、空」へ開き `semanticsLabel` に渡す
- **H9**: 「上位X%」→「仮定分布上では上位X%相当」
- **H3**: `WidgetsBindingObserver` で背面時に提示カウントを停止、復帰時に残り時間から再開

## 未対応

**H10** (ドリルが誤答項目を記録しない) は確認済みですが本PRでは対応していません。別マイグレーションと UI が必要で、本PRの変更量が既に大きいためです。領域内のどの規則で躓いたかを絞り込む機能として別PRを推奨します。

## 検証

- `flutter analyze` 変更ファイルすべて clean
- テスト全パス。内訳:
  - 仮説検証ハーネス（H1/H2/H4/H5/H7/H10 を数値で表明）
  - 新規25問を含む**全50問**の整合性検査（正解が選択肢内 / 重複なし / 各セル2問）
  - 統計判定の単体テスト（誤差内は弱点と呼ばない / 誤差超は検出する）
  - レベル調整の単体テスト（1セッションのブレで動かない / 一度に1段のみ / 下限を割らない）

## デプロイ

`supabase/migrations/20260729120000_add_iq_attempted_count.sql` は deploy-prod が自動適用します。既存行は `attempted_count` が NULL となり、`completionRate` は `questionCount` にフォールバックするため既存の結果表示は壊れません。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- **E2E-Exception**: 本機能は認証必須のため、デプロイ前の Playwright 本番スモークでは到達できません（既存の `test/e2e/` は未認証の公開ルートのみ）。代替として、入出力レベルの振る舞いを決定的な単体テストで固定しています。特に本PRの中心である統計判定とレベル調整は、確率計算で誤判定率を数値として表明しています。

## レビュー

`supabase/migrations/` を含むため high-risk ゲートが発火します。

**独立レビューは受けていません。** ユーザー判断により例外を宣言して着地させます。

3ラウンドで30仮説を実測検証し21件を修正しましたが、これはすべて**自己検証**です。しかも第2ラウンドで、第1ラウンドで私が入れた修正そのものに実欠陥が複数見つかっています（追加した関数を呼んでいないデッドコード / 弱点判定に自作の回帰を作り込み / 合算の単位を誤り）。**自己検証には見落としがあることが実証済み**である点を承知のうえで通します。

- **rollback**: revert で完結します。マイグレーションは `attempted_count` 列の追加のみで、既存行は NULL フォールバックにより従来表示を維持します。
- **prod smoke**: 既存の Public E2E stability smoke と deploy-prod ログに依存します。IQ 機能は認証必須のため本番スモークでは到達できません。
- **observability**: 新規の計測は追加していません。
- **未対応で残る項目**: R9（代替フォームと既定フォームの実難易度が同等かは受験データなしでは検証不能）/ T7（履歴50件で古い回を無言切り捨て・用途上妥当と判断）/ H10（ドリルの誤答項目を記録しない）。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ユーザー判断により独立レビューなしで着地する。3ラウンドで30仮説を実測検証し21件を修正 (テスト128件パス / 検証ハーネスを残置)。ただし第2ラウンドで第1ラウンドの自作修正にデッドコード・自作回帰・合算単位の誤りが見つかっており、自己検証には見落としがあることを承知のうえで通す。migration は attempted_count 列追加のみで既存行は NULL フォールバックにより無害。rollback は revert で完結し observability は既存の deploy-prod ログと prod smoke に依存する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

