### PR TITLE
feat(asset): import Rakuten and SBI holdings CSV

### DIFF
--- a/docs/cross-instance-prs/20260807_issue2470_investment_csv_review.md
+++ b/docs/cross-instance-prs/20260807_issue2470_investment_csv_review.md
@@ -1,0 +1,67 @@
+---
+date: 2026-08-07
+from: Codex #1 (Windows app)
+to: Claude Code #1 (Windows app)
+status: pending
+priority: high
+---
+
+# Issue #2470 投資CSV import 実装レビュー
+
+## 概要
+
+WBS期限順の次タスク Issue #2470 として、楽天証券/SBI証券の保有商品CSVを
+投資資産へ preview 後に取り込む実装です。Claude Code #1 は product/UX と
+安全境界をレビューし、Codex #1 が指摘対応・CI・merge・WBS同期を担当します。
+
+## 依頼内容
+
+1. 楽天/SBIの列mappingと、tickerを自然キーにした重複判定をレビューする。
+2. preview確定前に書き込みがないこと、既定値がskipであることを確認する。
+3. 同一CSV内の同一tickerを数量合算＋取得単価の加重平均で統合する判断を確認する。
+4. UTF-8→Shift_JIS→malformed UTF-8の共通decoderと既存SMBC回帰を確認する。
+5. 問題がなければPRをapproveし、問題があれば具体的な変更要求を残す。
+
+## Delegation Packet
+
+- WBS / Issue: `389a5139-d893-403d-9af6-dffeb22e60c6` / `#2470`
+- Due date: `2026-07-21..2026-07-22`
+- Current owner: Codex #1（実装・CI・WBS同期）/ Claude Code #1（レビュー）
+- Objective: 楽天証券/SBI証券CSVの選択・preview・重複ticker skip/update
+- Branch: `codex/issue-2470-investment-csv-import`
+- Worktree: `C:\tmp\my_web_app-issue2470`
+- Allowed write set: 下記関連ファイルへのレビュー指摘。修正実装はCodex #1が担当。
+- Prohibited write set: root worktreeの既存dirty 274 paths、NotebookLM intake 4変更、既存memory変更
+- Required validation: `flutter analyze --no-pub`、対象service/widget tests、GitHub Actions
+- Expected output: GitHub PR review（approve または actionable request changes）
+- Risk triggers that must return to Claude Code: 実CSVと列mappingの不一致、自然キー変更、production schema/RLS変更
+- Memory/disk hygiene action for this session: 重いFlutter処理を直列化し、merge後に専用worktree/.dart_toolを削除
+- Subagent plan: none（2トップレベルインスタンス制を維持）
+
+## 関連ファイル
+
+- `lib/services/investment_csv_import_service.dart`
+- `lib/services/csv_bytes_decoder.dart`
+- `lib/services/smbc_csv_import_service.dart`
+- `lib/widgets/investment_asset_management_panel.dart`
+- `lib/pages/asset_management_page.dart`
+- `test/services/investment_csv_import_service_test.dart`
+- `test/services/csv_bytes_decoder_test.dart`
+- `test/widgets/investment_asset_management_panel_test.dart`
+
+## Result Contract
+
+- Changed files: service 5、Flutter UI/page 2、tests 3、このhandoff 1
+- Validation result: `flutter analyze --no-pub` 0 issues、対象service 9 tests pass、投資panel 10 tests pass
+- PR / Issue links: Issue `#2470`、PRはpush後に追記
+- Remaining risk: broker側export列名変更、VM/nativeでのShift_JIS直接decode非対応（WebではTextDecoder対応）。ローカルClaude Code reviewはOAuth期限切れ（401）のため、PR上のreview laneへ引き継ぐ
+- Next owner: Claude Code #1 review → Codex #1 CI/merge/deploy/WBS同期
+- Subagent evidence: none
+
+## 完了条件
+
+- [ ] Claude Code #1 のレビュー結果がPRに記録されている
+- [ ] 指摘がある場合はCodex #1が修正し、再検証している
+- [ ] CI全緑後に通常mergeする
+
+完了後は `done/` へ移動してください。

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -2,9 +2,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:js_interop'
-    // ignore: uri_does_not_exist
-    if (dart.library.io) 'package:my_web_app/utils/js_interop_vm_stub.dart';
 import 'dart:math'; // ← ★この1行を追加してください！
 
 import 'package:file_picker/file_picker.dart';
@@ -85,6 +82,7 @@ import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_waste_training_snapshot_inputs.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
+import 'package:my_web_app/services/csv_bytes_decoder.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_progress_card_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
@@ -7711,7 +7709,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         throw Exception('CSVデータを読み込めませんでした');
       }
 
-      final text = _decodeSmbcCsvBytes(bytes);
+      final text = const CsvBytesDecoder().decode(
+        bytes,
+        looksValid: SmbcCsvImportService.looksLikeCsv,
+        formatName: '三井住友銀行CSV',
+      );
       final parsed = const SmbcCsvImportService().parse(text);
       if (parsed.transactions.isEmpty) {
         throw Exception('登録できる三井住友銀行の入出金明細が見つかりませんでした');
@@ -7838,32 +7840,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       debugPrint('Expense classification failed: $e');
     }
   }
-
-  String _decodeSmbcCsvBytes(Uint8List bytes) {
-    try {
-      final text = utf8.decode(bytes);
-      if (_looksLikeSmbcCsv(text)) return text;
-    } catch (_) {
-      // SMBC exports are commonly CP932/Shift_JIS. Fall through to TextDecoder.
-    }
-
-    try {
-      final text = web.TextDecoder('shift_jis').decode(bytes.toJS);
-      if (_looksLikeSmbcCsv(text)) return text;
-    } catch (e) {
-      debugPrint('Shift_JIS decode failed: $e');
-    }
-
-    final malformed = utf8.decode(bytes, allowMalformed: true);
-    if (_looksLikeSmbcCsv(malformed)) return malformed;
-    throw const FormatException('三井住友銀行CSVの列名を判定できませんでした');
-  }
-
-  bool _looksLikeSmbcCsv(String text) =>
-      text.contains('年月日') &&
-      text.contains('お引出し') &&
-      text.contains('お預入れ') &&
-      text.contains('お取り扱い内容');
 
   String _flowSourceForAssetType(String assetType) {
     final normalized = assetType.trim().isEmpty ? '口座' : assetType.trim();

--- a/lib/services/csv_bytes_decoder.dart
+++ b/lib/services/csv_bytes_decoder.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'csv_shift_jis_decoder_stub.dart'
+    if (dart.library.js_interop) 'csv_shift_jis_decoder_web.dart';
+
+typedef CsvTextValidator = bool Function(String text);
+typedef CsvLegacyDecoder = String? Function(Uint8List bytes);
+
+/// Decodes Japanese CSV exports without coupling the encoding fallback to a
+/// specific bank or broker header.
+class CsvBytesDecoder {
+  const CsvBytesDecoder({CsvLegacyDecoder? shiftJisDecoder})
+      : _shiftJisDecoder = shiftJisDecoder;
+
+  final CsvLegacyDecoder? _shiftJisDecoder;
+
+  String decode(
+    Uint8List bytes, {
+    required CsvTextValidator looksValid,
+    required String formatName,
+  }) {
+    try {
+      final text = utf8.decode(bytes);
+      if (looksValid(text)) return text;
+    } on FormatException {
+      // Japanese broker and bank exports are often CP932/Shift_JIS.
+    }
+
+    try {
+      final text = (_shiftJisDecoder ?? decodeShiftJis)(bytes);
+      if (text != null && looksValid(text)) return text;
+    } on Object {
+      // Continue to the malformed UTF-8 check so callers receive one error.
+    }
+
+    final malformed = utf8.decode(bytes, allowMalformed: true);
+    if (looksValid(malformed)) return malformed;
+    throw FormatException('$formatNameの列名を判定できませんでした');
+  }
+}

--- a/lib/services/csv_shift_jis_decoder_stub.dart
+++ b/lib/services/csv_shift_jis_decoder_stub.dart
@@ -1,0 +1,3 @@
+import 'dart:typed_data';
+
+String? decodeShiftJis(Uint8List bytes) => null;

--- a/lib/services/csv_shift_jis_decoder_web.dart
+++ b/lib/services/csv_shift_jis_decoder_web.dart
@@ -1,0 +1,7 @@
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
+
+String decodeShiftJis(Uint8List bytes) =>
+    web.TextDecoder('shift_jis').decode(bytes.toJS);

--- a/lib/services/investment_csv_import_service.dart
+++ b/lib/services/investment_csv_import_service.dart
@@ -1,0 +1,464 @@
+import '../models/investment_asset.dart';
+
+enum InvestmentCsvBroker {
+  rakuten('楽天証券'),
+  sbi('SBI証券');
+
+  const InvestmentCsvBroker(this.label);
+
+  final String label;
+}
+
+enum InvestmentCsvDuplicatePolicy { skip, update }
+
+class InvestmentCsvIssue {
+  const InvestmentCsvIssue({required this.lineNumber, required this.message});
+
+  final int lineNumber;
+  final String message;
+}
+
+class InvestmentCsvRow {
+  const InvestmentCsvRow({
+    required this.lineNumber,
+    required this.draft,
+    this.mergedRowCount = 1,
+  });
+
+  final int lineNumber;
+  final InvestmentAssetDraft draft;
+  final int mergedRowCount;
+}
+
+class InvestmentCsvParseResult {
+  const InvestmentCsvParseResult({
+    required this.broker,
+    required this.rows,
+    required this.issues,
+    required this.inputRowCount,
+  });
+
+  final InvestmentCsvBroker broker;
+  final List<InvestmentCsvRow> rows;
+  final List<InvestmentCsvIssue> issues;
+  final int inputRowCount;
+}
+
+class InvestmentCsvUpdate {
+  const InvestmentCsvUpdate({required this.asset, required this.draft});
+
+  final InvestmentAsset asset;
+  final InvestmentAssetDraft draft;
+}
+
+class InvestmentCsvImportPlan {
+  const InvestmentCsvImportPlan({
+    required this.creates,
+    required this.updates,
+    required this.skippedDuplicates,
+    required this.invalidRows,
+  });
+
+  final List<InvestmentAssetDraft> creates;
+  final List<InvestmentCsvUpdate> updates;
+  final int skippedDuplicates;
+  final int invalidRows;
+
+  int get writeCount => creates.length + updates.length;
+}
+
+/// Parses holdings snapshots exported by Rakuten Securities and SBI
+/// Securities, then creates a deterministic import plan keyed by ticker.
+class InvestmentCsvImportService {
+  const InvestmentCsvImportService();
+
+  static const _tickerHeaders = <String>[
+    '銘柄コード',
+    'コード',
+    'ティッカー',
+    'ticker',
+    'symbol',
+    '銘柄',
+  ];
+  static const _quantityHeaders = <String>['保有数量', '数量', '保有数', '株数', '口数'];
+  static const _buyPriceHeaders = <String>[
+    '平均取得価額',
+    '平均取得単価',
+    '取得単価',
+    '取得価額',
+    '買付単価',
+  ];
+  static const _currentPriceHeaders = <String>[
+    '現在値',
+    '現在価格',
+    '時価単価',
+    '評価単価',
+    '株価',
+  ];
+  static const _typeHeaders = <String>[
+    '商品種別',
+    '商品種類',
+    '資産タイプ',
+    '商品分類',
+    '種別',
+    '市場',
+  ];
+  static const _dateHeaders = <String>['取得日', '買付日', '約定日'];
+
+  static bool looksLikeCsv(String text) {
+    try {
+      final rows = _nonEmptyRows(text);
+      if (rows.isEmpty) return false;
+      final header = rows.first.map(_normalizeHeader).toList();
+      _detectBroker(header);
+      _requiredIndex(header, _tickerHeaders, '銘柄コード');
+      _requiredIndex(header, _quantityHeaders, '保有数量/数量');
+      _requiredIndex(header, _buyPriceHeaders, '平均取得価額/取得単価');
+      return true;
+    } on FormatException {
+      return false;
+    }
+  }
+
+  InvestmentCsvParseResult parse(String csvText) {
+    final rows = _nonEmptyRows(csvText);
+    if (rows.isEmpty) {
+      throw const FormatException('CSVに明細行がありません');
+    }
+
+    final header = rows.first.map(_normalizeHeader).toList();
+    final broker = _detectBroker(header);
+    final tickerIndex = _requiredIndex(header, _tickerHeaders, '銘柄コード');
+    final quantityIndex = _requiredIndex(header, _quantityHeaders, '保有数量/数量');
+    final buyPriceIndex = _requiredIndex(
+      header,
+      _buyPriceHeaders,
+      '平均取得価額/取得単価',
+    );
+    final currentPriceIndex = _optionalIndex(header, _currentPriceHeaders);
+    final typeIndex = _optionalIndex(header, _typeHeaders);
+    final dateIndex = _optionalIndex(header, _dateHeaders);
+
+    final parsedByTicker = <String, InvestmentCsvRow>{};
+    final issues = <InvestmentCsvIssue>[];
+    for (var index = 1; index < rows.length; index += 1) {
+      final row = rows[index];
+      final lineNumber = index + 1;
+      try {
+        final ticker = _parseTicker(_cell(row, tickerIndex));
+        final quantity = _requiredNumber(_cell(row, quantityIndex), '保有数量/数量');
+        final buyPrice = _requiredNumber(
+          _cell(row, buyPriceIndex),
+          '平均取得価額/取得単価',
+        );
+        final currentPrice = currentPriceIndex == null
+            ? null
+            : _optionalNumber(_cell(row, currentPriceIndex));
+        if (quantity <= 0) {
+          throw const FormatException('保有数量/数量は0より大きい必要があります');
+        }
+        if (buyPrice < 0 || (currentPrice != null && currentPrice < 0)) {
+          throw const FormatException('価格は0以上である必要があります');
+        }
+
+        final typeText = typeIndex == null ? '' : _cell(row, typeIndex);
+        final draft = InvestmentAssetDraft(
+          assetType: _assetType(typeText),
+          ticker: ticker,
+          quantity: quantity,
+          buyPriceJpy: buyPrice,
+          buyDate: dateIndex == null ? null : _parseDate(_cell(row, dateIndex)),
+          currentPriceJpy: currentPrice,
+        );
+        final existing = parsedByTicker[draft.normalizedTicker];
+        parsedByTicker[draft.normalizedTicker] = existing == null
+            ? InvestmentCsvRow(lineNumber: lineNumber, draft: draft)
+            : InvestmentCsvRow(
+                lineNumber: existing.lineNumber,
+                draft: _mergeDrafts(existing.draft, draft),
+                mergedRowCount: existing.mergedRowCount + 1,
+              );
+      } on FormatException catch (error) {
+        issues.add(
+          InvestmentCsvIssue(
+            lineNumber: lineNumber,
+            message: error.message.toString(),
+          ),
+        );
+      } on ArgumentError catch (error) {
+        issues.add(
+          InvestmentCsvIssue(
+            lineNumber: lineNumber,
+            message: error.message?.toString() ?? '値が不正です',
+          ),
+        );
+      }
+    }
+
+    final parsedRows = parsedByTicker.values.toList()
+      ..sort(
+        (left, right) =>
+            left.draft.normalizedTicker.compareTo(right.draft.normalizedTicker),
+      );
+    return InvestmentCsvParseResult(
+      broker: broker,
+      rows: List<InvestmentCsvRow>.unmodifiable(parsedRows),
+      issues: List<InvestmentCsvIssue>.unmodifiable(issues),
+      inputRowCount: rows.length - 1,
+    );
+  }
+
+  InvestmentCsvImportPlan buildPlan({
+    required InvestmentCsvParseResult parsed,
+    required Iterable<InvestmentAsset> existingAssets,
+    required InvestmentCsvDuplicatePolicy duplicatePolicy,
+  }) {
+    final existingByTicker = <String, InvestmentAsset>{};
+    final sortedExisting = existingAssets.toList()
+      ..sort((left, right) => left.id.compareTo(right.id));
+    for (final asset in sortedExisting) {
+      existingByTicker.putIfAbsent(
+        asset.ticker.trim().toUpperCase(),
+        () => asset,
+      );
+    }
+
+    final creates = <InvestmentAssetDraft>[];
+    final updates = <InvestmentCsvUpdate>[];
+    var skippedDuplicates = 0;
+    for (final row in parsed.rows) {
+      final existing = existingByTicker[row.draft.normalizedTicker];
+      if (existing == null) {
+        creates.add(row.draft);
+      } else if (duplicatePolicy == InvestmentCsvDuplicatePolicy.update) {
+        updates.add(
+          InvestmentCsvUpdate(
+            asset: existing,
+            draft: _mergeForUpdate(existing, row.draft),
+          ),
+        );
+      } else {
+        skippedDuplicates += 1;
+      }
+    }
+
+    return InvestmentCsvImportPlan(
+      creates: List<InvestmentAssetDraft>.unmodifiable(creates),
+      updates: List<InvestmentCsvUpdate>.unmodifiable(updates),
+      skippedDuplicates: skippedDuplicates,
+      invalidRows: parsed.issues.length,
+    );
+  }
+
+  static InvestmentAssetDraft _mergeForUpdate(
+    InvestmentAsset existing,
+    InvestmentAssetDraft imported,
+  ) {
+    final importedCurrentPrice = imported.currentPriceJpy;
+    return InvestmentAssetDraft(
+      assetType: imported.assetType == InvestmentAssetType.stock
+          ? existing.assetType
+          : imported.assetType,
+      ticker: imported.normalizedTicker,
+      quantity: imported.quantity,
+      buyPriceJpy: imported.buyPriceJpy,
+      buyDate: imported.buyDate ?? existing.buyDate,
+      currentPriceJpy: importedCurrentPrice ?? existing.currentPriceJpy,
+      lastPricedAt: importedCurrentPrice == null ? existing.lastPricedAt : null,
+    );
+  }
+
+  static InvestmentAssetDraft _mergeDrafts(
+    InvestmentAssetDraft left,
+    InvestmentAssetDraft right,
+  ) {
+    final quantity = left.quantity + right.quantity;
+    final acquisitionCost =
+        left.quantity * left.buyPriceJpy + right.quantity * right.buyPriceJpy;
+    return InvestmentAssetDraft(
+      assetType: left.assetType == InvestmentAssetType.stock
+          ? right.assetType
+          : left.assetType,
+      ticker: left.normalizedTicker,
+      quantity: quantity,
+      buyPriceJpy: acquisitionCost / quantity,
+      buyDate: _earlier(left.buyDate, right.buyDate),
+      currentPriceJpy: right.currentPriceJpy ?? left.currentPriceJpy,
+    );
+  }
+
+  static DateTime? _earlier(DateTime? left, DateTime? right) {
+    if (left == null) return right;
+    if (right == null) return left;
+    return left.isBefore(right) ? left : right;
+  }
+
+  static InvestmentCsvBroker _detectBroker(List<String> header) {
+    if (header.contains('平均取得価額') || header.contains('保有数量')) {
+      return InvestmentCsvBroker.rakuten;
+    }
+    if (header.contains('取得単価') || header.contains('数量')) {
+      return InvestmentCsvBroker.sbi;
+    }
+    throw const FormatException('楽天証券/SBI証券のCSV列を判定できません');
+  }
+
+  static int _requiredIndex(
+    List<String> header,
+    List<String> aliases,
+    String label,
+  ) {
+    final index = _optionalIndex(header, aliases);
+    if (index == null) throw FormatException('CSVに「$label」列がありません');
+    return index;
+  }
+
+  static int? _optionalIndex(List<String> header, List<String> aliases) {
+    for (final alias in aliases) {
+      final index = header.indexOf(_normalizeHeader(alias));
+      if (index >= 0) return index;
+    }
+    return null;
+  }
+
+  static String _cell(List<String> row, int index) =>
+      index < row.length ? row[index].trim() : '';
+
+  static String _parseTicker(String value) {
+    final normalized = _toHalfWidth(value).trim().toUpperCase();
+    if (normalized.isEmpty) {
+      throw const FormatException('銘柄コードが空です');
+    }
+    final candidates = RegExp(r'[A-Z0-9.\^=_-]{1,15}')
+        .allMatches(normalized)
+        .map((match) => match.group(0) ?? '')
+        .where((candidate) => candidate.isNotEmpty)
+        .toList();
+    if (candidates.isEmpty) {
+      throw const FormatException('銘柄コードを判定できません');
+    }
+    final domesticCode = candidates.where(
+      (candidate) => RegExp(r'^\d{4}[A-Z]?$').hasMatch(candidate),
+    );
+    return (domesticCode.isNotEmpty ? domesticCode.first : candidates.first)
+        .toUpperCase();
+  }
+
+  static double _requiredNumber(String value, String label) {
+    final parsed = _optionalNumber(value);
+    if (parsed == null) throw FormatException('$labelを数値として読めません');
+    return parsed;
+  }
+
+  static double? _optionalNumber(String value) {
+    var normalized = _toHalfWidth(value)
+        .replaceAll(',', '')
+        .replaceAll('¥', '')
+        .replaceAll('￥', '')
+        .replaceAll('円', '')
+        .replaceAll('株', '')
+        .replaceAll('口', '')
+        .replaceAll(RegExp(r'\s'), '')
+        .trim();
+    if (normalized.isEmpty || normalized == '-') return null;
+    if (normalized.startsWith('(') && normalized.endsWith(')')) {
+      normalized = '-${normalized.substring(1, normalized.length - 1)}';
+    }
+    return double.tryParse(normalized);
+  }
+
+  static DateTime? _parseDate(String value) {
+    final match = RegExp(
+      r'^(\d{4})[/\-.年](\d{1,2})[/\-.月](\d{1,2})日?$',
+    ).firstMatch(_toHalfWidth(value).trim());
+    if (match == null) return null;
+    final year = int.parse(match.group(1)!);
+    final month = int.parse(match.group(2)!);
+    final day = int.parse(match.group(3)!);
+    final parsed = DateTime(year, month, day);
+    if (parsed.year != year || parsed.month != month || parsed.day != day) {
+      return null;
+    }
+    return parsed;
+  }
+
+  static InvestmentAssetType _assetType(String value) {
+    final normalized = _toHalfWidth(value).toUpperCase();
+    if (normalized.contains('REIT') || normalized.contains('リート')) {
+      return InvestmentAssetType.reit;
+    }
+    if (normalized.contains('ETF') || normalized.contains('上場投信')) {
+      return InvestmentAssetType.etf;
+    }
+    if (normalized.contains('暗号') || normalized.contains('CRYPTO')) {
+      return InvestmentAssetType.crypto;
+    }
+    return InvestmentAssetType.stock;
+  }
+
+  static String _normalizeHeader(String value) => _toHalfWidth(value)
+      .replaceFirst('\ufeff', '')
+      .replaceAll(RegExp(r'[\[［(（][^\]］)）]*[\]］)）]'), '')
+      .replaceAll(RegExp(r'\s'), '')
+      .replaceAll('・', '')
+      .trim()
+      .toLowerCase();
+
+  static String _toHalfWidth(String value) {
+    final buffer = StringBuffer();
+    for (final rune in value.runes) {
+      if (rune >= 0xff10 && rune <= 0xff19) {
+        buffer.writeCharCode(rune - 0xfee0);
+      } else if (rune >= 0xff21 && rune <= 0xff3a) {
+        buffer.writeCharCode(rune - 0xfee0);
+      } else if (rune >= 0xff41 && rune <= 0xff5a) {
+        buffer.writeCharCode(rune - 0xfee0);
+      } else {
+        buffer.writeCharCode(rune);
+      }
+    }
+    return buffer.toString();
+  }
+
+  static List<List<String>> _nonEmptyRows(String input) => _parseCsvRows(input)
+      .where((row) => row.any((cell) => cell.trim().isNotEmpty))
+      .toList(growable: false);
+
+  static List<List<String>> _parseCsvRows(String input) {
+    final rows = <List<String>>[];
+    var row = <String>[];
+    final cell = StringBuffer();
+    var inQuotes = false;
+    for (var index = 0; index < input.length; index += 1) {
+      final character = input[index];
+      if (character == '"') {
+        if (inQuotes && index + 1 < input.length && input[index + 1] == '"') {
+          cell.write('"');
+          index += 1;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (!inQuotes && character == ',') {
+        row.add(cell.toString());
+        cell.clear();
+      } else if (!inQuotes && (character == '\n' || character == '\r')) {
+        if (character == '\r' &&
+            index + 1 < input.length &&
+            input[index + 1] == '\n') {
+          index += 1;
+        }
+        row.add(cell.toString());
+        cell.clear();
+        rows.add(row);
+        row = <String>[];
+      } else {
+        cell.write(character);
+      }
+    }
+    if (cell.isNotEmpty || row.isNotEmpty) {
+      row.add(cell.toString());
+      rows.add(row);
+    }
+    return rows;
+  }
+}

--- a/lib/services/smbc_csv_import_service.dart
+++ b/lib/services/smbc_csv_import_service.dart
@@ -83,10 +83,24 @@ class SmbcCsvImportService {
   static const _memoHeader = 'メモ';
   static const _labelHeader = 'ラベル';
 
+  static bool looksLikeCsv(String text) {
+    final rows = _parseCsvRows(
+      text,
+    ).where((row) => row.any((cell) => cell.trim().isNotEmpty)).toList();
+    if (rows.isEmpty) return false;
+    final header = rows.first.map(_normalizeHeader).toList();
+    return <String>[
+      _dateHeader,
+      _withdrawalHeader,
+      _depositHeader,
+      _contentHeader,
+    ].every(header.contains);
+  }
+
   SmbcCsvImportResult parse(final String csvText) {
-    final rows = _parseCsvRows(csvText)
-        .where((row) => row.any((cell) => cell.trim().isNotEmpty))
-        .toList();
+    final rows = _parseCsvRows(
+      csvText,
+    ).where((row) => row.any((cell) => cell.trim().isNotEmpty)).toList();
     if (rows.isEmpty) {
       throw const FormatException('CSVに明細行がありません');
     }

--- a/lib/widgets/investment_asset_management_panel.dart
+++ b/lib/widgets/investment_asset_management_panel.dart
@@ -1,14 +1,20 @@
 import 'dart:async';
+import 'dart:typed_data';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../models/investment_asset.dart';
 import '../models/investment_portfolio_history.dart';
+import '../services/csv_bytes_decoder.dart';
 import '../services/investment_asset_repository.dart';
+import '../services/investment_csv_import_service.dart';
 import '../services/investment_portfolio_history_service.dart';
 import '../services/investment_valuation_service.dart';
 import 'investment_portfolio_history_chart.dart';
+
+typedef InvestmentCsvBytesPicker = Future<Uint8List?> Function();
 
 /// 投資資産の登録・一覧・編集・削除をまとめたダッシュボードパネル。
 class InvestmentAssetManagementPanel extends StatefulWidget {
@@ -20,6 +26,9 @@ class InvestmentAssetManagementPanel extends StatefulWidget {
     this.historyService = const InvestmentPortfolioHistoryService(),
     this.currencyFormatter,
     this.now,
+    this.csvBytesPicker,
+    this.csvBytesDecoder = const CsvBytesDecoder(),
+    this.csvImportService = const InvestmentCsvImportService(),
   });
 
   final InvestmentAssetRepository repository;
@@ -28,6 +37,9 @@ class InvestmentAssetManagementPanel extends StatefulWidget {
   final InvestmentPortfolioHistoryService historyService;
   final String Function(double value)? currencyFormatter;
   final DateTime Function()? now;
+  final InvestmentCsvBytesPicker? csvBytesPicker;
+  final CsvBytesDecoder csvBytesDecoder;
+  final InvestmentCsvImportService csvImportService;
 
   @override
   State<InvestmentAssetManagementPanel> createState() =>
@@ -56,6 +68,7 @@ class _InvestmentAssetManagementPanelState
   bool _loading = false;
   bool _historyLoading = false;
   bool _saving = false;
+  bool _importingCsv = false;
   int _loadSequence = 0;
   int _historyLoadSequence = 0;
   InvestmentHistoryPeriod _historyPeriod = InvestmentHistoryPeriod.oneYear;
@@ -154,6 +167,101 @@ class _InvestmentAssetManagementPanelState
         _historyLoadError = error;
         _historyLoading = false;
       });
+    }
+  }
+
+  Future<Uint8List?> _pickCsvBytes() async {
+    final picker = widget.csvBytesPicker;
+    if (picker != null) return picker();
+    final result = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: const <String>['csv'],
+      allowMultiple: false,
+      withData: true,
+    );
+    return result?.files.single.bytes;
+  }
+
+  Future<void> _openCsvImport() async {
+    final userId = _normalizedUserId;
+    if (userId == null || _saving || _importingCsv) return;
+
+    setState(() => _importingCsv = true);
+    try {
+      final bytes = await _pickCsvBytes();
+      if (bytes == null || bytes.isEmpty || !mounted) return;
+      final text = widget.csvBytesDecoder.decode(
+        bytes,
+        looksValid: InvestmentCsvImportService.looksLikeCsv,
+        formatName: '投資資産CSV',
+      );
+      final parsed = widget.csvImportService.parse(text);
+      final policy = await showDialog<InvestmentCsvDuplicatePolicy>(
+        context: context,
+        builder: (context) => InvestmentCsvImportPreviewDialog(
+          parsed: parsed,
+          existingAssets: _assets,
+          importService: widget.csvImportService,
+        ),
+      );
+      if (policy == null || !mounted || _normalizedUserId != userId) return;
+
+      final plan = widget.csvImportService.buildPlan(
+        parsed: parsed,
+        existingAssets: _assets,
+        duplicatePolicy: policy,
+      );
+      if (plan.writeCount == 0) {
+        _showMessage('取り込む銘柄はありませんでした。');
+        return;
+      }
+
+      setState(() => _saving = true);
+      final saved = <InvestmentAsset>[];
+      for (final update in plan.updates) {
+        saved.add(
+          await widget.repository.update(
+            userId: userId,
+            assetId: update.asset.id,
+            draft: update.draft,
+          ),
+        );
+      }
+      for (final draft in plan.creates) {
+        saved.add(
+          await widget.repository.create(userId: userId, draft: draft),
+        );
+      }
+      if (!mounted) return;
+      final updatedIds = plan.updates.map((item) => item.asset.id).toSet();
+      setState(() {
+        _assets = _sorted(<InvestmentAsset>[
+          for (final asset in _assets)
+            if (!updatedIds.contains(asset.id)) asset,
+          ...saved,
+        ]);
+      });
+      unawaited(_loadHistory(userId));
+      _showMessage(
+        '${plan.creates.length}件追加・${plan.updates.length}件更新・'
+        '${plan.skippedDuplicates}件スキップしました。',
+      );
+    } catch (error, stackTrace) {
+      debugPrint('Investment CSV import failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      if (!mounted) return;
+      final detail = error is FormatException ? error.message : null;
+      _showMessage(
+        detail == null ? '投資資産CSVを取り込めませんでした。' : '投資資産CSVを取り込めませんでした: $detail',
+      );
+      unawaited(_load(showLoading: false));
+    } finally {
+      if (mounted) {
+        setState(() {
+          _saving = false;
+          _importingCsv = false;
+        });
+      }
     }
   }
 
@@ -293,6 +401,20 @@ class _InvestmentAssetManagementPanelState
                       fontWeight: FontWeight.bold,
                     ),
                   ),
+                ),
+                IconButton(
+                  key: const Key('investment_asset_csv_import'),
+                  tooltip: '証券CSVを取り込む',
+                  onPressed:
+                      _normalizedUserId == null || _saving || _importingCsv
+                          ? null
+                          : _openCsvImport,
+                  icon: _importingCsv
+                      ? const SizedBox.square(
+                          dimension: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.upload_file_outlined),
                 ),
                 IconButton(
                   key: const Key('investment_asset_add'),
@@ -518,6 +640,123 @@ class _InvestmentAssetManagementPanelState
               valueColor: valueColor,
             ),
           ],
+        ),
+      ],
+    );
+  }
+}
+
+class InvestmentCsvImportPreviewDialog extends StatefulWidget {
+  const InvestmentCsvImportPreviewDialog({
+    super.key,
+    required this.parsed,
+    required this.existingAssets,
+    required this.importService,
+  });
+
+  final InvestmentCsvParseResult parsed;
+  final List<InvestmentAsset> existingAssets;
+  final InvestmentCsvImportService importService;
+
+  @override
+  State<InvestmentCsvImportPreviewDialog> createState() =>
+      _InvestmentCsvImportPreviewDialogState();
+}
+
+class _InvestmentCsvImportPreviewDialogState
+    extends State<InvestmentCsvImportPreviewDialog> {
+  InvestmentCsvDuplicatePolicy _policy = InvestmentCsvDuplicatePolicy.skip;
+
+  @override
+  Widget build(BuildContext context) {
+    final plan = widget.importService.buildPlan(
+      parsed: widget.parsed,
+      existingAssets: widget.existingAssets,
+      duplicatePolicy: _policy,
+    );
+    final theme = Theme.of(context);
+    return AlertDialog(
+      key: const Key('investment_csv_preview_dialog'),
+      title: Text('${widget.parsed.broker.label} CSVプレビュー'),
+      content: SizedBox(
+        width: 520,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                '${widget.parsed.rows.length}銘柄を検出 '
+                '（新規${plan.creates.length}・更新${plan.updates.length}・'
+                'スキップ${plan.skippedDuplicates}・'
+                '読込不可${plan.invalidRows}）',
+                key: const Key('investment_csv_preview_summary'),
+              ),
+              const SizedBox(height: 12),
+              Text('重複ticker', style: theme.textTheme.labelLarge),
+              const SizedBox(height: 8),
+              SegmentedButton<InvestmentCsvDuplicatePolicy>(
+                key: const Key('investment_csv_duplicate_policy'),
+                segments: const <ButtonSegment<InvestmentCsvDuplicatePolicy>>[
+                  ButtonSegment<InvestmentCsvDuplicatePolicy>(
+                    value: InvestmentCsvDuplicatePolicy.skip,
+                    label: Text('スキップ'),
+                    icon: Icon(Icons.skip_next_outlined),
+                  ),
+                  ButtonSegment<InvestmentCsvDuplicatePolicy>(
+                    value: InvestmentCsvDuplicatePolicy.update,
+                    label: Text('更新'),
+                    icon: Icon(Icons.update_outlined),
+                  ),
+                ],
+                selected: <InvestmentCsvDuplicatePolicy>{_policy},
+                onSelectionChanged: (selection) {
+                  setState(() => _policy = selection.single);
+                },
+              ),
+              const SizedBox(height: 12),
+              for (final row in widget.parsed.rows.take(20))
+                ListTile(
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  title: Text(row.draft.normalizedTicker),
+                  subtitle: Text(
+                    '数量 ${row.draft.quantity} / '
+                    '取得単価 ¥${row.draft.buyPriceJpy.toStringAsFixed(2)}'
+                    '${row.mergedRowCount > 1 ? ' / ${row.mergedRowCount}行統合' : ''}',
+                  ),
+                ),
+              if (widget.parsed.rows.length > 20)
+                Text('ほか ${widget.parsed.rows.length - 20}銘柄'),
+              if (widget.parsed.issues.isNotEmpty) ...[
+                const Divider(),
+                Text(
+                  '読み込めない行',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+                for (final issue in widget.parsed.issues.take(5))
+                  Text('行${issue.lineNumber}: ${issue.message}'),
+                if (widget.parsed.issues.length > 5)
+                  Text('ほか ${widget.parsed.issues.length - 5}行'),
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton.icon(
+          key: const Key('investment_csv_import_confirm'),
+          onPressed: plan.writeCount == 0
+              ? null
+              : () => Navigator.of(context).pop(_policy),
+          icon: const Icon(Icons.upload_file_outlined),
+          label: Text('${plan.writeCount}件を取り込む'),
         ),
       ],
     );

--- a/test/services/csv_bytes_decoder_test.dart
+++ b/test/services/csv_bytes_decoder_test.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/csv_bytes_decoder.dart';
+
+void main() {
+  test('uses UTF-8 when the decoded header is valid', () {
+    final bytes = Uint8List.fromList(utf8.encode('銘柄コード,保有数量'));
+
+    final decoded = const CsvBytesDecoder().decode(
+      bytes,
+      looksValid: (text) => text.contains('銘柄コード'),
+      formatName: '投資資産CSV',
+    );
+
+    expect(decoded, '銘柄コード,保有数量');
+  });
+
+  test('uses the injected Shift_JIS decoder when UTF-8 is invalid', () {
+    final bytes = Uint8List.fromList(const <int>[0x82, 0xa0]);
+    final decoder = CsvBytesDecoder(shiftJisDecoder: (_) => '銘柄コード,保有数量');
+
+    final decoded = decoder.decode(
+      bytes,
+      looksValid: (text) => text.contains('銘柄コード'),
+      formatName: '投資資産CSV',
+    );
+
+    expect(decoded, '銘柄コード,保有数量');
+  });
+
+  test('rejects bytes when no decoded candidate has the expected header', () {
+    final bytes = Uint8List.fromList(utf8.encode('unknown,data'));
+
+    expect(
+      () => const CsvBytesDecoder().decode(
+        bytes,
+        looksValid: (_) => false,
+        formatName: '投資資産CSV',
+      ),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          '投資資産CSVの列名を判定できませんでした',
+        ),
+      ),
+    );
+  });
+}

--- a/test/services/investment_csv_import_service_test.dart
+++ b/test/services/investment_csv_import_service_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/investment_asset.dart';
+import 'package:my_web_app/services/investment_csv_import_service.dart';
+
+void main() {
+  const service = InvestmentCsvImportService();
+
+  test('maps and consolidates Rakuten holdings rows by ticker', () {
+    const csv = '''
+\ufeff銘柄コード,銘柄名,商品種類,保有数量[株/口],平均取得価額[円],現在値[円]
+7203,トヨタ自動車,国内株式,100,"2,000","2,500"
+7203,トヨタ自動車,国内株式,50,"3,000","2,500"
+1343,NEXT FUNDS 東証REIT指数連動型上場投信,REIT,10,"1,800","1,900"
+''';
+
+    final result = service.parse(csv);
+
+    expect(result.broker, InvestmentCsvBroker.rakuten);
+    expect(result.inputRowCount, 3);
+    expect(result.issues, isEmpty);
+    expect(result.rows, hasLength(2));
+    final reit = result.rows.first;
+    expect(reit.draft.normalizedTicker, '1343');
+    expect(reit.draft.assetType, InvestmentAssetType.reit);
+    final toyota = result.rows.last;
+    expect(toyota.draft.normalizedTicker, '7203');
+    expect(toyota.draft.quantity, 150);
+    expect(toyota.draft.buyPriceJpy, closeTo(2333.333333, 0.000001));
+    expect(toyota.draft.currentPriceJpy, 2500);
+    expect(toyota.mergedRowCount, 2);
+  });
+
+  test(
+    'maps SBI holdings and reports invalid rows without failing preview',
+    () {
+      const csv = '''
+銘柄,商品分類,数量,取得単価,現在値
+AAPL Apple Inc.,外国株式,2,15000,18000
+9432 日本電信電話,国内株式,0,170,180
+コードなし,国内株式,10,100,110
+''';
+
+      final result = service.parse(csv);
+
+      expect(result.broker, InvestmentCsvBroker.sbi);
+      expect(result.rows, hasLength(1));
+      expect(result.rows.single.draft.normalizedTicker, 'AAPL');
+      expect(result.rows.single.draft.quantity, 2);
+      expect(result.rows.single.draft.buyPriceJpy, 15000);
+      expect(result.issues, hasLength(2));
+      expect(result.issues.first.lineNumber, 3);
+    },
+  );
+
+  test(
+    'builds skip and update plans using normalized ticker as natural key',
+    () {
+      final parsed = service.parse('''
+銘柄,数量,取得単価,現在値
+aapl Apple,3,16000,19000
+MSFT Microsoft,4,20000,22000
+''');
+      final existing = <InvestmentAsset>[
+        _asset(id: 'asset-aapl', ticker: 'AAPL', quantity: 1),
+      ];
+
+      final skip = service.buildPlan(
+        parsed: parsed,
+        existingAssets: existing,
+        duplicatePolicy: InvestmentCsvDuplicatePolicy.skip,
+      );
+      expect(skip.creates.single.normalizedTicker, 'MSFT');
+      expect(skip.updates, isEmpty);
+      expect(skip.skippedDuplicates, 1);
+
+      final update = service.buildPlan(
+        parsed: parsed,
+        existingAssets: existing,
+        duplicatePolicy: InvestmentCsvDuplicatePolicy.update,
+      );
+      expect(update.creates.single.normalizedTicker, 'MSFT');
+      expect(update.updates.single.asset.id, 'asset-aapl');
+      expect(update.updates.single.draft.quantity, 3);
+      expect(update.skippedDuplicates, 0);
+    },
+  );
+
+  test('update preserves optional existing values omitted by the CSV', () {
+    final parsed = service.parse('''
+銘柄,数量,取得単価
+AAPL Apple,3,16000
+''');
+    final existing = _asset(
+      id: 'asset-aapl',
+      ticker: 'AAPL',
+      quantity: 1,
+      assetType: InvestmentAssetType.etf,
+      buyDate: DateTime.utc(2025, 4, 1),
+      currentPriceJpy: 19000,
+      lastPricedAt: DateTime.utc(2026, 8, 1),
+    );
+
+    final plan = service.buildPlan(
+      parsed: parsed,
+      existingAssets: <InvestmentAsset>[existing],
+      duplicatePolicy: InvestmentCsvDuplicatePolicy.update,
+    );
+
+    final draft = plan.updates.single.draft;
+    expect(draft.assetType, InvestmentAssetType.etf);
+    expect(draft.buyDate, DateTime.utc(2025, 4, 1));
+    expect(draft.currentPriceJpy, 19000);
+    expect(draft.lastPricedAt, DateTime.utc(2026, 8, 1));
+  });
+
+  test('rejects a CSV without a Rakuten or SBI holdings signature', () {
+    expect(
+      () => service.parse('date,amount\n2026-01-01,100'),
+      throwsFormatException,
+    );
+    expect(
+      InvestmentCsvImportService.looksLikeCsv('date,amount\n2026-01-01,100'),
+      isFalse,
+    );
+  });
+}
+
+InvestmentAsset _asset({
+  required String id,
+  required String ticker,
+  required double quantity,
+  InvestmentAssetType assetType = InvestmentAssetType.stock,
+  DateTime? buyDate,
+  double? currentPriceJpy,
+  DateTime? lastPricedAt,
+}) {
+  return InvestmentAsset(
+    id: id,
+    userId: 'user-1',
+    assetType: assetType,
+    ticker: ticker,
+    quantity: quantity,
+    buyPriceJpy: 10000,
+    buyDate: buyDate,
+    currentPriceJpy: currentPriceJpy,
+    lastPricedAt: lastPricedAt,
+    createdAt: DateTime.utc(2026, 1, 1),
+    updatedAt: DateTime.utc(2026, 1, 1),
+  );
+}

--- a/test/widgets/investment_asset_management_panel_test.dart
+++ b/test/widgets/investment_asset_management_panel_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -269,6 +272,89 @@ void main() {
     );
     expect(find.text('BTC'), findsOne);
   });
+
+  testWidgets('previews CSV and skips an existing ticker by default', (
+    tester,
+  ) async {
+    final repository = _FakeInvestmentAssetRepository([
+      _asset(
+        id: 'asset-aapl',
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPriceJpy: 10000,
+      ),
+    ]);
+    final csv = Uint8List.fromList(
+      utf8.encode('''
+銘柄,数量,取得単価,現在値
+AAPL Apple,3,16000,19000
+MSFT Microsoft,4,20000,22000
+'''),
+    );
+    await _pumpPanel(
+      tester,
+      repository: repository,
+      userId: 'user-1',
+      csvBytesPicker: () async => csv,
+    );
+
+    await tester.tap(find.byKey(const Key('investment_asset_csv_import')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byKey(const Key('investment_csv_preview_dialog')), findsOne);
+    expect(find.text('SBI証券 CSVプレビュー'), findsOne);
+    expect(find.textContaining('新規1・更新0・スキップ1'), findsOne);
+
+    await tester.tap(find.byKey(const Key('investment_csv_import_confirm')));
+    await tester.pumpAndSettle();
+
+    expect(repository.createCalls, 1);
+    expect(repository.updateCalls, 0);
+    expect(repository.lastCreatedDraft?.normalizedTicker, 'MSFT');
+    expect(find.text('MSFT'), findsOne);
+  });
+
+  testWidgets('updates an existing ticker when update policy is selected', (
+    tester,
+  ) async {
+    final repository = _FakeInvestmentAssetRepository([
+      _asset(
+        id: 'asset-aapl',
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPriceJpy: 10000,
+      ),
+    ]);
+    final csv = Uint8List.fromList(
+      utf8.encode('''
+銘柄,数量,取得単価,現在値
+AAPL Apple,3,16000,19000
+'''),
+    );
+    await _pumpPanel(
+      tester,
+      repository: repository,
+      userId: 'user-1',
+      csvBytesPicker: () async => csv,
+    );
+
+    await tester.tap(find.byKey(const Key('investment_asset_csv_import')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text('更新'));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.textContaining('新規0・更新1・スキップ0'), findsOne);
+    await tester.tap(find.byKey(const Key('investment_csv_import_confirm')));
+    await tester.pumpAndSettle();
+
+    expect(repository.createCalls, 0);
+    expect(repository.updateCalls, 1);
+    expect(repository.lastUpdatedDraft?.normalizedTicker, 'AAPL');
+    expect(repository.lastUpdatedDraft?.quantity, 3);
+    expect(repository.lastUpdatedDraft?.buyPriceJpy, 16000);
+  });
 }
 
 Future<void> _pumpPanel(
@@ -276,6 +362,7 @@ Future<void> _pumpPanel(
   required InvestmentAssetRepository repository,
   required String? userId,
   DateTime Function()? now,
+  InvestmentCsvBytesPicker? csvBytesPicker,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -287,6 +374,7 @@ Future<void> _pumpPanel(
               repository: repository,
               userId: userId,
               now: now,
+              csvBytesPicker: csvBytesPicker,
             ),
           ),
         ),


### PR DESCRIPTION
## 概要

Issue #2470 の投資資産CSVインポートを実装します。

- 楽天証券 / SBI証券の保有銘柄CSVを自動判別
- 書き込み前のプレビュー（件数・先頭20行・不正行）
- 既存ticker重複時の skip（既定）/ update 選択
- CSV内の同一tickerは数量と取得価額を加重平均して統合
- UTF-8 / Shift_JIS の共通デコード経路
- 既存SMBC CSVインポートも共通デコーダーへ移行

## 安全性・仕様判断

- インポートは明示的なユーザー操作時のみ実行
- プレビュー確認まではRepositoryへの書き込みなし
- update時、CSVに含まれない既存の任意項目（購入日・現在価格・価格更新時刻）は保持
- ダイアログ後にユーザーIDを再確認してから書き込み
- feature flagは不要（バックグラウンド書き込みや自動実行なし）

## 検証

- 対象service/widget/SMBCテスト: 20件成功
- `flutter analyze --no-pub`: 0 issues
- pre-commit fast gate: 成功
- pre-push full quality gate: 成功（2086.78秒）
  - Dart format: 1079 files / 変更0
  - Flutter VM full suite: 成功
  - Deno tests: 601 passed / 0 failed

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: The user-visible preview, duplicate skip/update, invalid-row, and write-confirmation flows are covered by deterministic Flutter service and widget tests; adding a browser file-picker E2E case would not add stable coverage in this scoped PR.

## レビュー

Claude Code #1向けレビュー依頼:
`docs/cross-instance-prs/20260807_issue2470_investment_csv_review.md`

ローカルClaude OAuthは期限切れだったため、GitHub ActionsのAI Agent PR Review経路でもレビューを依頼します。

WBS task: `389a5139-d893-403d-9af6-dffeb22e60c6`

Closes #2470
