### PR TITLE
fix(musubi): support existing pg_trgm extension schemas

### DIFF
--- a/supabase/migrations/20260810090000_create_musubi_social_platform.sql
+++ b/supabase/migrations/20260810090000_create_musubi_social_platform.sql
@@ -2,6 +2,7 @@
 -- moderation audit trail, and consent-based user research.
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA extensions;
+SET search_path = public, extensions;
 
 CREATE TABLE public.musubi_profiles (
   user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -66,7 +67,7 @@ CREATE INDEX musubi_posts_author_created_idx
 CREATE INDEX musubi_posts_search_idx
   ON public.musubi_posts USING gin (search_vector);
 CREATE INDEX musubi_posts_content_trgm_idx
-  ON public.musubi_posts USING gin (content extensions.gin_trgm_ops);
+  ON public.musubi_posts USING gin (content gin_trgm_ops);
 
 CREATE TABLE public.musubi_threads (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -466,3 +467,5 @@ COMMENT ON TABLE public.musubi_reports IS
   'MUSUBI moderation audit trail. Resolution is restricted to existing app admins.';
 COMMENT ON TABLE public.musubi_research_feedback IS
   'Consent-gated UX validation responses. Users may delete their own responses.';
+
+RESET search_path;

--- a/test/scripts/test_musubi_migration.py
+++ b/test/scripts/test_musubi_migration.py
@@ -66,6 +66,12 @@ class MusubiMigrationTest(unittest.TestCase):
         self.assertIn("trigger musubi_posts_refresh_search_vector", self.normalized)
         self.assertNotIn("search_vector tsvector generated always", self.normalized)
 
+    def test_trigram_index_supports_existing_extension_schemas(self):
+        self.assertIn("set search_path = public, extensions", self.normalized)
+        self.assertIn("content gin_trgm_ops", self.normalized)
+        self.assertNotIn("extensions.gin_trgm_ops", self.normalized)
+        self.assertIn("reset search_path", self.normalized)
+
     def test_research_storage_requires_consent_and_supports_deletion(self):
         self.assertIn("consent_to_research boolean not null", self.normalized)
         self.assertIn("and consent_to_research", self.normalized)


### PR DESCRIPTION
## What changed

- Make the MUSUBI trigram index resolve `gin_trgm_ops` from either `public` or `extensions` by setting a migration-local search path.
- Reset the search path at the end of the migration.
- Add a regression contract test that rejects a schema-fixed `extensions.gin_trgm_ops` reference.

## Why

Production deploy run `31662210624` stopped safely before Edge Functions and Hosting because the existing `pg_trgm` extension is installed in `public`, while staging had it in `extensions`. The failed migration was not recorded as applied, so rerunning the corrected migration is safe.

## Validation

- MUSUBI migration contract: 6/6 passed.
- Migration time-relative detector: passed.
- Pre-commit fast quality gate: passed, including Flutter analyze and Deno lint.
- Pre-push full quality gate: passed, including Flutter VM tests and 607/607 Edge Function tests.
- Local Supabase DB lint could not be rerun because Docker Engine is currently stopped; staging linked DB lint passed before launch, and this hotfix directly matches the Production SQLSTATE 42704 evidence.

## Minimal E2E Gate

- Implementation-detail independent: verification asserts migration input/output contracts, not private implementation internals.
- Minimal scope: about 3 cases (public schema, extensions schema, and search-path reset).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: This is a database migration operator-class resolution fix with no user-visible UI path; it is covered by the migration contract test and the Production deployment retry.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Independent ultrareview was not rerun for this two-file Production hotfix. The exact Production SQLSTATE 42704 failure is addressed by PostgreSQL search-path resolution, with a regression test and the full repository quality gate; the deployment retry provides the final migration and production-smoke evidence.

## Rollback

If the retry fails, the workflow stops before Hosting. The migration remains unapplied and the currently deployed site remains unchanged.