### PR TITLE
feat(asset): 資産管理に「今日やること」ToDoを追加し細木数子AIの行動入力にする

### DIFF
--- a/lib/models/daily_todo.dart
+++ b/lib/models/daily_todo.dart
@@ -1,0 +1,354 @@
+/// 資産管理画面「今日やること」機能のモデル。
+///
+/// 思想: 「今日やるべきタスクをやらずに寝ると、それは翌日やらねばならない
+/// タスク＝概念的な借金になる」。未完了で予定日を過ぎたタスクは
+/// 「繰り越し(明日への借金)」として日数付きで重く扱い、日々こなした実績は
+/// 完遂ログとして蓄積して細木数子AIの行動アドバイス材料にする。
+library;
+
+/// 日付のみ(ローカル、時刻を切り捨て)へ正規化する。
+DateTime _dateOnly(DateTime value) =>
+    DateTime(value.year, value.month, value.day);
+
+/// `yyyy-MM-dd` 形式の日付キー(ローカル)。
+String dailyTodoDateKey(DateTime value) {
+  final d = _dateOnly(value);
+  return '${d.year.toString().padLeft(4, '0')}-'
+      '${d.month.toString().padLeft(2, '0')}-'
+      '${d.day.toString().padLeft(2, '0')}';
+}
+
+/// 「今日やること」1件。
+class DailyTodoTask {
+  final String id;
+  final String title;
+
+  /// 「その日にやる」と決めた日(日付のみ, ローカル)。未完了のまま過ぎると
+  /// 繰り越し(借金)になる基準日。
+  final DateTime plannedDate;
+  final bool completed;
+  final DateTime? completedAt;
+  final String note;
+
+  DailyTodoTask({
+    required this.id,
+    required this.title,
+    required DateTime plannedDate,
+    this.completed = false,
+    this.completedAt,
+    this.note = '',
+  }) : plannedDate = _dateOnly(plannedDate);
+
+  DailyTodoTask copyWith({
+    String? id,
+    String? title,
+    DateTime? plannedDate,
+    bool? completed,
+    Object? completedAt = _sentinel,
+    String? note,
+  }) {
+    return DailyTodoTask(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      plannedDate: plannedDate ?? this.plannedDate,
+      completed: completed ?? this.completed,
+      completedAt: completedAt == _sentinel
+          ? this.completedAt
+          : completedAt as DateTime?,
+      note: note ?? this.note,
+    );
+  }
+
+  /// 未完了かつ予定日が [today] より前 = 繰り越し(明日への借金)。
+  bool isCarriedOverAsOf(DateTime today) =>
+      !completed && plannedDate.isBefore(_dateOnly(today));
+
+  /// 繰り越し日数(予定日から [today] までの経過日数)。繰り越しでなければ 0。
+  int carryOverDaysAsOf(DateTime today) {
+    if (!isCarriedOverAsOf(today)) {
+      return 0;
+    }
+    return _dateOnly(today).difference(plannedDate).inDays;
+  }
+
+  /// 予定日が [today] と同じ日か。
+  bool isForToday(DateTime today) => plannedDate == _dateOnly(today);
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'title': title,
+        'planned_date': dailyTodoDateKey(plannedDate),
+        'completed': completed,
+        'completed_at': completedAt?.toUtc().toIso8601String(),
+        'note': note,
+      };
+
+  /// 破損データは null を返す(呼び出し側で除外)。
+  static DailyTodoTask? fromJson(Object? raw) {
+    if (raw is! Map) {
+      return null;
+    }
+    final id = raw['id']?.toString().trim() ?? '';
+    final title = raw['title']?.toString().trim() ?? '';
+    if (id.isEmpty || title.isEmpty) {
+      return null;
+    }
+    final plannedDate = _parseDate(raw['planned_date']);
+    if (plannedDate == null) {
+      return null;
+    }
+    final completed = raw['completed'] == true;
+    final completedAt = DateTime.tryParse(
+      raw['completed_at']?.toString() ?? '',
+    )?.toLocal();
+    return DailyTodoTask(
+      id: id,
+      title: title,
+      plannedDate: plannedDate,
+      completed: completed,
+      completedAt: completed ? completedAt : null,
+      note: raw['note']?.toString() ?? '',
+    );
+  }
+
+  static const Object _sentinel = Object();
+}
+
+/// 完遂ログの1件(append-only)。日々こなしたタスクの durable な記録。
+class DailyTodoCompletionLogEntry {
+  /// 完了した日(ローカル, `yyyy-MM-dd`)。
+  final String dateKey;
+  final String title;
+  final DateTime completedAt;
+
+  DailyTodoCompletionLogEntry({
+    required this.dateKey,
+    required this.title,
+    required this.completedAt,
+  });
+
+  /// 和集合マージ時の一意キー(日 × タイトル × 完了時刻)。
+  String get mergeKey =>
+      '$dateKey|$title|${completedAt.toUtc().toIso8601String()}';
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'date': dateKey,
+        'title': title,
+        'completed_at': completedAt.toUtc().toIso8601String(),
+      };
+
+  static DailyTodoCompletionLogEntry? fromJson(Object? raw) {
+    if (raw is! Map) {
+      return null;
+    }
+    final title = raw['title']?.toString().trim() ?? '';
+    final completedAt = DateTime.tryParse(
+      raw['completed_at']?.toString() ?? '',
+    )?.toLocal();
+    if (title.isEmpty || completedAt == null) {
+      return null;
+    }
+    final rawDate = raw['date']?.toString().trim() ?? '';
+    final dateKey =
+        rawDate.isNotEmpty ? rawDate : dailyTodoDateKey(completedAt);
+    return DailyTodoCompletionLogEntry(
+      dateKey: dateKey,
+      title: title,
+      completedAt: completedAt,
+    );
+  }
+}
+
+/// 1日分の完遂サマリ(細木数子AIへ渡す日別の行動記録)。
+class DailyTodoDaySummary {
+  final String dateKey;
+  final List<String> completedTitles;
+
+  const DailyTodoDaySummary({
+    required this.dateKey,
+    required this.completedTitles,
+  });
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'date': dateKey,
+        'completed_titles': completedTitles,
+        'completed_count': completedTitles.length,
+      };
+}
+
+/// タスク・完遂ログから算出した、UI表示と細木数子AI入力の両方に使う要約。
+class DailyTodoDigest {
+  final DateTime asOf;
+  final int todayTotal;
+  final int todayCompleted;
+  final int todayPending;
+
+  /// 繰り越し(未完了で予定日超過 = 明日への借金)の件数。
+  final int carriedOverCount;
+
+  /// 最も長く繰り越されているタスクの日数。
+  final int maxCarryOverDays;
+
+  /// 繰り越しタスクのタイトル(古い順, 最大5件)。
+  final List<String> carriedOverTitles;
+
+  /// 直近7日間の完了件数。
+  final int completedLast7Days;
+
+  /// 今日まで連続で1件以上完了した日数(連続実行日数)。
+  final int activeStreakDays;
+
+  /// 直近7日間の日別完遂サマリ(新しい日が先頭)。
+  final List<DailyTodoDaySummary> recentDays;
+
+  const DailyTodoDigest({
+    required this.asOf,
+    required this.todayTotal,
+    required this.todayCompleted,
+    required this.todayPending,
+    required this.carriedOverCount,
+    required this.maxCarryOverDays,
+    required this.carriedOverTitles,
+    required this.completedLast7Days,
+    required this.activeStreakDays,
+    required this.recentDays,
+  });
+
+  /// タスク一覧が空でログも無い = ToDo 未利用。
+  bool get isEmpty =>
+      todayTotal == 0 && carriedOverCount == 0 && completedLast7Days == 0;
+
+  /// 細木数子AIへ渡す構造化ペイロード。
+  Map<String, dynamic> toAiJson() => <String, dynamic>{
+        'as_of': dailyTodoDateKey(asOf),
+        'today_total': todayTotal,
+        'today_completed': todayCompleted,
+        'today_pending': todayPending,
+        'carried_over_count': carriedOverCount,
+        'max_carry_over_days': maxCarryOverDays,
+        'carried_over_titles': carriedOverTitles,
+        'completed_last_7_days': completedLast7Days,
+        'active_streak_days': activeStreakDays,
+        'recent_days': recentDays.map((day) => day.toJson()).toList(),
+        'philosophy': 'やらずに寝たタスクは翌日の借金になる。carried_over は溜めた行動の借金、'
+            'active_streak_days と recent_days は日々こなした実績。金銭の負債と'
+            '同じ熱量で、行動の借金と実績にも具体的に言及すること。',
+      };
+
+  /// AI無効時などに使う決定論的な1〜2行サマリ。
+  String toHeadline() {
+    if (isEmpty) {
+      return '今日やることは未登録です。まず1つ登録して、やり切って寝ましょう。';
+    }
+    final parts = <String>[
+      '本日 $todayCompleted/$todayTotal 完了',
+      if (carriedOverCount > 0)
+        '繰り越し(借金) $carriedOverCount件(最長$maxCarryOverDays日)'
+      else
+        '繰り越しの借金なし',
+      if (activeStreakDays > 0) '連続$activeStreakDays日実行中',
+    ];
+    return parts.join(' / ');
+  }
+
+  /// タスク一覧と完遂ログから要約を算出する純関数。
+  factory DailyTodoDigest.fromState({
+    required List<DailyTodoTask> tasks,
+    required List<DailyTodoCompletionLogEntry> log,
+    required DateTime now,
+  }) {
+    final today = _dateOnly(now);
+    final todayKey = dailyTodoDateKey(today);
+
+    final todayTasks = tasks.where((t) => t.isForToday(today)).toList();
+    final todayCompleted = todayTasks.where((t) => t.completed).length;
+
+    final carriedOver = tasks.where((t) => t.isCarriedOverAsOf(today)).toList()
+      ..sort((a, b) => a.plannedDate.compareTo(b.plannedDate));
+    final maxCarryOverDays = carriedOver.isEmpty
+        ? 0
+        : carriedOver
+            .map((t) => t.carryOverDaysAsOf(today))
+            .reduce((a, b) => a > b ? a : b);
+
+    // 日別に完了タイトルを集約(タスクの completedAt とログの両方を統合)。
+    final byDay = <String, List<String>>{};
+    void addToDay(String dateKey, String title) {
+      (byDay[dateKey] ??= <String>[]).add(title);
+    }
+
+    for (final entry in log) {
+      addToDay(entry.dateKey, entry.title);
+    }
+    // ログに未記録の完了タスク(古い実装や取りこぼし)も補完する。
+    for (final task in tasks) {
+      if (task.completed && task.completedAt != null) {
+        final key = dailyTodoDateKey(task.completedAt!);
+        final existing = byDay[key];
+        if (existing == null || !existing.contains(task.title)) {
+          addToDay(key, task.title);
+        }
+      }
+    }
+
+    // 直近7日(今日を含む)の日別サマリ。新しい日が先頭。
+    final recentDays = <DailyTodoDaySummary>[];
+    var completedLast7Days = 0;
+    for (var i = 0; i < 7; i++) {
+      final day = today.subtract(Duration(days: i));
+      final key = dailyTodoDateKey(day);
+      final titles = byDay[key] ?? const <String>[];
+      completedLast7Days += titles.length;
+      recentDays.add(
+        DailyTodoDaySummary(
+          dateKey: key,
+          completedTitles: List<String>.unmodifiable(titles),
+        ),
+      );
+    }
+
+    // 連続実行日数: 今日から遡って1件以上完了した日が続く限りカウント。
+    // 今日が未完了でも、昨日以前の連続は途切れていない扱い(今日はこれから)。
+    var streak = 0;
+    var cursor = today;
+    if ((byDay[todayKey] ?? const <String>[]).isEmpty) {
+      // 今日まだ0件なら昨日から数える(今日の猶予を残す)。
+      cursor = today.subtract(const Duration(days: 1));
+    }
+    for (var i = 0; i < 366; i++) {
+      final key = dailyTodoDateKey(cursor);
+      if ((byDay[key] ?? const <String>[]).isEmpty) {
+        break;
+      }
+      streak += 1;
+      cursor = cursor.subtract(const Duration(days: 1));
+    }
+
+    return DailyTodoDigest(
+      asOf: today,
+      todayTotal: todayTasks.length,
+      todayCompleted: todayCompleted,
+      todayPending: todayTasks.length - todayCompleted,
+      carriedOverCount: carriedOver.length,
+      maxCarryOverDays: maxCarryOverDays,
+      carriedOverTitles: List<String>.unmodifiable(
+        carriedOver.take(5).map((t) => t.title),
+      ),
+      completedLast7Days: completedLast7Days,
+      activeStreakDays: streak,
+      recentDays: List<DailyTodoDaySummary>.unmodifiable(recentDays),
+    );
+  }
+}
+
+DateTime? _parseDate(Object? raw) {
+  final text = raw?.toString().trim() ?? '';
+  if (text.isEmpty) {
+    return null;
+  }
+  final parsed = DateTime.tryParse(text);
+  if (parsed == null) {
+    return null;
+  }
+  return _dateOnly(parsed.toLocal());
+}

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -63,6 +63,8 @@ import 'package:my_web_app/services/asset_salary_deposit_detector.dart';
 import 'package:my_web_app/services/asset_salary_reset_marker_store.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
+import 'package:my_web_app/models/daily_todo.dart';
+import 'package:my_web_app/services/daily_todo_store.dart';
 import 'package:my_web_app/services/asset_triage_guide_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
@@ -417,6 +419,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final _keyFlow = GlobalKey();
   final _keySubs = GlobalKey();
   final _keyMust = GlobalKey();
+  final _keyDailyTodo = GlobalKey();
   // 将来CF予測カードの「支払日を見直す」からマネーカレンダーへスクロールする。
   final _keyCalendar = GlobalKey();
   // 将来CF予測の安全余裕(見込み残高がこれを下回る時期に注意表示)。
@@ -448,8 +451,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 何度も 1 分超のプレミアム生成 (直列 4 プロバイダ) が走る。この時間内は
   /// 同日最新の保存済み分析を再利用し、即時反映したい場合のみ手動の
   /// 「AI要約を更新」(force) を使う。
-  static const Duration _assetManagementAiSummaryAutoRefreshCooldown =
-      Duration(minutes: 60);
+  static const Duration _assetManagementAiSummaryAutoRefreshCooldown = Duration(
+    minutes: 60,
+  );
 
   /// 直近の AI 要約「生成試行」時刻を端末に残す pref キー (基準日|ISO)。
   /// 成功分析は履歴テーブルに保存され再利用できるが、ai-hub の 500 等で失敗した
@@ -875,6 +879,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // 月をまたいだ負債トレンド(リボ複利・残高増加)判定のための口座別残高履歴。
   final AssetAccountBalanceHistoryStore _assetBalanceHistoryStore =
       const AssetAccountBalanceHistoryStore();
+  // 「今日やること」ToDo(登録+完了チェック+日々の完遂ログ)。
+  // やらずに寝たタスクは翌日の借金という思想で、繰り越し日数と実績を細木数子AIへ渡す。
+  final DailyTodoStore _dailyTodoStore = const DailyTodoStore();
+  List<DailyTodoTask> _dailyTodos = <DailyTodoTask>[];
+  List<DailyTodoCompletionLogEntry> _dailyTodoLog =
+      <DailyTodoCompletionLogEntry>[];
+  bool _isLoadingDailyTodos = false;
   // 前月末の口座別残高(accountId -> 残高絶対値)。非同期ロードでキャッシュ。
   Map<String, double> _assetDebtTrendPriorBalances = const <String, double>{};
   // 上記キャッシュが対象としている月キー(月跨ぎでの取り違え防止)。
@@ -1087,6 +1098,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchRecentFlows();
     _fetchSubscriptions();
     _fetchMustTasks();
+    unawaited(_loadDailyTodos());
     _loadDisplayMode();
     _loadMainAccount();
     unawaited(_loadHouseholdTrackerPublishing());
@@ -1221,8 +1233,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _openProfileSettingsForAssetManagement() async {
     await Navigator.of(context).push(
       MaterialPageRoute<void>(
-          settings: const RouteSettings(name: '/profile-settings'),
-          builder: (_) => const ProfileSettingsPage()),
+        settings: const RouteSettings(name: '/profile-settings'),
+        builder: (_) => const ProfileSettingsPage(),
+      ),
     );
     if (!mounted) {
       return;
@@ -1299,8 +1312,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // に留まり、支払済みチェック等の月次stateを保持する(暦の給料日では切り替えない)。
     // マーカー未設定(初回)は当日サイクルを採用。load/save/sync すべてこの実効月を
     // 共有するため、ウィンドウ中の編集も前サイクルへ対称に書かれる(非対称消失なし)。
-    final dateCycleKey =
-        AssetLiabilityMonthlyStateStore.formatMonthKey(dateCycle);
+    final dateCycleKey = AssetLiabilityMonthlyStateStore.formatMonthKey(
+      dateCycle,
+    );
     if (!AssetSalaryResetMarkerStore.isResetPending(
       dateCycleKey: dateCycleKey,
       ackedCycleKey: _ackedResetCycleKey,
@@ -1541,8 +1555,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if ((flow['action_type']?.toString() ?? '') != 'conquer') {
         continue;
       }
-      final occurredAt =
-          DateTime.tryParse(flow['occurred_at']?.toString() ?? '')?.toLocal();
+      final occurredAt = DateTime.tryParse(
+        flow['occurred_at']?.toString() ?? '',
+      )?.toLocal();
       if (occurredAt == null) {
         continue;
       }
@@ -4198,8 +4213,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
     var selectedDate = existing?.date ?? _now;
     var received = existing?.received ?? false;
-    final destinationOptions =
-        incomeDestinationAccountOptions(workbook.accounts);
+    final destinationOptions = incomeDestinationAccountOptions(
+      workbook.accounts,
+    );
     // 候補に無い入金先IDは保持しない (Dropdown の value 整合を保つ)。
     final destinationIds = destinationOptions.map((a) => a.id).toSet();
     var selectedDestinationId =
@@ -4349,8 +4365,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final dayController = TextEditingController(
       text: initial == null ? '' : initial.dayOfMonth.toString(),
     );
-    final destinationOptions =
-        incomeDestinationAccountOptions(workbook.accounts);
+    final destinationOptions = incomeDestinationAccountOptions(
+      workbook.accounts,
+    );
     // 候補に無い入金先IDは保持しない(Dropdown の値整合を保つ)。
     final destinationIds = destinationOptions.map((a) => a.id).toSet();
     var selectedDestinationId =
@@ -6766,9 +6783,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     if (amounts.isEmpty) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('同額で記録できる未更新口座はありません')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('同額で記録できる未更新口座はありません')));
       return;
     }
 
@@ -6809,8 +6826,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ]);
 
       setState(() {
-        final todayMap =
-            _assetData.putIfAbsent(today, () => <String, double>{});
+        final todayMap = _assetData.putIfAbsent(
+          today,
+          () => <String, double>{},
+        );
         amounts.forEach((type, amount) => todayMap[type] = amount);
         _updateLastUpdatedDates();
         _sortAssetTypes();
@@ -8314,6 +8333,421 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  // ===== 「今日やること」ToDo =====
+  //
+  // 思想: やらずに寝たタスクは翌日の借金。未完了で予定日を過ぎたタスクは
+  // 「繰り越し(借金)」として日数付きで重く表示し、完遂ログは細木数子AIへ渡す。
+  // 永続化はローカル(SharedPreferences)+ asset_pref_mirror(pref_key='daily_todo')の
+  // 軽量ミラーで、DBマイグレーション不要・端末跨ぎ同期。
+
+  static const String _dailyTodoMirrorKey = 'daily_todo';
+
+  Future<void> _loadDailyTodos() async {
+    if (mounted) {
+      setState(() => _isLoadingDailyTodos = true);
+    }
+    try {
+      final snapshot = await _dailyTodoStore.load();
+      if (mounted) {
+        setState(() {
+          _dailyTodos = _orderedDailyTodos(snapshot.tasks);
+          _dailyTodoLog = snapshot.log;
+          _isLoadingDailyTodos = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() => _isLoadingDailyTodos = false);
+      }
+    }
+    // ローカル反映後に他端末のミラーを取り込む(空でも実行してリモートを拾う)。
+    unawaited(_restoreDailyTodosFromMirror());
+  }
+
+  /// 予定日の古い順→未完了を先に、という並びに整える(繰り越し借金を上へ)。
+  List<DailyTodoTask> _orderedDailyTodos(List<DailyTodoTask> tasks) {
+    final ordered = List<DailyTodoTask>.from(tasks);
+    ordered.sort((a, b) {
+      if (a.completed != b.completed) {
+        return a.completed ? 1 : -1;
+      }
+      final byDate = a.plannedDate.compareTo(b.plannedDate);
+      if (byDate != 0) {
+        return byDate;
+      }
+      return a.title.compareTo(b.title);
+    });
+    return ordered;
+  }
+
+  /// ローカルへ保存し、ミラーへ退避する(端末跨ぎ同期)。
+  Future<void> _persistDailyTodos() async {
+    await _dailyTodoStore.save(
+      tasks: _dailyTodos,
+      log: _dailyTodoLog,
+      updatedAt: _now,
+    );
+    unawaited(_mirrorDailyTodos());
+  }
+
+  Future<void> _mirrorDailyTodos() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final value = await _dailyTodoStore.encodeMirror();
+      if (value == null) {
+        return;
+      }
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _dailyTodoMirrorKey,
+        'value': value,
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('daily todo mirror upsert failed: $e');
+    }
+  }
+
+  Future<void> _restoreDailyTodosFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', _dailyTodoMirrorKey);
+      if (rows.isEmpty) {
+        return;
+      }
+      final result = await _dailyTodoStore.mergeRemote(rows.first['value']);
+      if (!result.changed || !mounted) {
+        return;
+      }
+      setState(() {
+        _dailyTodos = _orderedDailyTodos(result.snapshot.tasks);
+        _dailyTodoLog = result.snapshot.log;
+      });
+    } catch (e) {
+      debugPrint('daily todo mirror restore failed: $e');
+    }
+  }
+
+  Future<void> _addDailyTodo() async {
+    final titleController = TextEditingController();
+    var plannedDate = DateTime(_now.year, _now.month, _now.day);
+    final added = await showDialog<bool>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setDialogState) {
+          return AlertDialog(
+            title: const Text('今日やることを追加'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: titleController,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    labelText: 'やること (例: 請求書の確認・30分運動)',
+                  ),
+                  onSubmitted: (_) => Navigator.pop(context, true),
+                ),
+                const SizedBox(height: 16),
+                InkWell(
+                  onTap: () async {
+                    final date = await showDatePicker(
+                      context: context,
+                      initialDate: plannedDate,
+                      firstDate: DateTime(_now.year - 1),
+                      lastDate: DateTime(_now.year + 2),
+                    );
+                    if (date != null) {
+                      setDialogState(() => plannedDate = date);
+                    }
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 12,
+                    ),
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          '予定日: ${DateFormat('yyyy/MM/dd').format(plannedDate)}',
+                        ),
+                        Icon(
+                          Icons.calendar_today,
+                          size: 16,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('キャンセル'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('追加'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+    if (added != true) {
+      return;
+    }
+    final title = titleController.text.trim();
+    if (title.isEmpty) {
+      return;
+    }
+    final task = DailyTodoTask(
+      id: 'todo_${DateTime.now().microsecondsSinceEpoch}',
+      title: title,
+      plannedDate: plannedDate,
+    );
+    setState(() {
+      _dailyTodos = _orderedDailyTodos(<DailyTodoTask>[..._dailyTodos, task]);
+    });
+    await _persistDailyTodos();
+  }
+
+  Future<void> _toggleDailyTodo(DailyTodoTask task, bool completed) async {
+    final now = DateTime.now();
+    final previousCompletedAt = task.completedAt;
+    final updated = task.copyWith(
+      completed: completed,
+      completedAt: completed ? now : null,
+    );
+    final nextLog = List<DailyTodoCompletionLogEntry>.from(_dailyTodoLog);
+    if (completed) {
+      nextLog.add(
+        DailyTodoCompletionLogEntry(
+          dateKey: dailyTodoDateKey(now),
+          title: task.title,
+          completedAt: now,
+        ),
+      );
+    } else if (previousCompletedAt != null) {
+      // 完了取り消しは、その完了で積んだログ行だけ取り除く(実績の捏造/残留を防ぐ)。
+      final removeDateKey = dailyTodoDateKey(previousCompletedAt);
+      nextLog.removeWhere(
+        (entry) => entry.title == task.title && entry.dateKey == removeDateKey,
+      );
+    }
+    setState(() {
+      _dailyTodos = _orderedDailyTodos(
+        _dailyTodos
+            .map((t) => t.id == task.id ? updated : t)
+            .toList(growable: false),
+      );
+      _dailyTodoLog = nextLog;
+    });
+    await _persistDailyTodos();
+  }
+
+  Future<void> _deleteDailyTodo(DailyTodoTask task) async {
+    setState(() {
+      _dailyTodos =
+          _dailyTodos.where((t) => t.id != task.id).toList(growable: false);
+    });
+    await _persistDailyTodos();
+  }
+
+  /// 現在のタスク・完遂ログから細木数子AI/UI用の要約を算出する。
+  DailyTodoDigest _currentDailyTodoDigest() {
+    return DailyTodoDigest.fromState(
+      tasks: _dailyTodos,
+      log: _dailyTodoLog,
+      now: _now,
+    );
+  }
+
+  // 「今日やること」カード。やらずに寝たタスクは翌日の借金、という思想を
+  // 繰り越し日数で可視化し、こなした実績は細木数子AIの行動アドバイス材料にする。
+  Widget _buildDailyTodoCard() {
+    final digest = _currentDailyTodoDigest();
+    final today = DateTime(_now.year, _now.month, _now.day);
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Row(
+              children: [
+                Icon(Icons.event_available, color: Color(0xFF4F46E5)),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '今日やること',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const Text(
+              'やらずに寝たタスクは、明日への借金。今日のうちにチェックを入れて片づけよ。'
+              '日々こなした実績は細木数子AIの行動アドバイスに使われる。',
+              style: TextStyle(
+                fontSize: 11,
+                color: Color(0xFF9CA3AF),
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 12),
+            _buildDailyTodoSummaryChips(digest),
+            const SizedBox(height: 8),
+            if (_isLoadingDailyTodos)
+              const Padding(
+                padding: EdgeInsets.all(16),
+                child: Center(child: CircularProgressIndicator()),
+              )
+            else if (_dailyTodos.isEmpty)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Text(
+                  'まだ登録がありません。まず今日やることを1つ登録して、'
+                  'やり切ってから寝ましょう。',
+                  style: TextStyle(color: Color(0xFF9CA3AF), height: 1.5),
+                ),
+              )
+            else
+              ListView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: _dailyTodos.length,
+                itemBuilder: (context, index) =>
+                    _buildDailyTodoRow(_dailyTodos[index], today),
+              ),
+            TextButton.icon(
+              onPressed: _addDailyTodo,
+              icon: const Icon(Icons.add),
+              label: const Text('今日やることを追加'),
+              style: TextButton.styleFrom(
+                foregroundColor: const Color(0xFF4F46E5),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDailyTodoSummaryChips(DailyTodoDigest digest) {
+    Widget chip(String label, Color color) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: color.withValues(alpha: 0.4)),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: color,
+            height: 1.4,
+          ),
+        ),
+      );
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        chip(
+          '本日 ${digest.todayCompleted}/${digest.todayTotal} 完了',
+          const Color(0xFF0D9488),
+        ),
+        if (digest.carriedOverCount > 0)
+          chip(
+            '繰り越し(借金) ${digest.carriedOverCount}件・最長${digest.maxCarryOverDays}日',
+            const Color(0xFFB91C1C),
+          )
+        else
+          chip('繰り越しの借金なし', const Color(0xFF0D9488)),
+        if (digest.activeStreakDays > 0)
+          chip('連続${digest.activeStreakDays}日実行中', const Color(0xFFFF6B35)),
+        chip('直近7日 ${digest.completedLast7Days}件完了', const Color(0xFF4F46E5)),
+      ],
+    );
+  }
+
+  Widget _buildDailyTodoRow(DailyTodoTask task, DateTime today) {
+    final isCarriedOver = task.isCarriedOverAsOf(today);
+    final carryDays = task.carryOverDaysAsOf(today);
+    final String subtitle;
+    final Color subtitleColor;
+    if (task.completed) {
+      final at = task.completedAt;
+      subtitle = at == null
+          ? '完了'
+          : '完了: ${DateFormat('M/d HH:mm').format(at.toLocal())}';
+      subtitleColor = const Color(0xFF0D9488);
+    } else if (isCarriedOver) {
+      subtitle = '$carryDays日前から繰り越し(借金) '
+          '・予定日 ${DateFormat('M/d').format(task.plannedDate)}';
+      subtitleColor = const Color(0xFFB91C1C);
+    } else if (task.isForToday(today)) {
+      subtitle = '今日やること';
+      subtitleColor = const Color(0xFF9CA3AF);
+    } else {
+      subtitle = '予定日 ${DateFormat('yyyy/M/d').format(task.plannedDate)}';
+      subtitleColor = const Color(0xFF9CA3AF);
+    }
+    return CheckboxListTile(
+      value: task.completed,
+      onChanged: (value) => _toggleDailyTodo(task, value ?? false),
+      title: Text(
+        task.title,
+        style: TextStyle(
+          decoration: task.completed ? TextDecoration.lineThrough : null,
+          height: 1.5,
+          fontWeight: isCarriedOver ? FontWeight.w600 : FontWeight.normal,
+        ),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: TextStyle(color: subtitleColor, fontSize: 12, height: 1.5),
+      ),
+      secondary: IconButton(
+        icon: const Icon(Icons.delete_outline, size: 20),
+        color: const Color(0xFF9CA3AF),
+        tooltip: '削除',
+        onPressed: () => _deleteDailyTodo(task),
+      ),
+      controlAffinity: ListTileControlAffinity.leading,
+      contentPadding: EdgeInsets.zero,
+      dense: true,
+    );
+  }
+
   Future<void> _fetchMustTasks() async {
     setState(() => _isLoadingTasks = true);
     try {
@@ -8980,9 +9414,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               const SizedBox(height: 16),
               _buildCashflowForecastCard(assetLiabilityWorkbook),
             ],
-            if (_isSectionShown(
-              AssetManagementSectionId.monthlyDashboard,
-            )) ...[
+            if (_isSectionShown(AssetManagementSectionId.monthlyDashboard)) ...[
               _sectionAnchor(AssetManagementSectionId.monthlyDashboard),
               _buildMonthlyDashboardGrid(assetLiabilityWorkbook),
             ],
@@ -9405,8 +9837,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         if (_isIncomeActionType(flow['action_type']?.toString() ?? ''))
           SalaryDepositFlowObservation(
             amount: ((flow['amount'] as num?)?.toDouble() ?? 0).abs(),
-            occurredAt: DateTime.tryParse(flow['occurred_at']?.toString() ?? '')
-                    ?.toLocal() ??
+            occurredAt: DateTime.tryParse(
+                  flow['occurred_at']?.toString() ?? '',
+                )?.toLocal() ??
                 _now,
           ),
     ];
@@ -10466,7 +10899,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 登録済みサブスクを「経由ソース × 請求先カード」で集計し、カード名ラベルへ解決する。
   /// 同じ Apple経由でも請求先カードが分かれる場合に、各カードの集約請求と突き合わせる。
   Map<String, List<GatewayCardBreakdownLine>> _subscriptionGatewayCardBreakdown(
-      List<AssetLiabilityAccount> accounts) {
+    List<AssetLiabilityAccount> accounts,
+  ) {
     final accountNames = <String, String>{
       for (final account in accounts) account.id: account.name,
     };
@@ -12799,8 +13233,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (rows.isEmpty) {
         return;
       }
-      final changed =
-          await _assetBalanceHistoryStore.mergeRemote(rows.first['value']);
+      final changed = await _assetBalanceHistoryStore.mergeRemote(
+        rows.first['value'],
+      );
       if (!changed || !mounted) {
         return;
       }
@@ -13618,8 +14053,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     setState(() {
       final start = _calendarCycleStart;
       // start.day = 給料日 (clamp 1-28) なので月加算で日あふれしない。
-      _calendarCycleAnchor =
-          DateTime(start.year, start.month + delta, start.day);
+      _calendarCycleAnchor = DateTime(
+        start.year,
+        start.month + delta,
+        start.day,
+      );
       _calendarSelectedDate = null;
     });
   }
@@ -14243,9 +14681,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     Expanded(
                       child: OutlinedButton(
                         key: const Key(
-                            'asset_payment_source_bulk_apply_monthly'),
-                        onPressed: () => Navigator.of(sheetContext)
-                            .pop(_PaymentSourceSaveScope.monthlyOverride),
+                          'asset_payment_source_bulk_apply_monthly',
+                        ),
+                        onPressed: () => Navigator.of(
+                          sheetContext,
+                        ).pop(_PaymentSourceSaveScope.monthlyOverride),
                         child: const Text('今月だけ設定'),
                       ),
                     ),
@@ -14253,9 +14693,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     Expanded(
                       child: FilledButton(
                         key: const Key(
-                            'asset_payment_source_bulk_apply_default'),
-                        onPressed: () => Navigator.of(sheetContext)
-                            .pop(_PaymentSourceSaveScope.defaultSetting),
+                          'asset_payment_source_bulk_apply_default',
+                        ),
+                        onPressed: () => Navigator.of(
+                          sheetContext,
+                        ).pop(_PaymentSourceSaveScope.defaultSetting),
                         child: const Text('毎月の既定にする'),
                       ),
                     ),
@@ -14306,9 +14748,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_saveAssetLiabilityMonthlyState());
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('${plan.assignments.length}件の支払いに原資口座を設定しました。'),
-        ),
+        SnackBar(content: Text('${plan.assignments.length}件の支払いに原資口座を設定しました。')),
       );
     }
   }
@@ -14375,9 +14815,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 Align(
                   alignment: Alignment.centerLeft,
                   child: OutlinedButton.icon(
-                    onPressed: () => unawaited(
-                      _confirmAllAutoDebitsWithoutWarning(entries),
-                    ),
+                    onPressed: () =>
+                        unawaited(_confirmAllAutoDebitsWithoutWarning(entries)),
                     icon: const Icon(Icons.done_all, size: 16),
                     label: Text(
                       '警告のない'
@@ -14738,8 +15177,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // ライブの当月スナップショットを履歴サービスで生成し、未保存でも当月CFを反映する。
     AssetLiabilityMonthlySnapshot? currentMonthSnapshot;
     if (workbook != null) {
-      final monthKey =
-          AssetLiabilityMonthlyStateStore.formatMonthKey(DateTime.now());
+      final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(
+        DateTime.now(),
+      );
       currentMonthSnapshot = _assetLiabilityHistoryService.buildSnapshot(
         monthKey: monthKey,
         workbook: workbook,
@@ -14766,8 +15206,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Widget? _assetNetWorthPanelChild(AssetLiabilityWorkbook? workbook) {
     AssetLiabilityMonthlySnapshot? currentMonthSnapshot;
     if (workbook != null) {
-      final monthKey =
-          AssetLiabilityMonthlyStateStore.formatMonthKey(DateTime.now());
+      final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(
+        DateTime.now(),
+      );
       currentMonthSnapshot = _assetLiabilityHistoryService.buildSnapshot(
         monthKey: monthKey,
         workbook: workbook,
@@ -14781,10 +15222,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (!panel.hasData) {
       return null;
     }
-    return AssetNetWorthPanelCard(
-      panel: panel,
-      currencyFormatter: _formatYen,
-    );
+    return AssetNetWorthPanelCard(panel: panel, currencyFormatter: _formatYen);
   }
 
   /// dismiss 済みアラート id をローカルから読み込む (Issue #2475)。
@@ -14880,8 +15318,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               inflow.date.isBefore(cycleEndExclusive),
         ),
     ];
-    final monthSubscriptions =
-        _subscriptionsForRange(cycleStart, cycleEndExclusive);
+    final monthSubscriptions = _subscriptionsForRange(
+      cycleStart,
+      cycleEndExclusive,
+    );
     final debtInputs = <AssetCalendarDebtInput>[
       for (final row in debtRows)
         AssetCalendarDebtInput(
@@ -15093,9 +15533,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                       children: [
                         ElevatedButton.icon(
                           key: const Key('asset_salary_inflow_register'),
-                          onPressed: () => _registerSalaryInflowRule(
-                            salarySuggestionAmount,
-                          ),
+                          onPressed: () =>
+                              _registerSalaryInflowRule(salarySuggestionAmount),
                           icon: const Icon(Icons.repeat, size: 16),
                           label: Text(
                             '給料 ${_formatYen(salarySuggestionAmount)} を毎月$_salaryDay日に登録',
@@ -19113,8 +19552,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 判定(リボ複利・残高増加)に供給する。残高が変わったときだけ再記録し、
   /// 前月残高が更新されたときだけ setState で再描画する。
   void _scheduleAssetDebtTrendHistorySync(AssetLiabilityWorkbook workbook) {
-    final monthKey =
-        AssetAccountBalanceHistoryStore.formatMonthKey(workbook.baseDate);
+    final monthKey = AssetAccountBalanceHistoryStore.formatMonthKey(
+      workbook.baseDate,
+    );
     final balances = <String, double>{
       for (final row in workbook.debtMasterRows)
         if (row.balance < 0) row.id: row.balance.abs(),
@@ -19145,8 +19585,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     String signature,
   ) async {
     try {
-      final prior =
-          await _assetBalanceHistoryStore.priorMonthBalances(baseDate);
+      final prior = await _assetBalanceHistoryStore.priorMonthBalances(
+        baseDate,
+      );
       await _assetBalanceHistoryStore.recordMonth(baseDate, balances);
       // 記録した最新履歴を端末跨ぎミラーへ退避（ログイン時のみ実効）。
       unawaited(_mirrorAssetBalanceHistory());
@@ -19174,8 +19615,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     _scheduleAssetLiabilityStateIdMigration(workbook);
     _scheduleAssetDebtTrendHistorySync(workbook);
-    final currentMonthKey =
-        AssetAccountBalanceHistoryStore.formatMonthKey(workbook.baseDate);
+    final currentMonthKey = AssetAccountBalanceHistoryStore.formatMonthKey(
+      workbook.baseDate,
+    );
     // キャッシュ済み前月残高が当月のものでない間は渡さない(取り違え防止)。
     final priorMonthAccountBalances =
         _assetDebtTrendPriorBalancesMonth == currentMonthKey
@@ -19187,6 +19629,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       mainAccountId: _assetManagementMainAccountId,
       minimumSafetyBalance: _minimumSafetyBalance,
       priorMonthAccountBalances: priorMonthAccountBalances,
+      dailyTodoDigest: _currentDailyTodoDigest(),
     );
     final warningColor = workbook.cashAfterScheduledPayments < 0
         ? const Color(0xFFB91C1C)
@@ -19227,6 +19670,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             _buildAssetLiabilitySyncPanel(),
             const SizedBox(height: 12),
             _buildAssetManagementAiAssistantSection(insightReport),
+            const SizedBox(height: 12),
+            Container(key: _keyDailyTodo, child: _buildDailyTodoCard()),
             const SizedBox(height: 12),
             _buildDrinkChallengeCard(workbook),
             const SizedBox(height: 12),
@@ -20798,8 +21243,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 省く。キャッシュ未ロード or 基準日変化時のみ実フェッチする。
   Future<AssetManagementAiAnalysisHistoryEntry?>
       _latestAssetManagementAiAnalysisForBaseDate(DateTime baseDate) async {
-    final baseKey =
-        AssetManagementAiAnalysisHistoryService.reportBaseDateKey(baseDate);
+    final baseKey = AssetManagementAiAnalysisHistoryService.reportBaseDateKey(
+      baseDate,
+    );
     if (_assetManagementLatestForBaseDateCacheLoaded &&
         _assetManagementLatestForBaseDateCacheKey == baseKey) {
       return _assetManagementLatestForBaseDateCache;
@@ -20850,13 +21296,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
-  Future<void> _recordAssetManagementAiSummaryAttempt(
-    DateTime baseDate,
-  ) async {
+  Future<void> _recordAssetManagementAiSummaryAttempt(DateTime baseDate) async {
     try {
       final store = await SharedPreferences.getInstance();
-      final baseKey =
-          AssetManagementAiAnalysisHistoryService.reportBaseDateKey(baseDate);
+      final baseKey = AssetManagementAiAnalysisHistoryService.reportBaseDateKey(
+        baseDate,
+      );
       await store.setString(
         _assetManagementAiSummaryLastAttemptPrefKey,
         '$baseKey|${DateTime.now().toIso8601String()}',
@@ -21523,10 +21968,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               height: 1.4,
             ),
           ),
-          buildStage(
-            '今日やること（${plan.todaySteps.length}つだけ）',
-            plan.todaySteps,
-          ),
+          buildStage('今日やること（${plan.todaySteps.length}つだけ）', plan.todaySteps),
           if (plan.todaySteps.isNotEmpty) ...[
             const SizedBox(height: 6),
             const Text(
@@ -21582,9 +22024,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// 「借金しない宣言」の遵守状況（達成は緑で称賛、違反は赤で具体指摘）を描画する。
-  Widget _buildAssetManagementDisciplineCard(
-    AssetDebtDisciplineReport report,
-  ) {
+  Widget _buildAssetManagementDisciplineCard(AssetDebtDisciplineReport report) {
     final compliant = report.isCompliant;
     final headerColor =
         compliant ? const Color(0xFF0D9488) : const Color(0xFFB91C1C);
@@ -22070,10 +22510,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           Row(
             children: [
               Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 6,
-                  vertical: 2,
-                ),
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                 decoration: BoxDecoration(
                   color: color.withValues(alpha: 0.12),
                   borderRadius: BorderRadius.circular(6),
@@ -22118,9 +22555,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }) async {
     if (_advisoryBriefingPosting) return;
     if (!_householdTrackerScheduleAllowed) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('X API投稿は管理者のみ実行できます')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('X API投稿は管理者のみ実行できます')));
       return;
     }
     final snapshot = advisoryBriefingSnapshotFrom(
@@ -22172,8 +22609,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       );
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('投稿に失敗しました: $error')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('投稿に失敗しました: $error')));
     } finally {
       if (mounted) setState(() => _advisoryBriefingPosting = false);
     }
@@ -22252,17 +22690,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (queuedUserId == null) {
       return Future<void>.error(StateError('ログインが必要です'));
     }
-    final queued = _householdTrackerMirrorWriteQueue.then<void>(
-      (_) {
-        if (_supabase.auth.currentUser?.id != queuedUserId) {
-          throw StateError('ユーザーが切り替わったため同期を中止しました');
-        }
-        return _saveHouseholdTrackerPublishMirror(
-          snapshot,
-          userId: queuedUserId,
-        );
-      },
-    );
+    final queued = _householdTrackerMirrorWriteQueue.then<void>((_) {
+      if (_supabase.auth.currentUser?.id != queuedUserId) {
+        throw StateError('ユーザーが切り替わったため同期を中止しました');
+      }
+      return _saveHouseholdTrackerPublishMirror(snapshot, userId: queuedUserId);
+    });
     _householdTrackerMirrorWriteQueue = queued.then<void>(
       (_) {},
       onError: (Object _, StackTrace __) {},
@@ -22295,14 +22728,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (_householdTrackerSnapshotSyncSignature == signature) return;
     _householdTrackerSnapshotSyncSignature = signature;
     unawaited(
-      _queueHouseholdTrackerPublishMirror(snapshot).catchError(
-        (Object error) {
-          if (_householdTrackerSnapshotSyncSignature == signature) {
-            _householdTrackerSnapshotSyncSignature = null;
-          }
-          debugPrint('household tracker snapshot sync failed: $error');
-        },
-      ),
+      _queueHouseholdTrackerPublishMirror(snapshot).catchError((Object error) {
+        if (_householdTrackerSnapshotSyncSignature == signature) {
+          _householdTrackerSnapshotSyncSignature = null;
+        }
+        debugPrint('household tracker snapshot sync failed: $error');
+      }),
     );
   }
 
@@ -22311,9 +22742,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   ) async {
     if (_householdTrackerScheduleSaving) return;
     if (!_householdTrackerScheduleAllowed) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('週次投稿の設定は管理者のみ変更できます')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('週次投稿の設定は管理者のみ変更できます')));
       return;
     }
     if (!_salaryDayConfigured) {
@@ -22372,10 +22803,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         // 最新snapshotを先に保存し、成功後にだけ投稿同意を有効化する。
         await _queueHouseholdTrackerPublishMirror(snapshot);
       }
-      await _saveHouseholdTrackerPublishConsent(
-        nextEnabled,
-        userId: userId,
-      );
+      await _saveHouseholdTrackerPublishConsent(nextEnabled, userId: userId);
       if (!mounted) return;
       setState(() {
         _householdTrackerAutoPostEnabled = nextEnabled;
@@ -22383,16 +22811,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       });
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(
-            nextEnabled ? '匿名家計トラッカーの週次投稿を有効にしました' : '週次投稿を停止しました',
-          ),
+          content: Text(nextEnabled ? '匿名家計トラッカーの週次投稿を有効にしました' : '週次投稿を停止しました'),
         ),
       );
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('週次投稿の設定を保存できませんでした: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('週次投稿の設定を保存できませんでした: $error')));
     } finally {
       if (mounted) setState(() => _householdTrackerScheduleSaving = false);
     }
@@ -22409,8 +22835,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       );
       return;
     }
-    final currentMonthKey =
-        AssetAccountBalanceHistoryStore.formatMonthKey(workbook.baseDate);
+    final currentMonthKey = AssetAccountBalanceHistoryStore.formatMonthKey(
+      workbook.baseDate,
+    );
     // キャッシュ済み前月残高が当月のものでない間は渡さない(取り違え防止)。
     final priorMonthAccountBalances =
         _assetDebtTrendPriorBalancesMonth == currentMonthKey
@@ -22434,9 +22861,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   ) async {
     if (_householdTrackerPosting) return;
     if (!_householdTrackerScheduleAllowed) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('X API投稿は管理者のみ実行できます')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('X API投稿は管理者のみ実行できます')));
       return;
     }
     if (!_salaryDayConfigured) {
@@ -22495,8 +22922,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       );
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('投稿に失敗しました: $error')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('投稿に失敗しました: $error')));
     } finally {
       if (mounted) setState(() => _householdTrackerPosting = false);
     }
@@ -24046,8 +24474,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // 照合グループのホストは shoppingDebt も正当（planning service の
     // isCardBillingHostKind と同じ集合）。creditCard 限定だと解消アクション
     // からの選択がサイレントに別カードへフォールバックし誤取込を招く。
-    final cardOptions =
-        _cardBillingAccountOptions(workbook, includeShoppingDebt: true);
+    final cardOptions = _cardBillingAccountOptions(
+      workbook,
+      includeShoppingDebt: true,
+    );
     final selected = _selectedCardStatementBillingAccountId;
     final validSelected = selected != null &&
         cardOptions.any((account) => account.id == selected);
@@ -27143,17 +27573,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     setState(() {
       _highlightedDebtCardId = accountId;
     });
-    _debtCardHighlightTimer = Timer(
-      const Duration(milliseconds: 2600),
-      () {
-        if (!mounted) {
-          return;
-        }
-        setState(() {
-          _highlightedDebtCardId = null;
-        });
-      },
-    );
+    _debtCardHighlightTimer = Timer(const Duration(milliseconds: 2600), () {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _highlightedDebtCardId = null;
+      });
+    });
   }
 
   /// 削除した支払日上書きのトゥームストーン (#part293: MirrorTombstoneStore 3例目)。
@@ -31278,10 +31705,7 @@ class _PaymentCheckGuideDialogState extends State<_PaymentCheckGuideDialog> {
 /// [active] が true の間だけ枠が明滅する。false のときは子をそのまま描画するが、
 /// レイアウトのずれを避けるため常に幅 2px の枠 (非アクティブ時は透明) を確保する。
 class _DebtPaidCheckboxHighlight extends StatefulWidget {
-  const _DebtPaidCheckboxHighlight({
-    required this.active,
-    required this.child,
-  });
+  const _DebtPaidCheckboxHighlight({required this.active, required this.child});
 
   final bool active;
   final Widget child;

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -261,6 +261,8 @@ class AssetManagementAiSummaryService {
         ),
       },
       'personal_context_signals': _buildPersonalContextSignals(report),
+      if (report.dailyTodoDigest != null && !report.dailyTodoDigest!.isEmpty)
+        'daily_todo': report.dailyTodoDigest!.toAiJson(),
       'priority_situation_cards': report.actionItems
           .map(
             (item) => _actionToDetailedSituationCard(
@@ -306,25 +308,23 @@ class AssetManagementAiSummaryService {
         ),
         'note': '定型生成の既知提案。already_issued=true は既にGitHub Issue起票済みで、'
             'AIはこれらを繰り返さず未起票の新規提案だけを返す。',
-        'items': report.developerRequests.map(
-          (request) {
-            final existingIssue = _existingIssueSummary(
-              existingDeveloperIssuesByTitle[request.title],
-            );
-            if (existingIssue != null) {
-              // 起票済み提案は echo の材料にならないよう本文を渡さない。
-              return <String, dynamic>{
-                'title': request.title,
-                'already_issued': true,
-                'existing_github_issue': existingIssue,
-                'note': '起票済み。本文・JSONブロックとも再掲禁止。',
-              };
-            }
-            return _developerRequestToJson(request)
-              ..['already_issued'] = false
-              ..['existing_github_issue'] = null;
-          },
-        ).toList(growable: false),
+        'items': report.developerRequests.map((request) {
+          final existingIssue = _existingIssueSummary(
+            existingDeveloperIssuesByTitle[request.title],
+          );
+          if (existingIssue != null) {
+            // 起票済み提案は echo の材料にならないよう本文を渡さない。
+            return <String, dynamic>{
+              'title': request.title,
+              'already_issued': true,
+              'existing_github_issue': existingIssue,
+              'note': '起票済み。本文・JSONブロックとも再掲禁止。',
+            };
+          }
+          return _developerRequestToJson(request)
+            ..['already_issued'] = false
+            ..['existing_github_issue'] = null;
+        }).toList(growable: false),
         'required_output_contract': const <String>[
           '現状の痛み',
           '根拠データ',
@@ -492,6 +492,7 @@ class AssetManagementAiSummaryService {
       '出力ルール: FlutterのMarkdownプレビューで表示します。必ずGitHub Flavored Markdownで、## 見出し、- 箇条書き、**強調**を使ってください。見出し、箇条書き、ラベル、本文はすべて自然な日本語にし、英語の見出しや英語ラベルは使わないでください。プロフィールの生年月日、性別、職業、年収、住所、学歴、職歴、趣味、飲酒、喫煙、好きな食べ物を生活背景として引用し、口座名、残高、支払日、推定最低支払額、今月支払予定額、年利、月利息、元金返済見込み、負債割合と結びつけて具体的に助言してください。金額はDart計算値を正として扱い、追加計算は概算と明記してください。細木数子を彷彿とさせる、厳しめで愛情のある断言口調にしてください。曖昧にせず、今日・今週・今月にやることを具体的に言い切ってください。飢える、水だけで耐える、食事を抜くといった健康を害する提案はしないでください。食費、住居、医療、支払先への連絡、公的・地域の緊急支援を優先してください。',
       '現在データ優先ルール: 唯一の「現在の事実」は「AIに渡す詳細ペイロード」とアクションアイテムだけです。previous_ai_analyses（metrics_snapshot）は過去時点のスナップショットで、現在の事実ではありません。履歴に出てくる金額・使用可能額・未払い・期限超過を、現在のものとして断定・督促してはいけません。現在の使用可能額がプラスなら「不足」「マイナス」と言わず、現在のアクションアイテムや支払日別リスクに無い負債を「期限超過」「未払い」と呼ばないでください。現在値と履歴が矛盾する場合は必ず現在値を採用してください。',
       '履歴利用ルール: previous_ai_analyses がある場合は、各 metrics_snapshot（純資産・未払い合計・使用可能額）の数値と今回の現在値を比較し、「前回比 純資産○円」「未払い合計が△円減/増」のように差分（改善点・悪化点・据え置き点）を述べてください。過去の本文や言い回しを引用・再掲するのではなく、必ず今回の現在値を主語にして書いてください。',
+      '日々の行動ルール: daily_todo がある場合は、金銭の負債と同じ熱量で「行動の借金」にも言及してください。carried_over（やらずに繰り越したタスク）は max_carry_over_days が大きいほど厳しく叱り、具体的なタイトルを挙げて「今日こそ片づけなさい」と言い切ってください。active_streak_days が続いていれば必ず褒め、recent_days のこなした実績を根拠に「この調子」と背中を押してください。today_pending が残っていれば寝る前にやり切るよう促してください。daily_todo が無い、または空のときは行動の借金には触れず、金銭面の助言に集中してください（存在しない実績を捏造しないこと）。',
       '完結性ルール: 途中で切れないよう、各章は最大3〜5個の短い箇条書きに圧縮してください。必ず「8. 最後にズバッと総評」まで書き切り、最後の行を「以上。今日やることは、支払い確認、生活費確保、余剰支出停止。この3つよ。」で締めてください。長くなりそうな場合は、負債明細は利息負担の大きい上位5件と合計に絞ってください。',
       '開発者向け改善提案の出力ルール: implementation_context を読んで現状の機能を実際にレビューしてから提案してください。developer_requests は定型生成の既知提案一覧で、already_issued が true のものは既にGitHub Issue起票済みです。本文の「7. 開発者向け改善提案」にも既知提案・起票済み提案やその言い換えを書かないでください。items の title と同一または類似のタイトルは本文にもJSONにも出力禁止です。まだ起票されていない新規の改善提案だけを最大3件返し、新規提案が1件も無い場合は本文には「新規提案なし（既知の提案はすべて起票済みです）」と1行だけ書いてください。各提案は「現状できること（機能レビュー）」「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず含め、実装者がそのままGitHub Issueとして着手できる粒度にしてください。現実装にない機能を断言せず、推測は「追加調査」と明記してください。',
       '新規改善提案の機械可読出力ルール: 応答の最後にコードブロックを1つだけ出力してください。コードブロックの開始行は必ず「```json ai-new-proposals」の1行とし、ai-new-proposals を次の行に分けないでください。中身は本文の「7. 開発者向け改善提案」と同じ新規提案を {"title","description","evidence":[],"implementation_steps":[],"acceptance_criteria":[],"source_references":[]} の配列で返し、evidence・implementation_steps・acceptance_criteria・source_references も本文と同じ内容で必ず埋めてください。タイトルは既存Issueと区別できる具体的な日本語にしてください。新規提案がない場合は空配列 [] だけを出力してください。',
@@ -867,8 +868,10 @@ class AssetManagementAiSummaryService {
       'balance': row.balance,
       'liability_share': row.liabilityShare,
       'payment_day': row.paymentDay,
-      'scheduled_payment_date':
-          _paymentDateFor(row, baseDate)?.toIso8601String(),
+      'scheduled_payment_date': _paymentDateFor(
+        row,
+        baseDate,
+      )?.toIso8601String(),
       'payment_source_account_id': row.paymentSourceAccountId,
       'payment_source_account_name': row.paymentSourceAccountName,
       'payment_method': row.paymentMethod.name,
@@ -1084,14 +1087,12 @@ class AssetManagementAiSummaryService {
         'reconciliation_note': 'リボ払いカード。請求額=リボ設定額+max(0,リボ残高-利用限度額)で確定する。'
             '取込明細(今月の新規利用)はリボ残高へ積み増される参考値、設定内訳は紐づけ管理用の参考値で、'
             'いずれも請求額とは一致しないのが正常。不一致・要修正として扱わず、照合は完了とみなすこと。',
-        'configured_items':
-            group.configuredItems.map(_cardReviewItemToJson).toList(
-                  growable: false,
-                ),
-        'statement_lines':
-            group.statementLines.map(_statementLineToJson).toList(
-                  growable: false,
-                ),
+        'configured_items': group.configuredItems
+            .map(_cardReviewItemToJson)
+            .toList(growable: false),
+        'statement_lines': group.statementLines
+            .map(_statementLineToJson)
+            .toList(growable: false),
       };
     }
     return <String, dynamic>{
@@ -1106,13 +1107,12 @@ class AssetManagementAiSummaryService {
       'needs_review': group.needsReview,
       'alerts': group.alerts,
       'is_revolving': false,
-      'configured_items':
-          group.configuredItems.map(_cardReviewItemToJson).toList(
-                growable: false,
-              ),
-      'statement_lines': group.statementLines.map(_statementLineToJson).toList(
-            growable: false,
-          ),
+      'configured_items': group.configuredItems
+          .map(_cardReviewItemToJson)
+          .toList(growable: false),
+      'statement_lines': group.statementLines
+          .map(_statementLineToJson)
+          .toList(growable: false),
     };
   }
 

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -1,4 +1,5 @@
 import '../models/asset_liability_workbook.dart';
+import '../models/daily_todo.dart';
 import '../models/user_profile.dart';
 import 'asset_debt_discipline_monitor.dart';
 import 'asset_debt_trend_analyzer.dart';
@@ -268,6 +269,10 @@ class AssetManagementInsightReport {
   /// 「まず、これだけ」段階別トリアージ (今日3件まで/今週/今月/専門窓口)。null=未評価。
   final AssetTriagePlan? triagePlan;
 
+  /// 「今日やること」ToDo の日々の実行状況（完遂/繰り越し借金/連続日数）。
+  /// null=ToDo 未使用。細木数子AI が金銭の負債と並べて行動へ助言するための入力。
+  final DailyTodoDigest? dailyTodoDigest;
+
   const AssetManagementInsightReport({
     required this.workbook,
     this.userProfile,
@@ -285,6 +290,7 @@ class AssetManagementInsightReport {
     this.debtTrendInsights = const <AssetDebtTrendInsight>[],
     this.disciplineReport,
     this.triagePlan,
+    this.dailyTodoDigest,
   });
 
   bool get hasAccountShortfallAlerts => accountShortfallAlerts.isNotEmpty;
@@ -293,9 +299,7 @@ class AssetManagementInsightReport {
 
   List<AssetDebtTrendInsight> get criticalDebtTrendInsights {
     return debtTrendInsights
-        .where(
-          (insight) => insight.severity == AssetDebtTrendSeverity.critical,
-        )
+        .where((insight) => insight.severity == AssetDebtTrendSeverity.critical)
         .toList(growable: false);
   }
 
@@ -334,6 +338,7 @@ class AssetManagementInsightService {
         const AssetDebtDisciplineMonitor(),
     AssetTriageGuideService triageGuideService =
         const AssetTriageGuideService(),
+    DailyTodoDigest? dailyTodoDigest,
   }) {
     final breakdown = _availableMoneyBreakdown(
       workbook: workbook,
@@ -413,6 +418,7 @@ class AssetManagementInsightService {
       debtTrendInsights: debtTrendInsights,
       disciplineReport: disciplineReport,
       triagePlan: triagePlan,
+      dailyTodoDigest: dailyTodoDigest,
     );
   }
 
@@ -686,8 +692,10 @@ class AssetManagementInsightService {
   }) {
     final today = _dateOnly(workbook.baseDate);
     final payday = AssetManagementAvailableMoney.nextPayday(today);
-    final remainingDays =
-        AssetManagementAvailableMoney.remainingDaysToPayday(today, payday);
+    final remainingDays = AssetManagementAvailableMoney.remainingDaysToPayday(
+      today,
+      payday,
+    );
     final daysThisWeek = AssetManagementAvailableMoney.daysUntilWeekEnd(
       today,
       remainingDays: remainingDays,
@@ -721,8 +729,9 @@ class AssetManagementInsightService {
     };
     final end = switch (window) {
       AssetManagementInsightWindow.today => start,
-      AssetManagementInsightWindow.week =>
-        start.add(Duration(days: breakdown.daysThisWeek - 1)),
+      AssetManagementInsightWindow.week => start.add(
+          Duration(days: breakdown.daysThisWeek - 1),
+        ),
       AssetManagementInsightWindow.month => breakdown.payday,
     };
     return AssetManagementAvailableMoneyInsight(
@@ -1816,24 +1825,32 @@ class AssetManagementInsightPromptBuilder {
       return '- 規律モニター未評価。\n';
     }
     final buffer = StringBuffer()
-      ..writeln('- 誓約①「追加の借金をしない」: '
-          '${discipline.zeroNewBorrowingAchieved ? '達成' : '違反あり'}'
-          '${discipline.hasPriorMonthData ? '' : '（前月データ未蓄積のため判定保留）'}')
-      ..writeln('- 誓約②「カードは必ず一括返済」: '
-          '${discipline.lumpSumAchieved ? '達成' : '違反あり'}')
+      ..writeln(
+        '- 誓約①「追加の借金をしない」: '
+        '${discipline.zeroNewBorrowingAchieved ? '達成' : '違反あり'}'
+        '${discipline.hasPriorMonthData ? '' : '（前月データ未蓄積のため判定保留）'}',
+      )
+      ..writeln(
+        '- 誓約②「カードは必ず一括返済」: '
+        '${discipline.lumpSumAchieved ? '達成' : '違反あり'}',
+      )
       ..writeln('- 今月の新規借入推定合計: ${_formatAmount(discipline.totalNewBorrowing)}')
-      ..writeln('- リボ/分割で翌月へ繰り越す残高合計: '
-          '${_formatAmount(discipline.totalCarriedOver)}');
+      ..writeln(
+        '- リボ/分割で翌月へ繰り越す残高合計: '
+        '${_formatAmount(discipline.totalCarriedOver)}',
+      );
     if (discipline.isCompliant) {
       buffer.writeln('- 今月は両誓約を守れています。AIはこの達成を必ず褒め、継続を後押ししてください。');
       return buffer.toString();
     }
     for (final violation in discipline.allViolations) {
       buffer
-        ..writeln('- [${violation.severity.name}] '
-            '${_disciplineTypeLabel(violation.type)} / ${violation.accountName} / '
-            '金額:${_formatAmount(violation.amount)} / '
-            '残高:${_formatAmount(violation.currentBalance)}')
+        ..writeln(
+          '- [${violation.severity.name}] '
+          '${_disciplineTypeLabel(violation.type)} / ${violation.accountName} / '
+          '金額:${_formatAmount(violation.amount)} / '
+          '残高:${_formatAmount(violation.currentBalance)}',
+        )
         ..writeln('  - 問題点: ${violation.problem}')
         ..writeln('  - 対応: ${violation.action}');
     }

--- a/lib/services/daily_todo_store.dart
+++ b/lib/services/daily_todo_store.dart
@@ -1,0 +1,244 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/daily_todo.dart';
+
+/// ローカルに読み込んだ「今日やること」の状態(タスク + 完遂ログ + 更新時刻)。
+class DailyTodoSnapshot {
+  final List<DailyTodoTask> tasks;
+  final List<DailyTodoCompletionLogEntry> log;
+
+  /// タスク一覧をこの端末が最後に更新した時刻(端末跨ぎ LWW 判定に使う)。
+  final DateTime? updatedAt;
+
+  const DailyTodoSnapshot({
+    required this.tasks,
+    required this.log,
+    required this.updatedAt,
+  });
+
+  static const DailyTodoSnapshot empty = DailyTodoSnapshot(
+    tasks: <DailyTodoTask>[],
+    log: <DailyTodoCompletionLogEntry>[],
+    updatedAt: null,
+  );
+}
+
+/// ミラー取り込みの結果(マージ後の状態 + 変化有無)。
+class DailyTodoMergeResult {
+  final DailyTodoSnapshot snapshot;
+  final bool changed;
+
+  const DailyTodoMergeResult({required this.snapshot, required this.changed});
+}
+
+/// 「今日やること」をローカル(SharedPreferences)へ永続化するストア。
+///
+/// 端末跨ぎ同期は `asset_pref_mirror` の 1 pref_key(`daily_todo`)を使うため
+/// マイグレーション不要。値の形は
+/// `{ "tasks": [...], "log": [...], "updated_at": iso }`。
+///
+/// タスク一覧は端末間で最終更新時刻の新しい方を採用(LWW)。完遂ログは
+/// 「日々こなした実績」という durable な記録なので和集合マージで消えないよう守る。
+class DailyTodoStore {
+  static const String prefsKey = 'daily_todo_v1';
+
+  /// 完遂ログを保持する日数(古い日は間引く)。
+  static const int logRetentionDays = 90;
+
+  /// 完遂ログの最大件数(保険の上限)。
+  static const int maxLogEntries = 500;
+
+  /// 完了済みタスクを一覧に残す日数(未完了は日数に関わらず常に残す)。
+  static const int completedTaskRetentionDays = 14;
+
+  /// タスク一覧の最大件数(保険の上限)。
+  static const int maxTasks = 300;
+
+  const DailyTodoStore();
+
+  Future<DailyTodoSnapshot> load({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return _decode(store.getString(prefsKey));
+  }
+
+  /// タスク・ログ・更新時刻をまとめて保存する。
+  Future<void> save({
+    required List<DailyTodoTask> tasks,
+    required List<DailyTodoCompletionLogEntry> log,
+    required DateTime updatedAt,
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final prunedTasks = _pruneTasks(tasks, updatedAt);
+    final prunedLog = _pruneLog(log, updatedAt);
+    await store.setString(
+      prefsKey,
+      jsonEncode(_encode(prunedTasks, prunedLog, updatedAt)),
+    );
+  }
+
+  /// ミラー upsert 用の jsonb 値(現在のローカル状態を丸ごと)。空なら null。
+  Future<Map<String, dynamic>?> encodeMirror({SharedPreferences? prefs}) async {
+    final snapshot = await load(prefs: prefs);
+    if (snapshot.tasks.isEmpty && snapshot.log.isEmpty) {
+      return null;
+    }
+    return _encode(snapshot.tasks, snapshot.log, snapshot.updatedAt);
+  }
+
+  /// 他端末由来のミラー値をローカルへマージする。
+  ///
+  /// - タスク一覧: リモートの updated_at がローカルより新しければリモートを採用(LWW)。
+  /// - 完遂ログ: 常に和集合マージ(実績記録を消さない)。
+  ///
+  /// 変化があれば永続化し、マージ後スナップショットと変化有無を返す。
+  Future<DailyTodoMergeResult> mergeRemote(
+    Object? remoteValue, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final local = _decode(store.getString(prefsKey));
+    if (remoteValue is! Map) {
+      return DailyTodoMergeResult(snapshot: local, changed: false);
+    }
+    final remote = _decode(jsonEncode(remoteValue));
+
+    // ログは和集合(mergeKey で重複排除)。
+    final mergedLogByKey = <String, DailyTodoCompletionLogEntry>{};
+    for (final entry in local.log) {
+      mergedLogByKey[entry.mergeKey] = entry;
+    }
+    var logChanged = false;
+    for (final entry in remote.log) {
+      if (!mergedLogByKey.containsKey(entry.mergeKey)) {
+        mergedLogByKey[entry.mergeKey] = entry;
+        logChanged = true;
+      }
+    }
+
+    // タスクは LWW。リモートが厳密に新しいときだけ採用する。
+    final remoteTasksNewer = remote.updatedAt != null &&
+        (local.updatedAt == null ||
+            remote.updatedAt!.isAfter(local.updatedAt!));
+    final adoptRemoteTasks = remoteTasksNewer && remote.tasks.isNotEmpty;
+    final tasks = adoptRemoteTasks ? remote.tasks : local.tasks;
+    final tasksChanged = adoptRemoteTasks;
+
+    if (!logChanged && !tasksChanged) {
+      return DailyTodoMergeResult(snapshot: local, changed: false);
+    }
+
+    final mergedLog = mergedLogByKey.values.toList()
+      ..sort((a, b) => a.completedAt.compareTo(b.completedAt));
+    // タスクを採用した場合はその updated_at を、そうでなければローカルを保つ。
+    final updatedAt = adoptRemoteTasks ? remote.updatedAt : local.updatedAt;
+    final merged = DailyTodoSnapshot(
+      tasks: _pruneTasks(tasks, updatedAt ?? DateTime.now()),
+      log: _pruneLog(mergedLog, updatedAt ?? DateTime.now()),
+      updatedAt: updatedAt,
+    );
+    await store.setString(
+      prefsKey,
+      jsonEncode(_encode(merged.tasks, merged.log, merged.updatedAt)),
+    );
+    return DailyTodoMergeResult(snapshot: merged, changed: true);
+  }
+
+  Map<String, dynamic> _encode(
+    List<DailyTodoTask> tasks,
+    List<DailyTodoCompletionLogEntry> log,
+    DateTime? updatedAt,
+  ) {
+    return <String, dynamic>{
+      'tasks': tasks.map((task) => task.toJson()).toList(),
+      'log': log.map((entry) => entry.toJson()).toList(),
+      'updated_at': updatedAt?.toUtc().toIso8601String(),
+    };
+  }
+
+  DailyTodoSnapshot _decode(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return DailyTodoSnapshot.empty;
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return DailyTodoSnapshot.empty;
+      }
+      final tasks = <DailyTodoTask>[];
+      final rawTasks = decoded['tasks'];
+      if (rawTasks is List) {
+        for (final item in rawTasks) {
+          final task = DailyTodoTask.fromJson(item);
+          if (task != null) {
+            tasks.add(task);
+          }
+        }
+      }
+      final log = <DailyTodoCompletionLogEntry>[];
+      final rawLog = decoded['log'];
+      if (rawLog is List) {
+        for (final item in rawLog) {
+          final entry = DailyTodoCompletionLogEntry.fromJson(item);
+          if (entry != null) {
+            log.add(entry);
+          }
+        }
+      }
+      final updatedAt = DateTime.tryParse(
+        decoded['updated_at']?.toString() ?? '',
+      )?.toLocal();
+      return DailyTodoSnapshot(tasks: tasks, log: log, updatedAt: updatedAt);
+    } catch (_) {
+      return DailyTodoSnapshot.empty;
+    }
+  }
+
+  List<DailyTodoTask> _pruneTasks(List<DailyTodoTask> tasks, DateTime now) {
+    final cutoff = DateTime(
+      now.year,
+      now.month,
+      now.day,
+    ).subtract(const Duration(days: completedTaskRetentionDays));
+    final kept = <DailyTodoTask>[];
+    for (final task in tasks) {
+      if (!task.completed) {
+        kept.add(task);
+        continue;
+      }
+      final completedAt = task.completedAt;
+      if (completedAt == null || !completedAt.isBefore(cutoff)) {
+        kept.add(task);
+      }
+    }
+    if (kept.length <= maxTasks) {
+      return kept;
+    }
+    // 上限超過時は新しい予定日から残す。
+    kept.sort((a, b) => b.plannedDate.compareTo(a.plannedDate));
+    return kept.take(maxTasks).toList();
+  }
+
+  List<DailyTodoCompletionLogEntry> _pruneLog(
+    List<DailyTodoCompletionLogEntry> log,
+    DateTime now,
+  ) {
+    final cutoffKey = dailyTodoDateKey(
+      DateTime(
+        now.year,
+        now.month,
+        now.day,
+      ).subtract(const Duration(days: logRetentionDays)),
+    );
+    final kept = log
+        .where((entry) => entry.dateKey.compareTo(cutoffKey) >= 0)
+        .toList()
+      ..sort((a, b) => a.completedAt.compareTo(b.completedAt));
+    if (kept.length <= maxLogEntries) {
+      return kept;
+    }
+    return kept.sublist(kept.length - maxLogEntries);
+  }
+}

--- a/test/models/daily_todo_test.dart
+++ b/test/models/daily_todo_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/daily_todo.dart';
+
+void main() {
+  // 固定の「今日」。時刻付きでも日付のみへ正規化される前提。
+  final now = DateTime(2026, 7, 31, 22, 0);
+  final today = DateTime(2026, 7, 31);
+
+  group('DailyTodoTask', () {
+    test('予定日が過去で未完了なら繰り越し(借金)・日数付き', () {
+      final task = DailyTodoTask(
+        id: 't1',
+        title: '請求確認',
+        plannedDate: DateTime(2026, 7, 28),
+      );
+      expect(task.isCarriedOverAsOf(today), isTrue);
+      expect(task.carryOverDaysAsOf(today), 3);
+      expect(task.isForToday(today), isFalse);
+    });
+
+    test('今日の予定は繰り越しでない', () {
+      final task = DailyTodoTask(id: 't2', title: '運動', plannedDate: now);
+      expect(task.isForToday(today), isTrue);
+      expect(task.isCarriedOverAsOf(today), isFalse);
+      expect(task.carryOverDaysAsOf(today), 0);
+    });
+
+    test('完了済みは予定日が過去でも繰り越しにならない', () {
+      final task = DailyTodoTask(
+        id: 't3',
+        title: '納税',
+        plannedDate: DateTime(2026, 7, 20),
+        completed: true,
+        completedAt: DateTime(2026, 7, 21, 9),
+      );
+      expect(task.isCarriedOverAsOf(today), isFalse);
+      expect(task.carryOverDaysAsOf(today), 0);
+    });
+
+    test('toJson/fromJson ラウンドトリップ', () {
+      final task = DailyTodoTask(
+        id: 't4',
+        title: '掃除',
+        plannedDate: DateTime(2026, 7, 30),
+        completed: true,
+        completedAt: DateTime(2026, 7, 30, 12, 34),
+        note: 'メモ',
+      );
+      final restored = DailyTodoTask.fromJson(task.toJson());
+      expect(restored, isNotNull);
+      expect(restored!.id, 't4');
+      expect(restored.title, '掃除');
+      expect(restored.plannedDate, DateTime(2026, 7, 30));
+      expect(restored.completed, isTrue);
+      expect(restored.completedAt, isNotNull);
+      expect(restored.note, 'メモ');
+    });
+
+    test('copyWith で completedAt を null へ戻せる(センチネル)', () {
+      final task = DailyTodoTask(
+        id: 't5',
+        title: 'x',
+        plannedDate: today,
+        completed: true,
+        completedAt: DateTime(2026, 7, 31, 8),
+      );
+      final reopened = task.copyWith(completed: false, completedAt: null);
+      expect(reopened.completed, isFalse);
+      expect(reopened.completedAt, isNull);
+      // completedAt 未指定なら保持される。
+      final kept = task.copyWith(title: 'y');
+      expect(kept.completedAt, isNotNull);
+    });
+
+    test('id/title が欠けた壊れた JSON は null', () {
+      expect(DailyTodoTask.fromJson(<String, dynamic>{'title': 'x'}), isNull);
+      expect(
+        DailyTodoTask.fromJson(<String, dynamic>{'id': 'a', 'title': ''}),
+        isNull,
+      );
+      expect(DailyTodoTask.fromJson('not a map'), isNull);
+    });
+  });
+
+  group('DailyTodoDigest.fromState', () {
+    test('今日の集計と繰り越し借金を算出する', () {
+      final tasks = <DailyTodoTask>[
+        // 今日: 1件完了・1件未完了。
+        DailyTodoTask(
+          id: 'a',
+          title: '今日A',
+          plannedDate: today,
+          completed: true,
+          completedAt: DateTime(2026, 7, 31, 10),
+        ),
+        DailyTodoTask(id: 'b', title: '今日B', plannedDate: today),
+        // 繰り越し2件(2日前・5日前)。
+        DailyTodoTask(
+          id: 'c',
+          title: '借金C',
+          plannedDate: DateTime(2026, 7, 29),
+        ),
+        DailyTodoTask(
+          id: 'd',
+          title: '借金D',
+          plannedDate: DateTime(2026, 7, 26),
+        ),
+      ];
+      final digest = DailyTodoDigest.fromState(
+        tasks: tasks,
+        log: const <DailyTodoCompletionLogEntry>[],
+        now: now,
+      );
+      expect(digest.todayTotal, 2);
+      expect(digest.todayCompleted, 1);
+      expect(digest.todayPending, 1);
+      expect(digest.carriedOverCount, 2);
+      expect(digest.maxCarryOverDays, 5);
+      // 古い順で並ぶ(5日前が先頭)。
+      expect(digest.carriedOverTitles, <String>['借金D', '借金C']);
+      expect(digest.isEmpty, isFalse);
+    });
+
+    test('完了ログと完了タスクの重複は同日同名で二重計上しない', () {
+      final tasks = <DailyTodoTask>[
+        DailyTodoTask(
+          id: 'a',
+          title: '重複',
+          plannedDate: today,
+          completed: true,
+          completedAt: DateTime(2026, 7, 31, 9),
+        ),
+      ];
+      final log = <DailyTodoCompletionLogEntry>[
+        DailyTodoCompletionLogEntry(
+          dateKey: dailyTodoDateKey(today),
+          title: '重複',
+          completedAt: DateTime(2026, 7, 31, 9),
+        ),
+        DailyTodoCompletionLogEntry(
+          dateKey: dailyTodoDateKey(today),
+          title: '別件',
+          completedAt: DateTime(2026, 7, 31, 11),
+        ),
+      ];
+      final digest =
+          DailyTodoDigest.fromState(tasks: tasks, log: log, now: now);
+      // 「重複」は1回、「別件」は1回 = 今日2件。
+      expect(digest.completedLast7Days, 2);
+      final todayRecent = digest.recentDays.first;
+      expect(todayRecent.dateKey, dailyTodoDateKey(today));
+      expect(todayRecent.completedTitles.toSet(), <String>{'重複', '別件'});
+    });
+
+    test('連続実行日数: 今日未完了でも昨日以前の連続は途切れない(猶予)', () {
+      // 昨日・一昨日は完了、今日はまだ未完了。
+      final log = <DailyTodoCompletionLogEntry>[
+        DailyTodoCompletionLogEntry(
+          dateKey: dailyTodoDateKey(DateTime(2026, 7, 30)),
+          title: 'x',
+          completedAt: DateTime(2026, 7, 30, 9),
+        ),
+        DailyTodoCompletionLogEntry(
+          dateKey: dailyTodoDateKey(DateTime(2026, 7, 29)),
+          title: 'y',
+          completedAt: DateTime(2026, 7, 29, 9),
+        ),
+      ];
+      final digest = DailyTodoDigest.fromState(
+        tasks: const <DailyTodoTask>[],
+        log: log,
+        now: now,
+      );
+      expect(digest.activeStreakDays, 2);
+    });
+
+    test('連続実行日数: 今日も完了していれば今日を含めて数える', () {
+      final log = <DailyTodoCompletionLogEntry>[
+        for (final d in <DateTime>[
+          DateTime(2026, 7, 31),
+          DateTime(2026, 7, 30),
+          DateTime(2026, 7, 29),
+        ])
+          DailyTodoCompletionLogEntry(
+            dateKey: dailyTodoDateKey(d),
+            title: 'x',
+            completedAt: DateTime(d.year, d.month, d.day, 9),
+          ),
+      ];
+      final digest = DailyTodoDigest.fromState(
+        tasks: const <DailyTodoTask>[],
+        log: log,
+        now: now,
+      );
+      expect(digest.activeStreakDays, 3);
+    });
+
+    test('タスクもログも無ければ isEmpty かつ toAiJson は主要キーを持つ', () {
+      final digest = DailyTodoDigest.fromState(
+        tasks: const <DailyTodoTask>[],
+        log: const <DailyTodoCompletionLogEntry>[],
+        now: now,
+      );
+      expect(digest.isEmpty, isTrue);
+      final json = digest.toAiJson();
+      expect(json['today_total'], 0);
+      expect(json['carried_over_count'], 0);
+      expect(json.containsKey('recent_days'), isTrue);
+      expect(json.containsKey('active_streak_days'), isTrue);
+    });
+  });
+}

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/models/asset_management_ai_analysis_history.dart';
+import 'package:my_web_app/models/daily_todo.dart';
 import 'package:my_web_app/models/user_profile.dart';
 import 'package:my_web_app/services/ai_hub_chat_service.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
@@ -705,6 +706,67 @@ void main() {
       expect(result.text, response);
     });
   });
+
+  group('daily_todo をAIペイロードへ載せる', () {
+    final service = AssetManagementAiSummaryService(aiEnabled: false);
+
+    test('digest があり非空なら daily_todo を含み、行動の借金/実績を渡す', () {
+      final now = DateTime(2026, 7, 31, 22);
+      final digest = DailyTodoDigest.fromState(
+        tasks: <DailyTodoTask>[
+          DailyTodoTask(id: 'today', title: '今日の分', plannedDate: now),
+          DailyTodoTask(
+            id: 'debt',
+            title: '溜めた借金',
+            plannedDate: DateTime(2026, 7, 28),
+          ),
+        ],
+        log: const <DailyTodoCompletionLogEntry>[],
+        now: now,
+      );
+      final payload = service.buildAiDetailedPayload(
+        _reportWithDailyTodo(digest: digest),
+      );
+      expect(payload.containsKey('daily_todo'), isTrue);
+      final todo = payload['daily_todo'] as Map<String, dynamic>;
+      expect(todo['today_total'], 1);
+      expect(todo['carried_over_count'], 1);
+      expect(todo['max_carry_over_days'], 3);
+    });
+
+    test('digest が null なら daily_todo を含まない', () {
+      final payload = service.buildAiDetailedPayload(_report());
+      expect(payload.containsKey('daily_todo'), isFalse);
+    });
+
+    test('digest が空(ToDo未使用)なら daily_todo を含まない', () {
+      final emptyDigest = DailyTodoDigest.fromState(
+        tasks: const <DailyTodoTask>[],
+        log: const <DailyTodoCompletionLogEntry>[],
+        now: DateTime(2026, 7, 31),
+      );
+      expect(emptyDigest.isEmpty, isTrue);
+      final payload = service.buildAiDetailedPayload(
+        _reportWithDailyTodo(digest: emptyDigest),
+      );
+      expect(payload.containsKey('daily_todo'), isFalse);
+    });
+  });
+}
+
+AssetManagementInsightReport _reportWithDailyTodo({DailyTodoDigest? digest}) {
+  const planner = AssetLiabilityPlanningService();
+  const insight = AssetManagementInsightService();
+  final workbook = planner.buildWorkbook(
+    latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
+    baseDate: DateTime(2026, 7, 31),
+  );
+  return insight.buildReport(
+    workbook: workbook,
+    userProfile: _userProfile(),
+    minimumSafetyBalance: 10000,
+    dailyTodoDigest: digest,
+  );
 }
 
 AssetManagementInsightReport _reportWithDeveloperRequests() {

--- a/test/services/daily_todo_store_test.dart
+++ b/test/services/daily_todo_store_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/daily_todo.dart';
+import 'package:my_web_app/services/daily_todo_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const store = DailyTodoStore();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  Future<SharedPreferences> prefs() => SharedPreferences.getInstance();
+
+  test('save → load ラウンドトリップ(タスク+ログ+更新時刻)', () async {
+    final p = await prefs();
+    final tasks = <DailyTodoTask>[
+      DailyTodoTask(id: 'a', title: 'A', plannedDate: DateTime(2026, 7, 31)),
+    ];
+    final log = <DailyTodoCompletionLogEntry>[
+      DailyTodoCompletionLogEntry(
+        dateKey: '2026-07-30',
+        title: 'done',
+        completedAt: DateTime(2026, 7, 30, 9),
+      ),
+    ];
+    await store.save(
+      tasks: tasks,
+      log: log,
+      updatedAt: DateTime(2026, 7, 31, 12),
+      prefs: p,
+    );
+    final loaded = await store.load(prefs: p);
+    expect(loaded.tasks.map((t) => t.id), <String>['a']);
+    expect(loaded.log.map((e) => e.title), <String>['done']);
+    expect(loaded.updatedAt, DateTime(2026, 7, 31, 12));
+  });
+
+  test('mergeRemote: リモートが新しければタスクを採用(LWW)・ログは和集合', () async {
+    final p = await prefs();
+    // ローカル: 古い更新時刻・タスク1件・ログ1件。
+    await store.save(
+      tasks: <DailyTodoTask>[
+        DailyTodoTask(
+          id: 'local',
+          title: 'ローカル',
+          plannedDate: DateTime(2026, 7, 31),
+        ),
+      ],
+      log: <DailyTodoCompletionLogEntry>[
+        DailyTodoCompletionLogEntry(
+          dateKey: '2026-07-30',
+          title: 'ローカル完了',
+          completedAt: DateTime(2026, 7, 30, 9),
+        ),
+      ],
+      updatedAt: DateTime(2026, 7, 31, 8),
+      prefs: p,
+    );
+    // リモート: より新しい更新時刻・別タスク・別ログ。
+    const remoteStore = DailyTodoStore();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final rp = await SharedPreferences.getInstance();
+    await remoteStore.save(
+      tasks: <DailyTodoTask>[
+        DailyTodoTask(
+          id: 'remote',
+          title: 'リモート',
+          plannedDate: DateTime(2026, 7, 31),
+        ),
+      ],
+      log: <DailyTodoCompletionLogEntry>[
+        DailyTodoCompletionLogEntry(
+          dateKey: '2026-07-29',
+          title: 'リモート完了',
+          completedAt: DateTime(2026, 7, 29, 9),
+        ),
+      ],
+      updatedAt: DateTime(2026, 7, 31, 20),
+      prefs: rp,
+    );
+    final remoteValue = await remoteStore.encodeMirror(prefs: rp);
+
+    final result = await store.mergeRemote(remoteValue, prefs: p);
+    expect(result.changed, isTrue);
+    // タスクはリモートを採用。
+    expect(result.snapshot.tasks.map((t) => t.id), <String>['remote']);
+    // ログは両方残る(和集合)。
+    expect(
+      result.snapshot.log.map((e) => e.title).toSet(),
+      <String>{'ローカル完了', 'リモート完了'},
+    );
+  });
+
+  test('mergeRemote: リモートが古ければタスクは保持・ログだけ補完', () async {
+    final p = await prefs();
+    await store.save(
+      tasks: <DailyTodoTask>[
+        DailyTodoTask(
+          id: 'local',
+          title: 'ローカル',
+          plannedDate: DateTime(2026, 7, 31),
+        ),
+      ],
+      log: const <DailyTodoCompletionLogEntry>[],
+      updatedAt: DateTime(2026, 7, 31, 20),
+      prefs: p,
+    );
+    // リモート: 古い更新時刻。タスクは採用されないが、ログは補完される。
+    final remoteValue = <String, dynamic>{
+      'tasks': <Map<String, dynamic>>[
+        DailyTodoTask(
+          id: 'remote',
+          title: 'リモート',
+          plannedDate: DateTime(2026, 7, 31),
+        ).toJson(),
+      ],
+      'log': <Map<String, dynamic>>[
+        DailyTodoCompletionLogEntry(
+          dateKey: '2026-07-29',
+          title: '古い完了',
+          completedAt: DateTime(2026, 7, 29, 9),
+        ).toJson(),
+      ],
+      'updated_at': DateTime(2026, 7, 30, 8).toUtc().toIso8601String(),
+    };
+    final result = await store.mergeRemote(remoteValue, prefs: p);
+    expect(result.changed, isTrue);
+    // タスクはローカルのまま。
+    expect(result.snapshot.tasks.map((t) => t.id), <String>['local']);
+    // ログは補完された。
+    expect(result.snapshot.log.map((e) => e.title), <String>['古い完了']);
+  });
+
+  test('mergeRemote: 変化が無ければ changed=false', () async {
+    final p = await prefs();
+    await store.save(
+      tasks: <DailyTodoTask>[
+        DailyTodoTask(id: 'a', title: 'A', plannedDate: DateTime(2026, 7, 31)),
+      ],
+      log: const <DailyTodoCompletionLogEntry>[],
+      updatedAt: DateTime(2026, 7, 31, 20),
+      prefs: p,
+    );
+    // 同じログ・古いタスク → 何も変わらない。
+    final result = await store.mergeRemote(
+      <String, dynamic>{
+        'tasks': const <dynamic>[],
+        'log': const <dynamic>[],
+        'updated_at': DateTime(2026, 7, 30).toUtc().toIso8601String(),
+      },
+      prefs: p,
+    );
+    expect(result.changed, isFalse);
+  });
+
+  test('prune: 保持期間を超えた完了タスク/ログは間引くが未完了は残す', () async {
+    final p = await prefs();
+    final now = DateTime(2026, 7, 31, 12);
+    await store.save(
+      tasks: <DailyTodoTask>[
+        // 未完了で大幅に過去 → 残る(繰り越し借金)。
+        DailyTodoTask(
+          id: 'old-open',
+          title: '古い未完了',
+          plannedDate: DateTime(2026, 1, 1),
+        ),
+        // 完了が保持期間(14日)より前 → 間引く。
+        DailyTodoTask(
+          id: 'old-done',
+          title: '古い完了',
+          plannedDate: DateTime(2026, 6, 1),
+          completed: true,
+          completedAt: DateTime(2026, 6, 1, 9),
+        ),
+      ],
+      log: <DailyTodoCompletionLogEntry>[
+        // 90日より前 → 間引く。
+        DailyTodoCompletionLogEntry(
+          dateKey: '2026-01-01',
+          title: '大昔',
+          completedAt: DateTime(2026, 1, 1, 9),
+        ),
+        // 最近 → 残る。
+        DailyTodoCompletionLogEntry(
+          dateKey: '2026-07-30',
+          title: '最近',
+          completedAt: DateTime(2026, 7, 30, 9),
+        ),
+      ],
+      updatedAt: now,
+      prefs: p,
+    );
+    final loaded = await store.load(prefs: p);
+    expect(loaded.tasks.map((t) => t.id), <String>['old-open']);
+    expect(loaded.log.map((e) => e.title), <String>['最近']);
+  });
+
+  test('空ならミラー値は null(不要な upsert を避ける)', () async {
+    final p = await prefs();
+    expect(await store.encodeMirror(prefs: p), isNull);
+  });
+}


### PR DESCRIPTION
## 目的

「今日やるべきタスクをやらずに寝ると、それは翌日やらねばならないタスク＝概念的な借金になる」という思想で、資産管理画面にデイリー ToDo を追加する。日々こなしたタスクを細木数子AI（AI資産管理アシスタント）へのインプットにし、金銭の負債だけでなく**日々の行動そのもの**にアドバイスできるようにする。

## 追加内容

### 「今日やること」カード
資産/負債ボードの細木数子AI 直下に新設（`_keyDailyTodo`）。

- やることを登録 → 完了チェック（完了時刻を記録）
- 未完了で予定日を過ぎたタスクは **「繰り越し（明日への借金）」** として日数付き・赤字で強調表示（借金思想の可視化）
- サマリチップ: 本日 X/Y 完了 / 繰り越し借金の件数・最長日数 / 連続実行日数 / 直近7日完了数
- 空状態は「まず1つ登録して、やり切ってから寝ましょう」と促す

### 細木数子AI 連携
- `AssetManagementInsightReport.dailyTodoDigest` を追加し、`buildReport` から渡す
- AI ペイロード（`buildAiDetailedPayload`）に `daily_todo`（今日集計・繰り越し借金・連続日数・直近7日の日別完遂）を載せる
- プロンプトに「金銭の負債と同じ熱量で行動の借金/実績にも言及。繰り越しは叱り、連続実行は褒める。ToDo が無い/空なら実績を捏造せず金銭面に集中」の指示を追加

## 設計判断

- 既存の月次「必須タスク（事務手続き）」とは**別物**として新設。日次スコープ＋借金思想で意味が異なるため。
- 永続化は**ローカル（SharedPreferences）+ `asset_pref_mirror`（`pref_key='daily_todo'`）の軽量ミラー**。負債残高履歴（#129996af5）と同じ方式で **DB マイグレーション不要・端末跨ぎ同期**。
  - タスク一覧は更新時刻で **LWW**、完遂ログは**和集合マージ**（実績記録を消さない）。

## テスト

- `test/models/daily_todo_test.dart`: 繰り越し判定/日数・今日集計・完遂ログ重複排除・連続日数（今日未完了の猶予含む）・`toAiJson`
- `test/services/daily_todo_store_test.dart`: save/load・LWW 採用/非採用・ログ和集合・保持期間 prune・空ならミラー null
- `test/services/asset_management_ai_summary_service_test.dart`: digest ありで `daily_todo` を含み、null/空では含まない
- 既存 `asset_management_page` smoke（64件）緑を確認
- `flutter analyze` クリーン / `dart format` 済み

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: UIカードはローカル+ミラー永続で外部到達不能。純粋ロジック(digest/store/model)を22ユニットテスト+既存ページsmoke64件で検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
