### PR TITLE
fix(asset): 固定額¥80,000の組み込み資金移動を撤去 (残高不足に無関係な移動提案のユーザー報告バグ)

### DIFF
--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -129,10 +129,15 @@ class AssetLiabilityPlanningService {
   /// 振替元に選んでも保存 ID がこのカードローンを指して「原資未設定」に倒れる
   /// バグの原因だった (#part341)。両者は別 ID に分離する。
   static const String jibunBankCardLoanAccountId = 'jibun_bank_card_loan';
+  // 旧・固定額(¥80,000)の組み込み資金移動タスクの ID。かつては毎ビルドで
+  // 三井住友大塚→じぶん銀行の ¥80,000 移動を自動注入していたが、これは不足額と
+  // 無関係の固定値で、給料の入金先がじぶん銀行のとき「給料入金 + 移動入金」の
+  // 二重計上になり、逆に三井住友を ¥80,000 減らして幻の不足→逆方向の提案を
+  // 生んでいた (ユーザー報告)。自動注入は撤去し、資金移動は不足額に上限が
+  // 掛かる動的提案 (_buildTransferSuggestions) に一本化した。ID 定数は、過去に
+  // 「完了」で退避された永続タスクを組み込み扱いと認識するためだけに残す。
   static const String auPayCardFundingTransferTaskId =
       'transfer_smbc_otsuka_to_jibun_aupay_card_funding';
-  static const int auPayCardFundingTransferDay = 26;
-  static const double auPayCardFundingTransferAmount = 80000;
 
   /// ハードコードされた既定固定費 (家賃/KDDI/水道/ガス) のデータ駆動定義。
   /// `buildWorkbook(includeDefaultFixedPayments: true)` で当月該当かつ未計上の
@@ -273,14 +278,8 @@ class AssetLiabilityPlanningService {
       incomePlans: incomePlans,
       accountsById: accountsById,
     );
-    final effectiveTransferTasks = _withDefaultAuPayCardFundingTransfer(
-      transferTasks: transferTasks,
-      accounts: accounts,
-      baseDate: baseDate,
-      salaryDay: salaryDay,
-    );
     final resolvedTransferTasks = _resolveTransferTasks(
-      transferTasks: effectiveTransferTasks,
+      transferTasks: transferTasks,
       accounts: accounts,
       accountsById: accountsById,
     );
@@ -1711,45 +1710,6 @@ class AssetLiabilityPlanningService {
       return a.id.compareTo(b.id);
     });
     return result;
-  }
-
-  List<AssetLiabilityTransferTask> _withDefaultAuPayCardFundingTransfer({
-    required List<AssetLiabilityTransferTask> transferTasks,
-    required List<AssetLiabilityAccount> accounts,
-    required DateTime baseDate,
-    int? salaryDay,
-  }) {
-    if (transferTasks.any(
-      (task) => task.id == auPayCardFundingTransferTaskId,
-    )) {
-      return transferTasks;
-    }
-
-    final fromAccount = _findCashLikeAccountById(
-      accounts,
-      smbcOtsukaBranchAccountId,
-    );
-    final toAccount = _findCashLikeAccountById(accounts, jibunBankAccountId);
-    if (fromAccount == null || toAccount == null) {
-      return transferTasks;
-    }
-
-    return <AssetLiabilityTransferTask>[
-      ...transferTasks,
-      AssetLiabilityTransferTask(
-        id: auPayCardFundingTransferTaskId,
-        fromAccountId: fromAccount.id,
-        fromAccountName: fromAccount.name,
-        toAccountId: toAccount.id,
-        toAccountName: toAccount.name,
-        amount: auPayCardFundingTransferAmount,
-        dueDate: _resolveCyclePaymentDate(
-          baseDate,
-          salaryDay,
-          auPayCardFundingTransferDay,
-        ),
-      ),
-    ];
   }
 
   AssetLiabilityAccount? _findCashLikeAccountById(

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1538,7 +1538,14 @@ void main() {
       expect(bankSummary.projectedBalance, -10000);
     });
 
-    test('adds monthly auPay card funding transfer to Jibun bank', () {
+    test('no longer injects a hardcoded auPay funding transfer', () {
+      // The old code auto-injected a fixed 80,000 transfer (SMBC Otsuka ->
+      // Jibun bank) on every build. It was unrelated to any shortfall and,
+      // when the salary lands in Jibun bank, double-counted (income + transfer
+      // -in) and drained SMBC by 80,000, creating a phantom shortfall and a
+      // reverse suggestion. It is removed; funding is now handled by the
+      // shortfall-capped dynamic suggestions. With no user transfer task there
+      // must be no transfer and no phantom transfer in/out.
       const smbcOtsukaName =
           '\u4e09\u4e95\u4f4f\u53cb\u9280\u884c\u5927\u585a\u652f\u5e97';
       const jibunBankName = '\u3058\u3076\u3093\u9280\u884c';
@@ -1559,11 +1566,6 @@ void main() {
         },
       );
 
-      final transfer = workbook.transferTasks.singleWhere(
-        (task) =>
-            task.id ==
-            AssetLiabilityPlanningService.auPayCardFundingTransferTaskId,
-      );
       final smbcSummary = workbook.accountCashflowSummaries.singleWhere(
         (summary) =>
             summary.accountId ==
@@ -1575,72 +1577,20 @@ void main() {
             AssetLiabilityPlanningService.jibunBankAccountId,
       );
 
+      // No hardcoded built-in transfer task exists anymore.
       expect(
-        transfer.fromAccountId,
-        AssetLiabilityPlanningService.smbcOtsukaBranchAccountId,
+        workbook.transferTasks.where(
+          (task) =>
+              task.id ==
+              AssetLiabilityPlanningService.auPayCardFundingTransferTaskId,
+        ),
+        isEmpty,
       );
-      expect(
-        transfer.toAccountId,
-        AssetLiabilityPlanningService.jibunBankAccountId,
-      );
-      expect(
-        transfer.amount,
-        AssetLiabilityPlanningService.auPayCardFundingTransferAmount,
-      );
-      expect(transfer.dueDate, DateTime(2026, 5, 26));
-      expect(smbcSummary.pendingTransferOut, 80000);
-      expect(smbcSummary.projectedBalance, 120000);
-      expect(jibunSummary.upcomingPayments, 80000);
-      expect(jibunSummary.pendingTransferIn, 80000);
-      expect(jibunSummary.projectedBalance, 10000);
-    });
-
-    test('does not duplicate completed built-in auPay funding transfer', () {
-      const smbcOtsukaName =
-          '\u4e09\u4e95\u4f4f\u53cb\u9280\u884c\u5927\u585a\u652f\u5e97';
-      const jibunBankName = '\u3058\u3076\u3093\u9280\u884c';
-      final workbook = service.buildWorkbook(
-        latestSnapshot: const <String, double>{
-          smbcOtsukaName: 200000,
-          jibunBankName: 10000,
-        },
-        baseDate: DateTime(2026, 5, 1),
-        transferTasks: <AssetLiabilityTransferTask>[
-          AssetLiabilityTransferTask(
-            id: AssetLiabilityPlanningService.auPayCardFundingTransferTaskId,
-            fromAccountId:
-                AssetLiabilityPlanningService.smbcOtsukaBranchAccountId,
-            fromAccountName: smbcOtsukaName,
-            toAccountId: AssetLiabilityPlanningService.jibunBankAccountId,
-            toAccountName: jibunBankName,
-            amount:
-                AssetLiabilityPlanningService.auPayCardFundingTransferAmount,
-            dueDate: DateTime(2026, 5, 26),
-            completed: true,
-            completedAt: DateTime(2026, 5, 26, 8),
-          ),
-        ],
-      );
-
-      final transfer = workbook.transferTasks.singleWhere(
-        (task) =>
-            task.id ==
-            AssetLiabilityPlanningService.auPayCardFundingTransferTaskId,
-      );
-      final smbcSummary = workbook.accountCashflowSummaries.singleWhere(
-        (summary) =>
-            summary.accountId ==
-            AssetLiabilityPlanningService.smbcOtsukaBranchAccountId,
-      );
-      final jibunSummary = workbook.accountCashflowSummaries.singleWhere(
-        (summary) =>
-            summary.accountId ==
-            AssetLiabilityPlanningService.jibunBankAccountId,
-      );
-
-      expect(transfer.completed, isTrue);
+      // And no phantom transfer in/out is applied to the accounts.
       expect(smbcSummary.pendingTransferOut, 0);
       expect(jibunSummary.pendingTransferIn, 0);
+      // SMBC keeps its full projected balance (no 80,000 drain).
+      expect(smbcSummary.projectedBalance, 200000);
     });
 
     test('does not double count completed transfer tasks', () {


### PR DESCRIPTION
# fix(asset): 固定額¥80,000の組み込み資金移動を撤去し二重計上・幻の不足を解消

## ユーザー報告

> auPayカードの今回（8/12）の支払い予定額は36926円です。なので、じぶん銀行には40000円程度の残高があれば足りるはずですが、80000円の資金移動提案がでています。この部分を正しくなるように修正できますか？

## 原因 (調査で確定)

`asset_liability_planning_service.dart` の **固定定数 `auPayCardFundingTransferAmount = 80000`** を、毎ビルドで「三井住友大塚 → じぶん銀行 ¥80,000 (26日)」の移動タスクとして自動注入していた (#3028 / 2026-05-27 導入・特定ユーザー向けハードコード)。

これは不足額と無関係の固定値で、以下の連鎖を起こしていた:

| 現象 | 内訳 |
|---|---|
| じぶん銀行の二重計上 | 給料入金 +¥80,000 と本移動の入金 +¥80,000 が両方加算 → 過剰資金 |
| 三井住友の幻の不足 | 対の移動出金で三井住友が -¥80,000 → 幻の不足 ¥50,041 |
| 逆方向の提案 | その幻の不足が「じぶん銀行 → 三井住友 ¥18,918」提案を誘発 |
| 削除不能 | 組み込みタスクゆえゴミ箱は無効化、キャンセルは no-op で再注入 |

じぶん銀行は給料 ¥80,000 の入金先で、auPAYカード ¥36,926 + じぶんローン ¥29,523 = ¥66,449 を賄えるため、**この移動は本来不要**。

### `_buildAccountCashflowSummaries` の該当計算
```
projected = balance − payments + income + pendingTransferIn − pendingTransferOut
じぶん銀行: 18,918 − 66,449 + 80,000(給料) + 80,000(組み込み移動) = +112,469  ← 二重計上
三井住友:  ... − 80,000(組み込み移動の出金) → 幻の不足
```

## 修正

- 固定注入 `_withDefaultAuPayCardFundingTransfer` と定数 `auPayCardFundingTransferAmount` / `auPayCardFundingTransferDay` を撤去。
- 資金移動は **不足額に上限が掛かる動的提案** (`_buildTransferSuggestions` / #4233 で `min(shortfall, donorSurplus, currentBalance − pendingTransferOut)`) に一本化。
- ID 定数 `auPayCardFundingTransferTaskId` のみ、過去に「完了」で退避された永続タスクを組み込み扱いと認識するため残す。

## 効果

- じぶん銀行への幻の ¥80,000 移動が消える
- 三井住友の幻の不足 ¥50,041 が消える
- 逆方向の ¥18,918 提案も消える
- 以後、資金移動が本当に必要なときだけ、不足額に見合った額が (実残高上限付きで) 提案される

## 検証

- `flutter test`: planning **69 件緑** (旧「固定移動を注入する」2 テストを「もう注入しない=移動タスク無し + 幻の移動入出金ゼロ + 三井住友が満額の見込みを保つ」1 テストに置換)
- `flutter analyze` (service / test / page): **No issues found!** (page 側 `_isBuiltInTransferTask` は残した ID 定数を参照して compile OK)
- `dart format --set-exit-if-changed`: **0 changed**
- 差分は純減 (26 追加 / 116 削除)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 本文キーワード(支払/残高)による prose-only トリガ。変更は不足額と無関係だった固定額の組み込み資金移動注入の撤去と、それに紐づくテストの置換のみ。認証・認可・EF・migration・DB書き込み経路には触れない。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は純ロジック service の固定注入撤去 (単体テストで検証) のみで headless E2E 到達不能。planning 69件 + analyze 緑で担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
