### PR TITLE
feat(asset): 返済報告カードの画像をXに添付 (公開バケット + mediaUrl)

### DIFF
--- a/lib/services/debt_progress_card_service.dart
+++ b/lib/services/debt_progress_card_service.dart
@@ -102,19 +102,63 @@ class DebtProgressCardService {
     return lines.join('\n');
   }
 
+  /// カード画像を置く Storage 上のパス。
+  ///
+  /// 🔴 先頭セグメントは **必ず userId**。`debt-progress-cards` の RLS は
+  /// `(storage.foldername(name))[1] = auth.uid()` で他人のフォルダへの
+  /// 書き込みを弾いているため、ここが崩れると保存自体が失敗する。
+  ///
+  /// 同月に作り直しても衝突しないよう [uniqueSuffix] を末尾に付ける
+  /// (upsert にすると「投稿済みの画像が後から差し替わる」事故が起きる)。
+  String buildCardStoragePath({
+    required String userId,
+    required DateTime month,
+    required String uniqueSuffix,
+  }) {
+    final ym = '${month.year}${month.month.toString().padLeft(2, '0')}';
+    return '$userId/debt_progress_${ym}_$uniqueSuffix.png';
+  }
+
+  /// 画像の代替テキスト (X の alt)。
+  ///
+  /// 🔒 カードに描かれているのと同じ範囲だけを書く。alt は画像より機械可読な
+  /// ので、ここに余分な情報を足すと開示範囲が静かに広がる。
+  String buildCardAltText(DebtProgressCardData card,
+      {required DateTime month}) {
+    final parts = <String>[
+      '${month.year}年${month.month}月の返済報告カード',
+      '残債 ${_yen(card.totalDebt)}',
+      '今月の返済 ${_yen(card.monthlyPayment)}',
+    ];
+    final payoff = card.payoffLabel;
+    parts.add(payoff == null ? '現在の返済額では完済しない見込み' : '完済まであと$payoff');
+    return parts.join(' / ');
+  }
+
   /// X への投稿ペイロードを組み立てる。
   ///
   /// 🔴 [text] には**ユーザーが編集した後の文面**を渡すこと。ここで
   /// 下書きを再生成すると、本人が直した内容が捨てられて意図しない文が
   /// 公開される (HITL が形骸化する)。
+  ///
+  /// [mediaUrl] を渡すと画像付き投稿になる。null/空なら**テキストのみ**で
+  /// 投稿する — 画像のアップロードに失敗しても投稿自体は成立させたい
+  /// (数字が伝われば報告として機能するため)。
   Map<String, dynamic> buildPostPayload(
     DebtProgressCardData card, {
     required DateTime month,
     String? text,
+    String? mediaUrl,
   }) {
+    final resolvedMedia = (mediaUrl ?? '').trim();
     return <String, dynamic>{
       'action': 'x.post',
       'text': text ?? buildDraftText(card, month: month),
+      if (resolvedMedia.isNotEmpty) ...<String, dynamic>{
+        'mediaUrl': resolvedMedia,
+        'mediaType': 'image',
+        'mediaAlt': buildCardAltText(card, month: month),
+      },
       'source': 'debt_progress_card',
       'variant': 'debt_progress_report',
       'utmContent': 'debt_progress_card',

--- a/lib/services/debt_progress_card_service.dart
+++ b/lib/services/debt_progress_card_service.dart
@@ -123,8 +123,10 @@ class DebtProgressCardService {
   ///
   /// 🔒 カードに描かれているのと同じ範囲だけを書く。alt は画像より機械可読な
   /// ので、ここに余分な情報を足すと開示範囲が静かに広がる。
-  String buildCardAltText(DebtProgressCardData card,
-      {required DateTime month}) {
+  String buildCardAltText(
+    DebtProgressCardData card, {
+    required DateTime month,
+  }) {
     final parts = <String>[
       '${month.year}年${month.month}月の返済報告カード',
       '残債 ${_yen(card.totalDebt)}',

--- a/lib/widgets/debt_progress_share_dialog.dart
+++ b/lib/widgets/debt_progress_share_dialog.dart
@@ -27,6 +27,9 @@ class DebtProgressShareDialog extends StatefulWidget {
 }
 
 class _DebtProgressShareDialogState extends State<DebtProgressShareDialog> {
+  /// 返済カード専用の公開バケット (RLS で書き込みは所有者フォルダのみ)。
+  static const String _cardBucket = 'debt-progress-cards';
+
   final GlobalKey _repaintKey = GlobalKey();
   late final TextEditingController _textController;
   bool _saving = false;
@@ -127,12 +130,11 @@ class _DebtProgressShareDialogState extends State<DebtProgressShareDialog> {
     );
   }
 
-  /// 編集後の文面をそのまま X へ投稿する。
+  /// 編集後の文面とカード画像を X へ投稿する。
   ///
-  /// 🔴 画像は添付されない (EF は現状テキスト投稿のみ)。画像も出したい場合は
-  /// 「画像を保存」で落として手動添付する。ここで下書きを再生成せず
-  /// `_textController.text` を送るのが要点 — 再生成すると本人の編集が
-  /// 捨てられ、意図しない内容が公開される。
+  /// 🔴 ここで下書きを再生成せず `_textController.text` を送るのが要点 —
+  /// 再生成すると本人の編集が捨てられ、意図しない内容が公開される。
+  /// 画像は付けば添付し、失敗したらテキストのみで投稿する。
   Future<void> _postToX() async {
     final text = _textController.text.trim();
     if (text.isEmpty) {
@@ -162,12 +164,17 @@ class _DebtProgressShareDialogState extends State<DebtProgressShareDialog> {
     setState(() => _posting = true);
     try {
       const service = DebtProgressCardService();
+      // 画像は「付けば嬉しい」もの。アップロードに失敗しても投稿は続行する
+      // (数字が伝われば報告として機能する)。
+      final mediaUrl = await _uploadCardImage();
+      if (!mounted) return;
       final res = await Supabase.instance.client.functions.invoke(
         'growth-hub',
         body: service.buildPostPayload(
           widget.data,
           month: widget.month,
           text: text,
+          mediaUrl: mediaUrl,
         ),
       );
       if (!mounted) return;
@@ -194,6 +201,41 @@ class _DebtProgressShareDialogState extends State<DebtProgressShareDialog> {
       ).showSnackBar(SnackBar(content: Text('投稿に失敗しました: $error')));
     } finally {
       if (mounted) setState(() => _posting = false);
+    }
+  }
+
+  /// カードを PNG 化して公開バケットへ上げ、公開 URL を返す。
+  ///
+  /// 失敗したら null を返して**投稿は続行**する (画像なしのテキスト投稿)。
+  /// ここで例外を投げると、画像の都合で報告そのものが出せなくなる。
+  Future<String?> _uploadCardImage() async {
+    try {
+      final client = Supabase.instance.client;
+      final userId = client.auth.currentUser?.id;
+      if (userId == null) return null;
+      // 描画完了を待ってからキャプチャする (未確定フレームだと空画像になる)。
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      final bytes = await NoteCardService.captureWidgetSimple(_repaintKey);
+      if (bytes == null) return null;
+      const service = DebtProgressCardService();
+      final path = service.buildCardStoragePath(
+        userId: userId,
+        month: widget.month,
+        // 同月に作り直しても衝突させない (upsert だと投稿済み画像が差し替わる)。
+        uniqueSuffix: DateTime.now().millisecondsSinceEpoch.toString(),
+      );
+      await client.storage.from(_cardBucket).uploadBinary(
+            path,
+            bytes,
+            fileOptions: const FileOptions(
+              contentType: 'image/png',
+              upsert: false,
+            ),
+          );
+      return client.storage.from(_cardBucket).getPublicUrl(path);
+    } catch (error) {
+      debugPrint('debt progress card image upload failed: $error');
+      return null;
     }
   }
 

--- a/supabase/migrations/20260731090000_create_debt_progress_cards_bucket.sql
+++ b/supabase/migrations/20260731090000_create_debt_progress_cards_bucket.sql
@@ -1,0 +1,66 @@
+-- 返済報告カードの画像を X に添付するための公開バケット。
+--
+-- x.post は既に mediaUrl を受け付けるが、X の media upload は「公開 URL から
+-- 取得できる画像」を要求するため、クライアントで描画した PNG を一度公開 URL に
+-- 置く必要がある。
+--
+-- 用途を分離する理由: `ai-generated-images` (OpenAI 生成画像) と混ぜると、
+-- 後から「返済カードだけ消したい」ときに選別できない。個人の金額が載る画像
+-- なので、消せる単位を分けておく。
+--
+-- 🔴 public = true = **URL を知っていれば誰でも読める**。X に添付する時点で
+-- 公開されるので投稿分には問題ないが、「投稿をやめた画像も URL 上に残る」点は
+-- 設計上の受容事項 (パスは uuid なので推測は現実的でない)。
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'debt-progress-cards',
+  'debt-progress-cards',
+  true,
+  5242880,
+  array['image/png']::text[]
+)
+on conflict (id) do update
+set
+  public = true,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+-- 書き込みは所有者のみ。読み取りは public バケットなので anon にも開くが、
+-- **他人のフォルダへ書けない** ことがここでの肝
+-- (`attachments` の direct-upload 強化と同じ形)。
+drop policy if exists "Users can upload their own debt progress cards"
+  on storage.objects;
+drop policy if exists "Users can update their own debt progress cards"
+  on storage.objects;
+drop policy if exists "Users can delete their own debt progress cards"
+  on storage.objects;
+
+create policy "Users can upload their own debt progress cards"
+  on storage.objects for insert
+  to authenticated
+  with check (
+    bucket_id = 'debt-progress-cards'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "Users can update their own debt progress cards"
+  on storage.objects for update
+  to authenticated
+  using (
+    bucket_id = 'debt-progress-cards'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  )
+  with check (
+    bucket_id = 'debt-progress-cards'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- 投稿をやめた画像を本人が消せるようにする (公開 URL を残さない手段)。
+create policy "Users can delete their own debt progress cards"
+  on storage.objects for delete
+  to authenticated
+  using (
+    bucket_id = 'debt-progress-cards'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );

--- a/test/services/debt_progress_card_service_test.dart
+++ b/test/services/debt_progress_card_service_test.dart
@@ -281,6 +281,90 @@ void main() {
     });
   });
 
+  group('DebtProgressCardService card image', () {
+    DebtProgressCardData card({int? payoffMonths = 38}) => DebtProgressCardData(
+          totalDebt: 1234567,
+          monthlyPayment: 45000,
+          payoffMonths: payoffMonths,
+          estimatedInterest: 234567,
+          monthOverMonthDelta: -50000,
+          debtCount: 3,
+        );
+
+    test('puts the user id first so the storage RLS check passes', () {
+      // 🔴 RLS は (storage.foldername(name))[1] = auth.uid() を見る。
+      // 先頭が userId でなくなると保存自体が落ちる。
+      final path = service.buildCardStoragePath(
+        userId: 'user-uuid',
+        month: DateTime(2026, 7, 1),
+        uniqueSuffix: '1753900000000',
+      );
+
+      expect(path.split('/').first, 'user-uuid');
+      expect(path, endsWith('.png'));
+      expect(path, contains('202607'));
+    });
+
+    test('does not collide when the card is rebuilt in the same month', () {
+      final a = service.buildCardStoragePath(
+        userId: 'u',
+        month: DateTime(2026, 7, 1),
+        uniqueSuffix: '1',
+      );
+      final b = service.buildCardStoragePath(
+        userId: 'u',
+        month: DateTime(2026, 7, 1),
+        uniqueSuffix: '2',
+      );
+
+      expect(a, isNot(b));
+    });
+
+    test('alt text stays inside the disclosed range', () {
+      final alt = service.buildCardAltText(card(), month: DateTime(2026, 7, 1));
+
+      expect(alt, contains('残債 1,234,567円'));
+      expect(alt, contains('完済まであと3年2ヶ月'));
+      for (final forbidden in <String>['年収', '月収', '口座残高', '勤務先']) {
+        expect(alt, isNot(contains(forbidden)));
+      }
+    });
+
+    test('alt text says plainly when the debt never clears', () {
+      final alt = service.buildCardAltText(
+        card(payoffMonths: null),
+        month: DateTime(2026, 7, 1),
+      );
+
+      expect(alt, contains('完済しない見込み'));
+    });
+
+    test('attaches media only when a url is supplied', () {
+      final withMedia = service.buildPostPayload(
+        card(),
+        month: DateTime(2026, 7, 1),
+        text: 'x',
+        mediaUrl: 'https://example.com/card.png',
+      );
+      expect(withMedia['mediaUrl'], 'https://example.com/card.png');
+      expect(withMedia['mediaType'], 'image');
+      expect(withMedia['mediaAlt'], contains('返済報告カード'));
+
+      // 画像アップロードが失敗しても投稿自体は成立させる。
+      for (final empty in <String?>[null, '', '   ']) {
+        final textOnly = service.buildPostPayload(
+          card(),
+          month: DateTime(2026, 7, 1),
+          text: 'x',
+          mediaUrl: empty,
+        );
+        expect(textOnly.containsKey('mediaUrl'), isFalse);
+        expect(textOnly.containsKey('mediaAlt'), isFalse);
+        expect(textOnly['text'], 'x');
+      }
+    });
+  });
+
   group('DebtProgressCardData.payoffLabel', () {
     test('formats months, years and mixed spans', () {
       DebtProgressCardData card(int? months) => DebtProgressCardData(


### PR DESCRIPTION
## Summary

返済報告カードの**画像をXに添付**できるようにしました。ユーザーからの直接要望です。

### 差分精査の結果

**EF の改修は不要でした。** `growth-hub` の `x.post` は既に `mediaUrl` / `mediaType` / `mediaAlt` を受け付け、`uploadMediaFromUrl` で X の media upload まで通します。足りていなかったのは「クライアントで描いたカード PNG を公開 URL に置く」経路だけでした。

### 変更点

- **専用の公開バケット `debt-progress-cards` を新設** (migration)。`ai-generated-images` と混ぜないのは、後から「返済カードだけ消したい」ときに選別できなくなるため。個人の金額が載る画像なので**消せる単位を分ける**。
- RLS は `attachments` の direct-upload 強化と同じ形: **書き込み/更新/削除は `(storage.foldername(name))[1] = auth.uid()` の所有者フォルダのみ**。読み取りは public バケットなので anon にも開く。
- Flutter 側で `RepaintBoundary` → PNG → `uploadBinary` → `getPublicUrl` → `x.post` の `mediaUrl` へ。
- 画像の `alt` を追加 (`buildCardAltText`)。**カードに描かれているのと同じ範囲だけ**書く — alt は画像より機械可読なので、ここに余分を足すと開示範囲が静かに広がる。

## 設計判断

**🔴 画像アップロードに失敗しても投稿は続行する**。`_uploadCardImage()` は失敗時に null を返し、`buildPostPayload` は `mediaUrl` が空なら media キー自体を落としてテキストのみで投稿します。画像の都合で報告そのものが出せなくなる方が損失が大きいためです。

**同月に作り直しても衝突しない**よう、パスに時刻サフィックスを付けて `upsert: false` にしています。upsert にすると**投稿済みの画像が後から差し替わる**事故が起きます。

**🔴 public バケットの受容事項**: URL を知っていれば誰でも読めます。X に添付する時点で公開されるので投稿分は問題ありませんが、**投稿をやめた画像も URL 上に残ります**(パスは uuid ベースで推測は現実的でない)。本人が消せるよう delete ポリシーも付けました。

## 検証

- unit 20件 + widget 4件 = **24件 green** (RLS 要件の「先頭が userId」/ 同月再作成の非衝突 / alt の開示境界 / media 有無の出し分けを含む)
- `flutter analyze` No issues / `dart format` clean
- migration time-relative guard: clean

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: storage bucket policy plus an admin-only dialog path that reuses the already-shipped x.post media handling; payload and path construction are covered by unit tests and image upload degrades to text-only on failure

## High-Risk Ultrareview

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: additive bucket with owner-scoped write policies copied from the hardened attachments direct-upload pattern; no existing table or policy is modified, no server action is added, and posting still requires the operator confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
