### PR TITLE
feat: add Beatles guitar practice tabs

### DIFF
--- a/lib/data/dpj_official_endorsements.dart
+++ b/lib/data/dpj_official_endorsements.dart
@@ -4,9 +4,11 @@ library;
 
 import '../models/election_intelligence.dart';
 
-const String dpjOfficialEndorsementSourceUrl = 'https://new-kokumin.jp/local-election-list';
+const String dpjOfficialEndorsementSourceUrl =
+    'https://new-kokumin.jp/local-election-list';
 const String dpjOfficialEndorsementSourceAsOf = '2026-08-12';
-const String dpjOfficialEndorsementSourceDocumentSha256 = 'e0905c80109db785bdd601db329a8a8ee66855ccf6c09f52cb0f39528547d315';
+const String dpjOfficialEndorsementSourceDocumentSha256 =
+    'e0905c80109db785bdd601db329a8a8ee66855ccf6c09f52cb0f39528547d315';
 const int dpjOfficialRecommendationEntryCount = 9;
 
 const List<OfficialEndorsementPrefecture> dpjOfficialEndorsements =

--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -110,6 +110,7 @@ import '../pages/user_tasks_page.dart';
 import '../pages/guitar_recording_studio_page.dart';
 import '../pages/public_guitar_gallery_page.dart';
 import '../pages/music_collaboration_page.dart';
+import '../ui/features/beatles_guitar_tabs/beatles_guitar_tabs_feature.dart';
 import '../pages/focus_timer_page.dart';
 import '../pages/ai_writing_assistant_page.dart';
 import '../pages/wiki_database_page.dart';
@@ -1656,6 +1657,26 @@ List<HomeToolEntry> buildHomeToolCatalog({
       ],
       onOpen: (context) =>
           _pushPage(context, const GuitarRecordingStudioPage()),
+    ),
+    HomeToolEntry(
+      id: 'beatles-guitar-tabs',
+      sectionId: 'personal',
+      title: 'Beatles ギター・タブ練習',
+      subtitle: '代表曲の奏法を題材にした、権利に配慮したオリジナル練習タブとテンポ調整',
+      icon: Icons.queue_music_outlined,
+      color: const Color(0xFFFF6B35),
+      keywords: const <String>[
+        'Beatles',
+        'ビートルズ',
+        'ギター',
+        'タブ譜',
+        'TAB',
+        'フィンガーピッキング',
+        'リフ',
+        'コード',
+      ],
+      onOpen: (context) =>
+          _pushPage(context, const BeatlesGuitarTabsFeature()),
     ),
     HomeToolEntry(
       id: 'public-guitar-gallery',

--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -1675,8 +1675,7 @@ List<HomeToolEntry> buildHomeToolCatalog({
         'リフ',
         'コード',
       ],
-      onOpen: (context) =>
-          _pushPage(context, const BeatlesGuitarTabsFeature()),
+      onOpen: (context) => _pushPage(context, const BeatlesGuitarTabsFeature()),
     ),
     HomeToolEntry(
       id: 'public-guitar-gallery',

--- a/lib/data/models/guitar_tab_catalog_model.dart
+++ b/lib/data/models/guitar_tab_catalog_model.dart
@@ -1,0 +1,39 @@
+class GuitarTabSectionCatalogModel {
+  const GuitarTabSectionCatalogModel({
+    required this.title,
+    required this.practiceNote,
+    required this.lines,
+  });
+
+  final String title;
+  final String practiceNote;
+  final List<String> lines;
+}
+
+class GuitarTabCatalogModel {
+  const GuitarTabCatalogModel({
+    required this.id,
+    required this.title,
+    required this.album,
+    required this.year,
+    required this.difficulty,
+    required this.tuning,
+    required this.capo,
+    required this.practiceBpm,
+    required this.summary,
+    required this.techniques,
+    required this.sections,
+  });
+
+  final String id;
+  final String title;
+  final String album;
+  final int year;
+  final String difficulty;
+  final String tuning;
+  final String capo;
+  final int practiceBpm;
+  final String summary;
+  final List<String> techniques;
+  final List<GuitarTabSectionCatalogModel> sections;
+}

--- a/lib/data/repositories/guitar_tab_repository.dart
+++ b/lib/data/repositories/guitar_tab_repository.dart
@@ -1,0 +1,52 @@
+import '../../domain/models/guitar_tab_song.dart';
+import '../models/guitar_tab_catalog_model.dart';
+import '../services/guitar_tab_catalog_service.dart';
+
+abstract interface class GuitarTabRepository {
+  Future<List<GuitarTabSong>> getSongs();
+}
+
+class LocalGuitarTabRepository implements GuitarTabRepository {
+  const LocalGuitarTabRepository({required this.catalogService});
+
+  final GuitarTabCatalogService catalogService;
+
+  @override
+  Future<List<GuitarTabSong>> getSongs() async {
+    final catalog = await catalogService.loadCatalog();
+    return List<GuitarTabSong>.unmodifiable(catalog.map(_toDomain));
+  }
+
+  GuitarTabSong _toDomain(GuitarTabCatalogModel model) {
+    return GuitarTabSong(
+      id: model.id,
+      title: model.title,
+      album: model.album,
+      year: model.year,
+      difficulty: _parseDifficulty(model.difficulty),
+      tuning: model.tuning,
+      capo: model.capo,
+      practiceBpm: model.practiceBpm,
+      summary: model.summary,
+      techniques: List<String>.unmodifiable(model.techniques),
+      sections: List<GuitarTabSection>.unmodifiable(
+        model.sections.map(
+          (section) => GuitarTabSection(
+            title: section.title,
+            practiceNote: section.practiceNote,
+            lines: List<String>.unmodifiable(section.lines),
+          ),
+        ),
+      ),
+    );
+  }
+
+  GuitarTabDifficulty _parseDifficulty(String raw) {
+    return switch (raw) {
+      'beginner' => GuitarTabDifficulty.beginner,
+      'intermediate' => GuitarTabDifficulty.intermediate,
+      'advanced' => GuitarTabDifficulty.advanced,
+      _ => throw FormatException('Unknown guitar tab difficulty: $raw'),
+    };
+  }
+}

--- a/lib/data/services/guitar_tab_catalog_service.dart
+++ b/lib/data/services/guitar_tab_catalog_service.dart
@@ -1,0 +1,119 @@
+import '../models/guitar_tab_catalog_model.dart';
+
+/// Bundled practice catalog. The notation is original instructional material,
+/// not a transcription of a copyrighted Beatles recording or score.
+class GuitarTabCatalogService {
+  const GuitarTabCatalogService();
+
+  Future<List<GuitarTabCatalogModel>> loadCatalog() async {
+    return _catalog;
+  }
+
+  static const List<GuitarTabCatalogModel> _catalog = <GuitarTabCatalogModel>[
+    GuitarTabCatalogModel(
+      id: 'blackbird-fingerstyle',
+      title: 'Blackbird',
+      album: 'The Beatles',
+      year: 1968,
+      difficulty: 'intermediate',
+      tuning: 'Standard (E A D G B E)',
+      capo: 'なし',
+      practiceBpm: 72,
+      summary: '2音の響きと親指のベースを分けて練習する、フィンガースタイル入門です。',
+      techniques: <String>['フィンガーピッキング', '2音ボイシング', 'ベース独立'],
+      sections: <GuitarTabSectionCatalogModel>[
+        GuitarTabSectionCatalogModel(
+          title: 'Interval walk — オリジナル練習',
+          practiceNote: '親指で6・4弦、人差し指で3弦を弾きます。各音を重ねず、粒をそろえましょう。',
+          lines: <String>[
+            'e|----------------|',
+            'B|----------------|',
+            'G|----0-----2---0-|',
+            'D|------0-----0---|',
+            'A|----------------|',
+            'E|--3-------------|',
+          ],
+        ),
+      ],
+    ),
+    GuitarTabCatalogModel(
+      id: 'day-tripper-riff',
+      title: 'Day Tripper',
+      album: '1965 single',
+      year: 1965,
+      difficulty: 'beginner',
+      tuning: 'Standard (E A D G B E)',
+      capo: 'なし',
+      practiceBpm: 88,
+      summary: '低音弦の短いフレーズで、休符とオルタネイトピッキングを整えます。',
+      techniques: <String>['単音リフ', 'オルタネイト', '休符'],
+      sections: <GuitarTabSectionCatalogModel>[
+        GuitarTabSectionCatalogModel(
+          title: 'E blues pulse — オリジナル練習',
+          practiceNote: '最後の休符までを1小節として数え、音を止めるタイミングをそろえます。',
+          lines: <String>[
+            'e|----------------|',
+            'B|----------------|',
+            'G|----------------|',
+            'D|------2-4-2-----|',
+            'A|--2-4-------4-2-|',
+            'E|0---------------|',
+          ],
+        ),
+      ],
+    ),
+    GuitarTabCatalogModel(
+      id: 'here-comes-the-sun-arpeggio',
+      title: 'Here Comes the Sun',
+      album: 'Abbey Road',
+      year: 1969,
+      difficulty: 'intermediate',
+      tuning: 'Standard (E A D G B E)',
+      capo: 'なし',
+      practiceBpm: 76,
+      summary: 'Dフォーム周辺のアルペジオで、明るい響きとアクセント移動を学びます。',
+      techniques: <String>['アルペジオ', 'アクセント', 'コード保持'],
+      sections: <GuitarTabSectionCatalogModel>[
+        GuitarTabSectionCatalogModel(
+          title: 'D-shape sunrise — オリジナル練習',
+          practiceNote: '左手のDフォームを保ち、1音ずつ同じ音量で鳴らします。',
+          lines: <String>[
+            'e|2-----0---------|',
+            'B|--3-----3-2-----|',
+            'G|----2-------2---|',
+            'D|0-------------0-|',
+            'A|----------------|',
+            'E|----------------|',
+          ],
+        ),
+      ],
+    ),
+    GuitarTabCatalogModel(
+      id: 'let-it-be-chords',
+      title: 'Let It Be',
+      album: 'Let It Be',
+      year: 1970,
+      difficulty: 'beginner',
+      tuning: 'Standard (E A D G B E)',
+      capo: 'なし',
+      practiceBpm: 68,
+      summary: '開放コードの切り替えと、一定の8分ストロークを落ち着いて練習します。',
+      techniques: <String>['オープンコード', 'ストローク', 'コードチェンジ'],
+      sections: <GuitarTabSectionCatalogModel>[
+        GuitarTabSectionCatalogModel(
+          title: 'Open-chord cadence — オリジナル練習',
+          practiceNote: '各フォームを4拍ずつ保ちます。まずはダウンストロークだけで始めましょう。',
+          lines: <String>[
+            '   C       G       Am      Fmaj7',
+            'e|0-------3-------0-------0-----|',
+            'B|1-------0-------1-------1-----|',
+            'G|0-------0-------2-------2-----|',
+            'D|2-------0-------2-------3-----|',
+            'A|3-------2-------0-------------|',
+            'E|--------3---------------------|',
+          ],
+        ),
+      ],
+    ),
+  ];
+}

--- a/lib/domain/models/guitar_tab_song.dart
+++ b/lib/domain/models/guitar_tab_song.dart
@@ -1,0 +1,41 @@
+enum GuitarTabDifficulty { beginner, intermediate, advanced }
+
+class GuitarTabSection {
+  const GuitarTabSection({
+    required this.title,
+    required this.practiceNote,
+    required this.lines,
+  });
+
+  final String title;
+  final String practiceNote;
+  final List<String> lines;
+}
+
+class GuitarTabSong {
+  const GuitarTabSong({
+    required this.id,
+    required this.title,
+    required this.album,
+    required this.year,
+    required this.difficulty,
+    required this.tuning,
+    required this.capo,
+    required this.practiceBpm,
+    required this.summary,
+    required this.techniques,
+    required this.sections,
+  });
+
+  final String id;
+  final String title;
+  final String album;
+  final int year;
+  final GuitarTabDifficulty difficulty;
+  final String tuning;
+  final String capo;
+  final int practiceBpm;
+  final String summary;
+  final List<String> techniques;
+  final List<GuitarTabSection> sections;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -224,6 +224,7 @@ import 'package:my_web_app/pages/fitness_health_tracker_page.dart';
 import 'package:my_web_app/pages/guitar_recording_studio_page.dart';
 import 'package:my_web_app/pages/public_guitar_gallery_page.dart';
 import 'package:my_web_app/pages/music_collaboration_page.dart';
+import 'package:my_web_app/ui/features/beatles_guitar_tabs/beatles_guitar_tabs_feature.dart';
 import 'package:my_web_app/pages/event_ticketing_page.dart';
 import 'package:my_web_app/pages/ai_assistant_chat_page.dart';
 import 'package:my_web_app/pages/ai_writing_assistant_page.dart';
@@ -1293,6 +1294,10 @@ Route<dynamic> generateAppRoute(
     case '/guitar-recording-studio':
       return MaterialPageRoute(
         builder: (_) => const GuitarRecordingStudioPage(),
+      );
+    case '/beatles-guitar-tabs':
+      return MaterialPageRoute(
+        builder: (_) => const BeatlesGuitarTabsFeature(),
       );
     case '/public-guitar-gallery':
       return MaterialPageRoute(

--- a/lib/ui/features/beatles_guitar_tabs/beatles_guitar_tabs_feature.dart
+++ b/lib/ui/features/beatles_guitar_tabs/beatles_guitar_tabs_feature.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import '../../../data/repositories/guitar_tab_repository.dart';
+import '../../../data/services/guitar_tab_catalog_service.dart';
+import 'view_models/beatles_guitar_tabs_view_model.dart';
+import 'views/beatles_guitar_tabs_page.dart';
+
+class BeatlesGuitarTabsFeature extends StatelessWidget {
+  const BeatlesGuitarTabsFeature({super.key, this.repository});
+
+  final GuitarTabRepository? repository;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedRepository = repository ??
+        const LocalGuitarTabRepository(
+          catalogService: GuitarTabCatalogService(),
+        );
+
+    return ChangeNotifierProvider<BeatlesGuitarTabsViewModel>(
+      create: (_) =>
+          BeatlesGuitarTabsViewModel(repository: resolvedRepository)..load(),
+      child: const BeatlesGuitarTabsPage(),
+    );
+  }
+}

--- a/lib/ui/features/beatles_guitar_tabs/view_models/beatles_guitar_tabs_view_model.dart
+++ b/lib/ui/features/beatles_guitar_tabs/view_models/beatles_guitar_tabs_view_model.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../../data/repositories/guitar_tab_repository.dart';
+import '../../../../domain/models/guitar_tab_song.dart';
+
+enum BeatlesGuitarTabsStatus { initial, loading, ready, failure }
+
+class BeatlesGuitarTabsViewModel extends ChangeNotifier {
+  BeatlesGuitarTabsViewModel({required GuitarTabRepository repository})
+      : _repository = repository;
+
+  final GuitarTabRepository _repository;
+
+  BeatlesGuitarTabsStatus _status = BeatlesGuitarTabsStatus.initial;
+  List<GuitarTabSong> _songs = const <GuitarTabSong>[];
+  String _query = '';
+  GuitarTabDifficulty? _difficulty;
+  String? _selectedSongId;
+  int _practiceBpm = 72;
+  String? _errorMessage;
+
+  BeatlesGuitarTabsStatus get status => _status;
+  List<GuitarTabSong> get songs => List<GuitarTabSong>.unmodifiable(_songs);
+  String get query => _query;
+  GuitarTabDifficulty? get difficulty => _difficulty;
+  int get practiceBpm => _practiceBpm;
+  String? get errorMessage => _errorMessage;
+
+  GuitarTabSong? get selectedSong {
+    for (final song in _songs) {
+      if (song.id == _selectedSongId) return song;
+    }
+    return null;
+  }
+
+  List<GuitarTabSong> get filteredSongs {
+    final normalizedQuery = _query.trim().toLowerCase();
+    return List<GuitarTabSong>.unmodifiable(
+      _songs.where((song) {
+        if (_difficulty != null && song.difficulty != _difficulty) {
+          return false;
+        }
+        if (normalizedQuery.isEmpty) return true;
+        final searchable = <String>[
+          song.title,
+          song.album,
+          song.summary,
+          ...song.techniques,
+        ].join(' ').toLowerCase();
+        return searchable.contains(normalizedQuery);
+      }),
+    );
+  }
+
+  Future<void> load() async {
+    _status = BeatlesGuitarTabsStatus.loading;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _songs = await _repository.getSongs();
+      _status = BeatlesGuitarTabsStatus.ready;
+      _selectFirstVisibleSong();
+    } catch (_) {
+      _songs = const <GuitarTabSong>[];
+      _selectedSongId = null;
+      _status = BeatlesGuitarTabsStatus.failure;
+      _errorMessage = 'タブ譜カタログを読み込めませんでした。もう一度お試しください。';
+    }
+    notifyListeners();
+  }
+
+  void setQuery(String value) {
+    if (_query == value) return;
+    _query = value;
+    _ensureSelectedSongIsVisible();
+    notifyListeners();
+  }
+
+  void setDifficulty(GuitarTabDifficulty? value) {
+    if (_difficulty == value) return;
+    _difficulty = value;
+    _ensureSelectedSongIsVisible();
+    notifyListeners();
+  }
+
+  void selectSong(String songId) {
+    for (final song in _songs) {
+      if (song.id != songId) continue;
+      _selectedSongId = song.id;
+      _practiceBpm = song.practiceBpm;
+      notifyListeners();
+      return;
+    }
+  }
+
+  void setPracticeBpm(double value) {
+    final next = value.round().clamp(60, 180);
+    if (_practiceBpm == next) return;
+    _practiceBpm = next;
+    notifyListeners();
+  }
+
+  void resetPracticeBpm() {
+    final song = selectedSong;
+    if (song == null || _practiceBpm == song.practiceBpm) return;
+    _practiceBpm = song.practiceBpm;
+    notifyListeners();
+  }
+
+  void _ensureSelectedSongIsVisible() {
+    final visible = filteredSongs;
+    if (visible.any((song) => song.id == _selectedSongId)) return;
+    _selectFirstVisibleSong();
+  }
+
+  void _selectFirstVisibleSong() {
+    final visible = filteredSongs;
+    if (visible.isEmpty) {
+      _selectedSongId = null;
+      return;
+    }
+    _selectedSongId = visible.first.id;
+    _practiceBpm = visible.first.practiceBpm;
+  }
+}

--- a/lib/ui/features/beatles_guitar_tabs/views/beatles_guitar_tabs_page.dart
+++ b/lib/ui/features/beatles_guitar_tabs/views/beatles_guitar_tabs_page.dart
@@ -1,0 +1,784 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../domain/models/guitar_tab_song.dart';
+import '../../../../theme/design_tokens.dart';
+import '../view_models/beatles_guitar_tabs_view_model.dart';
+import 'widgets/guitar_tab_staff.dart';
+
+class BeatlesGuitarTabsPage extends StatelessWidget {
+  const BeatlesGuitarTabsPage({super.key});
+
+  static const double _wideBreakpoint = 860;
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.read<BeatlesGuitarTabsViewModel>();
+
+    return Scaffold(
+      backgroundColor: DesignTokens.background,
+      appBar: AppBar(
+        backgroundColor: DesignTokens.surface1,
+        foregroundColor: DesignTokens.textPrimary,
+        elevation: 0,
+        title: const Text(
+          'Beatles Guitar Lab',
+          style: TextStyle(fontWeight: FontWeight.w700),
+        ),
+      ),
+      body: SafeArea(
+        child: ListenableBuilder(
+          listenable: viewModel,
+          builder: (context, _) {
+            return switch (viewModel.status) {
+              BeatlesGuitarTabsStatus.initial ||
+              BeatlesGuitarTabsStatus.loading =>
+                const Center(
+                  child: CircularProgressIndicator(color: DesignTokens.orange),
+                ),
+              BeatlesGuitarTabsStatus.failure => _ErrorState(
+                  message: viewModel.errorMessage ?? '読み込みに失敗しました。',
+                  onRetry: viewModel.load,
+                ),
+              BeatlesGuitarTabsStatus.ready => LayoutBuilder(
+                  builder: (context, constraints) {
+                    if (constraints.maxWidth >= _wideBreakpoint) {
+                      return _WideLayout(viewModel: viewModel);
+                    }
+                    return _CompactLayout(viewModel: viewModel);
+                  },
+                ),
+            };
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _WideLayout extends StatelessWidget {
+  const _WideLayout({required this.viewModel});
+
+  final BeatlesGuitarTabsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 1440),
+        child: Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 24, 24, 20),
+              child: Column(
+                children: <Widget>[
+                  const _HeroPanel(),
+                  const SizedBox(height: DesignTokens.space16),
+                  _CatalogControls(viewModel: viewModel),
+                ],
+              ),
+            ),
+            Expanded(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  SizedBox(
+                    width: 340,
+                    child: _SongLibrary(
+                      viewModel: viewModel,
+                      horizontal: false,
+                    ),
+                  ),
+                  const VerticalDivider(
+                    width: 1,
+                    thickness: 1,
+                    color: DesignTokens.divider,
+                  ),
+                  Expanded(
+                    child: _SongDetail(viewModel: viewModel, scrollable: true),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CompactLayout extends StatelessWidget {
+  const _CompactLayout({required this.viewModel});
+
+  final BeatlesGuitarTabsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      key: const Key('beatles_tabs_compact_layout'),
+      padding: const EdgeInsets.all(DesignTokens.space16),
+      children: <Widget>[
+        const _HeroPanel(),
+        const SizedBox(height: DesignTokens.space16),
+        _CatalogControls(viewModel: viewModel),
+        const SizedBox(height: DesignTokens.space16),
+        SizedBox(
+          height: 164,
+          child: _SongLibrary(viewModel: viewModel, horizontal: true),
+        ),
+        const SizedBox(height: DesignTokens.space24),
+        _SongDetail(viewModel: viewModel, scrollable: false),
+      ],
+    );
+  }
+}
+
+class _HeroPanel extends StatelessWidget {
+  const _HeroPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: <Color>[Color(0xFF1A1A2E), Color(0xFF16213E)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(DesignTokens.radiusLarge),
+        border: Border.all(color: DesignTokens.indigo.withValues(alpha: 0.3)),
+      ),
+      padding: const EdgeInsets.all(DesignTokens.space20),
+      child: const Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          _HeroIcon(),
+          SizedBox(width: DesignTokens.space16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  '名曲の奏法を、短い練習から',
+                  style: TextStyle(
+                    color: DesignTokens.textPrimary,
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700,
+                    height: 1.4,
+                    letterSpacing: 0.96,
+                  ),
+                ),
+                SizedBox(height: DesignTokens.space8),
+                Text(
+                  'Beatlesの代表曲を題材に、フィンガースタイル、リフ、コードチェンジを段階的に練習できます。',
+                  style: TextStyle(
+                    color: DesignTokens.textSecondary,
+                    fontSize: 14,
+                    height: 1.7,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroIcon extends StatelessWidget {
+  const _HeroIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 52,
+      height: 52,
+      decoration: BoxDecoration(
+        color: DesignTokens.orange.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+      ),
+      child: const Icon(Icons.music_note, color: DesignTokens.orange, size: 30),
+    );
+  }
+}
+
+class _CatalogControls extends StatelessWidget {
+  const _CatalogControls({required this.viewModel});
+
+  final BeatlesGuitarTabsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        TextField(
+          key: const Key('beatles_tabs_search'),
+          onChanged: viewModel.setQuery,
+          style: const TextStyle(color: DesignTokens.textPrimary),
+          decoration: InputDecoration(
+            hintText: '曲名・アルバム・奏法で検索',
+            hintStyle: const TextStyle(color: DesignTokens.textTertiary),
+            prefixIcon: const Icon(
+              Icons.search,
+              color: DesignTokens.textSecondary,
+            ),
+            filled: true,
+            fillColor: DesignTokens.surface3,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+              borderSide: BorderSide.none,
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+              borderSide: const BorderSide(
+                color: DesignTokens.orange,
+                width: 1.5,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: DesignTokens.space12),
+        Wrap(
+          spacing: DesignTokens.space8,
+          runSpacing: DesignTokens.space8,
+          children: <Widget>[
+            _DifficultyChip(
+              label: 'すべて',
+              selected: viewModel.difficulty == null,
+              onSelected: () => viewModel.setDifficulty(null),
+            ),
+            for (final difficulty in GuitarTabDifficulty.values)
+              _DifficultyChip(
+                label: _difficultyLabel(difficulty),
+                selected: viewModel.difficulty == difficulty,
+                onSelected: () => viewModel.setDifficulty(difficulty),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _DifficultyChip extends StatelessWidget {
+  const _DifficultyChip({
+    required this.label,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChoiceChip(
+      label: Text(label),
+      selected: selected,
+      onSelected: (_) => onSelected(),
+      selectedColor: DesignTokens.orange.withValues(alpha: 0.24),
+      backgroundColor: DesignTokens.surface3,
+      side: BorderSide(
+        color: selected ? DesignTokens.orange : DesignTokens.divider,
+      ),
+      labelStyle: TextStyle(
+        color: selected ? DesignTokens.orangeLight : DesignTokens.textSecondary,
+        fontSize: 12,
+      ),
+      showCheckmark: false,
+    );
+  }
+}
+
+class _SongLibrary extends StatelessWidget {
+  const _SongLibrary({required this.viewModel, required this.horizontal});
+
+  final BeatlesGuitarTabsViewModel viewModel;
+  final bool horizontal;
+
+  @override
+  Widget build(BuildContext context) {
+    final songs = viewModel.filteredSongs;
+    if (songs.isEmpty) {
+      return const _EmptyLibrary();
+    }
+
+    return ListView.separated(
+      key: Key(
+        horizontal ? 'beatles_song_list_horizontal' : 'beatles_song_list',
+      ),
+      scrollDirection: horizontal ? Axis.horizontal : Axis.vertical,
+      padding: EdgeInsets.symmetric(
+        horizontal: horizontal ? 0 : DesignTokens.space16,
+        vertical: horizontal ? 0 : DesignTokens.space8,
+      ),
+      itemCount: songs.length,
+      separatorBuilder: (_, __) => SizedBox(
+        width: horizontal ? DesignTokens.space12 : 0,
+        height: horizontal ? 0 : DesignTokens.space12,
+      ),
+      itemBuilder: (context, index) {
+        final song = songs[index];
+        return SizedBox(
+          width: horizontal ? 272 : null,
+          child: _SongCard(
+            song: song,
+            selected: viewModel.selectedSong?.id == song.id,
+            onTap: () => viewModel.selectSong(song.id),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SongCard extends StatelessWidget {
+  const _SongCard({
+    required this.song,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final GuitarTabSong song;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: selected ? const Color(0xFF2A211E) : DesignTokens.surface2,
+      borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+      child: InkWell(
+        key: Key('beatles_song_${song.id}'),
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+            border: Border.all(
+              color: selected
+                  ? DesignTokens.orange
+                  : DesignTokens.orange.withValues(alpha: 0.16),
+            ),
+          ),
+          padding: const EdgeInsets.all(DesignTokens.space16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Text(
+                      song.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: DesignTokens.textPrimary,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                        height: 1.4,
+                      ),
+                    ),
+                  ),
+                  if (selected)
+                    const Icon(
+                      Icons.play_arrow_rounded,
+                      color: DesignTokens.orange,
+                      size: 22,
+                    ),
+                ],
+              ),
+              const SizedBox(height: DesignTokens.space4),
+              Text(
+                '${song.album} • ${song.year}',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: DesignTokens.textTertiary,
+                  fontSize: 11,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: DesignTokens.space12),
+              Row(
+                children: <Widget>[
+                  _MetaChip(
+                    icon: Icons.equalizer,
+                    label: _difficultyLabel(song.difficulty),
+                  ),
+                  const SizedBox(width: DesignTokens.space8),
+                  _MetaChip(
+                    icon: Icons.speed,
+                    label: '${song.practiceBpm} BPM',
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SongDetail extends StatelessWidget {
+  const _SongDetail({required this.viewModel, required this.scrollable});
+
+  final BeatlesGuitarTabsViewModel viewModel;
+  final bool scrollable;
+
+  @override
+  Widget build(BuildContext context) {
+    final song = viewModel.selectedSong;
+    if (song == null) return const _EmptyLibrary();
+
+    final children = <Widget>[
+      Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  song.title,
+                  key: const Key('beatles_selected_song_title'),
+                  style: const TextStyle(
+                    color: DesignTokens.textPrimary,
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700,
+                    height: 1.4,
+                    letterSpacing: 0.96,
+                  ),
+                ),
+                const SizedBox(height: DesignTokens.space4),
+                Text(
+                  'The Beatles • ${song.album} • ${song.year}',
+                  style: const TextStyle(
+                    color: DesignTokens.textSecondary,
+                    fontSize: 12,
+                    height: 1.6,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Icon(Icons.graphic_eq, color: DesignTokens.orange, size: 32),
+        ],
+      ),
+      const SizedBox(height: DesignTokens.space16),
+      Text(
+        song.summary,
+        style: const TextStyle(
+          color: DesignTokens.textOnDark,
+          fontSize: 14,
+          height: 1.7,
+        ),
+      ),
+      const SizedBox(height: DesignTokens.space16),
+      Wrap(
+        spacing: DesignTokens.space8,
+        runSpacing: DesignTokens.space8,
+        children: <Widget>[
+          _MetaChip(icon: Icons.tune, label: song.tuning),
+          _MetaChip(
+            icon: Icons.vertical_align_top,
+            label: 'Capo: ${song.capo}',
+          ),
+          for (final technique in song.techniques)
+            _MetaChip(icon: Icons.auto_awesome, label: technique),
+        ],
+      ),
+      const SizedBox(height: DesignTokens.space20),
+      const _RightsNotice(),
+      const SizedBox(height: DesignTokens.space20),
+      _TempoControl(viewModel: viewModel, song: song),
+      const SizedBox(height: DesignTokens.space24),
+      for (var index = 0; index < song.sections.length; index++) ...<Widget>[
+        GuitarTabStaff(section: song.sections[index]),
+        if (index != song.sections.length - 1)
+          const SizedBox(height: DesignTokens.space16),
+      ],
+      const SizedBox(height: DesignTokens.space24),
+      const _PracticeTip(),
+    ];
+
+    if (scrollable) {
+      return ListView(
+        key: const Key('beatles_song_detail_scroll'),
+        padding: const EdgeInsets.all(DesignTokens.space24),
+        children: <Widget>[
+          Align(
+            alignment: Alignment.topCenter,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 620),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: children,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    );
+  }
+}
+
+class _TempoControl extends StatelessWidget {
+  const _TempoControl({required this.viewModel, required this.song});
+
+  final BeatlesGuitarTabsViewModel viewModel;
+  final GuitarTabSong song;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: DesignTokens.surface2,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+        border: Border.all(color: DesignTokens.divider),
+      ),
+      padding: const EdgeInsets.all(DesignTokens.space16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              const Icon(Icons.speed, color: DesignTokens.indigoLight),
+              const SizedBox(width: DesignTokens.space8),
+              const Expanded(
+                child: Text(
+                  '練習テンポ',
+                  style: TextStyle(
+                    color: DesignTokens.textPrimary,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              Text(
+                '${viewModel.practiceBpm} BPM',
+                key: const Key('beatles_practice_bpm'),
+                style: const TextStyle(
+                  color: DesignTokens.orangeLight,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+          Slider(
+            key: const Key('beatles_tempo_slider'),
+            value: viewModel.practiceBpm.toDouble(),
+            min: 60,
+            max: 180,
+            divisions: 120,
+            activeColor: DesignTokens.orange,
+            inactiveColor: DesignTokens.surface3,
+            label: '${viewModel.practiceBpm} BPM',
+            onChanged: viewModel.setPracticeBpm,
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              onPressed: viewModel.practiceBpm == song.practiceBpm
+                  ? null
+                  : viewModel.resetPracticeBpm,
+              icon: const Icon(Icons.restart_alt, size: 18),
+              label: Text('推奨 ${song.practiceBpm} BPM に戻す'),
+              style: TextButton.styleFrom(
+                foregroundColor: DesignTokens.orange,
+                disabledForegroundColor: DesignTokens.textDisabled,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RightsNotice extends StatelessWidget {
+  const _RightsNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: DesignTokens.indigo.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+        border: Border.all(color: DesignTokens.indigo.withValues(alpha: 0.3)),
+      ),
+      padding: const EdgeInsets.all(DesignTokens.space16),
+      child: const Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(Icons.info_outline, color: DesignTokens.indigoLight, size: 20),
+          SizedBox(width: DesignTokens.space12),
+          Expanded(
+            child: Text(
+              '掲載譜面は奏法学習用のオリジナル練習フレーズです。原曲の完全な採譜ではありません。原曲どおりに演奏する場合は、権利者が許諾した公式楽譜をご利用ください。',
+              style: TextStyle(
+                color: DesignTokens.textSecondary,
+                fontSize: 12,
+                height: 1.7,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PracticeTip extends StatelessWidget {
+  const _PracticeTip();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Icon(Icons.lightbulb_outline, color: DesignTokens.amber, size: 20),
+        SizedBox(width: DesignTokens.space8),
+        Expanded(
+          child: Text(
+            'まず推奨テンポの70%で3回連続ノーミスを目指し、5 BPMずつ上げると安定します。',
+            style: TextStyle(
+              color: DesignTokens.textSecondary,
+              fontSize: 12,
+              height: 1.7,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: DesignTokens.surface3,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(icon, size: 13, color: DesignTokens.textSecondary),
+          const SizedBox(width: DesignTokens.space4),
+          Text(
+            label,
+            style: const TextStyle(
+              color: DesignTokens.textSecondary,
+              fontSize: 11,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyLibrary extends StatelessWidget {
+  const _EmptyLibrary();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(DesignTokens.space24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(Icons.search_off, color: DesignTokens.orange, size: 42),
+            SizedBox(height: DesignTokens.space12),
+            Text(
+              '条件に合う練習曲がありません',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: DesignTokens.textSecondary,
+                fontSize: 14,
+                height: 1.7,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(DesignTokens.space24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(Icons.error_outline, color: DesignTokens.red, size: 48),
+            const SizedBox(height: DesignTokens.space16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: DesignTokens.textSecondary,
+                fontSize: 14,
+                height: 1.7,
+              ),
+            ),
+            const SizedBox(height: DesignTokens.space16),
+            ElevatedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('再読み込み'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: DesignTokens.orange,
+                foregroundColor: DesignTokens.textPrimary,
+                minimumSize: const Size(48, 48),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(
+                    DesignTokens.radiusMedium,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _difficultyLabel(GuitarTabDifficulty difficulty) {
+  return switch (difficulty) {
+    GuitarTabDifficulty.beginner => '初級',
+    GuitarTabDifficulty.intermediate => '中級',
+    GuitarTabDifficulty.advanced => '上級',
+  };
+}

--- a/lib/ui/features/beatles_guitar_tabs/views/widgets/guitar_tab_staff.dart
+++ b/lib/ui/features/beatles_guitar_tabs/views/widgets/guitar_tab_staff.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../theme/design_tokens.dart';
+import '../../../../../domain/models/guitar_tab_song.dart';
+
+class GuitarTabStaff extends StatelessWidget {
+  const GuitarTabStaff({super.key, required this.section});
+
+  final GuitarTabSection section;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: DesignTokens.surface1,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+        border: Border.all(color: DesignTokens.orange.withValues(alpha: 0.22)),
+      ),
+      padding: const EdgeInsets.all(DesignTokens.space16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            section.title,
+            style: const TextStyle(
+              color: DesignTokens.textPrimary,
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: DesignTokens.space8),
+          Text(
+            section.practiceNote,
+            style: const TextStyle(
+              color: DesignTokens.textSecondary,
+              fontSize: 13,
+              height: 1.7,
+            ),
+          ),
+          const SizedBox(height: DesignTokens.space16),
+          Semantics(
+            label: '${section.title}のギタータブ譜',
+            child: Container(
+              width: double.infinity,
+              decoration: BoxDecoration(
+                color: DesignTokens.background,
+                borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+              ),
+              padding: const EdgeInsets.all(DesignTokens.space16),
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: SelectableText(
+                  section.lines.join('\n'),
+                  key: const Key('beatles_tab_notation'),
+                  style: const TextStyle(
+                    color: DesignTokens.textOnDark,
+                    fontFamily: 'monospace',
+                    fontSize: 13,
+                    height: 1.6,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/supabase/functions/local-election-intelligence/election_mode.ts
+++ b/supabase/functions/local-election-intelligence/election_mode.ts
@@ -425,14 +425,14 @@ export function fallbackElectionModeRegistry(): ElectionModeRegistry {
 export function fallbackOfficialEndorsementSnapshot(): OfficialEndorsementSnapshot {
   return {
     sourceUrl: "https://new-kokumin.jp/local-election-list",
-    sourceAsOf: "2026-08-05",
+    sourceAsOf: "2026-08-12",
     sourceDocumentSha256: "",
-    totalCount: 217,
+    totalCount: 218,
     incumbentCount: 102,
-    newcomerCount: 106,
+    newcomerCount: 107,
     formerCount: 9,
     recommendationCount: 9,
-    prefectureCount: 32,
+    prefectureCount: 33,
     prefectures: [],
   };
 }

--- a/supabase/functions/local-election-intelligence/election_mode_test.ts
+++ b/supabase/functions/local-election-intelligence/election_mode_test.ts
@@ -156,9 +156,9 @@ Deno.test("local snapshot resolves goal progress and official achievements", () 
 Deno.test("generated endorsement asset passes the shared validator", () => {
   const snapshot = normalizeOfficialEndorsementSnapshot(endorsementAsset);
 
-  assertEquals(snapshot.totalCount, 217);
+  assertEquals(snapshot.totalCount, 218);
   assertEquals(snapshot.incumbentCount, 102);
-  assertEquals(snapshot.newcomerCount, 106);
+  assertEquals(snapshot.newcomerCount, 107);
   assertEquals(snapshot.formerCount, 9);
   assertEquals(snapshot.recommendationCount, 9);
   assertEquals(snapshot.prefectureCount, 33);

--- a/test/data/dpj_official_endorsements_test.dart
+++ b/test/data/dpj_official_endorsements_test.dart
@@ -10,7 +10,7 @@ void main() {
     expect(dpjOfficialEndorsementPrefectureCount, 33);
   });
 
-  test('8月10日更新で佐賀が追加され高知の掲載が2件になっている', () {
+  test('8月12日更新で佐賀が追加され高知の掲載が2件になっている', () {
     final saga = dpjOfficialEndorsementFor('佐賀県');
     expect(saga, isNotNull);
     expect(saga!.totalCount, 1);
@@ -34,9 +34,9 @@ void main() {
   });
 
   test('公認掲載の全国集計は現元新の内訳と一致する', () {
-    expect(dpjOfficialEndorsementTotal, 217);
+    expect(dpjOfficialEndorsementTotal, 218);
     expect(dpjOfficialEndorsementIncumbentTotal, 102);
-    expect(dpjOfficialEndorsementNewcomerTotal, 106);
+    expect(dpjOfficialEndorsementNewcomerTotal, 107);
     expect(dpjOfficialEndorsementFormerTotal, 9);
     expect(
       dpjOfficialEndorsementIncumbentTotal +
@@ -62,7 +62,7 @@ void main() {
   test('党公式一覧の基準日と推薦除外件数が最新値になっている', () {
     expect(dpjOfficialEndorsementSourceUrl, startsWith('https://'));
     expect(dpjOfficialEndorsementSourceUrl, contains('new-kokumin.jp'));
-    expect(dpjOfficialEndorsementSourceAsOf, '2026-08-10');
+    expect(dpjOfficialEndorsementSourceAsOf, '2026-08-12');
     expect(DateTime.tryParse(dpjOfficialEndorsementSourceAsOf), isNotNull);
     expect(dpjOfficialRecommendationEntryCount, 9);
   });

--- a/test/data/repositories/guitar_tab_repository_test.dart
+++ b/test/data/repositories/guitar_tab_repository_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/data/repositories/guitar_tab_repository.dart';
+import 'package:my_web_app/data/services/guitar_tab_catalog_service.dart';
+import 'package:my_web_app/domain/models/guitar_tab_song.dart';
+
+void main() {
+  group('LocalGuitarTabRepository', () {
+    const repository = LocalGuitarTabRepository(
+      catalogService: GuitarTabCatalogService(),
+    );
+
+    test('maps the bundled catalog to immutable domain models', () async {
+      final songs = await repository.getSongs();
+
+      expect(songs, hasLength(4));
+      expect(songs.first.title, 'Blackbird');
+      expect(songs.first.difficulty, GuitarTabDifficulty.intermediate);
+      expect(songs.first.sections.single.lines, hasLength(6));
+      expect(() => songs.add(songs.first), throwsUnsupportedError);
+      expect(
+        () => songs.first.techniques.add('mutated'),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => songs.first.sections.single.lines.add('mutated'),
+        throwsUnsupportedError,
+      );
+    });
+  });
+}

--- a/test/data/repositories/official_endorsement_repository_test.dart
+++ b/test/data/repositories/official_endorsement_repository_test.dart
@@ -8,8 +8,8 @@ void main() {
   test('generated official snapshot is the deterministic offline fallback', () {
     final snapshot = repository.resolve(null);
 
-    expect(snapshot.sourceAsOf, '2026-08-10');
-    expect(snapshot.totalCount, 217);
+    expect(snapshot.sourceAsOf, '2026-08-12');
+    expect(snapshot.totalCount, 218);
     expect(snapshot.prefectureCount, 33);
     expect(snapshot.forPrefecture('佐賀県')?.newcomerCount, 1);
   });

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -59,6 +59,7 @@ const List<String> kAllAppRoutes = <String>[
   '/autonomous-ops-console',
   '/behavior-log',
   '/behavior-review',
+  '/beatles-guitar-tabs',
   '/billing',
   '/blog',
   '/blog-management',

--- a/test/services/local_election_share_service_test.dart
+++ b/test/services/local_election_share_service_test.dart
@@ -556,16 +556,16 @@ void main() {
 
     // 全国サマリー: 立憲だけでなく自民と公認予定候補も出す。
     expect(draft.content, contains('自民地方議員参考合計: 474人'));
-    expect(draft.content, contains('公認予定候補: 217件'));
+    expect(draft.content, contains('公認予定候補: 218件'));
     expect(draft.content, contains('33/47都道府県に掲載'));
     // 県別行: 自民参考と地力差 (ラベルは自民であって立憲ではない)。
     expect(draft.content, contains('自民参考362人'));
     expect(draft.content, contains('自民+319'));
     // metadata にも機械可読で載る。
     expect(draft.metadata['totalLdpLocalMembers'], 474);
-    expect(draft.metadata['officialEndorsementTotal'], 217);
-    expect(draft.metadata['officialEndorsementAsOf'], '2026-08-10');
-    expect(draft.metadata['firstEndorsementTotal'], 217);
+    expect(draft.metadata['officialEndorsementTotal'], 218);
+    expect(draft.metadata['officialEndorsementAsOf'], '2026-08-12');
+    expect(draft.metadata['firstEndorsementTotal'], 218);
     final prefectures = draft.metadata['prefectures'] as List<dynamic>;
     final tokyo =
         Map<String, dynamic>.from(prefectures.first as Map<dynamic, dynamic>);

--- a/test/ui/features/beatles_guitar_tabs/view_models/beatles_guitar_tabs_view_model_test.dart
+++ b/test/ui/features/beatles_guitar_tabs/view_models/beatles_guitar_tabs_view_model_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/data/repositories/guitar_tab_repository.dart';
+import 'package:my_web_app/data/services/guitar_tab_catalog_service.dart';
+import 'package:my_web_app/domain/models/guitar_tab_song.dart';
+import 'package:my_web_app/ui/features/beatles_guitar_tabs/view_models/beatles_guitar_tabs_view_model.dart';
+
+void main() {
+  group('BeatlesGuitarTabsViewModel', () {
+    late BeatlesGuitarTabsViewModel viewModel;
+
+    setUp(() {
+      viewModel = BeatlesGuitarTabsViewModel(
+        repository: const LocalGuitarTabRepository(
+          catalogService: GuitarTabCatalogService(),
+        ),
+      );
+    });
+
+    tearDown(() => viewModel.dispose());
+
+    test('loads songs and selects the first practice', () async {
+      await viewModel.load();
+
+      expect(viewModel.status, BeatlesGuitarTabsStatus.ready);
+      expect(viewModel.songs, hasLength(4));
+      expect(viewModel.selectedSong?.title, 'Blackbird');
+      expect(viewModel.practiceBpm, 72);
+    });
+
+    test(
+      'filters by query and difficulty while keeping selection visible',
+      () async {
+        await viewModel.load();
+
+        viewModel.setQuery('sun');
+        expect(viewModel.filteredSongs.map((song) => song.title), <String>[
+          'Here Comes the Sun',
+        ]);
+        expect(viewModel.selectedSong?.title, 'Here Comes the Sun');
+
+        viewModel.setQuery('');
+        viewModel.setDifficulty(GuitarTabDifficulty.beginner);
+        expect(viewModel.filteredSongs.map((song) => song.title), <String>[
+          'Day Tripper',
+          'Let It Be',
+        ]);
+        expect(viewModel.selectedSong?.title, 'Day Tripper');
+      },
+    );
+
+    test(
+      'changes tempo and resets it to the selected song recommendation',
+      () async {
+        await viewModel.load();
+        viewModel.selectSong('day-tripper-riff');
+
+        viewModel.setPracticeBpm(124);
+        expect(viewModel.practiceBpm, 124);
+
+        viewModel.resetPracticeBpm();
+        expect(viewModel.practiceBpm, 88);
+      },
+    );
+
+    test('exposes a retryable failure state', () async {
+      final failed = BeatlesGuitarTabsViewModel(
+        repository: const _FailingGuitarTabRepository(),
+      );
+      addTearDown(failed.dispose);
+
+      await failed.load();
+
+      expect(failed.status, BeatlesGuitarTabsStatus.failure);
+      expect(failed.errorMessage, isNotEmpty);
+      expect(failed.songs, isEmpty);
+    });
+  });
+}
+
+class _FailingGuitarTabRepository implements GuitarTabRepository {
+  const _FailingGuitarTabRepository();
+
+  @override
+  Future<List<GuitarTabSong>> getSongs() {
+    return Future<List<GuitarTabSong>>.error(StateError('catalog unavailable'));
+  }
+}

--- a/test/ui/features/beatles_guitar_tabs/views/beatles_guitar_tabs_page_test.dart
+++ b/test/ui/features/beatles_guitar_tabs/views/beatles_guitar_tabs_page_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/data/repositories/guitar_tab_repository.dart';
+import 'package:my_web_app/data/services/guitar_tab_catalog_service.dart';
+import 'package:my_web_app/ui/features/beatles_guitar_tabs/beatles_guitar_tabs_feature.dart';
+
+void main() {
+  const repository = LocalGuitarTabRepository(
+    catalogService: GuitarTabCatalogService(),
+  );
+
+  testWidgets(
+    'compact layout filters songs and updates the selected practice',
+    (tester) async {
+      await _setSurfaceSize(tester, const Size(390, 844));
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: BeatlesGuitarTabsFeature(repository: repository),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('beatles_tabs_compact_layout')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('beatles_song_blackbird-fingerstyle')),
+        findsOneWidget,
+      );
+
+      await tester.enterText(
+        find.byKey(const Key('beatles_tabs_search')),
+        'sun',
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('beatles_song_blackbird-fingerstyle')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const Key('beatles_song_here-comes-the-sun-arpeggio')),
+        findsOneWidget,
+      );
+      final selectedTitle = tester.widget<Text>(
+        find.byKey(const Key('beatles_selected_song_title')),
+      );
+      expect(selectedTitle.data, 'Here Comes the Sun');
+    },
+  );
+
+  testWidgets('wide layout uses a vertical library and changes song on tap', (
+    tester,
+  ) async {
+    await _setSurfaceSize(tester, const Size(1200, 900));
+    await tester.pumpWidget(
+      const MaterialApp(home: BeatlesGuitarTabsFeature(repository: repository)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('beatles_song_list')), findsOneWidget);
+    expect(find.byKey(const Key('beatles_tabs_compact_layout')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('beatles_song_day-tripper-riff')));
+    await tester.pump();
+
+    final selectedTitle = tester.widget<Text>(
+      find.byKey(const Key('beatles_selected_song_title')),
+    );
+    expect(selectedTitle.data, 'Day Tripper');
+    expect(find.byKey(const Key('beatles_tab_notation')), findsOneWidget);
+  });
+}
+
+Future<void> _setSurfaceSize(WidgetTester tester, Size size) async {
+  tester.view.devicePixelRatio = 1;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.resetDevicePixelRatio);
+  addTearDown(tester.view.resetPhysicalSize);
+}

--- a/test/ui/features/election_victory/view_models/official_endorsement_view_model_test.dart
+++ b/test/ui/features/election_victory/view_models/official_endorsement_view_model_test.dart
@@ -7,8 +7,8 @@ void main() {
     final viewModel = OfficialEndorsementViewModel();
     addTearDown(viewModel.dispose);
 
-    expect(viewModel.snapshot.sourceAsOf, '2026-08-10');
-    expect(viewModel.snapshot.totalCount, 217);
+    expect(viewModel.snapshot.sourceAsOf, '2026-08-12');
+    expect(viewModel.snapshot.totalCount, 218);
     expect(viewModel.forPrefecture('佐賀県')?.newcomerCount, 1);
   });
 
@@ -40,8 +40,8 @@ void main() {
     );
 
     expect(notificationCount, 1);
-    expect(viewModel.snapshot.sourceAsOf, '2026-08-10');
-    expect(viewModel.snapshot.totalCount, 217);
+    expect(viewModel.snapshot.sourceAsOf, '2026-08-12');
+    expect(viewModel.snapshot.totalCount, 218);
   });
 }
 


### PR DESCRIPTION
## What

- Beatles を題材にしたギター練習タブページを `/beatles-guitar-tabs` に追加
- Domain / Data / UI のレイヤー構成、Repository、ChangeNotifier ViewModel を採用
- 検索、難易度フィルター、曲選択、テンポ調整、レスポンシブ表示を実装
- 収録フレーズは短いオリジナル練習パターンとし、既存楽曲の完全な採譜は含めない

## Deployment unblocker

- 2026-08-12 の公認データ更新に追従していなかった Flutter / Deno テスト期待値を同期
- Edge Function の緊急フォールバック集計も 218 件へ同期
- `dart format` で検出された既存の機械的な整形漏れを修正

## Validation

- pre-push full quality gate: passed
- Flutter VM tests: 2,200+ passed
- Deno tests: 607 passed
- feature / route tests: 20 passed
- endorsement regression tests: Flutter 32 passed, Deno 4 passed
- `flutter analyze`: no issues
- Dart / Deno format and Deno lint: passed
- Flutter Web release build: passed before main rebase

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Feature flow is covered by widget and route tests; production route smoke follows deploy.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Only generated endorsement fallback values and matching tests were synchronized; no schema, secret, auth, or migration behavior changed.
