### PR TITLE
feat(agent-board): AIエージェントがWBSタスクを進める様子を眺めるカンバンを追加

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -9,6 +9,7 @@ import '../pages/abstinence_guard_page.dart';
 import '../pages/sobriety_campaign_page.dart';
 import '../pages/admin_analytics_page.dart';
 import '../pages/agent_org_page.dart';
+import '../pages/agent_board_page.dart';
 import '../pages/autonomous_ops_console_page.dart';
 import '../pages/agent_gpa_dashboard_page.dart';
 import '../pages/english_reading_curriculum_page.dart';
@@ -375,6 +376,27 @@ List<HomeToolEntry> buildHomeToolCatalog({
         'ops',
       ],
       onOpen: (context) => _pushPage(context, const AutonomousOpsConsolePage()),
+    ),
+    HomeToolEntry(
+      id: 'agent-board',
+      sectionId: 'growth',
+      title: 'AIエージェント ボード',
+      subtitle: 'Claude Code / Codex がWBSタスクを進める様子を眺める',
+      icon: Icons.view_kanban_outlined,
+      color: const Color(0xFF3D5AFE),
+      keywords: const <String>[
+        'エージェント',
+        'ボード',
+        'カンバン',
+        'WBS',
+        'claude',
+        'codex',
+        'gemini',
+        'agent',
+        'board',
+        'kanban',
+      ],
+      onOpen: (context) => _pushPage(context, const AgentBoardPage()),
     ),
     HomeToolEntry(
       id: 'daily-habits',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:my_web_app/models/site_guide_catalog_item.dart';
 import 'package:my_web_app/pages/abstinence_guard_page.dart';
 import 'package:my_web_app/pages/self_touch_tracker_page.dart';
 import 'package:my_web_app/pages/agent_org_page.dart';
+import 'package:my_web_app/pages/agent_board_page.dart';
 import 'package:my_web_app/pages/autonomous_ops_console_page.dart';
 import 'package:my_web_app/pages/ai_company_builder_page.dart';
 import 'package:my_web_app/pages/ai_agent_page.dart';
@@ -534,6 +535,11 @@ Route<dynamic> generateAppRoute(
       return MaterialPageRoute(
         builder: (_) => const AutonomousOpsConsolePage(),
         settings: settings,
+      );
+    case '/agent-board':
+      return MaterialPageRoute(
+        builder: (_) => const AgentBoardPage(),
+        settings: const RouteSettings(name: '/agent-board'),
       );
     case '/ai-company-builder':
       return MaterialPageRoute(

--- a/lib/models/agent_board_models.dart
+++ b/lib/models/agent_board_models.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 /// `wbs_tasks` の行を「4 列カンバン + エージェント一覧」の表示状態へ変換する。
 /// ここはネットワーク・時刻に依存しない (now は引数で受け取る) ため、単体
 /// テストで決定的に検証できる。
-library;
 
 /// カンバンの列 (= wbs_tasks.status をそのまま採用。読み替えはしない)。
 enum BoardLane { notStarted, inProgress, blocked, completed }

--- a/lib/models/agent_board_models.dart
+++ b/lib/models/agent_board_models.dart
@@ -261,8 +261,9 @@ BoardSnapshot buildBoardSnapshot(
   });
 
   final notStarted = lanes[BoardLane.notStarted]!;
-  final hidden =
-      notStarted.length > notStartedLimit ? notStarted.length - notStartedLimit : 0;
+  final hidden = notStarted.length > notStartedLimit
+      ? notStarted.length - notStartedLimit
+      : 0;
   if (hidden > 0) {
     lanes[BoardLane.notStarted] = notStarted.take(notStartedLimit).toList();
   }

--- a/lib/models/agent_board_models.dart
+++ b/lib/models/agent_board_models.dart
@@ -1,0 +1,336 @@
+import 'package:flutter/material.dart';
+
+/// AI エージェント カンバンボードの表示モデルと純粋変換ロジック。
+///
+/// `wbs_tasks` の行を「4 列カンバン + エージェント一覧」の表示状態へ変換する。
+/// ここはネットワーク・時刻に依存しない (now は引数で受け取る) ため、単体
+/// テストで決定的に検証できる。
+library;
+
+/// カンバンの列 (= wbs_tasks.status をそのまま採用。読み替えはしない)。
+enum BoardLane { notStarted, inProgress, blocked, completed }
+
+extension BoardLaneLabel on BoardLane {
+  String get label => switch (this) {
+        BoardLane.notStarted => '未着手',
+        BoardLane.inProgress => '進行中',
+        BoardLane.blocked => 'ブロック',
+        BoardLane.completed => '完了',
+      };
+
+  /// DB の status 値。
+  String get statusValue => switch (this) {
+        BoardLane.notStarted => 'not_started',
+        BoardLane.inProgress => 'in_progress',
+        BoardLane.blocked => 'blocked',
+        BoardLane.completed => 'completed',
+      };
+}
+
+/// status 文字列 → 列。未知の値・未着手系はすべて「未着手」へ寄せる。
+BoardLane laneFromStatus(String status) => switch (status) {
+      'in_progress' => BoardLane.inProgress,
+      'blocked' => BoardLane.blocked,
+      'completed' => BoardLane.completed,
+      _ => BoardLane.notStarted,
+    };
+
+// ── エージェント (instance) ───────────────────────────────────
+
+/// `instance` / `owner_instance` の生値を表示用に正規化する。
+///
+/// 許可値には別名 (codex1 / cx / co-pilot / ps1..ps6 等) が混在するため、
+/// 表示上は同じエージェントへまとめる。未知の値はそのまま ID として扱い、
+/// 新しいエージェントが増えてもコード変更なしで盤面に現れるようにする。
+String normalizeAgentId(String raw) {
+  final v = raw.trim().toLowerCase();
+  if (v.isEmpty) return 'unknown';
+  if (v.startsWith('codex') || v == 'cx') return 'codex';
+  if (v.startsWith('claude')) return 'claude';
+  if (v == 'co-pilot' || v == 'copilot') return 'copilot';
+  if (v.startsWith('gemini')) return 'gemini';
+  if (v.startsWith('ps')) return 'ps';
+  if (v == 'usr' || v == 'human') return 'user';
+  if (v == 'auto') return 'automation';
+  return v;
+}
+
+/// 表示名。未知の ID は素の値を返す (新エージェントもそれらしく出る)。
+String agentDisplayName(String agentId) => switch (agentId) {
+      'claude' => 'Claude Code',
+      'codex' => 'Codex',
+      'gemini' => 'Gemini',
+      'copilot' => 'GitHub Copilot',
+      'antigravity' => 'Antigravity',
+      'schedule' => 'Claude Schedule',
+      'gha' => 'GitHub Actions',
+      'automation' => 'Automation',
+      'ps' => 'PowerShell 版',
+      'vscode' => 'VSCode 版',
+      'win' => 'Windows 版',
+      'user' => '人間',
+      'all' => '全体共有',
+      'unknown' => '未割当',
+      _ => agentId,
+    };
+
+/// エージェント色 (DESIGN.md の Orange + Indigo 系から決定的に割り当てる)。
+Color agentColor(String agentId) => switch (agentId) {
+      'claude' => const Color(0xFFFF6B35), // orange
+      'codex' => const Color(0xFF3D5AFE), // indigo
+      'gemini' => const Color(0xFF26C6DA), // cyan
+      'copilot' => const Color(0xFF9C27B0), // purple
+      'antigravity' => const Color(0xFF00E676), // green accent
+      'schedule' => const Color(0xFFFFC107), // amber
+      'gha' => const Color(0xFF7986CB), // indigo light
+      'automation' => const Color(0xFF66BB6A),
+      'ps' => const Color(0xFF29B6F6),
+      'user' => const Color(0xFFEC407A),
+      _ => const Color(0xFFB0B0B0),
+    };
+
+// ── カード / 集計 ─────────────────────────────────────────────
+
+/// 盤面に置く 1 枚のカード。
+class BoardCard {
+  const BoardCard({
+    required this.id,
+    required this.title,
+    required this.agentId,
+    required this.lane,
+    required this.progress,
+    required this.priority,
+    required this.categoryIcon,
+    required this.updatedAt,
+    this.issueNumber,
+    this.issueUrl = '',
+  });
+
+  final String id;
+  final String title;
+  final String agentId;
+  final BoardLane lane;
+  final int progress; // 0-100
+  final String priority;
+  final String categoryIcon;
+  final DateTime? updatedAt;
+  final int? issueNumber;
+  final String issueUrl;
+
+  /// 最終更新からの経過表記 ("3分前" 等)。now は呼び出し側から渡す。
+  String elapsedLabel(DateTime now) => formatElapsed(updatedAt, now);
+}
+
+/// 稼働中エージェントの集計 1 件。
+class AgentSummary {
+  const AgentSummary({
+    required this.agentId,
+    required this.inProgress,
+    required this.blocked,
+    required this.notStarted,
+    required this.completedRecently,
+    required this.currentTaskTitle,
+  });
+
+  final String agentId;
+  final int inProgress;
+  final int blocked;
+  final int notStarted;
+  final int completedRecently;
+  final String currentTaskTitle;
+
+  /// 進行中タスクを持っていれば「稼働中」。
+  bool get isActive => inProgress > 0;
+
+  int get total => inProgress + blocked + notStarted + completedRecently;
+}
+
+/// 盤面の表示状態全体。
+class BoardSnapshot {
+  const BoardSnapshot({
+    required this.lanes,
+    required this.hiddenNotStarted,
+    required this.agents,
+    required this.totalTasks,
+  });
+
+  /// 列 → その列に表示するカード。
+  final Map<BoardLane, List<BoardCard>> lanes;
+
+  /// 未着手列で上限を超えて隠したカード数 (「他 N 件」表示用)。
+  final int hiddenNotStarted;
+
+  final List<AgentSummary> agents;
+
+  /// 盤面に載ったカードの総数。
+  final int totalTasks;
+
+  List<BoardCard> cardsOf(BoardLane lane) => lanes[lane] ?? const <BoardCard>[];
+}
+
+/// 完了列に残す時間窓 (直近 24 時間)。
+const Duration completedWindow = Duration(hours: 24);
+
+/// 未着手列の表示上限 (超過分は「他 N 件」)。
+const int notStartedLimit = 20;
+
+const Map<String, int> _priorityRank = <String, int>{
+  'critical': 0,
+  'high': 1,
+  'medium': 2,
+  'low': 3,
+};
+
+int _priorityOrder(String priority) =>
+    _priorityRank[priority.toLowerCase()] ?? 2;
+
+/// `wbs_tasks` の行 (Map) → カード。パースは防御的に行う。
+BoardCard cardFromRow(Map<String, dynamic> row) {
+  final rawAgent = (row['owner_instance'] as String?)?.trim().isNotEmpty == true
+      ? row['owner_instance'] as String
+      : (row['instance'] as String? ?? '');
+  final progressRaw = row['progress'];
+  final progress = progressRaw is int
+      ? progressRaw
+      : (progressRaw is num ? progressRaw.round() : 0);
+  final issueRaw = row['github_issue_number'];
+  final issueNumber = issueRaw is int
+      ? issueRaw
+      : (issueRaw is String ? int.tryParse(issueRaw) : null);
+
+  return BoardCard(
+    id: (row['id'] as String?) ?? '',
+    title: (row['title'] as String?) ?? '(無題)',
+    agentId: normalizeAgentId(rawAgent),
+    lane: laneFromStatus((row['status'] as String?) ?? ''),
+    progress: progress.clamp(0, 100),
+    priority: (row['priority'] as String?) ?? 'medium',
+    categoryIcon: (row['category_icon'] as String?) ?? '📋',
+    updatedAt: row['updated_at'] is String
+        ? DateTime.tryParse(row['updated_at'] as String)
+        : null,
+    issueNumber: issueNumber,
+    issueUrl: (row['github_issue_url'] as String?) ?? '',
+  );
+}
+
+/// 行群 → 盤面スナップショット。
+///
+/// スコープ (grill-me で確定):
+///   - 未着手 / 進行中 / ブロック … 全件 (未着手のみ [notStartedLimit] で打ち切り)
+///   - 完了 … 直近 [completedWindow] に更新されたものだけ
+BoardSnapshot buildBoardSnapshot(
+  List<Map<String, dynamic>> rows,
+  DateTime now,
+) {
+  final cards = rows.map(cardFromRow).where((c) => c.id.isNotEmpty).toList();
+
+  final lanes = <BoardLane, List<BoardCard>>{
+    for (final lane in BoardLane.values) lane: <BoardCard>[],
+  };
+
+  for (final card in cards) {
+    if (card.lane == BoardLane.completed) {
+      final updated = card.updatedAt;
+      // 完了は「今日 AI が片付けた分」だけを残す (時間経過で盤面から流れる)。
+      if (updated == null || now.difference(updated) > completedWindow) {
+        continue;
+      }
+    }
+    lanes[card.lane]!.add(card);
+  }
+
+  // 進行中 / ブロック / 完了は「最近動いたものが上」。
+  int byUpdatedDesc(BoardCard a, BoardCard b) {
+    final ta = a.updatedAt;
+    final tb = b.updatedAt;
+    if (ta == null && tb == null) return a.title.compareTo(b.title);
+    if (ta == null) return 1;
+    if (tb == null) return -1;
+    return tb.compareTo(ta);
+  }
+
+  lanes[BoardLane.inProgress]!.sort(byUpdatedDesc);
+  lanes[BoardLane.blocked]!.sort(byUpdatedDesc);
+  lanes[BoardLane.completed]!.sort(byUpdatedDesc);
+
+  // 未着手は優先度順 → 同順位は最近更新順。
+  lanes[BoardLane.notStarted]!.sort((a, b) {
+    final p = _priorityOrder(a.priority).compareTo(_priorityOrder(b.priority));
+    if (p != 0) return p;
+    return byUpdatedDesc(a, b);
+  });
+
+  final notStarted = lanes[BoardLane.notStarted]!;
+  final hidden =
+      notStarted.length > notStartedLimit ? notStarted.length - notStartedLimit : 0;
+  if (hidden > 0) {
+    lanes[BoardLane.notStarted] = notStarted.take(notStartedLimit).toList();
+  }
+
+  final visible = lanes.values.fold<int>(0, (sum, list) => sum + list.length);
+
+  return BoardSnapshot(
+    lanes: lanes,
+    hiddenNotStarted: hidden,
+    agents: summarizeAgents(lanes),
+    totalTasks: visible,
+  );
+}
+
+/// 盤面に出ているカードから、エージェント別の稼働サマリを作る。
+///
+/// 実データに現れたエージェントだけを返すので、新しい instance 値が
+/// 増えてもコード変更なしで一覧に出る。稼働中 (進行中あり) を先頭へ。
+List<AgentSummary> summarizeAgents(Map<BoardLane, List<BoardCard>> lanes) {
+  final byAgent = <String, List<BoardCard>>{};
+  for (final entry in lanes.entries) {
+    for (final card in entry.value) {
+      byAgent.putIfAbsent(card.agentId, () => <BoardCard>[]).add(card);
+    }
+  }
+
+  final summaries = byAgent.entries.map((entry) {
+    final cards = entry.value;
+    final inProgress =
+        cards.where((c) => c.lane == BoardLane.inProgress).toList();
+    // 現在のタスク = 進行中のうち最も新しく更新されたもの。
+    inProgress.sort((a, b) {
+      final ta = a.updatedAt;
+      final tb = b.updatedAt;
+      if (ta == null || tb == null) return 0;
+      return tb.compareTo(ta);
+    });
+    return AgentSummary(
+      agentId: entry.key,
+      inProgress: inProgress.length,
+      blocked: cards.where((c) => c.lane == BoardLane.blocked).length,
+      notStarted: cards.where((c) => c.lane == BoardLane.notStarted).length,
+      completedRecently:
+          cards.where((c) => c.lane == BoardLane.completed).length,
+      currentTaskTitle: inProgress.isEmpty ? '' : inProgress.first.title,
+    );
+  }).toList();
+
+  summaries.sort((a, b) {
+    // 稼働中を上へ → 進行中件数の多い順 → 総件数 → 名前順で安定化。
+    if (a.isActive != b.isActive) return a.isActive ? -1 : 1;
+    if (a.inProgress != b.inProgress) {
+      return b.inProgress.compareTo(a.inProgress);
+    }
+    if (a.total != b.total) return b.total.compareTo(a.total);
+    return a.agentId.compareTo(b.agentId);
+  });
+  return summaries;
+}
+
+/// 経過時間の表記。更新時刻が無い場合は空文字。
+String formatElapsed(DateTime? updatedAt, DateTime now) {
+  if (updatedAt == null) return '';
+  final diff = now.difference(updatedAt);
+  if (diff.isNegative) return 'たった今';
+  if (diff.inSeconds < 60) return 'たった今';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}分前';
+  if (diff.inHours < 24) return '${diff.inHours}時間前';
+  return '${diff.inDays}日前';
+}

--- a/lib/pages/agent_board_page.dart
+++ b/lib/pages/agent_board_page.dart
@@ -1,0 +1,649 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../models/agent_board_models.dart';
+import '../services/agent_board_service.dart';
+import '../theme/design_tokens.dart';
+
+/// AI エージェント カンバンボード。
+///
+/// Claude Code / Codex / Gemini などの AI エージェントが `wbs_tasks` 上の
+/// タスクをこなしていく様子を、動的に更新されるカンバンで眺めるページ。
+/// カードの移動は演出ではなく **実データの状態遷移** で、Supabase Realtime
+/// により変更が届いた瞬間に盤面が動く (60 秒のフォールバック再取得つき)。
+///
+/// WBS には未公開の開発計画が含まれるため **ログイン済みユーザー限定**。
+class AgentBoardPage extends StatefulWidget {
+  const AgentBoardPage({super.key, this.service});
+
+  /// データ供給 (テスト時に差し替え可能)。
+  final AgentBoardService? service;
+
+  @override
+  State<AgentBoardPage> createState() => _AgentBoardPageState();
+}
+
+class _AgentBoardPageState extends State<AgentBoardPage> {
+  late final AgentBoardService _service;
+
+  BoardSnapshot? _snapshot;
+  bool _loading = true;
+  String _error = '';
+  DateTime _now = DateTime.now();
+  DateTime? _lastUpdatedAt;
+  Timer? _clock;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? AgentBoardService();
+    if (_service.isSignedIn) {
+      _reload();
+      _service.subscribe(_reload);
+      // 「◯分前」表示を進めるための時計 (盤面データは触らない)。
+      _clock = Timer.periodic(const Duration(seconds: 30), (_) {
+        if (mounted) setState(() => _now = DateTime.now());
+      });
+    } else {
+      _loading = false;
+    }
+  }
+
+  @override
+  void dispose() {
+    _clock?.cancel();
+    unawaited(_service.dispose());
+    super.dispose();
+  }
+
+  Future<void> _reload() async {
+    try {
+      final rows = await _service.fetchRows();
+      if (!mounted) return;
+      final now = DateTime.now();
+      setState(() {
+        _snapshot = buildBoardSnapshot(rows, now);
+        _now = now;
+        _lastUpdatedAt = now;
+        _loading = false;
+        _error = '';
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = 'タスクの取得に失敗しました: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: DesignTokens.background,
+      appBar: AppBar(
+        backgroundColor: DesignTokens.background,
+        elevation: 0,
+        title: const Row(
+          children: [
+            Icon(Icons.view_kanban_outlined,
+                color: DesignTokens.orange, size: 20),
+            SizedBox(width: DesignTokens.space8),
+            Text(
+              'AIエージェント ボード',
+              style: TextStyle(fontWeight: FontWeight.w800),
+            ),
+          ],
+        ),
+        actions: [
+          if (_service.isSignedIn)
+            IconButton(
+              tooltip: '再読み込み',
+              onPressed: _reload,
+              icon: const Icon(Icons.refresh,
+                  size: 20, color: DesignTokens.textSecondary),
+            ),
+          const SizedBox(width: DesignTokens.space8),
+        ],
+      ),
+      body: !_service.isSignedIn
+          ? _buildSignInGate()
+          : _loading
+              ? const Center(
+                  child: CircularProgressIndicator(
+                    color: DesignTokens.orange,
+                  ),
+                )
+              : _buildBoard(),
+    );
+  }
+
+  // ── 未ログイン導線 ─────────────────────────────────────────
+  Widget _buildSignInGate() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(DesignTokens.space24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.lock_outline,
+                size: 40, color: DesignTokens.textTertiary),
+            const SizedBox(height: DesignTokens.space16),
+            const Text(
+              'この機能はログインが必要です',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: DesignTokens.textPrimary,
+              ),
+            ),
+            const SizedBox(height: DesignTokens.space8),
+            const Text(
+              'AIエージェントが進めている開発タスクを表示するため、\n'
+              'ログインしたユーザーのみ閲覧できます。',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 13,
+                color: DesignTokens.textSecondary,
+                height: 1.6,
+              ),
+            ),
+            const SizedBox(height: DesignTokens.space24),
+            FilledButton.icon(
+              style: FilledButton.styleFrom(
+                backgroundColor: DesignTokens.orange,
+              ),
+              onPressed: () => Navigator.of(context).pushNamed('/login'),
+              icon: const Icon(Icons.login, size: 18),
+              label: const Text('ログインする'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ── 盤面 ───────────────────────────────────────────────────
+  Widget _buildBoard() {
+    final snapshot = _snapshot;
+    if (_error.isNotEmpty && snapshot == null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(DesignTokens.space24),
+          child: Text(
+            _error,
+            textAlign: TextAlign.center,
+            style: const TextStyle(color: DesignTokens.red),
+          ),
+        ),
+      );
+    }
+    if (snapshot == null) return const SizedBox.shrink();
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final wide = constraints.maxWidth >= 900;
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(DesignTokens.space16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _buildStatusBar(snapshot),
+              const SizedBox(height: DesignTokens.space16),
+              if (wide)
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(width: 240, child: _buildAgentPanel(snapshot)),
+                    const SizedBox(width: DesignTokens.space12),
+                    Expanded(child: _buildLanes(snapshot, wide)),
+                  ],
+                )
+              else ...[
+                _buildAgentPanel(snapshot),
+                const SizedBox(height: DesignTokens.space12),
+                _buildLanes(snapshot, wide),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  BoxDecoration get _cardDecoration => BoxDecoration(
+        color: DesignTokens.surface1,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+        border: Border.all(color: DesignTokens.divider),
+      );
+
+  Widget _buildStatusBar(BoardSnapshot snapshot) {
+    final active = snapshot.agents.where((a) => a.isActive).length;
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: DesignTokens.space16,
+        vertical: DesignTokens.space12,
+      ),
+      decoration: _cardDecoration,
+      child: Wrap(
+        spacing: DesignTokens.space12,
+        runSpacing: DesignTokens.space8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          _pill('$active エージェント稼働中', DesignTokens.green, filled: true),
+          _pill('${snapshot.totalTasks} タスク表示中',
+              DesignTokens.indigoLight),
+          _meta(
+            '最終更新',
+            _lastUpdatedAt == null ? '—' : formatElapsed(_lastUpdatedAt, _now),
+          ),
+          const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.circle, size: 8, color: DesignTokens.green),
+              SizedBox(width: 4),
+              Text(
+                'LIVE',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  color: DesignTokens.green,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _pill(String text, Color color, {bool filled = false}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: filled ? color.withValues(alpha: 0.18) : DesignTokens.surface3,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  Widget _meta(String label, String value) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '$label ',
+          style: const TextStyle(
+            fontSize: 11,
+            color: DesignTokens.textTertiary,
+          ),
+        ),
+        Text(
+          value,
+          style: const TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+            color: DesignTokens.textPrimary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── エージェント一覧 ───────────────────────────────────────
+  Widget _buildAgentPanel(BoardSnapshot snapshot) {
+    return Container(
+      padding: const EdgeInsets.all(DesignTokens.space12),
+      decoration: _cardDecoration,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'AIエージェント',
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: DesignTokens.textPrimary,
+            ),
+          ),
+          const SizedBox(height: DesignTokens.space12),
+          if (snapshot.agents.isEmpty)
+            const Text(
+              '担当エージェントなし',
+              style: TextStyle(
+                fontSize: 12,
+                color: DesignTokens.textTertiary,
+              ),
+            )
+          else
+            for (final agent in snapshot.agents) _agentTile(agent),
+        ],
+      ),
+    );
+  }
+
+  Widget _agentTile(AgentSummary agent) {
+    final color = agentColor(agent.agentId);
+    final name = agentDisplayName(agent.agentId);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: DesignTokens.space12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Stack(
+            children: [
+              CircleAvatar(
+                radius: 14,
+                backgroundColor: color.withValues(alpha: 0.2),
+                child: Text(
+                  name.isEmpty ? '?' : name.substring(0, 1).toUpperCase(),
+                  style: TextStyle(
+                    color: color,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+              if (agent.isActive)
+                Positioned(
+                  right: 0,
+                  bottom: 0,
+                  child: Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: DesignTokens.green,
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: DesignTokens.surface1,
+                        width: 1.5,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(width: DesignTokens.space8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  name,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: DesignTokens.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  agent.isActive
+                      ? '進行中 ${agent.inProgress}'
+                          '${agent.blocked > 0 ? ' / ブロック ${agent.blocked}' : ''}'
+                      : '待機中'
+                          '${agent.blocked > 0 ? ' (ブロック ${agent.blocked})' : ''}',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: agent.isActive ? color : DesignTokens.textTertiary,
+                  ),
+                ),
+                if (agent.currentTaskTitle.isNotEmpty)
+                  Text(
+                    agent.currentTaskTitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: DesignTokens.textSecondary,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── カンバン ───────────────────────────────────────────────
+  Widget _buildLanes(BoardSnapshot snapshot, bool wide) {
+    const lanes = BoardLane.values;
+    if (wide) {
+      return Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (int i = 0; i < lanes.length; i++) ...[
+            Expanded(child: _laneColumn(snapshot, lanes[i])),
+            if (i != lanes.length - 1)
+              const SizedBox(width: DesignTokens.space8),
+          ],
+        ],
+      );
+    }
+    return Column(
+      children: [
+        for (final lane in lanes) ...[
+          _laneColumn(snapshot, lane),
+          const SizedBox(height: DesignTokens.space8),
+        ],
+      ],
+    );
+  }
+
+  Color _laneColor(BoardLane lane) => switch (lane) {
+        BoardLane.notStarted => DesignTokens.textSecondary,
+        BoardLane.inProgress => DesignTokens.orange,
+        BoardLane.blocked => DesignTokens.red,
+        BoardLane.completed => DesignTokens.green,
+      };
+
+  Widget _laneColumn(BoardSnapshot snapshot, BoardLane lane) {
+    final cards = snapshot.cardsOf(lane);
+    final color = _laneColor(lane);
+    return Container(
+      padding: const EdgeInsets.all(DesignTokens.space8),
+      decoration: BoxDecoration(
+        color: DesignTokens.surface2,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+        border: Border.all(color: DesignTokens.divider),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 4,
+              vertical: DesignTokens.space4,
+            ),
+            child: Row(
+              children: [
+                Container(width: 6, height: 6,
+                    decoration: BoxDecoration(
+                        color: color, shape: BoxShape.circle)),
+                const SizedBox(width: 6),
+                Text(
+                  lane.label,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: DesignTokens.textSecondary,
+                  ),
+                ),
+                const Spacer(),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 7, vertical: 1),
+                  decoration: BoxDecoration(
+                    color: DesignTokens.surface3,
+                    borderRadius:
+                        BorderRadius.circular(DesignTokens.radiusCircle),
+                  ),
+                  child: Text(
+                    '${cards.length}',
+                    style: const TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: DesignTokens.textSecondary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: DesignTokens.space4),
+          if (cards.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: DesignTokens.space16),
+              child: Text(
+                '—',
+                textAlign: TextAlign.center,
+                style: TextStyle(color: DesignTokens.textDisabled),
+              ),
+            )
+          else
+            for (final card in cards) _taskCard(card),
+          if (lane == BoardLane.notStarted && snapshot.hiddenNotStarted > 0)
+            Padding(
+              padding: const EdgeInsets.only(top: DesignTokens.space4),
+              child: Text(
+                '他 ${snapshot.hiddenNotStarted} 件',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 11,
+                  color: DesignTokens.textTertiary,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _taskCard(BoardCard card) {
+    final color = agentColor(card.agentId);
+    final elapsed = card.elapsedLabel(_now);
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      margin: const EdgeInsets.only(bottom: DesignTokens.space8),
+      padding: const EdgeInsets.all(DesignTokens.space8),
+      decoration: BoxDecoration(
+        color: DesignTokens.surface1,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+        border: Border.all(
+          color: card.lane == BoardLane.blocked
+              ? DesignTokens.red.withValues(alpha: 0.5)
+              : DesignTokens.divider,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(card.categoryIcon, style: const TextStyle(fontSize: 12)),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  card.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 12.5,
+                    fontWeight: FontWeight.w600,
+                    color: DesignTokens.textPrimary,
+                    height: 1.3,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          // 進捗バー (更新のたびに伸びるのが見える)。
+          ClipRRect(
+            borderRadius: BorderRadius.circular(DesignTokens.radiusCircle),
+            child: LinearProgressIndicator(
+              value: card.progress / 100,
+              minHeight: 4,
+              backgroundColor: DesignTokens.surface3,
+              valueColor: AlwaysStoppedAnimation<Color>(color),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Row(
+            children: [
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+                decoration: BoxDecoration(
+                  color: color.withValues(alpha: 0.16),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusCircle),
+                ),
+                child: Text(
+                  agentDisplayName(card.agentId),
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    color: color,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 6),
+              Text(
+                '${card.progress}%',
+                style: const TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  color: DesignTokens.textSecondary,
+                ),
+              ),
+              const Spacer(),
+              if (elapsed.isNotEmpty)
+                Text(
+                  elapsed,
+                  style: const TextStyle(
+                    fontSize: 10,
+                    color: DesignTokens.textTertiary,
+                  ),
+                ),
+            ],
+          ),
+          if (card.issueNumber != null && card.issueUrl.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: InkWell(
+                onTap: () => unawaited(
+                  launchUrl(
+                    Uri.parse(card.issueUrl),
+                    mode: LaunchMode.externalApplication,
+                  ),
+                ),
+                child: Text(
+                  '#${card.issueNumber}',
+                  style: const TextStyle(
+                    fontSize: 10,
+                    color: DesignTokens.indigoLight,
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/agent_board_page.dart
+++ b/lib/pages/agent_board_page.dart
@@ -88,8 +88,11 @@ class _AgentBoardPageState extends State<AgentBoardPage> {
         elevation: 0,
         title: const Row(
           children: [
-            Icon(Icons.view_kanban_outlined,
-                color: DesignTokens.orange, size: 20),
+            Icon(
+              Icons.view_kanban_outlined,
+              color: DesignTokens.orange,
+              size: 20,
+            ),
             SizedBox(width: DesignTokens.space8),
             Text(
               'AIエージェント ボード',
@@ -102,8 +105,11 @@ class _AgentBoardPageState extends State<AgentBoardPage> {
             IconButton(
               tooltip: '再読み込み',
               onPressed: _reload,
-              icon: const Icon(Icons.refresh,
-                  size: 20, color: DesignTokens.textSecondary),
+              icon: const Icon(
+                Icons.refresh,
+                size: 20,
+                color: DesignTokens.textSecondary,
+              ),
             ),
           const SizedBox(width: DesignTokens.space8),
         ],
@@ -128,8 +134,11 @@ class _AgentBoardPageState extends State<AgentBoardPage> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.lock_outline,
-                size: 40, color: DesignTokens.textTertiary),
+            const Icon(
+              Icons.lock_outline,
+              size: 40,
+              color: DesignTokens.textTertiary,
+            ),
             const SizedBox(height: DesignTokens.space16),
             const Text(
               'この機能はログインが必要です',
@@ -233,8 +242,10 @@ class _AgentBoardPageState extends State<AgentBoardPage> {
         crossAxisAlignment: WrapCrossAlignment.center,
         children: [
           _pill('$active エージェント稼働中', DesignTokens.green, filled: true),
-          _pill('${snapshot.totalTasks} タスク表示中',
-              DesignTokens.indigoLight),
+          _pill(
+            '${snapshot.totalTasks} タスク表示中',
+            DesignTokens.indigoLight,
+          ),
           _meta(
             '最終更新',
             _lastUpdatedAt == null ? '—' : formatElapsed(_lastUpdatedAt, _now),
@@ -469,9 +480,14 @@ class _AgentBoardPageState extends State<AgentBoardPage> {
             ),
             child: Row(
               children: [
-                Container(width: 6, height: 6,
-                    decoration: BoxDecoration(
-                        color: color, shape: BoxShape.circle)),
+                Container(
+                  width: 6,
+                  height: 6,
+                  decoration: BoxDecoration(
+                    color: color,
+                    shape: BoxShape.circle,
+                  ),
+                ),
                 const SizedBox(width: 6),
                 Text(
                   lane.label,
@@ -584,8 +600,7 @@ class _AgentBoardPageState extends State<AgentBoardPage> {
           Row(
             children: [
               Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+                padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
                 decoration: BoxDecoration(
                   color: color.withValues(alpha: 0.16),
                   borderRadius:

--- a/lib/services/agent_board_service.dart
+++ b/lib/services/agent_board_service.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// AI エージェント カンバンボードのデータ供給。
+///
+/// `wbs_tasks` を RLS 下で直接読み、Supabase Realtime で変更を購読する。
+/// 購読が張れない環境 (publication 無効など) でも壊れないよう、60 秒の
+/// フォールバック再取得を常に併走させる。
+class AgentBoardService {
+  AgentBoardService({SupabaseClient? client}) : _injected = client;
+
+  // テストでサブクラスが差し替えられるよう、Supabase.instance は遅延解決する。
+  final SupabaseClient? _injected;
+
+  SupabaseClient get _client => _injected ?? Supabase.instance.client;
+
+  RealtimeChannel? _channel;
+  Timer? _fallbackTimer;
+
+  /// ログイン済みか (WBS はログイン済みユーザー限定)。
+  bool get isSignedIn => _client.auth.currentSession != null;
+
+  /// 盤面に必要な列だけを取得する。
+  ///
+  /// 完了タスクは全件だと数千行になるため、直近ぶんに絞ってから取得する
+  /// (盤面側でも 24 時間窓で再度絞り込む)。
+  Future<List<Map<String, dynamic>>> fetchRows() async {
+    final since = DateTime.now()
+        .toUtc()
+        .subtract(const Duration(hours: 48))
+        .toIso8601String();
+
+    // 未完了は全件、完了は直近のみ。PostgREST の or フィルタで 1 往復にする。
+    final data = await _client
+        .from('wbs_tasks')
+        .select(
+          'id,title,status,progress,priority,category_icon,instance,'
+          'owner_instance,updated_at,github_issue_number,github_issue_url',
+        )
+        .or('status.neq.completed,updated_at.gte.$since')
+        .order('updated_at', ascending: false)
+        .limit(400);
+
+    return List<Map<String, dynamic>>.from(data as List);
+  }
+
+  /// 変更の購読を開始する。
+  ///
+  /// [onChange] は Realtime の通知時とフォールバックタイマーの双方から呼ばれる
+  /// (呼び出し側で再取得する)。購読に失敗してもフォールバックは動き続ける。
+  void subscribe(void Function() onChange) {
+    _fallbackTimer?.cancel();
+    _fallbackTimer = Timer.periodic(
+      const Duration(seconds: 60),
+      (_) => onChange(),
+    );
+
+    try {
+      _channel = _client
+          .channel('public:wbs_tasks:agent_board')
+          .onPostgresChanges(
+            event: PostgresChangeEvent.all,
+            schema: 'public',
+            table: 'wbs_tasks',
+            callback: (_) => onChange(),
+          )
+          .subscribe();
+    } catch (_) {
+      // Realtime が使えない環境ではフォールバックのみで動作する。
+      _channel = null;
+    }
+  }
+
+  /// 購読とタイマーを解放する。
+  Future<void> dispose() async {
+    _fallbackTimer?.cancel();
+    _fallbackTimer = null;
+    final channel = _channel;
+    _channel = null;
+    if (channel != null) {
+      try {
+        await _client.removeChannel(channel);
+      } catch (_) {
+        // 解放時のエラーは握りつぶす (画面遷移を妨げない)。
+      }
+    }
+  }
+}

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -54,6 +54,7 @@ const List<String> kAllAppRoutes = <String>[
   '/asset-management',
   '/auction-marketplace',
   '/audio-effects-processor',
+  '/agent-board',
   '/autonomous-ops',
   '/autonomous-ops-console',
   '/behavior-log',

--- a/test/services/agent_board_test.dart
+++ b/test/services/agent_board_test.dart
@@ -152,8 +152,8 @@ void main() {
       ];
       final snapshot = buildBoardSnapshot(rows, kNow);
 
-      expect(
-          snapshot.cardsOf(BoardLane.notStarted), hasLength(notStartedLimit));
+      final shown = snapshot.cardsOf(BoardLane.notStarted);
+      expect(shown, hasLength(notStartedLimit));
       expect(snapshot.hiddenNotStarted, 5);
     });
 

--- a/test/services/agent_board_test.dart
+++ b/test/services/agent_board_test.dart
@@ -148,7 +148,8 @@ void main() {
       ];
       final snapshot = buildBoardSnapshot(rows, kNow);
 
-      expect(snapshot.cardsOf(BoardLane.notStarted), hasLength(notStartedLimit));
+      expect(
+          snapshot.cardsOf(BoardLane.notStarted), hasLength(notStartedLimit));
       expect(snapshot.hiddenNotStarted, 5);
     });
 

--- a/test/services/agent_board_test.dart
+++ b/test/services/agent_board_test.dart
@@ -32,6 +32,10 @@ class _FakeBoardService extends AgentBoardService {
 // 固定 now: 2026-07-26T12:00:00Z
 final DateTime kNow = DateTime.parse('2026-07-26T12:00:00Z');
 
+/// 固定 now でスナップショットを組む (呼び出しを短くするためのヘルパー)。
+BoardSnapshot snapOf(List<Map<String, dynamic>> rows) =>
+    buildBoardSnapshot(rows, kNow);
+
 Map<String, dynamic> row({
   String id = 't1',
   String title = 'タスク',
@@ -110,11 +114,11 @@ void main() {
 
   group('buildBoardSnapshot', () {
     test('未着手/進行中/ブロックは全件残る', () {
-      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+      final snapshot = snapOf(<Map<String, dynamic>>[
         row(id: 'a', status: 'not_started'),
         row(id: 'b', status: 'in_progress'),
         row(id: 'c', status: 'blocked'),
-      ], kNow);
+      ]);
 
       expect(snapshot.cardsOf(BoardLane.notStarted), hasLength(1));
       expect(snapshot.cardsOf(BoardLane.inProgress), hasLength(1));
@@ -123,7 +127,7 @@ void main() {
     });
 
     test('完了は直近24時間ぶんだけ残る', () {
-      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+      final snapshot = snapOf(<Map<String, dynamic>>[
         row(
           id: 'recent',
           status: 'completed',
@@ -134,7 +138,7 @@ void main() {
           status: 'completed',
           updatedAt: kNow.subtract(const Duration(hours: 30)),
         ),
-      ], kNow);
+      ]);
 
       final done = snapshot.cardsOf(BoardLane.completed);
       expect(done, hasLength(1));
@@ -154,11 +158,11 @@ void main() {
     });
 
     test('未着手は優先度順に並ぶ', () {
-      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+      final snapshot = snapOf(<Map<String, dynamic>>[
         row(id: 'low', status: 'not_started', priority: 'low'),
         row(id: 'critical', status: 'not_started', priority: 'critical'),
         row(id: 'medium', status: 'not_started', priority: 'medium'),
-      ], kNow);
+      ]);
 
       final ids =
           snapshot.cardsOf(BoardLane.notStarted).map((c) => c.id).toList();
@@ -166,7 +170,7 @@ void main() {
     });
 
     test('進行中は最近更新が上に来る', () {
-      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+      final snapshot = snapOf(<Map<String, dynamic>>[
         row(
           id: 'older',
           status: 'in_progress',
@@ -177,13 +181,13 @@ void main() {
           status: 'in_progress',
           updatedAt: kNow.subtract(const Duration(minutes: 5)),
         ),
-      ], kNow);
+      ]);
 
       expect(snapshot.cardsOf(BoardLane.inProgress).first.id, 'newer');
     });
 
     test('空入力でも壊れない', () {
-      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[], kNow);
+      final snapshot = snapOf(<Map<String, dynamic>>[]);
       expect(snapshot.totalTasks, 0);
       expect(snapshot.agents, isEmpty);
       expect(snapshot.hiddenNotStarted, 0);
@@ -192,12 +196,12 @@ void main() {
 
   group('summarizeAgents', () {
     test('実データに現れたエージェントだけを返し、稼働中を上にする', () {
-      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+      final snapshot = snapOf(<Map<String, dynamic>>[
         row(id: 'a', status: 'not_started', instance: 'gemini'),
         row(id: 'b', status: 'in_progress', instance: 'claude'),
         row(id: 'c', status: 'in_progress', instance: 'claude'),
         row(id: 'd', status: 'in_progress', instance: 'codex'),
-      ], kNow);
+      ]);
 
       final ids = snapshot.agents.map((a) => a.agentId).toList();
       // claude(進行中2) → codex(進行中1) → gemini(待機)
@@ -208,7 +212,7 @@ void main() {
     });
 
     test('現在のタスク名は進行中で最も新しいものになる', () {
-      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+      final snapshot = snapOf(<Map<String, dynamic>>[
         row(
           id: 'x',
           title: '古い作業',
@@ -223,7 +227,7 @@ void main() {
           instance: 'claude',
           updatedAt: kNow.subtract(const Duration(minutes: 1)),
         ),
-      ], kNow);
+      ]);
 
       expect(snapshot.agents.single.currentTaskTitle, '最新の作業');
     });

--- a/test/services/agent_board_test.dart
+++ b/test/services/agent_board_test.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/agent_board_models.dart';
+import 'package:my_web_app/pages/agent_board_page.dart';
+import 'package:my_web_app/services/agent_board_service.dart';
+
+/// Supabase を初期化せずに分岐を検証するためのフェイク。
+class _FakeBoardService extends AgentBoardService {
+  _FakeBoardService({
+    this.signedIn = true,
+    this.rows = const <Map<String, dynamic>>[],
+  }) : super();
+
+  final bool signedIn;
+  final List<Map<String, dynamic>> rows;
+
+  @override
+  bool get isSignedIn => signedIn;
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchRows() async => rows;
+
+  @override
+  void subscribe(void Function() onChange) {
+    // テストではタイマー/購読を張らない。
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+// 固定 now: 2026-07-26T12:00:00Z
+final DateTime kNow = DateTime.parse('2026-07-26T12:00:00Z');
+
+Map<String, dynamic> row({
+  String id = 't1',
+  String title = 'タスク',
+  String status = 'in_progress',
+  String instance = 'claude',
+  String? ownerInstance,
+  int progress = 50,
+  String priority = 'medium',
+  DateTime? updatedAt,
+  int? issueNumber,
+  String issueUrl = '',
+}) {
+  return <String, dynamic>{
+    'id': id,
+    'title': title,
+    'status': status,
+    'progress': progress,
+    'priority': priority,
+    'category_icon': '🛠',
+    'instance': instance,
+    'owner_instance': ownerInstance,
+    'updated_at': (updatedAt ?? kNow).toIso8601String(),
+    'github_issue_number': issueNumber,
+    'github_issue_url': issueUrl,
+  };
+}
+
+void main() {
+  group('laneFromStatus', () {
+    test('実 status をそのまま 4 列へ写像する', () {
+      expect(laneFromStatus('not_started'), BoardLane.notStarted);
+      expect(laneFromStatus('in_progress'), BoardLane.inProgress);
+      expect(laneFromStatus('blocked'), BoardLane.blocked);
+      expect(laneFromStatus('completed'), BoardLane.completed);
+    });
+
+    test('未知の status は未着手へ寄せる', () {
+      expect(laneFromStatus('pending'), BoardLane.notStarted);
+      expect(laneFromStatus(''), BoardLane.notStarted);
+    });
+  });
+
+  group('normalizeAgentId', () {
+    test('別名を正規の ID へ束ねる', () {
+      expect(normalizeAgentId('codex1'), 'codex');
+      expect(normalizeAgentId('cx'), 'codex');
+      expect(normalizeAgentId('co-pilot'), 'copilot');
+      expect(normalizeAgentId('ps3'), 'ps');
+      expect(normalizeAgentId('human'), 'user');
+      expect(normalizeAgentId('CLAUDE'), 'claude');
+    });
+
+    test('未知の値はそのまま ID になる (新エージェント追従)', () {
+      expect(normalizeAgentId('antigravity'), 'antigravity');
+      expect(agentDisplayName('antigravity'), 'Antigravity');
+    });
+
+    test('空文字は unknown', () {
+      expect(normalizeAgentId('  '), 'unknown');
+    });
+  });
+
+  group('cardFromRow', () {
+    test('owner_instance を優先し、無ければ instance を使う', () {
+      final a = cardFromRow(row(instance: 'codex', ownerInstance: 'claude'));
+      expect(a.agentId, 'claude');
+      final b = cardFromRow(row(instance: 'gemini'));
+      expect(b.agentId, 'gemini');
+    });
+
+    test('progress は 0-100 にクランプされる', () {
+      expect(cardFromRow(row(progress: 150)).progress, 100);
+      expect(cardFromRow(row(progress: -5)).progress, 0);
+    });
+  });
+
+  group('buildBoardSnapshot', () {
+    test('未着手/進行中/ブロックは全件残る', () {
+      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+        row(id: 'a', status: 'not_started'),
+        row(id: 'b', status: 'in_progress'),
+        row(id: 'c', status: 'blocked'),
+      ], kNow);
+
+      expect(snapshot.cardsOf(BoardLane.notStarted), hasLength(1));
+      expect(snapshot.cardsOf(BoardLane.inProgress), hasLength(1));
+      expect(snapshot.cardsOf(BoardLane.blocked), hasLength(1));
+      expect(snapshot.totalTasks, 3);
+    });
+
+    test('完了は直近24時間ぶんだけ残る', () {
+      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+        row(
+          id: 'recent',
+          status: 'completed',
+          updatedAt: kNow.subtract(const Duration(hours: 3)),
+        ),
+        row(
+          id: 'old',
+          status: 'completed',
+          updatedAt: kNow.subtract(const Duration(hours: 30)),
+        ),
+      ], kNow);
+
+      final done = snapshot.cardsOf(BoardLane.completed);
+      expect(done, hasLength(1));
+      expect(done.single.id, 'recent');
+    });
+
+    test('未着手は上限で打ち切り、超過数を hiddenNotStarted に出す', () {
+      final rows = <Map<String, dynamic>>[
+        for (int i = 0; i < notStartedLimit + 5; i++)
+          row(id: 'n$i', status: 'not_started'),
+      ];
+      final snapshot = buildBoardSnapshot(rows, kNow);
+
+      expect(snapshot.cardsOf(BoardLane.notStarted), hasLength(notStartedLimit));
+      expect(snapshot.hiddenNotStarted, 5);
+    });
+
+    test('未着手は優先度順に並ぶ', () {
+      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+        row(id: 'low', status: 'not_started', priority: 'low'),
+        row(id: 'critical', status: 'not_started', priority: 'critical'),
+        row(id: 'medium', status: 'not_started', priority: 'medium'),
+      ], kNow);
+
+      final ids =
+          snapshot.cardsOf(BoardLane.notStarted).map((c) => c.id).toList();
+      expect(ids, <String>['critical', 'medium', 'low']);
+    });
+
+    test('進行中は最近更新が上に来る', () {
+      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+        row(
+          id: 'older',
+          status: 'in_progress',
+          updatedAt: kNow.subtract(const Duration(hours: 2)),
+        ),
+        row(
+          id: 'newer',
+          status: 'in_progress',
+          updatedAt: kNow.subtract(const Duration(minutes: 5)),
+        ),
+      ], kNow);
+
+      expect(snapshot.cardsOf(BoardLane.inProgress).first.id, 'newer');
+    });
+
+    test('空入力でも壊れない', () {
+      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[], kNow);
+      expect(snapshot.totalTasks, 0);
+      expect(snapshot.agents, isEmpty);
+      expect(snapshot.hiddenNotStarted, 0);
+    });
+  });
+
+  group('summarizeAgents', () {
+    test('実データに現れたエージェントだけを返し、稼働中を上にする', () {
+      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+        row(id: 'a', status: 'not_started', instance: 'gemini'),
+        row(id: 'b', status: 'in_progress', instance: 'claude'),
+        row(id: 'c', status: 'in_progress', instance: 'claude'),
+        row(id: 'd', status: 'in_progress', instance: 'codex'),
+      ], kNow);
+
+      final ids = snapshot.agents.map((a) => a.agentId).toList();
+      // claude(進行中2) → codex(進行中1) → gemini(待機)
+      expect(ids, <String>['claude', 'codex', 'gemini']);
+      expect(snapshot.agents.first.inProgress, 2);
+      expect(snapshot.agents.first.isActive, isTrue);
+      expect(snapshot.agents.last.isActive, isFalse);
+    });
+
+    test('現在のタスク名は進行中で最も新しいものになる', () {
+      final snapshot = buildBoardSnapshot(<Map<String, dynamic>>[
+        row(
+          id: 'x',
+          title: '古い作業',
+          status: 'in_progress',
+          instance: 'claude',
+          updatedAt: kNow.subtract(const Duration(hours: 1)),
+        ),
+        row(
+          id: 'y',
+          title: '最新の作業',
+          status: 'in_progress',
+          instance: 'claude',
+          updatedAt: kNow.subtract(const Duration(minutes: 1)),
+        ),
+      ], kNow);
+
+      expect(snapshot.agents.single.currentTaskTitle, '最新の作業');
+    });
+  });
+
+  group('formatElapsed', () {
+    test('経過に応じた表記になる', () {
+      expect(formatElapsed(kNow, kNow), 'たった今');
+      expect(
+        formatElapsed(kNow.subtract(const Duration(minutes: 3)), kNow),
+        '3分前',
+      );
+      expect(
+        formatElapsed(kNow.subtract(const Duration(hours: 5)), kNow),
+        '5時間前',
+      );
+      expect(
+        formatElapsed(kNow.subtract(const Duration(days: 2)), kNow),
+        '2日前',
+      );
+      expect(formatElapsed(null, kNow), '');
+    });
+  });
+
+  group('AgentBoardPage', () {
+    testWidgets('未ログインはログイン導線のみ表示し、盤面を出さない', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AgentBoardPage(service: _FakeBoardService(signedIn: false)),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('この機能はログインが必要です'), findsOneWidget);
+      expect(find.text('ログインする'), findsOneWidget);
+      expect(find.text('未着手'), findsNothing);
+      expect(find.text('進行中'), findsNothing);
+    });
+
+    testWidgets('ログイン済みは盤面とカードを表示する', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AgentBoardPage(
+            service: _FakeBoardService(
+              rows: <Map<String, dynamic>>[
+                row(id: 'a', title: 'カンバン実装', status: 'in_progress'),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 20));
+
+      expect(find.text('この機能はログインが必要です'), findsNothing);
+      expect(find.text('未着手'), findsOneWidget);
+      expect(find.text('進行中'), findsOneWidget);
+      expect(find.text('ブロック'), findsOneWidget);
+      expect(find.text('完了'), findsOneWidget);
+      expect(find.text('カンバン実装'), findsOneWidget);
+      expect(find.text('Claude Code'), findsWidgets);
+    });
+  });
+}

--- a/test/services/agent_board_test.dart
+++ b/test/services/agent_board_test.dart
@@ -287,7 +287,8 @@ void main() {
       expect(find.text('進行中'), findsOneWidget);
       expect(find.text('ブロック'), findsOneWidget);
       expect(find.text('完了'), findsOneWidget);
-      expect(find.text('カンバン実装'), findsOneWidget);
+      // タイトルはカードと、エージェント一覧の「現在のタスク名」の 2 箇所に出る。
+      expect(find.text('カンバン実装'), findsNWidgets(2));
       expect(find.text('Claude Code'), findsWidgets);
     });
   });


### PR DESCRIPTION
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 盤面はログイン済みユーザー限定 + Supabase Realtime 購読 + 実DB が必要で CI 再現が重いため E2E は付けない。代わりに純粋変換ロジックを単体テストで固めた（4列振り分け / 完了24h絞り込み / 未着手上限と「他N件」/ エージェント集計 / 経過時間、happy・empty・未知値の3ケース相当）。加えてログイン分岐の widget テストを追加。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 既存テーブル `wbs_tasks` を RLS 下で read-only 参照するだけの新規ページ追加であり、DB スキーマ変更・data-migration・Edge Function 追加・Secret 追加はいずれも無し。security=ログイン済み限定（未ログインは導線のみで盤面を描画しない）＋ RLS 準拠で権限昇格なし。rollback=ページとルートの差し戻しのみで状態を残さない。prod-smoke=公開ルートには影響しない（新規ページは非公開・既存 Public E2E stability smoke で回帰確認）。observability=取得失敗時はエラーメッセージを画面に表示し、Realtime 不通時も 60 秒フォールバックで縮退継続。正式 `/ultrareview` は未実行のため exception ルートで宣言（unresolved findings: none）。

## 📝 変更内容

Claude Code / Codex / Gemini などの **AI エージェントが `wbs_tasks` 上のタスクをこなしていく様子**を、動的に更新されるカンバンボードで眺める新規ページ `/agent-board` を追加。カードの移動は演出ではなく **実データの状態遷移**。

### 変更の種類

- [x] 新機能 (breaking changeを含まない機能追加)

## 🎯 変更の目的

「AIエージェントがWBSのタスクを進めている様子を視覚的に眺められる」体験を作る。誰が・何を・どこまで進めたかが盤面の動きとして見える。

## 📋 実装の詳細

### 主な変更点

1. **`lib/models/agent_board_models.dart`（新規）** — 純粋変換ロジック（テストの中核）
   - `wbs_tasks.status` → 4列（未着手 / 進行中 / ブロック / 完了）。**読み替えなし**
   - スコープ: 未完了は全件（未着手のみ上限20件 +「他N件」）、**完了は直近24hのみ**（時間経過で盤面から流れる）
   - `instance` / `owner_instance` の別名（`codex1` / `cx` / `co-pilot` / `ps1-6` 等）を正規化。**未知の値はそのまま ID 化**するので、新エージェント（例: Antigravity）が増えてもコード変更なしで盤面に出る
   - エージェント集計（稼働中を上に、進行中件数順、現在のタスク名）
2. **`lib/services/agent_board_service.dart`（新規）** — `wbs_tasks` を RLS 下で直接取得 + **Supabase Realtime 購読**（変更が届いた瞬間にカードが動く）+ **60秒フォールバック再取得**（購読不可な環境では自動縮退）
3. **`lib/pages/agent_board_page.dart`（新規）** — 4列カンバン + エージェント一覧 + 未ログイン導線
   - カード: **タイトル / エージェントバッジ / 進捗バー / 経過時間**（+ 優先度アイコン・GitHub Issue リンク）
   - ワイド/ナローでレスポンシブ、`DesignTokens`（Orange+Indigo ダーク）準拠
4. **配線**: ルート `/agent-board` 登録 + ホームツールカタログ「成長・発信」に導線

### grill-me で確定した設計判断

新規ページ（既存 OMOCHA WORKS は残す）/ 列=実status 4列 / スコープ=動いてるもの主役・完了24h / 更新=Realtime+60sフォールバック / カード=4点主役 / エージェント一覧=実データ出現分のみ動的 / アクセス=ログイン済み限定 / 検証=単体+widget・E2E例外。

## ✅ テスト結果

- [x] Flutter 単体テスト（`test/services/agent_board_test.dart`）
  - 4列振り分け / 未知statusの扱い / エージェント別名正規化 / owner_instance優先 / progressクランプ
  - 完了24h絞り込み / 未着手上限と hiddenNotStarted / 優先度ソート / 更新順ソート / 空入力
  - エージェント集計（稼働中が上・現在タスク名）/ 経過時間表記
  - ログイン分岐の widget テスト（未ログイン=導線のみ / ログイン済み=盤面表示）
- [x] 手動レビュー（ブレース均衡・依存の実在確認）
> SDK 非搭載環境のためローカル `flutter analyze` は未実行。CI ゲートで検証。

## 🔒 セキュリティへの影響

- [x] WBS は未公開の開発計画を含むため**ログイン済みユーザー限定**。未ログインには盤面を一切描画しない
- [x] RLS 準拠（クライアントから既存テーブルを read-only 参照）。新たな権限・Secret・書き込みは無し

## 🚨 Breaking Changes

- [x] このPRにはBreaking Changesが含まれていません（新規ページの追加のみ、既存機能は不変）

## 🚀 デプロイメモ

- [x] 特別なデプロイ手順は不要（DBスキーマ変更・EF追加・環境変数追加なし）
- Realtime が対象テーブルで無効な場合も、60秒フォールバックで自動縮退して動作します

## ✅ レビュー観点

1. `buildBoardSnapshot` のスコープ絞り込み（完了24h / 未着手上限）とソート
2. Realtime 購読とフォールバックタイマーの解放（`dispose`）
3. 未ログイン時に盤面を描画しないこと（情報露出の防止）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0124Kh1sgmYBbfX5QK9vqE1j)_