### PR TITLE
feat(x-growth): surface ICP exemplars from imported history

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./x_analytics_import.ts";
 import {
   buildArchetypeTopicInteractionLine,
+  buildIcpHistoricalExemplarLine,
   buildIcpScopeLine,
   buildTopicLiftLine,
   classifyPostTopic,
@@ -1129,11 +1130,23 @@ function buildXPerformanceContextFromLogs(
   // 返済報告カードの共有はクリップボードのみで x_post_log に残らないので、
   // ICP の実績は事実上「取り込んだ履歴」にしか存在しない。件数を数えて
   // 「1本も無い」と「あるが年齢比較できない」を区別して報告する。
-  const icpHistoricalCount = rows.filter((row) =>
+  const icpHistoricalRows = rows.filter((row) =>
     row.learningCohort === "historical_benchmark" &&
     normalizeTopicBucket(row.topic) === icpCohort.target
-  ).length;
-  const icpScopeLine = buildIcpScopeLine(icpCohort, icpHistoricalCount);
+  );
+  const icpScopeLine = buildIcpScopeLine(icpCohort, icpHistoricalRows.length);
+  // R29: 順位付けと手本提示を分ける。取り込んだ ICP 履歴は lifetime cumulative
+  // なので winners には載せない (期間基準の混在は #4367 で禁止) が、
+  // 「どのフックがこの受け手にクリックされたか」は手本として渡す。
+  // 返済報告カードの共有は HITL 厳守でクリップボード専用のため、ICP の実績は
+  // 事実上ここにしか存在しない。
+  const icpExemplarLine = buildIcpHistoricalExemplarLine(
+    icpHistoricalRows,
+    (row) => row.urlClicks,
+    (row) => row.impressions,
+    (row) => row.text,
+    icpCohort.target,
+  );
   const winners = icpCohort.sufficient ? icpCohort.rows.slice(0, 5) : [];
   const underperformers = icpCohort.sufficient
     ? icpCohort.rows.slice(-5).reverse()
@@ -1383,6 +1396,7 @@ function buildXPerformanceContextFromLogs(
       `Optimize for site visits and replies, not for raw reach.`,
       ...(acquisitionLine ? [acquisitionLine] : []),
       icpScopeLine,
+      ...(icpExemplarLine ? [icpExemplarLine] : []),
       ...winners.map((row, index) =>
         `Winner ${
           index + 1

--- a/supabase/functions/growth-hub/x_topic_audience.ts
+++ b/supabase/functions/growth-hub/x_topic_audience.ts
@@ -297,3 +297,47 @@ export function buildIcpScopeLine<T>(
   return `${base} No ICP post has been measured at all yet — write for the ` +
     `ICP first, then collect measurements.`;
 }
+
+/// R29: ICP コホートの「手本」を、取り込んだ履歴から供給する。
+///
+/// なぜ必要か: ICP (借金・リボ) の投稿は、返済報告カードの共有が HITL 厳守で
+/// クリップボード専用のため `x_post_log` に入らない。実績は CSV 取込の
+/// `historical_benchmark` 行にしか存在せず、それは lifetime cumulative なので
+/// 年齢正規化ランキング (winners) には載せられない。結果、ICP 向けに何本
+/// 投稿しても「手本ゼロ」のままだった。
+///
+/// ここでは順位付けと手本提示を分ける。**順位付けには使わない** (期間基準の
+/// 混在は #4367 で禁止した) が、**どのフックがこの受け手にクリックされたか**は
+/// 手本として渡す。ランキングの主張はせず、事実と出所を明示する。
+///
+/// 返すのは URL クリック降順の上位。クリック 0 件しか無いときは、
+/// 「この受け手ではまだ 1 クリックも出ていない」ことを事実として返す
+/// (沈黙すると「手本が無い」と「手本はあるが効いていない」が混ざる)。
+export function buildIcpHistoricalExemplarLine<T>(
+  rows: readonly T[],
+  urlClicksOf: (row: T) => number,
+  impressionsOf: (row: T) => number | null,
+  hookOf: (row: T) => string,
+  target: TopicBucket = ICP_TARGET_TOPIC,
+  limit = 3,
+): string | null {
+  if (rows.length === 0) return null;
+  const withClicks = rows.filter((row) => urlClicksOf(row) > 0);
+  if (withClicks.length === 0) {
+    return `ICP exemplars (topic=${target}, imported lifetime-cumulative, ` +
+      `n=${rows.length}): none of them produced a single url click. Do not ` +
+      `reuse their shape as a proven pattern — nothing about this audience ` +
+      `has converted yet. Treat the next post as a fresh test.`;
+  }
+  const top = [...withClicks]
+    .sort((left, right) => urlClicksOf(right) - urlClicksOf(left))
+    .slice(0, limit);
+  const parts = top.map((row) =>
+    `${urlClicksOf(row)} clicks / ${impressionsOf(row) ?? "unknown"} imp — ` +
+    `"${hookOf(row)}"`
+  );
+  return `ICP exemplars (topic=${target}, imported lifetime-cumulative, ` +
+    `${withClicks.length}/${rows.length} posts got >=1 click): ` +
+    `${parts.join(" | ")}. These are NOT age-normalized and are excluded ` +
+    `from the winner ranking — copy their structure, not their rank.`;
+}

--- a/supabase/functions/growth-hub/x_topic_audience_test.ts
+++ b/supabase/functions/growth-hub/x_topic_audience_test.ts
@@ -4,6 +4,7 @@ import {
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   buildArchetypeTopicInteractionLine,
+  buildIcpHistoricalExemplarLine,
   buildIcpScopeLine,
   buildTopicLiftLine,
   classifyPostTopic,
@@ -210,4 +211,48 @@ Deno.test("buildIcpScopeLine: 十分なら履歴件数に関わらずスコー�
     buildIcpScopeLine(enough, 9).includes("scoped to topic=debt_recovery"),
   );
   assert(!buildIcpScopeLine(enough, 9).includes("imported historical"));
+});
+
+// R29: 取り込んだ ICP 履歴を「順位付けせず手本として」渡す。
+type Ex = { c: number; i: number | null; t: string };
+const exLine = (rows: Ex[]) =>
+  buildIcpHistoricalExemplarLine(
+    rows,
+    (r) => r.c,
+    (r) => r.i,
+    (r) => r.t,
+  );
+
+Deno.test("buildIcpHistoricalExemplarLine: 履歴が無ければ沈黙", () => {
+  assertEquals(exLine([]), null);
+});
+
+Deno.test("buildIcpHistoricalExemplarLine: 全件0クリックなら『効いていない』と言う", () => {
+  const line = exLine([
+    { c: 0, i: 120, t: "残債を減らした話" },
+    { c: 0, i: 80, t: "リボの利息を計算した" },
+  ]);
+  assert(line !== null);
+  // 「手本が無い」と「手本はあるが効いていない」を混ぜない。
+  assert(line!.includes("none of them produced a single url click"));
+  assert(line!.includes("fresh test"));
+  assert(!line!.includes("copy their structure"));
+});
+
+Deno.test("buildIcpHistoricalExemplarLine: クリック降順で手本を出す", () => {
+  const line = exLine([
+    { c: 1, i: 300, t: "低クリック" },
+    { c: 9, i: 4000, t: "高クリック" },
+    { c: 0, i: 50, t: "ゼロ" },
+    { c: 4, i: 900, t: "中クリック" },
+  ]);
+  assert(line !== null);
+  assert(line!.indexOf("高クリック") < line!.indexOf("中クリック"));
+  assert(!line!.includes("ゼロ"), "0クリックは手本にしない");
+  assert(line!.includes("2/4") === false);
+  assert(line!.includes("3/4 posts got >=1 click"));
+  // 順位の主張はしない = ランキングから除外されている旨を必ず添える。
+  assert(line!.includes("NOT age-normalized"));
+  assert(line!.includes("excluded"));
+  assert(line!.includes("copy their structure, not their rank"));
 });


### PR DESCRIPTION
## なぜ

[#4374](https://github.com/kanta13jp1/my_web_app/pull/4374) で勝者選定を ICP コホートへスコープし、[#4382](https://github.com/kanta13jp1/my_web_app/pull/4382) でそこへ到達する経路が無いことを報告できるようにした。ただし **ICP の手本は依然ゼロのまま**だった。

理由は `debt_progress_share_dialog.dart` の意図的な制約:

> 🔴 **HITL 厳守**: ここから自動投稿はしない。カード画像と下書き文面を用意するだけで、実際に X へ投稿するかどうか・何を書くかは必ず本人が決める。公開すると取り消せない個人情報なので、自動化してはいけない。

**この制約は覆さない。** 自動投稿経路を足す案は破棄した。

結果、ICP の実績は CSV 取込の `historical_benchmark` 行にしか存在しない。それは lifetime cumulative なので年齢正規化ランキング（winners）には載せられない（期間基準の混在は [#4367](https://github.com/kanta13jp1/my_web_app/pull/4367) で禁止した）。ICP 向けに何本投稿しても手本が出ない状態だった。

## 何を変えたか

**順位付けと手本提示を分ける。** 順位付けには使わないが、「どのフックがこの受け手にクリックされたか」は手本として渡す。ランキングの主張はせず、出所と非比較性を必ず添える。

- URL クリック降順の上位3件を提示。0クリックの行は手本にしない。
- **全件0クリックのときは沈黙せず**「この受け手ではまだ1クリックも出ていない。次は fresh test として扱え」と返す。「手本が無い」と「手本はあるが効いていない」を混ぜないため。
- 提示時は必ず `NOT age-normalized` / `excluded from the winner ranking` / `copy their structure, not their rank` を添える。

`winners` の構成には一切触れていないため、#4367 の「採点は全項同じ期間基準」も維持される。

## 現状の実データでの挙動

07-29 に 350 件を取り込み済み。分類結果は `debt_recovery` が **0 件**なので、本 PR の行は当面出ない（`rows.length === 0` → null）。ユーザーが ICP 向けに投稿し、次回 CSV を取り込んだ時点から機能する。

## Minimal E2E Gate

- 検証は **実装詳細に依存しない** 入出力ベース: 履歴行の配列を渡し、返る文字列に含まれる語と並び順だけで判定する。内部のソートや整形の構造には触れない。
- **最小限の3ケース**: (1) 履歴0件 → null（沈黙） (2) 全件0クリック → 「1クリックも出ていない / fresh test」で、手本の文言は出さない (3) クリックあり → 降順で並び、0クリック行は除外され、非比較性の注記が付く。
- E2E-Exception: 変更は Deno Edge Function の純ロジックで、Flutter Web のアプリバンドルに入らない。ブラウザ E2E から到達する UI 経路が無いため integration_test / playwright の対象にならない。`deno test` の入出力レベルで固定した。

## 検証

- `x_topic_audience_test.ts`: **17 passed**（新規3）
- 併せて `x_acquisition_score_test.ts` と合計 **27 passed**
- pre-commit fast quality gate: `flutter analyze` No issues found / deno lint 194 files

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 追加は performance_context に出す説明行を組み立てる純関数1つと、その呼び出し1箇所のみ。スコア計算・ランキング・投稿経路のいずれにも触れておらず、データが無いときは null で沈黙する。個人情報の公開に関わる HITL 制約は変更していない（むしろそれを前提に設計した）。新規3件を含む27件のテストと全体 analyze / deno lint で回帰を確認済み。

Refs #4382, #4373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
