### PR TITLE
fix(ci): three-dot diff in minimal E2E gate (2 remaining sites)

### DIFF
--- a/.github/workflows/minimal-e2e-gate.yml
+++ b/.github/workflows/minimal-e2e-gate.yml
@@ -51,9 +51,13 @@ jobs:
       - name: Collect changed files
         run: |
           mkdir -p .ci-logs
+          # Three-dot (base...head) diffs from the MERGE BASE = only this PR's
+          # changes. Two separate args is a two-dot diff against the base *tip*,
+          # so files that landed on main after the branch point get attributed
+          # here, turning docs-only PRs into "application code changed".
+          # fetch-depth: 0 above guarantees the merge base is present.
           git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             > .ci-logs/changed-files.txt
 
       - name: Skip if docs-only change
@@ -187,9 +191,11 @@ jobs:
         id: docs_check
         if: github.event_name == 'pull_request'
         run: |
+          # Three-dot: see the note on the same diff in the gate job above.
+          # A two-dot diff here made the docs-only exemption drop out whenever
+          # unrelated code landed on main after the branch point.
           git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             > /tmp/e2e-changed-files.txt
           DOCS_ONLY=true
           while IFS= read -r f; do


### PR DESCRIPTION
## 概要

[#4401](https://github.com/kanta13jp1/my_web_app/pull/4401) で high-risk gate 側の two-dot diff を直したが、**同じ誤りは 3 箇所あり、1 箇所しか直っていなかった**。残る 2 箇所を直す follow-up。

| 箇所 | 状態 |
|---|---|
| `claude-agent-review.yml` changed-files | ✅ #4401 で修正済 |
| `minimal-e2e-gate.yml:54` gate job | 🔧 この PR |
| `minimal-e2e-gate.yml:190` docs-only 判定 | 🔧 この PR |

## 何が起きるか

two-dot (`<base> <head>` = 引数 2 つ) は base の**先端**との比較なので、PR が分岐した後に main へ入った無関係なコミットのファイルまでこの PR の変更として計上される。

E2E ゲート側では、これが **docs-only 免除を外す**方向に効く。docs しか触っていない PR でも「アプリコードが変更された」と判定され、E2E 宣言を要求される。main は日に何度も進むので、数時間前に分岐した PR はほぼ確実に影響を受ける。

merge base から見る three-dot (`base...head`) へ変更。両 job とも既に `fetch-depth: 0` なので追加変更は不要。

## 触らなかったもの

`minimal-e2e-gate.yml:89` の `--range "<base>..<head>"` は **変更していない**。こちらは `git log` に渡す rev-range で、two-dot が正しい意味を持つ（`git diff` の two-dot とは別物）。ここを直すと逆に壊れる。

## 検証

```
$ grep -A3 'git diff --name-only' .github/workflows/minimal-e2e-gate.yml | grep 'sha }}'
60-  "...base.sha }}...${{ ...head.sha }}" \
198-  "...base.sha }}...${{ ...head.sha }}" \

$ # .github/workflows/*.yml 全体で two-dot git diff の残存
(0 件)
```

ローカル pre-commit gate 全通過（`flutter analyze` → No issues found / gate 単体テスト 20 passed）。

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI gate wiring only; a single git diff range operator per site, no runtime, auth, migration, or deploy surface. The change strictly narrows what the gate counts as this PR's files, and the git log rev-range on line 89 is deliberately left as two-dot.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CI gate wiring only (git diff range operator); no runtime, UI, or test surface. Verified there are zero remaining two-dot git-diff sites in .github/workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
