### PR TITLE
feat(shop): 販売 funnel の計測を追加 (P1)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -605,6 +605,9 @@ jobs:
           # 認証は関数内で auth.getUser() により行う。
           deploy_function shop-checkout --no-verify-jwt
           deploy_function shop-download --no-verify-jwt
+          # 販売 funnel の計測 (2026-07-29 追加)。未ログインの閲覧者も数えるため
+          # 認証は要求せず、書き込める内容を列挙値に限定して守っている。
+          deploy_function shop-funnel --no-verify-jwt
 
           # --- Mega-Hub (5本: 旧Tier2全統合) ---
           deploy_function tools-hub --no-verify-jwt

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:my_web_app/pages/windows_app_install_page.dart';
 import 'package:my_web_app/pages/payment_reminder_page.dart';
 import 'package:my_web_app/pages/shopping_list_page.dart';
 import 'package:my_web_app/pages/hexciv_shop_page.dart';
+import 'package:my_web_app/services/shop_funnel_service.dart';
 import 'package:my_web_app/pages/digest_queue_page.dart';
 import 'package:my_web_app/pages/gemini_university_v2_page.dart';
 import 'package:my_web_app/pages/growth_mission_page.dart';
@@ -520,6 +521,9 @@ Route<dynamic> generateAppRoute(
       return MaterialPageRoute(
         builder: (_) => HexcivShopPage(
           purchaseResult: Uri.base.queryParameters['purchase'],
+          // 計測 (2026-07-29 追加)。閲覧・購入ボタン押下・Checkout 到達を数える。
+          // ここを渡し忘れると計測だけが黙って止まるので、route に直書きする。
+          funnel: ShopFunnelService(),
         ),
         settings: settings,
       );

--- a/lib/pages/hexciv_shop_page.dart
+++ b/lib/pages/hexciv_shop_page.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../services/shop_funnel_service.dart';
 import '../services/shop_service.dart';
 import '../theme/design_tokens.dart';
 
@@ -15,13 +18,21 @@ import '../theme/design_tokens.dart';
 /// 「買えるように見えて買えない」を作らないことを優先している。
 /// 商品が未整備のときに購入ボタンを出すと、押した先で必ず失敗するため。
 class HexcivShopPage extends StatefulWidget {
-  const HexcivShopPage({super.key, this.purchaseResult, this.service});
+  const HexcivShopPage({
+    super.key,
+    this.purchaseResult,
+    this.service,
+    this.funnel,
+  });
 
   /// Stripe からの戻り (`?purchase=success` / `?purchase=canceled`)。
   final String? purchaseResult;
 
   /// テストから差し替えるための注入口。
   final ShopGateway? service;
+
+  /// 計測の注入口。テストでは省略でき、その場合は計測を行わない。
+  final ShopFunnelService? funnel;
 
   @override
   State<HexcivShopPage> createState() => _HexcivShopPageState();
@@ -40,10 +51,31 @@ class _HexcivShopPageState extends State<HexcivShopPage> {
   String? _actionError;
   DownloadTicket? _lastTicket;
 
+  /// 流入元。`?utm_source=itch_io` のように付いて来る。無ければ 'direct'。
+  /// **これが無いとチャネル別の効果が最後まで判定できない**ため、
+  /// 購入導線のどの記録にも同じ値を添える。
+  late final String _source = ShopFunnelService.sourceFromUri(Uri.base);
+  late final String _campaign = ShopFunnelService.campaignFromUri(Uri.base);
+
   @override
   void initState() {
     super.initState();
     _load();
+    _recordFunnel(ShopFunnelService.stageProductView);
+  }
+
+  /// funnel を1段記録する。計測は本体機能ではないので待たず、失敗も無視する。
+  void _recordFunnel(String stage) {
+    final funnel = widget.funnel;
+    if (funnel == null) return;
+    unawaited(
+      funnel.record(
+        stage,
+        productId: ShopService.hexcivProductId,
+        source: _source,
+        campaign: _campaign,
+      ),
+    );
   }
 
   Future<void> _load() async {
@@ -78,8 +110,15 @@ class _HexcivShopPageState extends State<HexcivShopPage> {
       _working = true;
       _actionError = null;
     });
+    // 押した時点で記録する。この後 Stripe 側で失敗しても「押された」事実は
+    // 残したい (押下と Checkout 到達の差が、決済側の問題を映す)。
+    _recordFunnel(ShopFunnelService.stagePurchaseClick);
     try {
-      final start = await _service.startCheckout(ShopService.hexcivProductId);
+      final start = await _service.startCheckout(
+        ShopService.hexcivProductId,
+        visitorId: await widget.funnel?.visitorId(),
+        source: _source,
+      );
       if (start.alreadyPurchased) {
         // 二重課金させず、そのまま購入済み表示へ切り替える。
         if (!mounted) return;
@@ -90,6 +129,8 @@ class _HexcivShopPageState extends State<HexcivShopPage> {
         return;
       }
       final url = Uri.parse(start.checkoutUrl!);
+      // Checkout URL が返った = 決済画面まで到達。押下との差が決済側の問題を映す。
+      _recordFunnel(ShopFunnelService.stageCheckoutRedirect);
       // 決済ページは同一タブで開く。別タブだと戻り先 (success_url) が
       // 元の画面と分かれてしまい、購入後の状態更新が伝わらない。
       await launchUrl(url, webOnlyWindowName: '_self');

--- a/lib/services/shop_funnel_service.dart
+++ b/lib/services/shop_funnel_service.dart
@@ -1,0 +1,124 @@
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'supabase_client_provider.dart';
+
+/// 販売 funnel の到達を記録する (2026-07-29 追加)。
+///
+/// 現状は購入完了しか記録が無く、「どこで落ちているか」が分からない。
+/// 閲覧・購入ボタン押下・Checkout 到達を数えて、施策の効果を判定できるようにする。
+///
+/// 方針:
+///  * **計測の失敗で画面を止めない**。ここは本体機能ではないので、
+///    どんな失敗も握り潰して呼び出し元へは影響させない。
+///  * **流入元 (source) を必ず持たせる**。itch.io / X / 直接流入を区別できないと
+///    「どのチャネルが効いたか」が最後まで分からない。これが計測の主目的。
+///  * `purchase_complete` はここから送らない。金銭の絡む段だけは
+///    クライアントの自己申告を信じず、webhook がサーバ側で記録する。
+class ShopFunnelService {
+  ShopFunnelService({SupabaseClient? client}) : _client = client ?? supabase;
+
+  final SupabaseClient _client;
+
+  /// 訪問者IDの保存キー。個人とは結び付かない乱数を1つ持つだけ。
+  static const String _visitorKey = 'shop.visitor_id';
+
+  String? _cachedVisitorId;
+
+  /// 閲覧。
+  static const String stageProductView = 'product_view';
+
+  /// 購入ボタンが押された。
+  static const String stagePurchaseClick = 'purchase_click';
+
+  /// Stripe の Checkout URL が返った。
+  static const String stageCheckoutRedirect = 'checkout_redirect';
+
+  /// 訪問者IDを取得する (無ければ作って保存する)。
+  ///
+  /// 端末内に留まる乱数で、こちらから人物へは辿れない。
+  /// 取得に失敗した場合は null を返し、計測を諦める (画面は動かす)。
+  Future<String?> visitorId() async {
+    final cached = _cachedVisitorId;
+    if (cached != null) return cached;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      var id = prefs.getString(_visitorKey);
+      if (id == null || id.isEmpty) {
+        id = _newUuidV4();
+        await prefs.setString(_visitorKey, id);
+      }
+      _cachedVisitorId = id;
+      return id;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// 1段を記録する。**例外は投げない**。
+  ///
+  /// [source] は流入元。URL の `utm_source` を渡す想定で、無ければ 'direct'。
+  Future<void> record(
+    String stage, {
+    required String productId,
+    String? source,
+    String? campaign,
+  }) async {
+    try {
+      final visitor = await visitorId();
+      if (visitor == null) return;
+      await _client.functions.invoke(
+        'shop-funnel',
+        body: {
+          'visitor_id': visitor,
+          'product_id': productId,
+          'stage': stage,
+          'source': _normalize(source) ?? 'direct',
+          'campaign': _normalize(campaign) ?? '',
+        },
+      );
+    } catch (_) {
+      // 計測できなくても購入体験は続ける。
+    }
+  }
+
+  /// EF 側の文字種制限に合わせて正規化する。
+  ///
+  /// 弾かれる値を送ると、その段が丸ごと欠測して母数が合わなくなるので、
+  /// 送る前にこちら側で整えておく。整えられない場合は null を返す。
+  static String? _normalize(String? raw) {
+    if (raw == null) return null;
+    final lowered = raw.trim().toLowerCase();
+    if (lowered.isEmpty) return null;
+    final cleaned = lowered.replaceAll(RegExp(r'[^a-z0-9_.-]'), '_');
+    if (cleaned.isEmpty) return null;
+    return cleaned.length <= 64 ? cleaned : cleaned.substring(0, 64);
+  }
+
+  /// 流入元を URL のクエリから取り出す。無ければ 'direct'。
+  static String sourceFromUri(Uri uri) {
+    final utm = uri.queryParameters['utm_source'];
+    return _normalize(utm) ?? 'direct';
+  }
+
+  /// キャンペーンを URL のクエリから取り出す。無ければ空。
+  static String campaignFromUri(Uri uri) {
+    return _normalize(uri.queryParameters['utm_campaign']) ?? '';
+  }
+
+  static final Random _random = Random.secure();
+
+  /// UUID v4。外部依存を増やさずに済ませる。
+  static String _newUuidV4() {
+    final bytes = List<int>.generate(16, (_) => _random.nextInt(256));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10
+    String hex(int start, int end) => bytes
+        .sublist(start, end)
+        .map((b) => b.toRadixString(16).padLeft(2, '0'))
+        .join();
+    return '${hex(0, 4)}-${hex(4, 6)}-${hex(6, 8)}-${hex(8, 10)}-${hex(10, 16)}';
+  }
+}

--- a/lib/services/shop_service.dart
+++ b/lib/services/shop_service.dart
@@ -25,7 +25,13 @@ abstract interface class ShopGateway {
 
   Future<bool> hasPurchased(String productId);
 
-  Future<CheckoutStart> startCheckout(String productId);
+  /// [visitorId] と [source] は funnel の最終段をサーバ側で記録するために
+  /// Stripe の metadata へ載せる。省略しても購入自体は成立する。
+  Future<CheckoutStart> startCheckout(
+    String productId, {
+    String? visitorId,
+    String? source,
+  });
 
   Future<DownloadTicket> requestDownloadUrl(String productId);
 }
@@ -82,10 +88,20 @@ class ShopService implements ShopGateway {
   /// 既に購入済みの場合、EF は課金せずに `already_purchased` を返す。
   /// 買い直しではなく再ダウンロードへ誘導したいため、二重課金させない。
   @override
-  Future<CheckoutStart> startCheckout(String productId) async {
+  Future<CheckoutStart> startCheckout(
+    String productId, {
+    String? visitorId,
+    String? source,
+  }) async {
     final response = await _client.functions.invoke(
       'shop-checkout',
-      body: {'product_id': productId},
+      body: {
+        'product_id': productId,
+        // funnel の最終段を webhook 側で書くために持ち回す。
+        // 無くても購入は成立する (計測が欠けるだけ)。
+        if (visitorId != null && visitorId.isNotEmpty) 'visitor_id': visitorId,
+        if (source != null && source.isNotEmpty) 'source': source,
+      },
     );
     final data = _asMap(response.data);
     if (data == null) {

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -1129,10 +1129,11 @@ function buildXPerformanceContextFromLogs(
   // 返済報告カードの共有はクリップボードのみで x_post_log に残らないので、
   // ICP の実績は事実上「取り込んだ履歴」にしか存在しない。件数を数えて
   // 「1本も無い」と「あるが年齢比較できない」を区別して報告する。
-  const icpHistoricalCount = rows.filter((row) =>
-    row.learningCohort === "historical_benchmark" &&
-    normalizeTopicBucket(row.topic) === icpCohort.target
-  ).length;
+  const icpHistoricalCount =
+    rows.filter((row) =>
+      row.learningCohort === "historical_benchmark" &&
+      normalizeTopicBucket(row.topic) === icpCohort.target
+    ).length;
   const icpScopeLine = buildIcpScopeLine(icpCohort, icpHistoricalCount);
   const winners = icpCohort.sufficient ? icpCohort.rows.slice(0, 5) : [];
   const underperformers = icpCohort.sufficient

--- a/supabase/functions/shop-checkout/index.ts
+++ b/supabase/functions/shop-checkout/index.ts
@@ -115,6 +115,14 @@ serve(async (req) => {
     // 権利が付与されない (= 客からは「金だけ取られた」に見える) 事故になる。
     form.set("metadata[user_id]", user.id);
     form.set("metadata[shop_product_id]", productId);
+    // funnel の最終段をサーバ側で記録するために持ち回す (2026-07-29 追加)。
+    // クライアントに「買えました」と自己申告させると、金銭の絡む段だけ
+    // 検証できない数字になる。visitor_id を Stripe 経由で webhook まで運び、
+    // 入金を確認した webhook が purchase_complete を書く。
+    const visitorId = asString((body as Record<string, unknown>).visitor_id);
+    if (visitorId) form.set("metadata[shop_visitor_id]", visitorId);
+    const source = asString((body as Record<string, unknown>).source);
+    if (source) form.set("metadata[shop_source]", source);
     if (user.email) form.set("customer_email", user.email);
 
     const response = await fetch(

--- a/supabase/functions/shop-funnel/index.ts
+++ b/supabase/functions/shop-funnel/index.ts
@@ -1,0 +1,129 @@
+// 販売 funnel の到達を記録する Edge Function (2026-07-29)
+//
+// 目的: 商品ページの閲覧・購入ボタン押下・Checkout 到達を数える。
+// 現状は購入完了しか記録が無く、「どこで落ちているか」が分からない。
+//
+// 設計の要点:
+//  * **認証を要求しない**。未ログインの閲覧者こそが母数なので、ログインを
+//    条件にすると funnel の入口が丸ごと欠測する。
+//  * 認証しない代わりに、**書き込める内容を列挙値に限定**する。stage は4種、
+//    source は文字種を制限。任意の文字列は入らない。
+//  * 主キー衝突は**無視する**(同じ訪問者の同じ段は1回だけ数えたい)。
+//    リロードのたびに閲覧数が増えると、到達人数として読めなくなる。
+//  * 記録の失敗で呼び出し元の体験を止めない。計測は本体機能ではない。
+//  * `purchase_complete` はここでは受け付けない。金銭が絡む段だけは
+//    **クライアントの自己申告を信じず**、webhook がサーバ側で記録する。
+
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ?? "";
+
+/** クライアントから受け付ける段。purchase_complete は意図的に含めない。 */
+const CLIENT_STAGES = new Set([
+  "product_view",
+  "purchase_click",
+  "checkout_redirect",
+]);
+
+const SOURCE_PATTERN = /^[a-z0-9_.-]{1,64}$/;
+const CAMPAIGN_PATTERN = /^[a-z0-9_.-]{0,64}$/;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value.trim() : fallback;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const payload = body as Record<string, unknown>;
+
+    const visitorId = asString(payload.visitor_id).toLowerCase();
+    const productId = asString(payload.product_id);
+    const stage = asString(payload.stage);
+    // 流入元が無い訪問は「直接」として数える。捨てると母数が合わなくなる。
+    const source = asString(payload.source, "direct").toLowerCase() || "direct";
+    const campaign = asString(payload.campaign).toLowerCase();
+
+    if (!UUID_PATTERN.test(visitorId)) {
+      return json({ error: "visitor_id must be a uuid" }, 400);
+    }
+    if (!productId) return json({ error: "product_id is required" }, 400);
+    if (!CLIENT_STAGES.has(stage)) {
+      // purchase_complete をここへ投げてきた場合もこちらで弾かれる。
+      return json({ error: "unsupported stage" }, 400);
+    }
+    if (!SOURCE_PATTERN.test(source)) {
+      return json({ error: "invalid source" }, 400);
+    }
+    if (!CAMPAIGN_PATTERN.test(campaign)) {
+      return json({ error: "invalid campaign" }, 400);
+    }
+
+    // ログイン済みなら紐付ける。未ログインでも記録は続ける (母数を欠かさない)。
+    let authUserId: string | null = null;
+    const authHeader = req.headers.get("Authorization");
+    if (authHeader) {
+      try {
+        const userClient = createClient(
+          SUPABASE_URL,
+          Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+          { global: { headers: { Authorization: authHeader } } },
+        );
+        const { data } = await userClient.auth.getUser();
+        authUserId = data?.user?.id ?? null;
+      } catch (_) {
+        // 認証できなくても計測は続ける。ここで失敗を伝播させる価値はない。
+        authUserId = null;
+      }
+    }
+
+    const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+    const { error } = await admin
+      .from("shop_funnel_events")
+      .upsert({
+        visitor_id: visitorId,
+        product_id: productId,
+        stage,
+        source,
+        campaign,
+        auth_user_id: authUserId,
+      }, {
+        onConflict: "visitor_id,product_id,source,stage",
+        // 既にある行は更新しない。first_occurred_at を「最初に到達した時刻」の
+        // ままにしておきたい (リロードで時刻が上書きされると経路の順序が壊れる)。
+        ignoreDuplicates: true,
+      });
+    if (error) throw new Error(error.message);
+
+    return json({ recorded: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[shop-funnel]", message);
+    return json({ error: message }, 500);
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -293,6 +293,43 @@ async function recordShopPurchase(
     purchased_at: paid ? new Date().toISOString() : null,
   }, { onConflict: "stripe_checkout_session_id" });
   if (error) throw new Error(error.message);
+
+  // funnel の最終段 (2026-07-29 追加)。入金を確認したここでだけ書く。
+  // クライアントの「買えました」を信じると、金銭の絡む段だけ検証できない
+  // 数字になるため。記録の失敗で購入処理を巻き戻さない (計測は本体ではない)。
+  if (paid) await recordPurchaseFunnelStage(admin, metadata);
+}
+
+/**
+ * 購入完了を funnel へ記録する (2026-07-29 追加)。
+ *
+ * visitor_id は shop-checkout が Stripe の metadata に載せて運んでいる。
+ * 無い場合 (metadata を持たない古いセッション等) は**何もしない**。
+ * 適当な値で埋めると、閲覧から購入までの経路が繋がっていない行が混ざり、
+ * 到達人数の集計が壊れる。
+ */
+async function recordPurchaseFunnelStage(
+  admin: SupabaseClient,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  const visitorId = asString(metadata.shop_visitor_id);
+  const productId = asString(metadata.shop_product_id);
+  if (!visitorId || !productId) return;
+
+  const source = asString(metadata.shop_source) || "direct";
+  const { error } = await admin.from("shop_funnel_events").upsert({
+    visitor_id: visitorId,
+    product_id: productId,
+    stage: "purchase_complete",
+    source,
+    auth_user_id: asString(metadata.user_id) || null,
+  }, {
+    onConflict: "visitor_id,product_id,source,stage",
+    ignoreDuplicates: true,
+  });
+  if (error) {
+    console.error("[stripe-webhook] funnel record failed:", error.message);
+  }
 }
 
 async function handleCheckoutCompleted(

--- a/supabase/migrations/20260729020000_create_shop_funnel_events.sql
+++ b/supabase/migrations/20260729020000_create_shop_funnel_events.sql
@@ -1,0 +1,73 @@
+-- 販売 funnel の計測 (2026-07-29)
+--
+-- 目的: HexCiv の買い切り販売で「どこで落ちているか」を測る。現状は購入完了しか
+-- 記録がなく、閲覧も購入ボタン押下も残っていないため、施策の効果を判定できない。
+--
+-- 既存の first_user_acquisition_events は流用しない。あちらは
+-- `utm_source = 'x'` / `utm_campaign = 'first_user_growth'` が CHECK 制約で固定された
+-- **単一キャンペーン専用**のテーブルで、制約を緩めると2つの計測目的が混ざる。
+--
+-- 設計の要点:
+--  * **source を必ず持たせる**。itch.io / X / 直接流入を区別できないと、
+--    「どのチャネルが効いたか」が最後まで分からない。これが計測の主目的。
+--  * 主キーを (visitor_id, product_id, source, stage) にして、
+--    **同じ訪問者の同じ段は1回だけ**数える。イベント数でなく到達人数を見たいため。
+--  * 個人を特定する値は持たない (IP・生 User-Agent は保存しない)。
+--    visitor_id はブラウザ側で生成する乱数で、こちらから人物には結び付かない。
+--  * 書き込みは service role のみ。既存の acquisition テーブルと同じ作法で、
+--    利用者トークンからは書けない (Edge Function 経由にする)。
+
+create table if not exists public.shop_funnel_events (
+  -- ブラウザ側で生成して localStorage に保持する乱数。人物とは結び付かない。
+  visitor_id uuid not null,
+  product_id text not null references public.shop_products(id) on delete cascade,
+
+  stage text not null
+    check (
+      stage in (
+        'product_view',      -- 商品ページが開かれた
+        'purchase_click',    -- 購入ボタンが押された
+        'checkout_redirect', -- Stripe の Checkout URL が返った
+        'purchase_complete'  -- webhook が入金を記録した (サーバ側の真実)
+      )
+    ),
+
+  -- 流入元。utm_source が無い場合は 'direct'。ここが計測の肝。
+  source text not null default 'direct'
+    check (source ~ '^[a-z0-9_.-]{1,64}$'),
+  -- 任意の補助軸 (キャンペーン名や投稿の識別子)。無ければ空文字。
+  campaign text not null default ''
+    check (campaign ~ '^[a-z0-9_.-]{0,64}$'),
+
+  -- ログイン済みなら紐付ける。未ログインの閲覧も数えたいので null 可。
+  auth_user_id uuid references auth.users(id) on delete set null,
+
+  first_occurred_at timestamptz not null default now(),
+
+  primary key (visitor_id, product_id, source, stage)
+);
+
+comment on table public.shop_funnel_events is
+  '買い切り販売の到達人数 funnel。同じ訪問者の同じ段は1回だけ数える。個人特定情報は持たない。';
+comment on column public.shop_funnel_events.source is
+  '流入元 (itch_io / x / direct 等)。これが無いとチャネル別の効果を判定できない。';
+comment on column public.shop_funnel_events.visitor_id is
+  'ブラウザ側で生成する乱数。IP や User-Agent は保存しない。';
+
+-- 集計の主経路: 商品×流入元×段 で人数を数える
+create index if not exists shop_funnel_events_report_idx
+  on public.shop_funnel_events (product_id, source, stage, first_occurred_at desc);
+
+-- ============================================================
+-- RLS
+-- ============================================================
+-- 既存の first_user_acquisition_events と同じ方針。
+-- 利用者トークンから書けると、閲覧数をいくらでも捏造できてしまう。
+-- 読みも塞ぐ (集計はダッシュボード側が service role で行う)。
+
+alter table public.shop_funnel_events enable row level security;
+
+revoke all on public.shop_funnel_events from public, anon, authenticated;
+
+-- ポリシーは意図的に1つも作らない。
+-- RLS 有効 + ポリシー不在 = service role 以外は読み書きできない、が既定の姿。

--- a/test/pages/hexciv_shop_page_test.dart
+++ b/test/pages/hexciv_shop_page_test.dart
@@ -26,6 +26,10 @@ class _FakeGateway implements ShopGateway {
   int startCheckoutCalls = 0;
   int downloadCalls = 0;
 
+  /// funnel の最終段を webhook 側で書くために渡される値。
+  String? lastVisitorId;
+  String? lastSource;
+
   @override
   bool get isSignedIn => signedIn;
 
@@ -39,8 +43,14 @@ class _FakeGateway implements ShopGateway {
   Future<bool> hasPurchased(String productId) async => purchased;
 
   @override
-  Future<CheckoutStart> startCheckout(String productId) async {
+  Future<CheckoutStart> startCheckout(
+    String productId, {
+    String? visitorId,
+    String? source,
+  }) async {
     startCheckoutCalls++;
+    lastVisitorId = visitorId;
+    lastSource = source;
     return const CheckoutStart.redirect('https://checkout.example/session');
   }
 

--- a/test/services/shop_funnel_service_test.dart
+++ b/test/services/shop_funnel_service_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/shop_funnel_service.dart';
+
+/// 流入元の正規化を固定する (2026-07-29 追加)。
+///
+/// 検証の主眼は**計測が黙って欠測しないこと**。EF 側は source を
+/// `^[a-z0-9_.-]{1,64}$` に制限しており、弾かれた段は記録されない。
+/// 記録されないことはエラーにならないので、**気づけないまま母数が欠ける**。
+/// クライアント側で必ず通る形へ整えておく、という契約をここで固定する。
+void main() {
+  group('ShopFunnelService.sourceFromUri', () {
+    test('utm_source が無ければ direct として数える', () {
+      // 捨てると母数が合わなくなる。直接流入も1つの流入元として扱う。
+      expect(
+        ShopFunnelService.sourceFromUri(Uri.parse('https://x.test/shop/hexciv')),
+        'direct',
+      );
+    });
+
+    test('utm_source をそのまま流入元にする', () {
+      expect(
+        ShopFunnelService.sourceFromUri(
+          Uri.parse('https://x.test/shop/hexciv?utm_source=itch_io'),
+        ),
+        'itch_io',
+      );
+    });
+
+    test('大文字は小文字に揃える (itch.io と Itch.io を別チャネルにしない)', () {
+      expect(
+        ShopFunnelService.sourceFromUri(
+          Uri.parse('https://x.test/shop/hexciv?utm_source=Itch_IO'),
+        ),
+        'itch_io',
+      );
+    });
+
+    test('EF が弾く文字は置換する — 弾かれるとその段が丸ごと欠測するため', () {
+      // 空白や日本語がそのまま行くと EF の 400 で記録されない。
+      final source = ShopFunnelService.sourceFromUri(
+        Uri.parse('https://x.test/shop/hexciv?utm_source=X%20%E6%8A%95%E7%A8%BF'),
+      );
+      expect(
+        RegExp(r'^[a-z0-9_.-]{1,64}$').hasMatch(source),
+        isTrue,
+        reason: 'EF の制限を満たさない値は記録されず、母数が欠ける',
+      );
+    });
+
+    test('64文字を超える値は切り詰める', () {
+      final long = 'a' * 200;
+      final source = ShopFunnelService.sourceFromUri(
+        Uri.parse('https://x.test/shop/hexciv?utm_source=$long'),
+      );
+      expect(source.length, 64);
+    });
+
+    test('空の utm_source は direct に倒す', () {
+      expect(
+        ShopFunnelService.sourceFromUri(
+          Uri.parse('https://x.test/shop/hexciv?utm_source='),
+        ),
+        'direct',
+      );
+    });
+  });
+
+  group('ShopFunnelService.campaignFromUri', () {
+    test('utm_campaign が無ければ空文字', () {
+      // campaign は補助軸なので、無いことが正常。source と違い direct へ倒さない。
+      expect(
+        ShopFunnelService.campaignFromUri(
+          Uri.parse('https://x.test/shop/hexciv'),
+        ),
+        '',
+      );
+    });
+
+    test('utm_campaign を正規化して返す', () {
+      expect(
+        ShopFunnelService.campaignFromUri(
+          Uri.parse('https://x.test/shop/hexciv?utm_campaign=Launch-2026'),
+        ),
+        'launch-2026',
+      );
+    });
+  });
+}

--- a/test/services/shop_funnel_service_test.dart
+++ b/test/services/shop_funnel_service_test.dart
@@ -7,43 +7,37 @@ import 'package:my_web_app/services/shop_funnel_service.dart';
 /// `^[a-z0-9_.-]{1,64}$` に制限しており、弾かれた段は記録されない。
 /// 記録されないことはエラーにならないので、**気づけないまま母数が欠ける**。
 /// クライアント側で必ず通る形へ整えておく、という契約をここで固定する。
+///
+/// 実装メモ: URL は必ずローカル変数へ出す。式を直接引数に埋めると行が長くなり、
+/// `ci-auto-fix.yml` の整形が折り返した先に末尾カンマが付かず
+/// `require_trailing_commas` で CI が赤くなる (2026-07-29 に実際に踏んだ)。
 void main() {
+  const base = 'https://x.test/shop/hexciv';
+
   group('ShopFunnelService.sourceFromUri', () {
     test('utm_source が無ければ direct として数える', () {
       // 捨てると母数が合わなくなる。直接流入も1つの流入元として扱う。
-      expect(
-        ShopFunnelService.sourceFromUri(
-            Uri.parse('https://x.test/shop/hexciv')),
-        'direct',
-      );
+      final uri = Uri.parse(base);
+      expect(ShopFunnelService.sourceFromUri(uri), 'direct');
     });
 
     test('utm_source をそのまま流入元にする', () {
-      expect(
-        ShopFunnelService.sourceFromUri(
-          Uri.parse('https://x.test/shop/hexciv?utm_source=itch_io'),
-        ),
-        'itch_io',
-      );
+      final uri = Uri.parse('$base?utm_source=itch_io');
+      expect(ShopFunnelService.sourceFromUri(uri), 'itch_io');
     });
 
     test('大文字は小文字に揃える (itch.io と Itch.io を別チャネルにしない)', () {
-      expect(
-        ShopFunnelService.sourceFromUri(
-          Uri.parse('https://x.test/shop/hexciv?utm_source=Itch_IO'),
-        ),
-        'itch_io',
-      );
+      final uri = Uri.parse('$base?utm_source=Itch_IO');
+      expect(ShopFunnelService.sourceFromUri(uri), 'itch_io');
     });
 
     test('EF が弾く文字は置換する — 弾かれるとその段が丸ごと欠測するため', () {
       // 空白や日本語がそのまま行くと EF の 400 で記録されない。
-      final source = ShopFunnelService.sourceFromUri(
-        Uri.parse(
-            'https://x.test/shop/hexciv?utm_source=X%20%E6%8A%95%E7%A8%BF'),
-      );
+      final uri = Uri.parse('$base?utm_source=X%20%E6%8A%95%E7%A8%BF');
+      final source = ShopFunnelService.sourceFromUri(uri);
+      final allowed = RegExp(r'^[a-z0-9_.-]{1,64}$');
       expect(
-        RegExp(r'^[a-z0-9_.-]{1,64}$').hasMatch(source),
+        allowed.hasMatch(source),
         isTrue,
         reason: 'EF の制限を満たさない値は記録されず、母数が欠ける',
       );
@@ -51,40 +45,26 @@ void main() {
 
     test('64文字を超える値は切り詰める', () {
       final long = 'a' * 200;
-      final source = ShopFunnelService.sourceFromUri(
-        Uri.parse('https://x.test/shop/hexciv?utm_source=$long'),
-      );
-      expect(source.length, 64);
+      final uri = Uri.parse('$base?utm_source=$long');
+      expect(ShopFunnelService.sourceFromUri(uri).length, 64);
     });
 
     test('空の utm_source は direct に倒す', () {
-      expect(
-        ShopFunnelService.sourceFromUri(
-          Uri.parse('https://x.test/shop/hexciv?utm_source='),
-        ),
-        'direct',
-      );
+      final uri = Uri.parse('$base?utm_source=');
+      expect(ShopFunnelService.sourceFromUri(uri), 'direct');
     });
   });
 
   group('ShopFunnelService.campaignFromUri', () {
     test('utm_campaign が無ければ空文字', () {
       // campaign は補助軸なので、無いことが正常。source と違い direct へ倒さない。
-      expect(
-        ShopFunnelService.campaignFromUri(
-          Uri.parse('https://x.test/shop/hexciv'),
-        ),
-        '',
-      );
+      final uri = Uri.parse(base);
+      expect(ShopFunnelService.campaignFromUri(uri), '');
     });
 
     test('utm_campaign を正規化して返す', () {
-      expect(
-        ShopFunnelService.campaignFromUri(
-          Uri.parse('https://x.test/shop/hexciv?utm_campaign=Launch-2026'),
-        ),
-        'launch-2026',
-      );
+      final uri = Uri.parse('$base?utm_campaign=Launch-2026');
+      expect(ShopFunnelService.campaignFromUri(uri), 'launch-2026');
     });
   });
 }

--- a/test/services/shop_funnel_service_test.dart
+++ b/test/services/shop_funnel_service_test.dart
@@ -12,7 +12,8 @@ void main() {
     test('utm_source が無ければ direct として数える', () {
       // 捨てると母数が合わなくなる。直接流入も1つの流入元として扱う。
       expect(
-        ShopFunnelService.sourceFromUri(Uri.parse('https://x.test/shop/hexciv')),
+        ShopFunnelService.sourceFromUri(
+            Uri.parse('https://x.test/shop/hexciv')),
         'direct',
       );
     });
@@ -38,7 +39,8 @@ void main() {
     test('EF が弾く文字は置換する — 弾かれるとその段が丸ごと欠測するため', () {
       // 空白や日本語がそのまま行くと EF の 400 で記録されない。
       final source = ShopFunnelService.sourceFromUri(
-        Uri.parse('https://x.test/shop/hexciv?utm_source=X%20%E6%8A%95%E7%A8%BF'),
+        Uri.parse(
+            'https://x.test/shop/hexciv?utm_source=X%20%E6%8A%95%E7%A8%BF'),
       );
       expect(
         RegExp(r'^[a-z0-9_.-]{1,64}$').hasMatch(source),


### PR DESCRIPTION
## 目的

HexCiv の買い切り販売を職業にするため 10 仮説の検証に入るが、**現状は購入完了しか記録が無く「どこで落ちているか」が分からない**。10 仮説のうち 7 つが検証不能なので、まず測れる状態を作る。

## 変更点

### DB (`20260729020000_create_shop_funnel_events.sql`)

測る4段: `product_view` / `purchase_click` / `checkout_redirect` / `purchase_complete`

- **`source` を必ず持たせる**。itch.io / X / 直接流入を区別できないと **H5**(プラットフォーム掲載で桁が変わるか)・**H6**(既存フォロワーは購買層か)・**H7**(AI 文脈は開発者層に刺さるか)がまとめて検証不能になる。ここが主目的
- 主キーを `(visitor_id, product_id, source, stage)` にして**同じ訪問者の同じ段は1回だけ**数える。リロードで閲覧数が増えると到達人数として読めない
- **既存の `first_user_acquisition_events` は流用しない**。`utm_source='x'` と `utm_campaign='first_user_growth'` が CHECK 制約で固定された単一キャンペーン専用テーブルで、緩めると2つの計測目的が混ざる
- 個人特定情報は持たない (IP・生 User-Agent は保存しない)。`visitor_id` はブラウザ側で生成する乱数
- RLS は既存の acquisition テーブルと同じ方針で anon/authenticated から REVOKE

### Edge Function

| 関数 | 要点 |
|---|---|
| `shop-funnel` (新規) | **認証を要求しない**(未ログインの閲覧者が母数のため)。代わりに書ける内容を列挙値に限定。`purchase_complete` は受け付けない |
| `shop-checkout` (変更) | `visitor_id` / `source` を Stripe の metadata へ載せる |
| `stripe-webhook` (変更) | 入金を確認したうえで `purchase_complete` を書く |

**`purchase_complete` をクライアントから送らないのが要点。** 金銭の絡む段を自己申告にすると検証に使えない数字になる。`visitor_id` を Stripe 経由で運び、サーバ側だけが書く。

**`deploy-prod.yml` の明示リストにも `shop-funnel` を追加した。** 忘れると migration だけ本番へ入り、計測が永久に動かない半着地になる。

## 検証

- `deno check` — 3 ファイルとも通過
- `flutter analyze` — **リポジトリ全体で No issues found**
- **テスト 17 件通過** — 商品ページの状態別 9 件 + 流入元正規化 8 件
- `check_migration_timestamps.py` — 1920 件で衝突なし
- 検証ツールが持ち込んだ無関係な差分 (`deno.lock` / `pubspec.lock` / `generated_plugin_registrant.*`) は revert 済み

## 入出力ベースの最小確認 (implementation-detail independent / 3ケース)

`shop-funnel` の受理判定を、実装詳細に依存しない入出力で3件に絞って確認した。

| 入力 | 期待する出力 |
|---|---|
| `visitor_id` が UUID でない | 400 |
| `stage` が `purchase_complete` | 400 (クライアントからは受け付けない) |
| 正当な `product_view` を2回 | 2回目も 200 だが行は増えない (到達人数として数える) |

- Minimal E2E-Exception: Deno Edge Function のため Flutter integration test / Playwright の対象外。上表の入出力契約をコード上の分岐と突き合わせ、流入元の正規化は Dart 側の単体テスト 8 件で固定した。

## 高リスクゲート

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ultrareview は現在 CI で evidence 経路を満たせない。決済経路に隣接する変更のため、購入処理を壊していないこと (funnel 記録の失敗は購入を巻き戻さない)・RLS が service role 限定であること・EF が列挙値以外を受け付けないことを人手で確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
