### PR TITLE
feat(asset): 返済報告カードをXへ直接投稿 + AppBar導線 (発見性と労力の欠陥修正)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8752,6 +8752,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           // 負債トレンドカードにしか無く投稿手段が見つからなかった。検出0件
           // でも「アラート: なし+給料日カウントダウン」の正直なスコアボードを
           // 投稿できる(金額は一切含まない)。
+          // 返済報告カード = 実数字を出す当事者向けの投稿。匿名トラッカー
+          // (右隣) は件数を幅表示するだけなので別物として並べる。
+          IconButton(
+            key: const Key('debt_progress_share_appbar_button'),
+            tooltip: '今月の返済報告カードを作る（実額を公開）',
+            icon: const Icon(Icons.receipt_long),
+            onPressed: _openDebtProgressShare,
+          ),
           if (_householdTrackerScheduleAllowed)
             IconButton(
               tooltip: '家計トラッカーをXへ投稿（計測対象・金額非公開）',

--- a/lib/services/debt_progress_card_service.dart
+++ b/lib/services/debt_progress_card_service.dart
@@ -102,6 +102,33 @@ class DebtProgressCardService {
     return lines.join('\n');
   }
 
+  /// X への投稿ペイロードを組み立てる。
+  ///
+  /// 🔴 [text] には**ユーザーが編集した後の文面**を渡すこと。ここで
+  /// 下書きを再生成すると、本人が直した内容が捨てられて意図しない文が
+  /// 公開される (HITL が形骸化する)。
+  Map<String, dynamic> buildPostPayload(
+    DebtProgressCardData card, {
+    required DateTime month,
+    String? text,
+  }) {
+    return <String, dynamic>{
+      'action': 'x.post',
+      'text': text ?? buildDraftText(card, month: month),
+      'source': 'debt_progress_card',
+      'variant': 'debt_progress_report',
+      'utmContent': 'debt_progress_card',
+      'route': '/asset-management',
+      'promptProfile': 'debt_progress_report_v1',
+      'contentKind': 'data_report',
+      'contentArchetype': 'data_report',
+      'experimentKey': 'x_first_user_growth_10k',
+      // 🔴 URL は本文に残す。リプライへ逃がすと流入が落ちることが実測済み
+      // ([[session_20260728_part346_x_acquisition_rerank]])。
+      'linkInReply': false,
+    };
+  }
+
   String _deltaSuffix(double? delta) {
     if (delta == null) return '';
     if (delta == 0) return '(前月比 ±0円)';

--- a/lib/widgets/debt_progress_share_dialog.dart
+++ b/lib/widgets/debt_progress_share_dialog.dart
@@ -4,6 +4,7 @@ import 'package:my_web_app/services/debt_progress_card_service.dart';
 import 'package:my_web_app/services/note_card_service.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/debt_progress_card.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// 返済進捗カードの共有ダイアログ。
 ///
@@ -29,6 +30,7 @@ class _DebtProgressShareDialogState extends State<DebtProgressShareDialog> {
   final GlobalKey _repaintKey = GlobalKey();
   late final TextEditingController _textController;
   bool _saving = false;
+  bool _posting = false;
 
   @override
   void initState() {
@@ -99,7 +101,7 @@ class _DebtProgressShareDialogState extends State<DebtProgressShareDialog> {
           icon: const Icon(Icons.copy, size: 16),
           label: const Text('文面をコピー'),
         ),
-        FilledButton.icon(
+        TextButton.icon(
           onPressed: _saving ? null : _downloadCard,
           icon: _saving
               ? const SizedBox(
@@ -108,10 +110,91 @@ class _DebtProgressShareDialogState extends State<DebtProgressShareDialog> {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               : const Icon(Icons.download, size: 16),
-          label: const Text('カード画像を保存'),
+          label: const Text('画像を保存'),
+        ),
+        FilledButton.icon(
+          onPressed: _posting ? null : _postToX,
+          icon: _posting
+              ? const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.send, size: 16),
+          label: const Text('Xへ投稿する'),
         ),
       ],
     );
+  }
+
+  /// 編集後の文面をそのまま X へ投稿する。
+  ///
+  /// 🔴 画像は添付されない (EF は現状テキスト投稿のみ)。画像も出したい場合は
+  /// 「画像を保存」で落として手動添付する。ここで下書きを再生成せず
+  /// `_textController.text` を送るのが要点 — 再生成すると本人の編集が
+  /// 捨てられ、意図しない内容が公開される。
+  Future<void> _postToX() async {
+    final text = _textController.text.trim();
+    if (text.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('投稿文が空です')));
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('この内容でXへ投稿します'),
+        content: SingleChildScrollView(child: SelectableText(text)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('やめる'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('投稿する'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    setState(() => _posting = true);
+    try {
+      const service = DebtProgressCardService();
+      final res = await Supabase.instance.client.functions.invoke(
+        'growth-hub',
+        body: service.buildPostPayload(
+          widget.data,
+          month: widget.month,
+          text: text,
+        ),
+      );
+      if (!mounted) return;
+      final data = res.data is Map
+          ? Map<String, dynamic>.from(res.data as Map)
+          : <String, dynamic>{};
+      final posted = data['posted'] == true;
+      final tweetId = data['tweetId']?.toString() ?? '';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            posted
+                ? '返済報告を投稿しました'
+                    '${tweetId.isNotEmpty ? ' https://x.com/i/status/$tweetId' : ''}'
+                : '投稿に失敗しました: ${data['error'] ?? data['code'] ?? '不明'}',
+          ),
+        ),
+      );
+      if (posted) Navigator.of(context).pop();
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('投稿に失敗しました: $error')));
+    } finally {
+      if (mounted) setState(() => _posting = false);
+    }
   }
 
   Future<void> _copyText() async {

--- a/test/services/debt_progress_card_service_test.dart
+++ b/test/services/debt_progress_card_service_test.dart
@@ -235,6 +235,52 @@ void main() {
     });
   });
 
+  group('DebtProgressCardService.buildPostPayload', () {
+    DebtProgressCardData card() => const DebtProgressCardData(
+          totalDebt: 1234567,
+          monthlyPayment: 45000,
+          payoffMonths: 38,
+          estimatedInterest: 234567,
+          monthOverMonthDelta: -50000,
+          debtCount: 3,
+        );
+
+    test('sends the edited text verbatim instead of regenerating the draft',
+        () {
+      // 🔴 これが崩れると本人が直した内容が捨てられ、意図しない文が公開される。
+      final payload = service.buildPostPayload(
+        card(),
+        month: DateTime(2026, 7, 1),
+        text: '手で直した本文',
+      );
+
+      expect(payload['text'], '手で直した本文');
+      expect(payload['action'], 'x.post');
+    });
+
+    test('falls back to the draft only when no text is supplied', () {
+      final payload = service.buildPostPayload(
+        card(),
+        month: DateTime(2026, 7, 1),
+      );
+
+      expect(payload['text'], contains('2026年7月の返済報告'));
+    });
+
+    test('keeps the acquisition URL in the main post, not the reply', () {
+      // リプライへ逃がすと流入が落ちることが実測済み (part346)。
+      final payload = service.buildPostPayload(
+        card(),
+        month: DateTime(2026, 7, 1),
+        text: 'x',
+      );
+
+      expect(payload['linkInReply'], false);
+      expect(payload['source'], 'debt_progress_card');
+      expect(payload['route'], '/asset-management');
+    });
+  });
+
   group('DebtProgressCardData.payoffLabel', () {
     test('formats months, years and mixed spans', () {
       DebtProgressCardData card(int? months) => DebtProgressCardData(


### PR DESCRIPTION
## Summary

返済報告カードを **1クリックでXへ投稿**できるようにし、AppBar から見つかるようにしました。実運用で判明した2つの欠陥を潰す修正です。

### 欠陥1: 導線が見つからない (前PRの設計ミス)

最も目立つ共有アイコンは AppBar にあるのに、カードのボタンをページ深部のセクション見出しに置いていたため、実際には AppBar の**既存の匿名トラッカー**が使われました。→ **AppBar にカードのボタンを追加**(`Icons.receipt_long`)。匿名トラッカー(`Icons.ios_share`)とは別物として並べます。

### 欠陥2: 労力の非対称

匿名トラッカーは1クリックで投稿完了、カードは「画像保存→文面コピー→Xを開く→貼る→添付」の**5手**。楽な方が使われるのは当然で、これでは月次の習慣になりません。→ **ダイアログに「Xへ投稿する」を追加**。

## 設計判断

**🔴 編集後の文面をそのまま送る**。`buildPostPayload(text: ...)` に `_textController.text` を渡し、**ここで下書きを再生成しない**。再生成すると本人が直した内容が捨てられ、意図しない文が公開されます。テストで固定済み。

**HITL は維持**。投稿前に全文の確認ダイアログを挟みます(匿名トラッカーと同じ作法)。自動投稿は一切しません。

**画像は添付されません**。EF は現状テキスト投稿のみで、X の media upload は未実装です。借金返済コミュニティはテキスト報告が主流なので、まず数字を出すことを優先しました。画像も出したい場合は「画像を保存」で落として手動添付できます。media upload は反応が得られてから投資する判断です。

**URL は本文に残す** (`linkInReply: false`)。リプライへ逃がすと流入が落ちることが実測済みのため (part346)。

## 検証

- unit 15件 + widget 4件 = **19件 green** (編集後文面の送出 / URL 位置 / 開示境界の回帰ガードを含む)
- `flutter analyze` No issues / `dart format` clean

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: admin-only dialog that posts through the existing growth-hub x.post action behind a confirmation step; payload construction is covered by unit tests and the network path is shared with the already-shipped household tracker

## High-Risk Ultrareview

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: reuses the existing x.post edge action and its operator gate with no new server surface; posting stays behind an explicit full-text confirmation dialog and sends only the operator-edited text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
