### PR TITLE
ci: handle disposed tools-hub error responses

### DIFF
--- a/scripts/tools_hub_mcp_smoke.ps1
+++ b/scripts/tools_hub_mcp_smoke.ps1
@@ -93,7 +93,17 @@ function Get-ResponseText {
     if ($null -eq $Response.Content) {
       return ""
     }
-    return $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+    try {
+      return $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+    } catch {
+      if (
+        $_.Exception -is [System.ObjectDisposedException] -or
+        $_.Exception.InnerException -is [System.ObjectDisposedException]
+      ) {
+        return ""
+      }
+      throw
+    }
   }
 
   $stream = $Response.GetResponseStream()
@@ -129,6 +139,11 @@ function Invoke-SmokeRequest {
     $params.Body = $Body | ConvertTo-Json -Depth 30
   }
 
+  $invokeWebRequestCommand = Get-Command Invoke-WebRequest -CommandType Cmdlet -ErrorAction Stop
+  if ($invokeWebRequestCommand.Parameters.ContainsKey("SkipHttpErrorCheck")) {
+    $params.SkipHttpErrorCheck = $true
+  }
+
   try {
     $response = Invoke-WebRequest @params
     $text = [string]$response.Content
@@ -147,7 +162,13 @@ function Invoke-SmokeRequest {
       throw
     }
 
-    $text = Get-ResponseText $response
+    $text = ""
+    if ($null -ne $_.ErrorDetails) {
+      $text = [string]$_.ErrorDetails.Message
+    }
+    if ([string]::IsNullOrWhiteSpace($text)) {
+      $text = Get-ResponseText $response
+    }
     return [pscustomobject]@{
       StatusCode = [int]$response.StatusCode
       Headers = $response.Headers

--- a/test/scripts/tools_hub_mcp_smoke_response_test.ps1
+++ b/test/scripts/tools_hub_mcp_smoke_response_test.ps1
@@ -41,6 +41,61 @@ try {
   $httpResponse.Dispose()
 }
 
+$disposedHttpResponse = [System.Net.Http.HttpResponseMessage]::new(
+  [System.Net.HttpStatusCode]::Unauthorized
+)
+$disposedHttpResponse.Content = [System.Net.Http.StringContent]::new(
+  '{"error":"disposed"}',
+  [System.Text.Encoding]::UTF8,
+  "application/json"
+)
+$disposedHttpResponse.Dispose()
+Assert-Equal `
+  "" `
+  (Get-ResponseText $disposedHttpResponse) `
+  "Disposed HttpResponseMessage content should fall back to empty text."
+
+$script:capturedSkipHttpErrorCheck = $false
+function Invoke-WebRequest {
+  param(
+    [string]$Method,
+    [string]$Uri,
+    [hashtable]$Headers,
+    [int]$TimeoutSec,
+    [switch]$UseBasicParsing,
+    [string]$ErrorAction,
+    [switch]$SkipHttpErrorCheck,
+    [string]$ContentType,
+    [object]$Body
+  )
+
+  $script:capturedSkipHttpErrorCheck = $PSBoundParameters.ContainsKey(
+    "SkipHttpErrorCheck"
+  )
+  return [pscustomobject]@{
+    StatusCode = 401
+    Headers = @{ "WWW-Authenticate" = "Bearer" }
+    Content = '{"error":"unauthorized"}'
+  }
+}
+
+try {
+  $supportsSkipHttpErrorCheck = (
+    Get-Command Invoke-WebRequest -CommandType Cmdlet -ErrorAction Stop
+  ).Parameters.ContainsKey("SkipHttpErrorCheck")
+  $mockResponse = Invoke-SmokeRequest `
+    -Method "POST" `
+    -Url "https://example.test/functions/v1/tools-hub" `
+    -Body @{ jsonrpc = "2.0" }
+  Assert-Equal "401" ([string]$mockResponse.StatusCode) "HTTP errors should be returned."
+  Assert-Equal `
+    ([string]$supportsSkipHttpErrorCheck) `
+    ([string]$script:capturedSkipHttpErrorCheck) `
+    "SkipHttpErrorCheck should be used only when the runtime supports it."
+} finally {
+  Remove-Item Function:\Invoke-WebRequest
+}
+
 $legacyResponse = [pscustomobject]@{}
 $legacyResponse | Add-Member -MemberType ScriptMethod -Name GetResponseStream -Value {
   $bytes = [System.Text.Encoding]::UTF8.GetBytes('{"error":"legacy"}')


### PR DESCRIPTION
## Summary

- Use `Invoke-WebRequest -SkipHttpErrorCheck` when the PowerShell runtime supports it so 401/409 responses remain readable.
- Prefer PowerShell's captured error details on legacy runtimes and tolerate already-disposed `HttpResponseMessage` content.
- Extend the tools-hub MCP response compatibility test for disposed content and runtime-dependent parameter binding.

## Root cause

On PowerShell 7, `Invoke-WebRequest` threw for the expected unauthenticated 401 response and disposed the gzip-backed `HttpContent` before the catch block read it. The smoke workflow therefore failed before it could assert the deny-by-default status and challenge header.

## Impact

The scheduled and manually dispatched tools-hub MCP smoke can validate expected HTTP error responses on both PowerShell 7 and Windows PowerShell 5.1 without treating disposed response content as a workflow failure.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File test/scripts/tools_hub_mcp_smoke_response_test.ps1`
- GitHub Actions workflow checker suite
- Fast quality gate: Flutter analyze clean; Deno lint clean
- Full pre-push quality gate: Flutter analyze clean, Dart format 1073 files / 0 changed, Flutter VM tests passed, Deno 601 passed / 0 failed

## Minimal E2E Gate

- Implementation-detail independent: exercises the public smoke request wrapper and expected HTTP status/body contract rather than matching source text.
- Minimal scope: one PowerShell compatibility test file covers the changed runtime behavior.
- E2E statement: the post-merge `tools-hub MCP Smoke` workflow will be manually dispatched against the deployed endpoint before cleanup.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Bounded CI smoke compatibility fix with deterministic PowerShell tests and no application or Edge Function behavior change.