### PR TITLE
feat(stripe): 全額返金でダウンロード権利を失効させる

### DIFF
--- a/docs/HEXCIV_PAID_DOWNLOAD.md
+++ b/docs/HEXCIV_PAID_DOWNLOAD.md
@@ -48,7 +48,7 @@ RLS の方針は「**読みは本人分だけ・書きは service role だけ**�
 | 関数 | 役割 | 要点 |
 |---|---|---|
 | `shop-checkout` | Checkout セッション作成 | 金額は**決めない**。Stripe の Price を参照するだけ (価格の二重管理を避ける)。`metadata` に `user_id` と `shop_product_id` を載せる |
-| `stripe-webhook` (拡張) | 購入行の作成 | `stripe_checkout_session_id` の unique + `onConflict` で**再送に対して冪等**。`payment_status` が paid でなければ `pending` で作る |
+| `stripe-webhook` (拡張) | 購入行の作成 / 返金時の権利失効 | `stripe_checkout_session_id` の unique + `onConflict` で**再送に対して冪等**。`payment_status` が paid でなければ `pending` で作る。`charge.refunded` (全額) で `status` を `refunded` にする |
 | `shop-download` | 署名付きURL発行 | 権利確認 → 有効期限 **5分**の URL。販売停止 (`is_active=false`) でも**購入済みの人には配信する** |
 
 ### Stripe API バージョン (2026-07-29)
@@ -141,8 +141,14 @@ update public.shop_products set is_active = true where id = 'hexciv-win64';
 - **発行回数は記録するが止めていない**。PC 故障や再インストールでの正当な
   再ダウンロードを機械的に阻むと、問い合わせ対応の方が高くつくため。
   `shop_download_events` を定期的に見て、異常な回数があれば個別に対処する。
-- **返金時**: Stripe 側で返金しても `shop_purchases.status` は自動では変わらない。
-  現状は手動で `refunded` に更新する必要がある (`charge.refunded` の webhook 対応は未実装)。
+- **返金時**: `charge.refunded` を受けて `shop_purchases.status` を `refunded` に
+  自動更新する (2026-07-30 実装 / 手動更新は不要になった)。紐付けは
+  `stripe_payment_intent_id`。**失効させるのは全額返金のときだけ** —
+  部分返金で権利を消すと、支払った分が残っている利用者から取り上げてしまう。
+  🔴 **Stripe 側で `charge.refunded` を購読していないと、この分岐は永久に動かない。**
+  Webhook endpoint の送信イベント一覧に入っているか確認すること (入っていなくても
+  コードも CI も緑のままなので、気付く手掛かりが無い)。動作確認は返金を 1 件試して
+  EF ログに `refund_revoked` が出るかを見るのが確実。
 - **版を上げるとき**: `pack_release.ps1` を実行 → 新しい zip をバケットへ配置 →
   `shop_products` の `version` / `storage_path` / `sha256` / `file_size_bytes` を更新。
   購入済みの利用者は追加の支払いなく最新版を落とせる (権利は商品単位のため)。
@@ -150,6 +156,6 @@ update public.shop_products set is_active = true where id = 'hexciv-win64';
 ## まだ無いもの
 
 - 購入・ダウンロードの UI (商品ページ / マイダウンロードページ)
-- `charge.refunded` を受けて `status` を `refunded` にする webhook 分岐
+- 部分返金の扱い (現状は権利を残すだけで、記録もしていない)
 - 領収書の発行 (Stripe の領収書メールで代替可能かは要判断)
 - Windows 以外のビルド

--- a/supabase/functions/stripe-webhook/event_processing.test.ts
+++ b/supabase/functions/stripe-webhook/event_processing.test.ts
@@ -3,6 +3,7 @@ import {
   assertRejects,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
+  chargeRefundDecision,
   checkoutPaymentDecision,
   claimStripeWebhookEvent,
   completeStripeWebhookEvent,
@@ -10,6 +11,28 @@ import {
   processStripeWebhookEventOnce,
   StripeWebhookRpcClient,
 } from "./event_processing.ts";
+
+/**
+ * `charge.refunded` の実 payload の形をそのまま再現する fixture。
+ * HexCiv 買い切り (¥500) の全額返金を想定。
+ */
+function refundedCharge(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: "ch_1QxYzAIriTNCQL2hexciv",
+    object: "charge",
+    amount: 500,
+    amount_refunded: 500,
+    currency: "jpy",
+    captured: true,
+    paid: true,
+    refunded: true,
+    payment_intent: "pi_1QxYzAIriTNCQL2hexciv",
+    status: "succeeded",
+    ...overrides,
+  };
+}
 
 class FakeRpcClient implements StripeWebhookRpcClient {
   calls: Array<{ functionName: string; args: Record<string, unknown> }> = [];
@@ -40,6 +63,74 @@ Deno.test("checkoutPaymentDecision only fulfills paid sessions", () => {
     paymentStatus: "",
     reason: "checkout_not_paid",
   });
+});
+
+Deno.test("chargeRefundDecision revokes access on a full refund", () => {
+  assertEquals(chargeRefundDecision(refundedCharge()), {
+    shouldRevoke: true,
+    paymentIntentId: "pi_1QxYzAIriTNCQL2hexciv",
+    amount: 500,
+    amountRefunded: 500,
+    reason: null,
+  });
+});
+
+Deno.test("chargeRefundDecision keeps access on a partial refund", () => {
+  // 部分返金で権利を消すと、支払った分が残っている利用者から取り上げてしまう。
+  assertEquals(
+    chargeRefundDecision(
+      refundedCharge({ refunded: false, amount_refunded: 200 }),
+    ),
+    {
+      shouldRevoke: false,
+      paymentIntentId: "pi_1QxYzAIriTNCQL2hexciv",
+      amount: 500,
+      amountRefunded: 200,
+      reason: "partial_refund",
+    },
+  );
+});
+
+Deno.test("chargeRefundDecision revokes when either full-refund signal fires", () => {
+  // 2 根拠の OR。片方のフィールドが API バージョンで移動しても
+  // 「返金済みなのに権利が残る」側へ倒れないことを固定する。
+  assertEquals(
+    chargeRefundDecision(refundedCharge({ refunded: false })).shouldRevoke,
+    true,
+    "amount_refunded >= amount だけでも失効させる",
+  );
+  assertEquals(
+    chargeRefundDecision(
+      refundedCharge({ amount: 0, amount_refunded: 0 }),
+    ).shouldRevoke,
+    true,
+    "refunded=true だけでも失効させる",
+  );
+});
+
+Deno.test("chargeRefundDecision unwraps an expanded payment intent", () => {
+  const decision = chargeRefundDecision(refundedCharge({
+    payment_intent: {
+      id: "pi_expanded",
+      object: "payment_intent",
+      status: "succeeded",
+    },
+  }));
+  assertEquals(decision.paymentIntentId, "pi_expanded");
+  assertEquals(decision.shouldRevoke, true);
+});
+
+Deno.test("chargeRefundDecision cannot act without a payment intent", () => {
+  // 紐付けキーが無い返金を「対象なし」と黙って流すと取りこぼしになるため、
+  // 理由を分けて呼び出し側がログに出せるようにする。
+  for (const value of [null, undefined, "", "   ", 42]) {
+    const decision = chargeRefundDecision(
+      refundedCharge({ payment_intent: value }),
+    );
+    assertEquals(decision.shouldRevoke, false);
+    assertEquals(decision.paymentIntentId, "");
+    assertEquals(decision.reason, "missing_payment_intent");
+  }
 });
 
 Deno.test("claimStripeWebhookEvent claims a new or retryable event", async () => {

--- a/supabase/functions/stripe-webhook/event_processing.ts
+++ b/supabase/functions/stripe-webhook/event_processing.ts
@@ -1,3 +1,5 @@
+import { referenceId } from "./stripe_api_compat.ts";
+
 export type RpcError = { message: string } | null;
 
 export type StripeWebhookRpcClient = {
@@ -13,12 +15,86 @@ export type CheckoutPaymentDecision = {
   reason: "checkout_not_paid" | null;
 };
 
+export type ChargeRefundDecision = {
+  shouldRevoke: boolean;
+  paymentIntentId: string;
+  amount: number;
+  amountRefunded: number;
+  reason: "missing_payment_intent" | "partial_refund" | null;
+};
+
 export type StripeEventProcessingResult<T> =
   | { duplicate: true }
   | { duplicate: false; value: T };
 
 function normalizedString(value: unknown): string {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function integerOrZero(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.trunc(parsed) : 0;
+  }
+  return 0;
+}
+
+/**
+ * `charge.refunded` を受けて、ダウンロード権利を失効させるべきかを判定する
+ * (2026-07-30 追加)。
+ *
+ * `charge.refunded` は**部分返金でも届く**。部分返金で権利を消すと、
+ * 支払った分が残っている利用者から取り上げてしまうので、失効させるのは
+ * 全額返金のときだけにする。
+ *
+ * 全額判定を 2 つの根拠の **OR** にしているのは意図的。`charge.refunded`
+ * (= 全額返金のときだけ true) と `amount_refunded >= amount` はどちらも
+ * 単独で全額返金を示すが、片方のフィールドが API バージョンで移動しても
+ * **「返金済みなのに権利が残る」側へ倒れない**ようにしたい。この誤りの向きは
+ * 非対称で、取りこぼし (返金者が商品を持ち続ける) の方が、部分返金を
+ * 全額と誤判定する場合より損害が大きい。
+ */
+export function chargeRefundDecision(
+  charge: Record<string, unknown>,
+): ChargeRefundDecision {
+  // expand されて object になっている場合も ID を拾う。
+  const paymentIntentId = referenceId(charge.payment_intent);
+  const amount = integerOrZero(charge.amount);
+  const amountRefunded = integerOrZero(charge.amount_refunded);
+
+  // payment intent が無いと、どの購入行なのか特定できない。
+  if (!paymentIntentId) {
+    return {
+      shouldRevoke: false,
+      paymentIntentId: "",
+      amount,
+      amountRefunded,
+      reason: "missing_payment_intent",
+    };
+  }
+
+  const fullyRefunded = charge.refunded === true ||
+    (amount > 0 && amountRefunded >= amount);
+  if (!fullyRefunded) {
+    return {
+      shouldRevoke: false,
+      paymentIntentId,
+      amount,
+      amountRefunded,
+      reason: "partial_refund",
+    };
+  }
+
+  return {
+    shouldRevoke: true,
+    paymentIntentId,
+    amount,
+    amountRefunded,
+    reason: null,
+  };
 }
 
 export function checkoutPaymentDecision(

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 import {
+  chargeRefundDecision,
   checkoutPaymentDecision,
   processStripeWebhookEventOnce,
 } from "./event_processing.ts";
@@ -388,6 +389,64 @@ async function handleCheckoutCompleted(
   );
 }
 
+/**
+ * 返金を受けてダウンロード権利を失効させる (2026-07-30 追加)。
+ *
+ * `shop_purchases` の status='paid' の行がそのまま権利なので (shop-download は
+ * この行だけを見る)、返金後もその行が残っていると**返金したのに落とせる**状態が
+ * 続く。これまでは手動で status を更新する必要があった。
+ *
+ * 対象の特定は `stripe_payment_intent_id`。サブスクの請求に対する返金でも同じ
+ * `charge.refunded` が届くが、その payment intent に一致する購入行は無いので
+ * 0 件更新で素通りする (エラーにしない)。ただし「0 件だった」ことは必ず残す —
+ * 本当に権利を消せていない取りこぼしと区別できなくなるため。
+ *
+ * 冪等性: 同じ payment intent に何度届いても status='refunded' を書くだけなので
+ * 結果は変わらない。`neq` で既に refunded の行を除くのは、updated_at を
+ * 無意味に動かして「いつ返金処理したか」を分からなくしないため。
+ */
+async function markShopPurchaseRefunded(
+  admin: SupabaseClient,
+  charge: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const decision = chargeRefundDecision(charge);
+  const chargeId = asString(charge.id);
+
+  if (!decision.shouldRevoke) {
+    console.warn(
+      "[stripe-webhook] refund did not revoke shop access",
+      JSON.stringify({
+        charge_id: chargeId,
+        reason: decision.reason,
+        amount: decision.amount,
+        amount_refunded: decision.amountRefunded,
+      }),
+    );
+    return { refund_revoked: 0, reason: decision.reason };
+  }
+
+  const { data, error } = await admin
+    .from("shop_purchases")
+    .update({ status: "refunded" })
+    .eq("stripe_payment_intent_id", decision.paymentIntentId)
+    .neq("status", "refunded")
+    .select("id");
+  if (error) throw new Error(error.message);
+
+  const revoked = Array.isArray(data) ? data.length : 0;
+  if (revoked === 0) {
+    // サブスク返金なら正常。買い切りの返金でここに来たら紐付けが壊れている。
+    console.warn(
+      "[stripe-webhook] refund matched no shop purchase",
+      JSON.stringify({
+        charge_id: chargeId,
+        payment_intent: decision.paymentIntentId,
+      }),
+    );
+  }
+  return { refund_revoked: revoked };
+}
+
 async function markPastDue(
   admin: SupabaseClient,
   invoice: Record<string, unknown>,
@@ -454,6 +513,8 @@ serve(async (req: Request) => {
           await upsertSubscriptionFromStripe(admin, data);
         } else if (type === "invoice.payment_failed") {
           await markPastDue(admin, data);
+        } else if (type === "charge.refunded") {
+          result = await markShopPurchaseRefunded(admin, data);
         }
 
         return result;

--- a/supabase/functions/stripe-webhook/stripe_api_compat.ts
+++ b/supabase/functions/stripe-webhook/stripe_api_compat.ts
@@ -36,7 +36,7 @@ function asRecord(value: unknown): Record<string, unknown> | null {
  * Stripe の参照フィールドは expand 指定で文字列 ID から object に化けるため、
  * 文字列だけを想定すると展開されていた場合に黙って空文字になる。
  */
-function referenceId(value: unknown): string {
+export function referenceId(value: unknown): string {
   if (typeof value === "string") return value.trim();
   const id = asRecord(value)?.id;
   return typeof id === "string" ? id.trim() : "";


### PR DESCRIPTION
## 背景

`shop_purchases` の `status='paid'` の行が**そのままダウンロード権利**になっている
(`shop-download` はこの行だけを見る)。そのため Stripe 側で返金しても行が残り、
**返金したのに落とせる**状態が続いていた。これまでは手動で status を更新する運用。

`docs/HEXCIV_PAID_DOWNLOAD.md` の「まだ無いもの」に挙がっていた項目の消化。

## 変更内容

`charge.refunded` を受けて `stripe_payment_intent_id` で購入行を特定し
`status='refunded'` にする。判定は純関数 `chargeRefundDecision()` に切り出した
(`index.ts` は `serve()` を呼ぶため import できずテストできないので)。

### 失効させるのは全額返金のときだけ

`charge.refunded` は**部分返金でも届く**。無条件に失効させると、支払った分が
残っている利用者から取り上げてしまう。

### 全額判定を OR にした理由

`charge.refunded === true` と `amount_refunded >= amount` の **OR** で判定する。
どちらも単独で全額返金を示すが、片方が API バージョンで移動しても
**「返金済みなのに権利が残る」側へ倒れない**ようにしている。

この誤りの向きは非対称で、取りこぼし (返金者が商品を持ち続ける) の方が、
部分返金を全額と誤判定する場合より損害が大きい。直前の #4391 が
「フィールドが黙って移動して読めなくなる」事故だったので、その再発に対して
安全側に倒れる形を選んだ。

### 何もしなかった場合を潰す

サブスク請求の返金でも同じイベントが届くが、一致する購入行が無いので 0 件更新で
素通りする (エラーにしない)。ただし **0 件だったことは `console.warn` に残す** —
「サブスク返金だから 0 件」と「買い切りなのに紐付けが壊れていて 0 件」を
区別できなくなるため。更新件数は `refund_revoked` としてレスポンスにも返す。

### 冪等性

何度届いても同じ status を書くだけ。既に `refunded` の行は `neq` で除外している。
`shop_purchases` には `updated_at` の更新トリガーがあるので、除外しないと
再送のたびに時刻が動いて「いつ返金処理したか」が分からなくなる。

## 🔴 マージ後に必要な確認 (コード側では担保できない)

**Stripe の webhook endpoint が `charge.refunded` を購読していないと、この分岐は
永久に動かない。** コードも CI も緑のままなので気付く手掛かりが無い
(`feedback_server_action_without_execution_path` と同型)。

endpoint の送信イベント一覧を確認し、入っていなければ追加すること。
動作確認は返金を 1 件試して EF ログに `refund_revoked` が出るかを見るのが確実。

イベント台帳側にブロッカーが無いことは確認済み —
`stripe_webhook_events.event_type` は制約なしの `text` で、許可リストも無い。

## テスト

`chargeRefundDecision()` に 5 件追加 (全額 / 部分 / OR の各根拠単独 / expand された
payment intent / 紐付けキー欠落の 5 系統)。fixture は実 payload の形をそのまま再現。

- `deno lint` 195 ファイル 0 エラー
- `deno check` 通過
- `deno test` **601 passed / 0 failed** (全体・既存への影響なし)

## 変更していないもの

- 決済・購入記録の既存経路 (`recordShopPurchase` / `checkoutPaymentDecision`) は無変更
- 新規 EF ではないので `deploy-prod.yml` の変更も不要 (`stripe-webhook` は既にリスト済)
- 部分返金は権利を残すだけで**記録もしていない** — 必要になったら別途。docs の
  「まだ無いもの」に移した

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Stripe 署名検証済み webhook の charge.refunded 分岐であり、integration_test/ や Playwright からは到達できない (Stripe からの署名付き POST が必要)。判定を純関数 chargeRefundDecision() に切り出し、全額/部分/expand/紐付けキー欠落の 4 系統を deno unit test 5 件で実 payload の形のまま固定した。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: DB マイグレーション・新規 Edge Function・secret 変更をいずれも伴わない、既存 webhook ハンドラへの charge.refunded 分岐追加のみ。既存の決済・購入記録の経路は無変更で、追加分は返金時に status を refunded にする更新だけ。deno lint 195 ファイル 0 エラー / deno test 601 passed。ultrareview は課金制でユーザー起動のため CI からは実行できず、証拠の代筆は行わない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
