### PR TITLE
feat(web): 残り45ページのタブ切替も URL に反映する (タブ URL 同期を完了)

### DIFF
--- a/lib/pages/access_control_page.dart
+++ b/lib/pages/access_control_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// アクセス制御・権限管理ページ
 /// ロール一覧・ユーザー権限・アクセスログ表示。
@@ -12,7 +13,13 @@ class AccessControlPage extends StatefulWidget {
 }
 
 class _AccessControlPageState extends State<AccessControlPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['roles', 'logs'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/agent_hub_page.dart
+++ b/lib/pages/agent_hub_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 class AgentHubPage extends StatefulWidget {
   const AgentHubPage({super.key});
@@ -9,7 +10,14 @@ class AgentHubPage extends StatefulWidget {
 }
 
 class _AgentHubPageState extends State<AgentHubPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['departments', 'performance', 'routing'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/ai_observability_page.dart
+++ b/lib/pages/ai_observability_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// AI Observability — プロバイダーヘルス + ヒートマップ + セッショントレース
 ///
@@ -22,7 +23,14 @@ class AiObservabilityPage extends StatefulWidget {
 }
 
 class _AiObservabilityPageState extends State<AiObservabilityPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['health', 'heatmap', 'sessions'];
+
+  @override
+  TabController get tabUrlController => _tab;
+
   late TabController _tab;
   final _supabase = Supabase.instance.client;
 

--- a/lib/pages/code_playground_page.dart
+++ b/lib/pages/code_playground_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// コードプレイグラウンドページ
 /// code-playground Edge Function と連携
@@ -13,7 +14,14 @@ class CodePlaygroundPage extends StatefulWidget {
 }
 
 class _CodePlaygroundPageState extends State<CodePlaygroundPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['snippets', 'collections', 'stats'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/crm_sales_pipeline_page.dart
+++ b/lib/pages/crm_sales_pipeline_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// CRM 営業パイプラインページ
 /// crm-sales-pipeline Edge Function と連携
@@ -12,7 +13,13 @@ class CrmSalesPipelinePage extends StatefulWidget {
 }
 
 class _CrmSalesPipelinePageState extends State<CrmSalesPipelinePage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['pipeline', 'leads', 'stats'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/dns_domain_manager_page.dart
+++ b/lib/pages/dns_domain_manager_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// DNS・ドメイン管理ページ
 /// dns-domain-manager Edge Function と連携してドメイン設定を管理
@@ -12,7 +13,13 @@ class DnsDomainManagerPage extends StatefulWidget {
 }
 
 class _DnsDomainManagerPageState extends State<DnsDomainManagerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['domains', 'records', 'ssl'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/document_esignature_page.dart
+++ b/lib/pages/document_esignature_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// ドキュメント電子署名ページ
 /// 文書のアップロード・署名依頼・署名状況確認。
@@ -12,7 +13,13 @@ class DocumentEsignaturePage extends StatefulWidget {
 }
 
 class _DocumentEsignaturePageState extends State<DocumentEsignaturePage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['pending', 'completed'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/elearning_course_manager_page.dart
+++ b/lib/pages/elearning_course_manager_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/elearning_course.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// eラーニングコース管理ページ
 /// コース一覧・学習進捗・クイズ・証明書。
@@ -15,7 +16,14 @@ class ElearningCourseManagerPage extends StatefulWidget {
 }
 
 class _ElearningCourseManagerPageState extends State<ElearningCourseManagerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['courses', 'learning', 'certificates'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/fitness_health_tracker_page.dart
+++ b/lib/pages/fitness_health_tracker_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// フィットネス・健康トラッカー
 /// ワークアウト記録・体重推移・健康メトリクス管理。
@@ -13,7 +14,14 @@ class FitnessHealthTrackerPage extends StatefulWidget {
 }
 
 class _FitnessHealthTrackerPageState extends State<FitnessHealthTrackerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['summary', 'workout', 'weight'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/focus_timer_page.dart
+++ b/lib/pages/focus_timer_page.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 集中タイマーページ (ポモドーロ)
 /// focus-timer Edge Function と連携して集中セッションを管理
@@ -15,7 +16,13 @@ class FocusTimerPage extends StatefulWidget {
 }
 
 class _FocusTimerPageState extends State<FocusTimerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['timer', 'stats'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabController;
 

--- a/lib/pages/freelance_manager_page.dart
+++ b/lib/pages/freelance_manager_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// フリーランス管理ページ
 /// 案件・請求書・契約・稼働時間・確定申告を一元管理。freee 対抗。
@@ -11,7 +12,13 @@ class FreelanceManagerPage extends StatefulWidget {
 }
 
 class _FreelanceManagerPageState extends State<FreelanceManagerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['projects', 'invoices'];
+
+  @override
+  TabController get tabUrlController => _tabCtrl;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabCtrl;
 

--- a/lib/pages/gantt_timeline_page.dart
+++ b/lib/pages/gantt_timeline_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// ガントチャート・タイムラインページ
 /// gantt-timeline-manager Edge Function と連携
@@ -12,7 +13,14 @@ class GanttTimelinePage extends StatefulWidget {
 }
 
 class _GanttTimelinePageState extends State<GanttTimelinePage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['projects', 'timeline', 'critical-path'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabController;
 

--- a/lib/pages/gemini_university_v2_page.dart
+++ b/lib/pages/gemini_university_v2_page.dart
@@ -21,6 +21,7 @@ import '../services/theme_service.dart';
 import '../services/user_data_finetune_readiness_service.dart';
 import 'ai_university_ranking_page.dart';
 import 'api_playground_page.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // プロバイダーメタデータ
@@ -5699,7 +5700,16 @@ class AiUniversityPage extends StatefulWidget {
 }
 
 class _AiUniversityPageState extends State<AiUniversityPage>
-    with TickerProviderStateMixin {
+    with TickerProviderStateMixin, TabRouteUrlSync {
+  // タブ = AI プロバイダ。ID (openai / anthropic ...) をそのまま URL に使う。
+  // プロバイダ一覧は非同期ロード後に決まるので、TabController を作り直した
+  // 直後に rebindTabUrlSync() を呼んで同期を張り替える。
+  @override
+  List<String> get tabUrlSlugs => _providers;
+
+  @override
+  TabController? get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
 
   List<String> _providers = [];
@@ -6298,6 +6308,7 @@ class _AiUniversityPageState extends State<AiUniversityPage>
           _error = null;
           _tabController = tc;
         });
+        rebindTabUrlSync();
       }
     } catch (e) {
       if (mounted) {
@@ -6309,6 +6320,7 @@ class _AiUniversityPageState extends State<AiUniversityPage>
           _providers = providers;
           _tabController = TabController(length: providers.length, vsync: this);
         });
+        rebindTabUrlSync();
       }
     }
   }

--- a/lib/pages/goal_tracker_page.dart
+++ b/lib/pages/goal_tracker_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 目標管理ページ
 /// goal-tracker Edge Function と連携
@@ -12,7 +13,13 @@ class GoalTrackerPage extends StatefulWidget {
 }
 
 class _GoalTrackerPageState extends State<GoalTrackerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['active', 'completed'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/habit_gamification_page.dart
+++ b/lib/pages/habit_gamification_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 習慣ゲーミフィケーションページ
 /// habit-gamification Edge Function と連携
@@ -12,7 +13,14 @@ class HabitGamificationPage extends StatefulWidget {
 }
 
 class _HabitGamificationPageState extends State<HabitGamificationPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['challenges', 'badges', 'leaderboard'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/health_coach_page.dart
+++ b/lib/pages/health_coach_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// ヘルスコーチ — Liven 対抗
 /// lifestyle-hub (fitness.* / meal.* / recipe.*) 連携
@@ -11,7 +12,13 @@ class HealthCoachPage extends StatefulWidget {
 }
 
 class _HealthCoachPageState extends State<HealthCoachPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['summary', 'meals', 'advice'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
 
   bool _isLoading = false;

--- a/lib/pages/home_iot_manager_page.dart
+++ b/lib/pages/home_iot_manager_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// ホーム IoT 管理ページ
 /// スマートデバイス一覧・状態制御・自動化ルール。
@@ -12,7 +13,13 @@ class HomeIotManagerPage extends StatefulWidget {
 }
 
 class _HomeIotManagerPageState extends State<HomeIotManagerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['devices', 'automations'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/inventory_barcode_page.dart
+++ b/lib/pages/inventory_barcode_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/inventory_item_summary.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 在庫バーコード管理ページ
 /// 商品一覧・在庫数・入出庫記録。
@@ -14,7 +15,13 @@ class InventoryBarcodePage extends StatefulWidget {
 }
 
 class _InventoryBarcodePageState extends State<InventoryBarcodePage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['items', 'movements'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/language_learning_page.dart
+++ b/lib/pages/language_learning_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/language_deck.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 語学学習ページ
 /// language-learning Edge Function と連携
@@ -14,7 +15,13 @@ class LanguageLearningPage extends StatefulWidget {
 }
 
 class _LanguageLearningPageState extends State<LanguageLearningPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['decks', 'review', 'stats'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/legal_compliance_manager_page.dart
+++ b/lib/pages/legal_compliance_manager_page.dart
@@ -3,6 +3,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../widgets/paddle_approval_readiness_card.dart';
 import '../widgets/legal_term_tooltip_text.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// Legal / compliance manager page
 /// - contracts and checklist come from legal-compliance-manager EF
@@ -16,7 +17,14 @@ class LegalComplianceManagerPage extends StatefulWidget {
 }
 
 class _LegalComplianceManagerPageState extends State<LegalComplianceManagerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['contracts', 'checklist', 'saas-review', 'harvey'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
   final _harveyPromptCtrl = TextEditingController();

--- a/lib/pages/life_goals_page.dart
+++ b/lib/pages/life_goals_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 人生目標管理ページ。
 /// 夢 → 大目標 → 中目標 → 小目標（日常行動）の4階層ツリーで
@@ -13,7 +14,14 @@ class LifeGoalsPage extends StatefulWidget {
 }
 
 class _LifeGoalsPageState extends State<LifeGoalsPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['dream', 'big', 'medium', 'small'];
+
+  @override
+  TabController get tabUrlController => _tabs;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabs;
   bool _loading = true;

--- a/lib/pages/meal_log_page.dart
+++ b/lib/pages/meal_log_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 食事ログ MVP — 1タップ記録 + 栄養バランスサマリ (#1665/#1744)
 /// meal.log / meal.today / meal.list actions on lifestyle-hub EF (Codex#2担当).
@@ -11,7 +12,13 @@ class MealLogPage extends StatefulWidget {
 }
 
 class _MealLogPageState extends State<MealLogPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['log', 'summary'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/money_forward_page.dart
+++ b/lib/pages/money_forward_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'asset_management_page.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// MoneyForward 連携ページ
 /// moneyforward-sync Edge Function と連携して家計簿・資産データを取り込む
@@ -13,7 +14,13 @@ class MoneyForwardPage extends StatefulWidget {
 }
 
 class _MoneyForwardPageState extends State<MoneyForwardPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['accounts', 'transactions'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
 
   bool _isLoading = false;

--- a/lib/pages/performance_review_page.dart
+++ b/lib/pages/performance_review_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// パフォーマンスレビューページ
 /// performance-review Edge Function と連携して評価・フィードバックを管理
@@ -11,7 +12,13 @@ class PerformanceReviewPage extends StatefulWidget {
 }
 
 class _PerformanceReviewPageState extends State<PerformanceReviewPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['new', 'history'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
   String? _errorMessage;

--- a/lib/pages/personal_dashboard_page.dart
+++ b/lib/pages/personal_dashboard_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 
 import '../models/kgi_csf_kpi.dart';
 import '../widgets/kgi_csf_kpi_panel.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 enum PersonalDashboardDataMode { live, fallback }
 
@@ -87,7 +88,13 @@ class PersonalDashboardPage extends StatefulWidget {
 }
 
 class _PersonalDashboardPageState extends State<PersonalDashboardPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['kpi', 'weekly', 'habits'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/pet_care_manager_page.dart
+++ b/lib/pages/pet_care_manager_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// ペットケア管理ページ
 /// ペット情報・健康記録・予防接種・食事管理。
@@ -12,7 +13,14 @@ class PetCareManagerPage extends StatefulWidget {
 }
 
 class _PetCareManagerPageState extends State<PetCareManagerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['pets', 'health', 'vaccination'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/podcast_manager_page.dart
+++ b/lib/pages/podcast_manager_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// ポッドキャスト管理ページ
 /// エピソード一覧・再生状態・チャンネル管理。
@@ -12,7 +13,13 @@ class PodcastManagerPage extends StatefulWidget {
 }
 
 class _PodcastManagerPageState extends State<PodcastManagerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['episodes', 'channels'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -7,6 +7,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../utils/web_image_downloader.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 const String _kGithubRepoUrl = 'https://github.com/kanta13jp1/my_web_app';
 const String _kAdditionalRequestText = '\u8ffd\u52a0\u8981\u671b';
@@ -629,7 +630,14 @@ class ProjectGanttPage extends StatefulWidget {
 }
 
 class _ProjectGanttPageState extends State<ProjectGanttPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['wbs', 'timeline', 'projects', 'hygiene'];
+
+  @override
+  TabController get tabUrlController => _tabs;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabs;
 

--- a/lib/pages/real_estate_tracker_page.dart
+++ b/lib/pages/real_estate_tracker_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 不動産管理ページ
 /// real-estate-tracker Edge Function と連携
@@ -12,7 +13,14 @@ class RealEstateTrackerPage extends StatefulWidget {
 }
 
 class _RealEstateTrackerPageState extends State<RealEstateTrackerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['properties', 'finances', 'stats'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/recruitment_job_board_page.dart
+++ b/lib/pages/recruitment_job_board_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 採用・求人ボードページ
 /// 求人掲載・応募者管理・選考フロー。
@@ -13,7 +14,13 @@ class RecruitmentJobBoardPage extends StatefulWidget {
 }
 
 class _RecruitmentJobBoardPageState extends State<RecruitmentJobBoardPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['jobs', 'applicants'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/screen_recorder_page.dart
+++ b/lib/pages/screen_recorder_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 画面録画・スクリーンショット管理ページ
 /// 録画一覧・スクリーンショット一覧・ダウンロード。
@@ -13,7 +14,13 @@ class ScreenRecorderPage extends StatefulWidget {
 }
 
 class _ScreenRecorderPageState extends State<ScreenRecorderPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['recordings', 'screenshots'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/sitemap_analytics_page.dart
+++ b/lib/pages/sitemap_analytics_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// サイトマップ・Web分析ページ
 /// ページ別アクセス数・直帰率・サイトマップ構造表示。
@@ -12,7 +13,13 @@ class SitemapAnalyticsPage extends StatefulWidget {
 }
 
 class _SitemapAnalyticsPageState extends State<SitemapAnalyticsPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['overview', 'pages'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/social_media_scheduler_page.dart
+++ b/lib/pages/social_media_scheduler_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/scheduled_post_entry.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// SNS投稿スケジュール管理ページ
 /// social-media-scheduler Edge Function と連携
@@ -14,7 +15,14 @@ class SocialMediaSchedulerPage extends StatefulWidget {
 }
 
 class _SocialMediaSchedulerPageState extends State<SocialMediaSchedulerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['scheduled', 'published', 'drafts'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/team_workspace_page.dart
+++ b/lib/pages/team_workspace_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// チームワークスペースページ
 /// チームの作成・参加・共有ノートの閲覧
@@ -12,7 +13,13 @@ class TeamWorkspacePage extends StatefulWidget {
 }
 
 class _TeamWorkspacePageState extends State<TeamWorkspacePage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['my-teams', 'joined'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/time_tracker_page.dart
+++ b/lib/pages/time_tracker_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 勤怠・時間追跡ページ
 /// app-hub:time.* と連携して作業時間を管理
@@ -12,7 +13,14 @@ class TimeTrackerPage extends StatefulWidget {
 }
 
 class _TimeTrackerPageState extends State<TimeTrackerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['entries', 'projects', 'clock'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/travel_itinerary_page.dart
+++ b/lib/pages/travel_itinerary_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 旅行プランナーページ
 /// lifestyle-hub (travel.*) 連携
@@ -12,7 +13,14 @@ class TravelItineraryPage extends StatefulWidget {
 }
 
 class _TravelItineraryPageState extends State<TravelItineraryPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['itinerary', 'bookings', 'packing', 'budget'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/vehicle_fleet_manager_page.dart
+++ b/lib/pages/vehicle_fleet_manager_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 車両・フリート管理ページ
 /// 車両一覧・走行記録・メンテナンス管理。
@@ -13,7 +14,14 @@ class VehicleFleetManagerPage extends StatefulWidget {
 }
 
 class _VehicleFleetManagerPageState extends State<VehicleFleetManagerPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['vehicles', 'trips', 'maintenance'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/video_meeting_page.dart
+++ b/lib/pages/video_meeting_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// ビデオ会議管理ページ
 /// video-meeting-manager Edge Function と連携 (Zoom/Google Meet/Teams競合)
@@ -11,7 +12,14 @@ class VideoMeetingPage extends StatefulWidget {
 }
 
 class _VideoMeetingPageState extends State<VideoMeetingPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['rooms', 'minutes', 'action-items', 'stats'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/viral_ad_generator_page.dart
+++ b/lib/pages/viral_ad_generator_page.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../models/kgi_csf_kpi.dart';
 import '../services/heygen_multilingual_sns_service.dart';
 import '../widgets/kgi_csf_kpi_panel.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// バイラル広告ジェネレーターページ
 /// viral-video-ad-generator / x-media-post / viral-growth-engine と連携
@@ -18,7 +19,14 @@ class ViralAdGeneratorPage extends StatefulWidget {
 }
 
 class _ViralAdGeneratorPageState extends State<ViralAdGeneratorPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['generator', 'stats', 'history'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/virtual_organization_page.dart
+++ b/lib/pages/virtual_organization_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// 仮想AI組織マネージャー
 /// 12部署20エージェントの仮想組織を管理する。
@@ -13,7 +14,14 @@ class VirtualOrganizationPage extends StatefulWidget {
 }
 
 class _VirtualOrganizationPageState extends State<VirtualOrganizationPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['departments', 'agents', 'tasks'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
 

--- a/lib/pages/virtual_whiteboard_page.dart
+++ b/lib/pages/virtual_whiteboard_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// バーチャルホワイトボードページ
 /// virtual-whiteboard Edge Function と連携
@@ -12,7 +13,13 @@ class VirtualWhiteboardPage extends StatefulWidget {
 }
 
 class _VirtualWhiteboardPageState extends State<VirtualWhiteboardPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['boards', 'templates'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/wardrobe_page.dart
+++ b/lib/pages/wardrobe_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:intl/intl.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 // =====================================================
 // モデル
@@ -51,7 +52,13 @@ class WardrobePage extends StatefulWidget {
 }
 
 class _WardrobePageState extends State<WardrobePage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['list', 'analysis'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabController;
 

--- a/lib/pages/wiki_database_page.dart
+++ b/lib/pages/wiki_database_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// Wiki・データベースページ
 /// wiki-database Edge Function と連携して階層型Wikiを管理
@@ -12,7 +13,13 @@ class WikiDatabasePage extends StatefulWidget {
 }
 
 class _WikiDatabasePageState extends State<WikiDatabasePage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['pages', 'detail'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late final TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/workflow_automation_page.dart
+++ b/lib/pages/workflow_automation_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// AIワークフロー自動化ページ
 /// ai-workflow-automation Edge Function と連携
@@ -11,7 +12,14 @@ class WorkflowAutomationPage extends StatefulWidget {
 }
 
 class _WorkflowAutomationPageState extends State<WorkflowAutomationPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs =>
+      const <String>['workflows', 'templates', 'stats'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   final _supabase = Supabase.instance.client;
   late TabController _tabController;
   bool _isLoading = false;

--- a/lib/pages/youtube_stats_page.dart
+++ b/lib/pages/youtube_stats_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 /// YouTube 動画統計インポート・管理ページ (/youtube-stats)
 ///
@@ -18,7 +19,13 @@ class YoutubeStatsPage extends StatefulWidget {
 }
 
 class _YoutubeStatsPageState extends State<YoutubeStatsPage>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, TabRouteUrlSync {
+  @override
+  List<String> get tabUrlSlugs => const <String>['import', 'stats'];
+
+  @override
+  TabController get tabUrlController => _tabController;
+
   late TabController _tabController;
   bool _importing = false;
   String? _importResult;

--- a/lib/utils/tab_route_url_sync.dart
+++ b/lib/utils/tab_route_url_sync.dart
@@ -65,33 +65,60 @@ mixin TabRouteUrlSync<T extends StatefulWidget> on State<T> {
   List<String> get tabUrlSlugs;
 
   /// URL と同期する `TabController`。
-  TabController get tabUrlController;
+  ///
+  /// まだ用意できていない場合 (タブ数が非同期ロード後に決まるページ) は null を
+  /// 返してよい。その間は同期を行わず、用意できた時点で [rebindTabUrlSync] を
+  /// 呼べば同期が始まる。
+  TabController? get tabUrlController;
 
-  bool _tabUrlBound = false;
   String? _tabUrlRouteName;
   int? _lastAnnouncedTabIndex;
+
+  /// 現在 listener を張っている controller。作り直しを検知して張り替えるために
+  /// 「束縛済みフラグ」ではなく実体を持つ (フラグだと古い controller に listener が
+  /// 残り、新しい方は同期されない)。
+  TabController? _boundController;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (_tabUrlBound) return;
-    _tabUrlBound = true;
+    _tabUrlRouteName ??= ModalRoute.of(context)?.settings.name;
+    _bindTabUrl();
+  }
 
-    _tabUrlRouteName = ModalRoute.of(context)?.settings.name;
+  /// `TabController` を作り直したページは、新しい controller を作った直後に
+  /// これを呼ぶ。古い listener を外して張り替え、URL からのタブ復元をやり直す。
+  ///
+  /// 例: プロバイダ一覧を取得してから `TabController(length: providers.length)` を
+  /// 作る AI 大学のようなページ。
+  void rebindTabUrlSync() {
+    _tabUrlRouteName ??= ModalRoute.of(context)?.settings.name;
+    _bindTabUrl();
+  }
+
+  void _bindTabUrl() {
+    final controller = tabUrlController;
+    if (controller == null || identical(controller, _boundController)) return;
+
+    _boundController?.removeListener(_announceTabUrl);
+    _boundController = controller;
+
     final initial = tabIndexFromRouteName(
       routeName: _tabUrlRouteName,
       slugs: tabUrlSlugs,
     );
-    if (initial != null && initial != tabUrlController.index) {
-      tabUrlController.index = initial;
+    if (initial != null && initial != controller.index) {
+      controller.index = initial;
     }
-    _lastAnnouncedTabIndex = tabUrlController.index;
-    tabUrlController.addListener(_announceTabUrl);
+    _lastAnnouncedTabIndex = controller.index;
+    controller.addListener(_announceTabUrl);
   }
 
   void _announceTabUrl() {
     if (!mounted) return;
-    final index = tabUrlController.index;
+    final controller = _boundController;
+    if (controller == null) return;
+    final index = controller.index;
     // TabController の listener はアニメーション中に何度も発火するため、
     // 実際に index が変わった 1 回だけ URL を更新する。
     if (index == _lastAnnouncedTabIndex) return;
@@ -116,9 +143,9 @@ mixin TabRouteUrlSync<T extends StatefulWidget> on State<T> {
 
   @override
   void dispose() {
-    if (_tabUrlBound) {
-      tabUrlController.removeListener(_announceTabUrl);
-    }
+    // 張り替え後は必ず最後に束縛した controller から外す (作り直し前の
+    // controller は既に _bindTabUrl で外してある)。
+    _boundController?.removeListener(_announceTabUrl);
     super.dispose();
   }
 }

--- a/test/routes/tab_route_url_sync_test.dart
+++ b/test/routes/tab_route_url_sync_test.dart
@@ -203,9 +203,17 @@ void main() {
       if (entity is! File || !entity.path.endsWith('.dart')) continue;
       final source = entity.readAsStringSync();
       if (!source.contains('TabRouteUrlSync')) continue;
+      if (_dynamicSlugPages.any(entity.path.replaceAll(r'\', '/').endsWith)) {
+        // タブが実行時に決まるページ。静的にスラッグ数を数えられないので、
+        // ここでは対象外にし、代わりに下の専用テストで契約を確認する。
+        continue;
+      }
 
+      // `=>` と `const` の間、`<String>[` の前後は dart format が行を折り返す
+      // ことがある (スラッグが多いページで必ず起きる)。空白・改行を許容しないと
+      // 「読めない」という偽の失敗になるため、区切りは \s* で受ける。
       final slugMatch = RegExp(
-        r'List<String> get tabUrlSlugs => const <String>\[([\s\S]*?)\];',
+        r'List<String>\s+get\s+tabUrlSlugs\s*=>\s*const\s*<String>\s*\[([\s\S]*?)\];',
       ).firstMatch(source);
       final lenMatch = RegExp(
         r'TabController\(\s*length:\s*(\d+)',
@@ -237,7 +245,44 @@ void main() {
     expect(checked, greaterThan(0), reason: '適用済みページを 1 つも検出できていない');
     expect(offenders, isEmpty, reason: 'タブとスラッグの不整合:\n${offenders.join('\n')}');
   });
+
+  // 動的スラッグのページは静的に数えられない代わりに、
+  // 「controller を作り直したら必ず張り替える」契約が守られているかを見る。
+  // これを忘れると古い controller に listener が残り、タブを切っても URL が
+  // 変わらない (= 対応したつもりで効いていない) 状態になる。
+  test('dynamic-slug pages rebind after recreating their TabController', () {
+    for (final rel in _dynamicSlugPages) {
+      final raw = File('lib/pages/${rel.split('/').last}').readAsStringSync();
+      // コメント中の `rebindTabUrlSync()` (使い方の説明) を実際の呼び出しと
+      // 数え間違えると、呼び出しを消しても緑のままになる。行コメントを落とす。
+      final source = raw
+          .split('\n')
+          .where((line) => !line.trimLeft().startsWith('//'))
+          .join('\n');
+      final assigns = RegExp(r'_tabController = ').allMatches(source).length;
+      final rebinds = RegExp(r'rebindTabUrlSync\(\)').allMatches(source).length;
+
+      expect(
+        assigns,
+        greaterThan(0),
+        reason: '$rel: TabController の代入が見つからない (このリストが古い可能性)',
+      );
+      expect(
+        rebinds,
+        greaterThanOrEqualTo(assigns),
+        reason: '$rel: TabController を $assigns 回作り直しているのに '
+            'rebindTabUrlSync() が $rebinds 回しかない。'
+            '張り替え漏れがあるとタブを切っても URL が変わらない。',
+      );
+    }
+  });
 }
+
+/// タブ数が実行時に決まるため、スラッグ数を静的に検証できないページ。
+/// (AI 大学はプロバイダ一覧を取得してからタブを作る)
+const List<String> _dynamicSlugPages = <String>[
+  'lib/pages/gemini_university_v2_page.dart',
+];
 
 class _TabProbe extends StatefulWidget {
   const _TabProbe();


### PR DESCRIPTION
## 何をするか

[#4378](https://github.com/kanta13jp1/my_web_app/pull/4378) で導入した `TabRouteUrlSync` を残りのタブ付きページへ展開する。これで**タブを持つ 51 ページ / 142 タブ全てが URL 同期対象**になり、未適用がゼロになる。

タブを切り替えると `?tab=<slug>` が URL に載り、共有・リロード・ブックマークで同じタブが復元される。

## 内容

- **44 ページに mixin を適用**。スラッグは `TabBarView` の children 並びから導出した。全ページで並び順を取得でき、順序が保証されないフォールバック経路は使っていない (実測確認済み)。
- **AI大学 (`/ai-university`)** はタブがプロバイダ取得後に確定し `TabController` を作り直すため、mixin に `rebindTabUrlSync()` を追加した。プロバイダ ID がそのまま URL になるので、**共有リンクでプロバイダを直接開ける**ようになる (従来は route arguments 経由のみで、リロードすると失われていた)。
- **`main.dart` の route 定義は 1 つも増やしていない** (340 のまま)。パス方式なら 142 case の追加が必要だった。

## #4378 のガードに 2 件の不備があったので直した

1. **偽の失敗**: 正規表現が `=>` と `const` の間の改行を許容せず、`dart format` が折り返す長いページ 16 件を「読めない」と誤検知していた。
2. **見逃し**: `rebindTabUrlSync()` の出現数をコメント行込みで数えており、**実呼び出しを消しても緑のまま**だった。

どちらも修正し、実際に回帰を捕まえることを実測で確認した (スラッグを 1 つ減らす → FAIL、rebind を 1 つ消す → FAIL)。

## 検証

- VM ガード含む **2069 件が緑**
- rebase で main の 18 commit を取り込んだ後、route ガード 29 本を再実行して緑を確認

なお `test/services/autonomous_ops_service_test.dart` はこのローカル環境でのみハングする (CPU 0 のまま停止)。**本 PR の変更とは無関係**で、根拠は ①このテストの import graph に本 PR の変更ファイルが 1 つも含まれない ②#4378 の CI (`flutter test` 含む) で success しており、このファイルは #4378 以前から存在する — の 2 点。ローカル検証ではこの 1 ファイルのみ除外し、CI では全件実行される。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: タブURL同期は VM ガード(mixin実ランタイム+全ページ静的検証)で担保。ブラウザ E2E はこの環境で起動不可のため非同梱

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
