### PR TITLE
fix(ci): stop high-risk gate from flagging unrelated changes

### DIFF
--- a/.github/workflows/claude-agent-review.yml
+++ b/.github/workflows/claude-agent-review.yml
@@ -281,9 +281,14 @@ jobs:
       - name: Collect changed files
         run: |
           mkdir -p .ci-logs
+          # Three-dot (base...head) diffs from the MERGE BASE, i.e. only what this
+          # PR changed. Two separate args (base head) is a two-dot diff against the
+          # base *tip*, so every file that landed on main after the branch point
+          # gets attributed to this PR. #4248 measured 1 real file reported as 97,
+          # which dragged unrelated PRs into the high-risk path patterns.
+          # fetch-depth: 0 above guarantees the merge base is present.
           git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             > .ci-logs/high-risk-changed-files.txt
 
       - name: Check high-risk ultrareview contract

--- a/scripts/check_high_risk_ultrareview_gate.py
+++ b/scripts/check_high_risk_ultrareview_gate.py
@@ -201,8 +201,39 @@ def path_risk_reasons(changed_files: list[str]) -> list[str]:
     return reasons
 
 
+# Dependency-bump PRs (dependabot etc.) paste the upstream project's release
+# notes and changelog into the body inside <details> blocks. Those are not words
+# the PR author wrote about *this* change, but the keyword scan used to read them
+# and flag the PR high-risk on its own.
+#
+# Measured on #4257 (a one-line `google-genai` version bump): the body contained
+# `token` x1 and `auth` x2, and **all three hits sat inside <details> blocks** --
+# upstream commit subjects like "Support mTLS in custom client using google auth
+# mtls.get_default_ssl_context". The PR touched no risky path and carried no
+# risky label, yet the gate demanded an ultrareview declaration.
+#
+# Collapsed sections are therefore excluded before matching. Text the author
+# actually wrote in the visible description still counts, so a genuinely risky
+# PR is unaffected; path and label signals are untouched either way.
+COLLAPSED_SECTION_RE = re.compile(
+    r"<details\b.*?</details\s*>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
+def strip_collapsed_sections(body: str) -> str:
+    """Drop <details>…</details> regions so quoted upstream notes are not scanned.
+
+    An unclosed <details> (truncated body) drops the remainder as well, which is
+    the safe direction here: everything after the marker is quoted material.
+    """
+    stripped = COLLAPSED_SECTION_RE.sub(" ", body)
+    opener = re.search(r"<details\b", stripped, flags=re.IGNORECASE)
+    return stripped[: opener.start()] if opener else stripped
+
+
 def text_risk_reasons(title: str, body: str) -> list[str]:
-    text = f"{title}\n{body}"
+    text = f"{title}\n{strip_collapsed_sections(body)}"
     if has_any(HIGH_RISK_TEXT_PATTERNS, text):
         return ["Title/body contains high-risk keywords."]
     return []

--- a/scripts/check_high_risk_ultrareview_gate_test.py
+++ b/scripts/check_high_risk_ultrareview_gate_test.py
@@ -12,8 +12,24 @@ from check_high_risk_ultrareview_gate import (
     missing_perspectives,
     passing_evidence_block,
     passing_exception_block,
+    strip_collapsed_sections,
+    text_risk_reasons,
     validate,
 )
+
+# Trimmed from the real body of #4257 ("deps: update google-genai requirement"),
+# a one-line version bump that the gate used to flag high-risk. All keyword hits
+# live inside the <details> blocks dependabot pastes upstream release notes into.
+DEPENDABOT_BODY = """\
+Updates the requirements on [google-genai](https://github.com/googleapis/python-genai) to permit the latest version.
+<details>
+<summary>Release notes</summary>
+<blockquote>
+<li>Support mTLS in custom client using google auth mtls.get_default_ssl_context</li>
+<li>Populate per-modality prompt token count in embedding responses</li>
+</blockquote>
+</details>
+"""
 
 
 GOOD_BODY = """
@@ -167,6 +183,54 @@ class PassingBlockTest(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         ok, messages, _, _ = validate(buffer.getvalue(), self.HIGH_RISK_FILES, set())
         self.assertTrue(ok, messages)
+
+
+class CollapsedSectionTextRiskTest(unittest.TestCase):
+    """#4257 regression: quoted upstream notes must not make a PR high-risk."""
+
+    def test_dependabot_release_notes_do_not_trigger_text_risk(self) -> None:
+        self.assertEqual(
+            text_risk_reasons(
+                "deps: update google-genai requirement from <3.0.0,>=2.12.0",
+                DEPENDABOT_BODY,
+            ),
+            [],
+        )
+
+    def test_keywords_written_by_the_author_still_trigger(self) -> None:
+        self.assertTrue(
+            text_risk_reasons("fix: rotate key", "This changes the auth flow.")
+        )
+
+    def test_title_keywords_still_trigger(self) -> None:
+        self.assertTrue(text_risk_reasons("fix(billing): stripe webhook", "see below"))
+
+    def test_author_text_outside_details_still_counts(self) -> None:
+        # A risky sentence next to quoted notes must not be masked by the strip.
+        body = "We rotate the service role token here.\n" + DEPENDABOT_BODY
+        self.assertTrue(text_risk_reasons("deps: bump x", body))
+
+    def test_unclosed_details_drops_the_remainder(self) -> None:
+        # Truncated bodies keep the quoted tail out of the scan.
+        self.assertEqual(
+            strip_collapsed_sections("visible part\n<details>\n<p>auth token</p>"),
+            "visible part\n",
+        )
+
+    def test_body_without_details_is_unchanged(self) -> None:
+        self.assertEqual(strip_collapsed_sections("plain body"), "plain body")
+
+    def test_multiple_details_blocks_are_all_removed(self) -> None:
+        body = "<details>auth</details>middle<details>token</details>"
+        self.assertNotIn("auth", strip_collapsed_sections(body))
+        self.assertNotIn("token", strip_collapsed_sections(body))
+        self.assertIn("middle", strip_collapsed_sections(body))
+
+    def test_details_with_attributes_is_removed(self) -> None:
+        self.assertEqual(
+            text_risk_reasons("deps: bump x", '<details open id="n">auth</details>'),
+            [],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

high-risk ultrareview gate の誤検知は **2 系統**あり、片方だけ直しても効果が出ない。両方を直す。

## ① two-dot diff が他人のコミットを PR の変更として数える

`claude-agent-review.yml` の changed-files 収集がこうなっていた:

```yaml
git diff --name-only "<base.sha>" "<head.sha>"   # 引数2つ = two-dot
```

two-dot は base の**先端**との比較なので、PR が分岐した後に main へ入った**無関係なコミットのファイル**までこの PR の変更として計上される。`#4248` 実測で 1 ファイルが **97 ファイル**として報告され、`HIGH_RISK_PATH_PATTERNS` に引っかかっていた。

merge base から見る three-dot (`base...head`) へ変更。同 job は既に `fetch-depth: 0` なので merge base は必ず取得済み。

## ② 引用された upstream changelog の 1 語で単独 FAIL

dependabot 系 PR は upstream の release notes を `<details>` ブロックに貼り付ける。そこは PR 作成者が「この変更について」書いた文章ではないのに、キーワード走査の対象になっていた。

**推測ではなく実入力で確認した。** `#4257`（`google-genai` の 1 行 bump）の本文を本物のマッチャに通したところ:

```
MATCH '\btoken\b': 1 hit
MATCH '\bauth\b' : 2 hits
```

そして 3 件**すべてが `<details>` の中**だった:

> `Support mTLS in custom client using google auth mtls.get_default_ssl_context`
> `Populate per-modality prompt token count in embedding responses`

この PR は危険パス 0・危険ラベル 0 なのに ultrareview 宣言を要求されていた。

text 走査の前に `<details>…</details>` を除去する。**可視の説明文に作成者が書いた語は従来どおり検出**され、path / label の判定は一切変更しない。

実 `#4257` 本文での before / after:

| | 判定 |
|---|---|
| BEFORE | `Title/body contains high-risk keywords.` |
| AFTER | 該当なし |

## 変更

| ファイル | 内容 |
|---|---|
| `scripts/check_high_risk_ultrareview_gate.py` | `strip_collapsed_sections()` 追加、`text_risk_reasons()` で適用 |
| `.github/workflows/claude-agent-review.yml` | changed-files 収集を three-dot へ |
| `scripts/check_high_risk_ultrareview_gate_test.py` | 回帰 8 ケース追加 |

追加テストは「捕まえる」と「捕まえない」を対で書いてある: 実 #4257 由来の本文で非該当 / 作成者が書いた語は検出継続 / 可視テキストと `<details>` の併存 / 属性付き `<details open id="n">` / 閉じタグ欠落 / 複数ブロック / title のみ。

## 検証

```
python -m unittest check_high_risk_ultrareview_gate_test
→ Ran 20 tests ... OK   (既存 12 + 新規 8)
```

ローカル pre-commit gate 全通過（`flutter analyze` → No issues found / `deno lint` → Checked 194 files）。

## 注記

この PR 自身は `.github/workflows/claude-agent-review.yml` を触るため high-risk と判定される。これは `HIGH_RISK_PATH_PATTERNS` の**正しい**マッチ（誤検知ではない）なので、下記の例外宣言で通す。

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI gate logic only; no runtime, auth, migration, or deploy surface is touched. Both changes narrow what the gate treats as risky, verified against the real #4257 body and covered by 20 unit tests that also pin the detection that must keep firing.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CI gate logic change with no runtime or UI surface; covered by 20 unit tests including a regression case built from the real #4257 body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
