### PR TITLE
fix(ci): stop competitor monitoring from publishing a silent static fallback

### DIFF
--- a/.github/workflows/competitor-monitoring.yml
+++ b/.github/workflows/competitor-monitoring.yml
@@ -261,6 +261,10 @@ jobs:
               echo "✅ Gemini Flash 生成成功 (${#AI_REPORT} chars)"
             else
               echo "⚠️ Gemini Flash 失敗 — Claude fallback へ"
+              # The response was already captured; it was simply never shown,
+              # so a retired-model 404 looked identical to a quota problem.
+              echo "$GEMINI_RESPONSE" | head -c 500
+              echo
             fi
           fi
 
@@ -283,14 +287,28 @@ jobs:
               if [ -n "$AI_REPORT" ] && [ ${#AI_REPORT} -gt 100 ]; then
                 USED_MODEL="claude-sonnet-4-6"
                 echo "✅ Claude fallback 成功 (${#AI_REPORT} chars)"
+              else
+                echo "⚠️ Claude fallback 失敗"
+                echo "$CLAUDE_RESPONSE" | head -c 500
+                echo
               fi
             fi
           fi
 
           # ── Fallback: スタティックテンプレート ─────────────────────────────
+          # This branch publishes a report that looks like the others, so a
+          # total AI outage reads as a normal green run. Say so out loud, and
+          # state the reason accurately: the old text blamed missing keys even
+          # when both were set and the providers had rejected the requests.
           if [ -z "$AI_REPORT" ] || [ ${#AI_REPORT} -le 100 ]; then
             USED_MODEL="static-template"
-            AI_REPORT=$(printf '## AI生成スキップ (API未設定 or 全プロバイダー失敗)\n\n競合インテリジェンス生成には GEMINI_API_KEY または ANTHROPIC_API_KEY が必要です。\n\n## 可用性チェック結果のみ記録\n\n%s' "$(cat /tmp/avail_results.txt)")
+            if [ -z "$GEMINI_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+              SKIP_REASON="API キー未設定"
+            else
+              SKIP_REASON="全プロバイダーが応答せず (上のログのレスポンス本文を確認)"
+            fi
+            echo "::warning::競合インテリジェンスは AI 生成されませんでした — ${SKIP_REASON}。static-template を公開します。"
+            AI_REPORT=$(printf '## AI生成スキップ (%s)\n\n本レポートは AI 生成ではなく静的テンプレートです。\n\n## 可用性チェック結果のみ記録\n\n%s' "$SKIP_REASON" "$(cat /tmp/avail_results.txt)")
           fi
 
           echo "used_model=$USED_MODEL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 概要

この系統の**最後の 1 本**。`competitor-monitoring.yml` は **2026-07-09 以降 AI レポートを一度も生成していない**。両プロバイダーが失敗 → static テンプレートへフォールバック → **それを公開して success**。

この故障モードは他の 2 本より厄介で、**「AI 生成レポート」と同じ形の文書が毎日公開され続ける**。緑であるだけでなく、成果物まで正常に見えてしまう。

## 原因と、それが見えなかった理由

本ファイルは `curl -s` を使っており(`wbs-ai-review.yml` と違い)**レスポンス本文は既に変数に入っていた**。ただ**一度も出力されず**、パース用の one-liner が `2>/dev/null || true` で終わるため捨てられていた。

原因は本日 他所で特定したものと同一:

```
Gemini  404: models/gemini-1.5-flash is not found for API version v1beta
Claude  400: Your credit balance is too low to access the Anthropic API
```

## 変更内容

- **両プロバイダーの失敗時にレスポンス本文を出力**(500 字)。
- **static テンプレート使用時に `::warning::`**。理由は**キーの有無を実際に判定**して出し分ける。旧テキストは常に「API未設定 or 全プロバイダー失敗」と主張しており、両キーが設定済みでも同じ文言だったため、全断が想定内に見えていた。
- **公開されるレポート自体に「AI 生成ではなく静的テンプレート」と明記**。本物と同じ形の文書を出す分岐なので、AI 出力として通用してはいけない。

## モデル ID は据え置き(#4381 / #4386 と一貫)

Gemini の置換 ID は `ListModels` での一次確認が必要。Claude 側は**アカウント残高の問題**なので、別 ID にしても直らない。

## 検証

記録済みのエラー本文で 2 ケースを再生:

| ケース | 結果 |
|---|---|
| 両キー設定済み(**現在の実状態**) | 両方の本文が出力 → `::warning::… 全プロバイダーが応答せず` → レポート冒頭が `## AI生成スキップ (全プロバイダーが応答せず…)` |
| キーなし | `::warning::… API キー未設定` → 冒頭が `## AI生成スキップ (API キー未設定)` |

YAML パース・shell 構文も検証済み。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ultrareview cannot launch from CI (see docs/automation/high-risk-ultrareview-gate.md); verified instead by replaying both branches against the recorded provider error bodies

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CI workflow definition only (.github/), no application code path; verified by replaying the keys-set and no-keys branches against the recorded provider error bodies.
