### PR TITLE
fix(stripe): 2025-03-31.basil で移動した invoice/subscription フィールドを新旧両対応で読む

### DIFF
--- a/docs/HEXCIV_PAID_DOWNLOAD.md
+++ b/docs/HEXCIV_PAID_DOWNLOAD.md
@@ -51,6 +51,28 @@ RLS の方針は「**読みは本人分だけ・書きは service role だけ**�
 | `stripe-webhook` (拡張) | 購入行の作成 | `stripe_checkout_session_id` の unique + `onConflict` で**再送に対して冪等**。`payment_status` が paid でなければ `pending` で作る |
 | `shop-download` | 署名付きURL発行 | 権利確認 → 有効期限 **5分**の URL。販売停止 (`is_active=false`) でも**購入済みの人には配信する** |
 
+### Stripe API バージョン (2026-07-29)
+
+webhook endpoint は **2026-06-24.dahlia** で作り直した。元の 2020-03-02 では
+checkout session に `payment_status` が無く、`checkoutPaymentDecision()` が
+「paid でなければ履行しない」で必ず止まるため、**購入が一切記録されなかった**。
+
+注意すべきなのは、この EF には**2つの API バージョンが同時に流れ込む**こと。
+
+| 経路 | 適用されるバージョン |
+|---|---|
+| webhook event の payload | endpoint に固定した **2026-06-24.dahlia** |
+| `stripeGet()` の戻り値 | `Stripe-Version` ヘッダ未指定 = **アカウント既定バージョン** |
+
+`upsertSubscriptionFromStripe()` はこの両方から呼ばれるため、片方の形しか
+読まない実装はもう片方で静かに null を書き込む。差の吸収は
+`stripe_api_compat.ts` に集約してある (2025-03-31.basil で **削除** された
+2フィールド — `invoice.subscription` と `subscription.current_period_end`)。
+
+> アカウント既定バージョンを引き上げても、この層は無害に効き続ける。
+> 「旧形はもう来ないから」と fallback を消すと、既定バージョンが古いままの
+> `stripeGet()` 経路が先に壊れる。消す前に Workbench で既定バージョンを確認すること。
+
 ## 公開までに残っている手順
 
 以下は**こちら側では実行できない**、または本人の判断が要るもの。

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -5,6 +5,10 @@ import {
   processStripeWebhookEventOnce,
 } from "./event_processing.ts";
 import { activateReferralForPaidCheckout } from "./referral_activation.ts";
+import {
+  invoiceSubscriptionId,
+  subscriptionCurrentPeriodEnd,
+} from "./stripe_api_compat.ts";
 
 // .trim(): Supabase secret に紛れ込んだ前後の空白/改行を吸収 (署名検証や
 // Stripe API 呼び出しがコピペ事故で失敗しないよう防御)。
@@ -176,7 +180,9 @@ async function upsertSubscriptionFromStripe(
     stripe_subscription_id: asString(subscription.id) || null,
     tier: normalizeTier(metadata.tier),
     status: normalizeStatus(subscription.status),
-    current_period_end: currentPeriodEnd(subscription.current_period_end),
+    current_period_end: currentPeriodEnd(
+      subscriptionCurrentPeriodEnd(subscription),
+    ),
     cancel_at_period_end: subscription.cancel_at_period_end === true,
     metadata: {
       stripe_event_source: "stripe-webhook",
@@ -349,7 +355,7 @@ async function markPastDue(
   admin: SupabaseClient,
   invoice: Record<string, unknown>,
 ): Promise<void> {
-  const subscriptionId = asString(invoice.subscription);
+  const subscriptionId = invoiceSubscriptionId(invoice);
   const customerId = asString(invoice.customer);
   let userId = "";
   if (customerId) userId = await userIdForCustomer(admin, customerId);

--- a/supabase/functions/stripe-webhook/stripe_api_compat.test.ts
+++ b/supabase/functions/stripe-webhook/stripe_api_compat.test.ts
@@ -1,0 +1,196 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  invoiceSubscriptionId,
+  subscriptionCurrentPeriodEnd,
+} from "./stripe_api_compat.ts";
+
+// fixture は実際の payload の入れ子をそのまま再現する。抜き出した 1 階層だけを
+// 渡す fixture だと「その形を読める」ことしか確かめられず、本番の payload で
+// パスが 1 段ずれていても緑のまま通ってしまう。
+
+/** 2026-06-24.dahlia の invoice.payment_failed。basil で `subscription` は消えている。 */
+const DAHLIA_INVOICE = {
+  id: "in_1QxYzAIriTNCQL2dahlia",
+  object: "invoice",
+  customer: "cus_TestCustomer",
+  status: "open",
+  attempted: true,
+  parent: {
+    type: "subscription_details",
+    quote_details: null,
+    subscription_details: {
+      subscription: "sub_1QxYzAIriTNCQL2dahlia",
+      subscription_proration_date: null,
+      metadata: { user_id: "user-123" },
+    },
+  },
+};
+
+/** 2020-03-02 の invoice。`parent` が存在しない。 */
+const LEGACY_INVOICE = {
+  id: "in_1QxYzAIriTNCQL2legacy",
+  object: "invoice",
+  customer: "cus_TestCustomer",
+  status: "open",
+  attempted: true,
+  subscription: "sub_1QxYzAIriTNCQL2legacy",
+};
+
+/** 2026-06-24.dahlia の subscription。期間は item 側にある。 */
+const DAHLIA_SUBSCRIPTION = {
+  id: "sub_1QxYzAIriTNCQL2dahlia",
+  object: "subscription",
+  customer: "cus_TestCustomer",
+  status: "active",
+  cancel_at_period_end: false,
+  latest_invoice: "in_1QxYzAIriTNCQL2dahlia",
+  metadata: { user_id: "user-123", tier: "pro" },
+  items: {
+    object: "list",
+    has_more: false,
+    url: "/v1/subscription_items?subscription=sub_1QxYzAIriTNCQL2dahlia",
+    data: [
+      {
+        id: "si_dahlia_pro",
+        object: "subscription_item",
+        current_period_start: 1774000000,
+        current_period_end: 1776592000,
+        price: { id: "price_pro_monthly", object: "price" },
+      },
+    ],
+  },
+};
+
+/** 2020-03-02 の subscription。`items.data` はあるが item に期間が無い。 */
+const LEGACY_SUBSCRIPTION = {
+  id: "sub_1QxYzAIriTNCQL2legacy",
+  object: "subscription",
+  customer: "cus_TestCustomer",
+  status: "active",
+  cancel_at_period_end: false,
+  latest_invoice: "in_1QxYzAIriTNCQL2legacy",
+  metadata: { user_id: "user-123", tier: "pro" },
+  current_period_start: 1774000000,
+  current_period_end: 1776592000,
+  items: {
+    object: "list",
+    has_more: false,
+    data: [
+      {
+        id: "si_legacy_pro",
+        object: "subscription_item",
+        price: { id: "price_pro_monthly", object: "price" },
+      },
+    ],
+  },
+};
+
+Deno.test("invoiceSubscriptionId reads the 2026-06-24.dahlia parent hash", () => {
+  assertEquals(
+    invoiceSubscriptionId(DAHLIA_INVOICE),
+    "sub_1QxYzAIriTNCQL2dahlia",
+  );
+});
+
+Deno.test("invoiceSubscriptionId still reads the pre-basil flat field", () => {
+  assertEquals(
+    invoiceSubscriptionId(LEGACY_INVOICE),
+    "sub_1QxYzAIriTNCQL2legacy",
+  );
+});
+
+Deno.test("invoiceSubscriptionId unwraps an expanded subscription object", () => {
+  const expanded = {
+    ...DAHLIA_INVOICE,
+    parent: {
+      type: "subscription_details",
+      subscription_details: {
+        subscription: {
+          id: "sub_expanded",
+          object: "subscription",
+          status: "past_due",
+        },
+      },
+    },
+  };
+  assertEquals(invoiceSubscriptionId(expanded), "sub_expanded");
+});
+
+Deno.test("invoiceSubscriptionId prefers the new path when both are present", () => {
+  // アカウント既定バージョンを上げる過渡期に両方載った場合でも結果が揺れないこと。
+  const both = { ...LEGACY_INVOICE, parent: DAHLIA_INVOICE.parent };
+  assertEquals(invoiceSubscriptionId(both), "sub_1QxYzAIriTNCQL2dahlia");
+});
+
+Deno.test("invoiceSubscriptionId returns empty for a non-subscription invoice", () => {
+  const quoteInvoice = {
+    id: "in_quote",
+    object: "invoice",
+    customer: "cus_TestCustomer",
+    parent: {
+      type: "quote_details",
+      quote_details: { quote: "qt_123" },
+      subscription_details: null,
+    },
+  };
+  assertEquals(invoiceSubscriptionId(quoteInvoice), "");
+  assertEquals(invoiceSubscriptionId({ id: "in_oneoff", parent: null }), "");
+  assertEquals(invoiceSubscriptionId({}), "");
+});
+
+Deno.test("subscriptionCurrentPeriodEnd reads the 2026-06-24.dahlia item period", () => {
+  assertEquals(subscriptionCurrentPeriodEnd(DAHLIA_SUBSCRIPTION), 1776592000);
+});
+
+Deno.test("subscriptionCurrentPeriodEnd still reads the pre-basil flat field", () => {
+  // 旧形は items.data が空振りするので、top-level へ落ちて同じ値を返す。
+  assertEquals(subscriptionCurrentPeriodEnd(LEGACY_SUBSCRIPTION), 1776592000);
+});
+
+Deno.test("subscriptionCurrentPeriodEnd takes the earliest of mixed intervals", () => {
+  // 「次回更新」として表示する値なので、次に請求が走る = 最も早い item を採る。
+  const mixed = {
+    ...DAHLIA_SUBSCRIPTION,
+    items: {
+      object: "list",
+      has_more: false,
+      data: [
+        {
+          id: "si_yearly",
+          object: "subscription_item",
+          current_period_end: 1805000000,
+          price: { id: "price_pro_yearly", object: "price" },
+        },
+        {
+          id: "si_monthly",
+          object: "subscription_item",
+          current_period_end: 1776592000,
+          price: { id: "price_addon_monthly", object: "price" },
+        },
+      ],
+    },
+  };
+  assertEquals(subscriptionCurrentPeriodEnd(mixed), 1776592000);
+});
+
+Deno.test("subscriptionCurrentPeriodEnd returns null when no period is available", () => {
+  assertEquals(
+    subscriptionCurrentPeriodEnd({
+      id: "sub_incomplete",
+      object: "subscription",
+      items: { object: "list", data: [] },
+    }),
+    null,
+  );
+  assertEquals(subscriptionCurrentPeriodEnd({}), null);
+  // 0 / 負値 / 非数値は「期間なし」として null に倒す (epoch 0 を 1970 年として
+  // 書き込むと、UI に「次回更新 1970/01/01」が出る)。
+  assertEquals(
+    subscriptionCurrentPeriodEnd({ current_period_end: 0 }),
+    null,
+  );
+  assertEquals(
+    subscriptionCurrentPeriodEnd({ current_period_end: "not-a-number" }),
+    null,
+  );
+});

--- a/supabase/functions/stripe-webhook/stripe_api_compat.ts
+++ b/supabase/functions/stripe-webhook/stripe_api_compat.ts
@@ -1,0 +1,100 @@
+/**
+ * Stripe API バージョン間で移動したフィールドを吸収する層 (2026-07-29 追加)。
+ *
+ * 背景: HexCiv 買い切り販売を有効化するため、webhook endpoint を
+ * 2020-03-02 から 2026-06-24.dahlia で作り直した。その間の
+ * **2025-03-31.basil** で、サブスク周りの 2 フィールドが削除されている
+ * (deprecated ではなく removed):
+ *
+ *   - `invoice.subscription`
+ *       → `invoice.parent.subscription_details.subscription`
+ *   - `subscription.current_period_end`
+ *       → `subscription.items.data[].current_period_end`
+ *
+ * なぜ新旧どちらも読むのか: 「削除済みなら新形だけ読めばよい」ように見えるが、
+ * この EF には **2 つの API バージョンが同時に流れ込む**。
+ *
+ *   - webhook event の payload → endpoint に固定した 2026-06-24.dahlia (新形)
+ *   - `stripeGet()` の戻り値   → `Stripe-Version` ヘッダを送っていないため
+ *                                アカウント既定バージョン (= 旧形のまま)
+ *
+ * `upsertSubscriptionFromStripe()` はこの両方から呼ばれる (checkout 経由は
+ * `stripeGet()`、`customer.subscription.*` は event payload) ので、片方の形しか
+ * 読まない実装は必ずもう片方で静かに null を書き込む。アカウント既定バージョンを
+ * 引き上げた後も、この層はそのまま無害に効き続ける。
+ */
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+/**
+ * expandable な参照フィールドから ID を取り出す。
+ *
+ * Stripe の参照フィールドは expand 指定で文字列 ID から object に化けるため、
+ * 文字列だけを想定すると展開されていた場合に黙って空文字になる。
+ */
+function referenceId(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  const id = asRecord(value)?.id;
+  return typeof id === "string" ? id.trim() : "";
+}
+
+function epochSeconds(value: unknown): number | null {
+  const seconds = typeof value === "string" ? Number(value.trim()) : value;
+  return typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+    ? Math.trunc(seconds)
+    : null;
+}
+
+/**
+ * invoice が属する subscription の ID を返す (見つからなければ空文字)。
+ *
+ * `parent.type === 'subscription_details'` の確認はあえてしない。もう一方の
+ * parent 種別である `quote_details` に `subscription` フィールドは存在せず、
+ * hash が埋まっていること自体が subscription 由来である十分条件になるため。
+ * type を必須にすると、将来 parent 種別が増えたときに読めなくなる側に倒れる。
+ */
+export function invoiceSubscriptionId(
+  invoice: Record<string, unknown>,
+): string {
+  // 2025-03-31.basil 以降。
+  const details = asRecord(asRecord(invoice.parent)?.subscription_details);
+  const fromParent = referenceId(details?.subscription);
+  if (fromParent) return fromParent;
+
+  // 2025-03-31.basil 未満。
+  return referenceId(invoice.subscription);
+}
+
+/**
+ * subscription の現在の請求期間の終了時刻を epoch 秒で返す。
+ *
+ * 新形では期間が item 単位になったため、単一の値へ畳む必要がある。ここでは
+ * **最小値** を採る: この値は UI で「次回更新」として表示されるので
+ * (`lib/pages/subscription_billing_page.dart`)、次に請求が走るのは最も早く
+ * 期間が終わる item だから。max を採ると、既に課金された後の日付を「次回」
+ * として見せてしまう。単一 price のサブスクでは全 item が同値なので一致する。
+ */
+export function subscriptionCurrentPeriodEnd(
+  subscription: Record<string, unknown>,
+): number | null {
+  const items = asRecord(subscription.items)?.data;
+  if (Array.isArray(items)) {
+    const ends: number[] = [];
+    for (const item of items) {
+      const end = epochSeconds(asRecord(item)?.current_period_end);
+      if (end !== null) ends.push(end);
+    }
+    // 注: `items` はページングされるリストなので、1 ページに収まらない数の item を
+    // 持つサブスクでは見えている範囲の最小値になる。現行商品は単一 price のため
+    // 影響しない。該当するプランを増やすときはここを API 再取得に変えること。
+    if (ends.length > 0) return Math.min(...ends);
+  }
+
+  // 2025-03-31.basil 未満。旧形でも `items.data` 自体は存在するが、item 側に
+  // 期間フィールドが無いため上のループは空振りしてここへ落ちる。
+  return epochSeconds(subscription.current_period_end);
+}


### PR DESCRIPTION
## 背景

HexCiv 買い切り販売 (#4364) を有効化するため、Stripe の webhook endpoint を
API バージョン **2020-03-02 → 2026-06-24.dahlia** で作り直した。2020-03-02 では
checkout session に `payment_status` が無く、`checkoutPaymentDecision()` の
「paid でなければ履行しない」で必ず止まるため、購入が一切記録されなかった。

買い切り購入 (`recordShopPurchase`) が読む項目は新版でも同じ場所にあり無傷。
影響があったのは既存のサブスク処理 2 箇所。

## 一次情報での確認結果

どちらも **`2025-03-31.basil` で deprecated ではなく削除 (Removed)**。

| 旧 | 新 |
|---|---|
| `invoice.subscription` | `invoice.parent.subscription_details.subscription` |
| `subscription.current_period_end` | `subscription.items.data[].current_period_end` |

- [Invoicing resources now specify how they were generated](https://docs.stripe.com/changelog/basil/2025-03-31/adds-new-parent-field-to-invoicing-objects)
- [Adds subscription item-level billing periods and removes subscription-level periods](https://docs.stripe.com/changelog/basil/2025-03-31/deprecate-subscription-current-period-start-and-end)

Clover / Dahlia の全 breaking change も確認したが、この 2 フィールドの再移動はない
([Clover](https://docs.stripe.com/changelog/clover) / [Dahlia](https://docs.stripe.com/changelog/dahlia))。
`cancel_at_period_end` / `latest_invoice` / `status` / `customer` / `metadata` は健在。

## 実測した実害

旧コードに dahlia payload を通した結果:

```
OLD invoice.subscription           : ""     → NEW: "sub_dahlia"
OLD subscription.current_period_end: null   → NEW: "2026-04-19T09:46:40.000Z"
```

- `markPastDue`: `status='past_due'` 自体は customer 経由で通るため、**黙って subscription id だけ落ちる**
- `upsertSubscriptionFromStripe`: subscription イベントのたびに `current_period_end` を **null で上書き**し、UI の「次回更新」が消える

どちらも例外を投げないため、緑のまま壊れる。

## なぜ新旧どちらも読むのか

`stripeGet()` は `Stripe-Version` ヘッダを送っていないため
[アカウント既定バージョン](https://docs.stripe.com/api/versioning)が適用される一方、
webhook payload は endpoint に固定した dahlia。

| 経路 | 適用バージョン |
|---|---|
| webhook event の payload | **2026-06-24.dahlia** |
| `stripeGet()` の戻り値 | **アカウント既定バージョン** |

`upsertSubscriptionFromStripe()` はこの両方から呼ばれるので、**新旧 2 つの形が
同時に流れ込む**。フォールバックはレガシー許容ではなく、現時点で両方必要。

## `min` を採った理由

新形は期間が item 単位なので単一値へ畳む必要がある。この値は
`subscription_billing_page.dart` で「次回更新」として表示されるだけで
アクセス制御には未使用と確認済。次に請求が走るのは最も早く期間が終わる item
なので最小値が正。`max` だと課金済みの後の日付を「次回」と表示してしまう。
単一 price のサブスクでは min/max は一致する。

## 変更していないもの

- **`checkoutPaymentDecision` は無変更**。既存テストごと触っていない
- **`deploy-prod.yml` も変更不要**。新規 EF ではなく既存 EF 内のモジュール追加で、`stripe-webhook` は既にリスト済 (`deploy-prod.yml:600`)
- `deno fmt --check` が既存 5 ファイルで落ちるが、全て `Text differed by line endings` (`core.autocrlf=true`)。触っていない `referral_activation.ts` 等も含む既存事象で、CI に該当ゲートは無いため無関係な全行差分を作らないよう据え置いた

## テスト

`stripe_api_compat.test.ts` に 9 件追加 (既存 `*.test.ts` の書式に準拠)。
fixture は実 payload の入れ子をそのまま再現している (1 階層だけ渡す fixture では
パスのズレを捕まえられないため)。旧形 subscription は `items.data` が存在するのに
item 側に期間が無い、という実際の形も含む。

- `deno lint` 194 ファイル 0 エラー
- `deno check` 通過
- `deno test` **593 passed / 0 failed** (全体・既存への影響なし)

## 補足

この口座 (`acct_1GsrVzAIriTNCQL2`) はサブスク顧客 0・成功決済 0 のため緊急度は低い。
HexCiv 販売そのものではなく、**将来サブスクを再開したときに静かにデータが欠ける
経路を先に塞ぐ**位置づけ。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Stripe 署名検証済み webhook エンドポイントの内部フィールド解決であり、integration_test/ や Playwright の経路からは到達できない (Stripe からの署名付き POST が必要)。代わりに deno unit test 9 件で新旧両 API バージョンの payload を実形で固定した。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: DB マイグレーション・新規 Edge Function・secret 変更をいずれも伴わない、既存 webhook ハンドラ内のフィールド読み替えのみ。対象口座 acct_1GsrVzAIriTNCQL2 はサブスク顧客 0・成功決済 0 で blast radius が実質ゼロ。新旧両 API バージョンの payload を実形の fixture で固定した deno unit test 9 件を追加済 (593 passed / 0 failed)。ultrareview は課金制でユーザー起動のため CI からは実行できず、証拠の代筆は行わない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


