### PR TITLE
ci: fix tools-hub MCP smoke parameter binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,10 @@ jobs:
         run: python scripts/check_github_actions_status_functions.py
         continue-on-error: false
 
+      - name: Check GitHub Actions PowerShell splatting
+        run: python scripts/check_github_actions_powershell_splatting.py
+        continue-on-error: false
+
       - name: Check duplicate dispose statements
         # part 280 実例 (二重 dispose → dispose 中断 → defunct setState) の再発防止。
         # part 286: timeout でハング検知 + --max-seconds で線形時間 (正規表現の

--- a/.github/workflows/tools-hub-mcp-smoke.yml
+++ b/.github/workflows/tools-hub-mcp-smoke.yml
@@ -90,17 +90,19 @@ jobs:
         continue-on-error: true
         shell: pwsh
         run: |
-          $args = @("-BaseUrl", $env:TOOLS_HUB_MCP_URL)
+          $smokeParams = @{
+            BaseUrl = $env:TOOLS_HUB_MCP_URL
+          }
 
           if (-not [string]::IsNullOrWhiteSpace($env:REGISTRATION_REDIRECT_URI)) {
-            $args += @("-RegistrationRedirectUri", $env:REGISTRATION_REDIRECT_URI)
+            $smokeParams.RegistrationRedirectUri = $env:REGISTRATION_REDIRECT_URI
           }
 
           if ($env:ENABLE_WRITE_CONFIRMATION_PROBE -eq "true") {
-            $args += "-EnableWriteConfirmationProbe"
+            $smokeParams.EnableWriteConfirmationProbe = $true
           }
 
-          ./scripts/tools_hub_mcp_smoke.ps1 @args
+          ./scripts/tools_hub_mcp_smoke.ps1 @smokeParams
 
       - name: Job summary
         if: always()

--- a/scripts/check_github_actions_powershell_splatting.py
+++ b/scripts/check_github_actions_powershell_splatting.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Reject PowerShell splatting of the automatic `$args` variable in workflows."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_ROOT = Path(".github/workflows")
+AUTOMATIC_ARGS_SPLAT = re.compile(r"(?<![\w])@args\b", re.IGNORECASE)
+
+
+def workflow_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted([*root.glob("*.yml"), *root.glob("*.yaml")])
+
+
+def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
+    violations: list[tuple[Path, int, str]] = []
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            if AUTOMATIC_ARGS_SPLAT.search(line):
+                violations.append((path, line_number, line.strip()))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    args = parser.parse_args(argv)
+
+    if not args.root.exists():
+        print(f"workflow directory not found: {args.root}", file=sys.stderr)
+        return 1
+
+    files = workflow_files(args.root)
+    violations = find_violations(files)
+    if violations:
+        print("Do not splat PowerShell's automatic `$args` variable.")
+        print("Use a named hashtable such as `$params` and splat it with `@params`.")
+        for path, line_number, line in violations:
+            print(f"{path}:{line_number}: {line}")
+        return 1
+
+    print(f"OK: checked {len(files)} workflow files for PowerShell @args splatting")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -107,6 +107,10 @@ def base_commands() -> list[GateCommand]:
             [python, "scripts/check_github_actions_status_functions.py"],
         ),
         GateCommand(
+            "github actions PowerShell splatting",
+            [python, "scripts/check_github_actions_powershell_splatting.py"],
+        ),
+        GateCommand(
             "wbs sync timeout resilience",
             [python, "scripts/check_wbs_sync_timeout_resilience.py"],
         ),

--- a/test/scripts/test_check_github_actions_powershell_splatting.py
+++ b/test/scripts/test_check_github_actions_powershell_splatting.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_github_actions_powershell_splatting import (
+    find_violations,
+    workflow_files,
+)
+
+
+class CheckGithubActionsPowershellSplattingTest(unittest.TestCase):
+    def test_allows_named_hashtable_splat(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workflows = Path(tmp) / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            path = workflows / "ci.yml"
+            path.write_text(
+                "jobs:\n"
+                "  test:\n"
+                "    steps:\n"
+                "      - shell: pwsh\n"
+                "        run: ./smoke.ps1 @smokeParams\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(find_violations(workflow_files(workflows)), [])
+
+    def test_rejects_automatic_args_splat(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workflows = Path(tmp) / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            path = workflows / "ci.yml"
+            path.write_text(
+                "jobs:\n"
+                "  test:\n"
+                "    steps:\n"
+                "      - shell: pwsh\n"
+                "        run: ./smoke.ps1 @args\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                find_violations(workflow_files(workflows)),
+                [(path, 5, "run: ./smoke.ps1 @args")],
+            )
+
+    def test_rejects_automatic_args_splat_case_insensitively(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workflows = Path(tmp) / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            path = workflows / "ci.yml"
+            path.write_text(
+                "jobs:\n"
+                "  test:\n"
+                "    steps:\n"
+                "      - shell: pwsh\n"
+                "        run: ./smoke.ps1 @Args\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                find_violations(workflow_files(workflows)),
+                [(path, 5, "run: ./smoke.ps1 @Args")],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace positional array splatting with a named PowerShell hashtable when invoking the tools-hub MCP smoke script
- preserve optional redirect and write-confirmation inputs through typed parameter binding
- add a repository-wide guard and regression tests against splatting PowerShell's automatic `@args` variable in workflows

## Root cause
Manual run 30597619479 proved the workflow was syntactically valid after #4422, but the smoke script printed `tools-hub MCP smoke target: -BaseUrl`. Array splatting passes values positionally and does not reinterpret `-BaseUrl` as a named parameter, so the script attempted DNS resolution for the literal string `-BaseUrl`.

## Validation
- PowerShell hashtable parameter binding probe passed
- PowerShell splatting regression tests: 3 passed
- repository guard: 117 workflow files passed
- pre-commit fast quality gate passed
- pre-push full quality gate passed
- `flutter analyze`: no issues
- Dart format: 1,072 files checked, 0 changed
- Flutter VM tests passed
- Deno tests: 601 passed, 0 failed

## Minimal E2E Gate
- Implementation-detail independent: the test protects the workflow parameter-binding contract.
- Minimal scope: valid named hashtable, invalid `@args`, and case-insensitive invalid `@Args`.
- E2E-Exception: CI workflow invocation only; no application runtime or user-visible flow changes.

Follow-up to #4422. Related: #4334, #3841