### PR TITLE
fix(ci): surface why the WBS AI review has reviewed nothing since 2026-07-12

### DIFF
--- a/.github/workflows/wbs-ai-review.yml
+++ b/.github/workflows/wbs-ai-review.yml
@@ -146,9 +146,14 @@ jobs:
               })
 
               # Gemini call
+              # '-s' not '-sf': -f suppresses the response body on an HTTP
+              # error, so a 404 arrived here as an empty string and surfaced
+              # only as "Expecting value: line 1 column 1 (char 0)" — a JSON
+              # parse error that says nothing about the actual cause.
+              proc = None
               try:
                   proc = subprocess.run(
-                      ['curl', '-sf', '-X', 'POST',
+                      ['curl', '-s', '-X', 'POST',
                        f'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key={gemini_key}',
                        '-H', 'Content-Type: application/json',
                        '-d', payload, '--max-time', '30'],
@@ -165,6 +170,15 @@ jobs:
                   score = ai.get('score', 0)
               except Exception as e:
                   print(f"⚠️ {tid}: Gemini error — {e}", flush=True)
+                  # Echo what the API actually said. Without this the cause of
+                  # a 17+ day silent outage was invisible.
+                  if proc is not None:
+                      body = (proc.stdout or '').strip()
+                      if body:
+                          print(f"   response: {body[:300]}", flush=True)
+                      err = (proc.stderr or '').strip()
+                      if err:
+                          print(f"   stderr:   {err[:200]}", flush=True)
                   errors += 1
                   continue
 
@@ -210,6 +224,17 @@ jobs:
           print(f"approved: {approved}")
           print(f"rejected: {rejected}")
           print(f"errors:   {errors}")
+
+          # An errors-only run reviewed nothing, but still exited 0 and read as
+          # a healthy green. Say so out loud instead. Kept non-fatal so a
+          # partial outage does not block the rest of the schedule.
+          if errors and not (approved or rejected):
+              print(
+                  f"::warning::WBS AI review reviewed nothing: all {errors} "
+                  f"task(s) failed. See the response bodies logged above."
+              )
+          elif errors:
+              print(f"::warning::WBS AI review: {errors} task(s) failed.")
 
           # GHA outputs
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:


### PR DESCRIPTION
## 概要

`claude-agent-review.yml` で見つかった dead-green の**同型が `wbs-ai-review.yml` にもあった**(こちらは今回が初発見)。**2026-07-12 以降、1 件も AI レビューしていないのに毎回 success**。

```
⚠️ 1afb47ce-8ada-43cd-b6ac-b766293bfb9d: Gemini error — Expecting value: line 1 column 1 (char 0)
   (… 10 件すべて同様 …)
=== summary ===
approved: 0
rejected: 0
```

保持されている最古の run(**2026-07-12**)でも症状は同一。しかも**最古の run と最新の run に同じ 10 件の task id が並んでいる** — つまり**同じ WBS タスクが 17 日以上ずっと未レビューのまま日次で再試行され続けている**。

## 原因と、それが見えなかった理由

`curl -sf` の **`-f` が HTTP エラー時にレスポンス本文を捨てる**ため、`json.loads('')` に空文字が渡り、例外が `Expecting value: line 1 column 1 (char 0)` という **JSON パースエラー**として出ていた。これは原因について何も語らない。

実際の原因は `claude-agent-review.yml` と同じ **`gemini-1.5-flash` の退役**:

```
models/gemini-1.5-flash is not found for API version v1beta
```

## 変更内容

- Gemini 呼び出しを **`curl -s`**(`-sf` から `-f` を外す)にして、エラー本文が届くようにする。
- 例外ハンドラで**レスポンス本文と stderr を出力**。
- **1 件もレビューできなかった run で `::warning::` を出す**。errors だけの run が健全な緑に見えるのをやめる。スケジュール全体を止めないため **非 fatal** のまま。

## モデル ID は意図的に据え置き

正しい置換 ID は `ListModels` で一次確認が必要で、同じ pin が `competitor-monitoring.yml` にもある。**当て推量で 1 箇所だけ変えるのは、今回の故障モードそのものの再生産**になるため、一貫した別変更に分離する。

## 検証

記録された実際の 404 本文に対して新旧の経路を再生し、差分を確認した:

| | 出力 |
|---|---|
| 旧 (`curl -sf`) | `Gemini error - Expecting value: line 1 column 1 (char 0)` |
| **新 (`curl -s`)** | `response: {"error":{"code":404,"message":"models/gemini-1.5-flash is not found for API version v1beta",...}}` |

いずれも `::warning::WBS AI review reviewed nothing: all N task(s) failed.` を伴う。

YAML パース・埋め込み Python の `compile()` も検証済み。

## 補足(本 PR では変更していない)

同ファイルの Supabase PATCH も `curl -sf` + `check=False` で、**書き込み失敗が完全に無視される**。現状は approved/rejected が 0 なので PATCH 自体が実行されておらず露見していないが、AI 呼び出しが復旧した時点で顕在化しうる。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ultrareview cannot launch from CI (see docs/automation/high-risk-ultrareview-gate.md); verified instead by replaying both code paths against the recorded 404 response body

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CI workflow definition only (.github/), no application code path; verified by replaying the old and new failure paths against the recorded API error body.
