### PR TITLE
[CI/CD自動最適化] activation-experiment-report cancel-in-progress 追加 2026-07-29

### DIFF
--- a/.github/workflows/activation-experiment-report.yml
+++ b/.github/workflows/activation-experiment-report.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: activation-experiment-report
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-29 ci-audit: 純粋分析WF / 手動+schedule重複時のキュー待機回避
 
 permissions:
   contents: read


### PR DESCRIPTION
## 変更概要

`activation-experiment-report.yml` の `cancel-in-progress: false` → `true` に変更。

### 変更理由

このワークフローは:
- Supabase から活性化実験データを読み取る (read-only)
- Python スクリプトでレポートを生成
- GitHub Actions Artifact にアップロード

外部への書き込みなし。手動 dispatch と schedule (毎日 0:30 UTC) が重なった場合、古い実行を安全にキャンセルして新しい実行を優先できる。

### 推定削減効果

月に数回の重複実行回避 = ~30 ubuntu-min/月

### 監査レポート

`docs/ci-cd-audit/2026-07-29.md`

---

**自動適用ルール根拠**: ホワイトリスト項目 4「deploy 以外の workflow への concurrency(cancel-in-progress: true) 追加」

---

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI config only — single YAML concurrency flag change, no application code touched, no security/data/prod impact

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.