### PR TITLE
MUSUBIの投稿リンクをクリック可能にする

### DIFF
--- a/lib/pages/musubi_engagement_views.dart
+++ b/lib/pages/musubi_engagement_views.dart
@@ -4,6 +4,7 @@ import '../models/musubi_engagement_models.dart';
 import '../models/musubi_social_models.dart';
 import '../services/musubi_engagement_controllers.dart';
 import '../theme/design_tokens.dart';
+import '../widgets/musubi_post_content.dart';
 
 enum MusubiDestination { feed, discover, communities, messages, saved, safety }
 
@@ -811,13 +812,7 @@ class MusubiSavedView extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 6),
-                  Text(
-                    post.content,
-                    style: const TextStyle(
-                      color: DesignTokens.textOnDark,
-                      height: 1.6,
-                    ),
-                  ),
+                  MusubiPostContent(text: post.content),
                 ],
               ),
             ),

--- a/lib/pages/social_feed_page.dart
+++ b/lib/pages/social_feed_page.dart
@@ -9,6 +9,7 @@ import '../services/musubi_engagement_controllers.dart';
 import '../services/musubi_feature_dependencies.dart';
 import '../services/musubi_social_controller.dart';
 import '../theme/design_tokens.dart';
+import '../widgets/musubi_post_content.dart';
 import 'musubi_engagement_views.dart';
 
 /// 既存の `/social-feed` 導線を保ったまま、MUSUBIを公開する互換エントリ。
@@ -1184,14 +1185,7 @@ class _MusubiPostCardState extends State<_MusubiPostCard> {
             ],
           ),
           const SizedBox(height: DesignTokens.space12),
-          Text(
-            displayedText,
-            style: const TextStyle(
-              color: DesignTokens.textOnDark,
-              fontSize: 14,
-              height: 1.75,
-            ),
-          ),
+          MusubiPostContent(text: displayedText),
           if (post.translatedContent != null) ...[
             const SizedBox(height: DesignTokens.space8),
             TextButton.icon(

--- a/lib/widgets/musubi_post_content.dart
+++ b/lib/widgets/musubi_post_content.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../theme/design_tokens.dart';
+
+typedef MusubiUrlOpener = Future<bool> Function(Uri uri);
+
+/// Renders post text and turns plain web URLs into safe, tappable links.
+class MusubiPostContent extends StatefulWidget {
+  const MusubiPostContent({
+    super.key,
+    required this.text,
+    this.urlOpener,
+  });
+
+  final String text;
+  final MusubiUrlOpener? urlOpener;
+
+  @override
+  State<MusubiPostContent> createState() => _MusubiPostContentState();
+}
+
+class _MusubiPostContentState extends State<MusubiPostContent> {
+  static final RegExp _webUrlPattern = RegExp(
+    r'https?://[^\s<>]+',
+    caseSensitive: false,
+  );
+  static const String _trailingPunctuation = '.,!?;:)]}、。！？；：）］｝」』】';
+  static const TextStyle _bodyStyle = TextStyle(
+    color: DesignTokens.textOnDark,
+    fontSize: 14,
+    height: 1.75,
+  );
+  static final TextStyle _linkStyle = _bodyStyle.copyWith(
+    color: DesignTokens.orangeLight,
+    fontWeight: FontWeight.w600,
+    decoration: TextDecoration.underline,
+    decorationColor: DesignTokens.orangeLight,
+  );
+
+  final List<TapGestureRecognizer> _recognizers = [];
+  late List<InlineSpan> _spans;
+
+  @override
+  void initState() {
+    super.initState();
+    _spans = _buildSpans();
+  }
+
+  @override
+  void didUpdateWidget(MusubiPostContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text) {
+      _disposeRecognizers();
+      _spans = _buildSpans();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposeRecognizers();
+    super.dispose();
+  }
+
+  static Future<bool> _launchExternalUrl(Uri uri) {
+    return launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<void> _openLink(String? href) async {
+    if (href == null) return;
+
+    final uri = Uri.tryParse(href);
+    final scheme = uri?.scheme.toLowerCase();
+    if (uri == null ||
+        (scheme != 'http' && scheme != 'https') ||
+        uri.host.isEmpty) {
+      return;
+    }
+
+    await (widget.urlOpener ?? _launchExternalUrl)(uri);
+  }
+
+  List<InlineSpan> _buildSpans() {
+    final spans = <InlineSpan>[];
+    var cursor = 0;
+
+    for (final match in _webUrlPattern.allMatches(widget.text)) {
+      if (match.start > cursor) {
+        spans.add(TextSpan(text: widget.text.substring(cursor, match.start)));
+      }
+
+      final matchedText = match.group(0)!;
+      final url = _withoutTrailingPunctuation(matchedText);
+      final punctuation = matchedText.substring(url.length);
+      final recognizer = TapGestureRecognizer()
+        ..onTap = () => unawaited(_openLink(url));
+      _recognizers.add(recognizer);
+
+      spans.add(
+        TextSpan(
+          text: url,
+          style: _linkStyle,
+          recognizer: recognizer,
+          mouseCursor: SystemMouseCursors.click,
+        ),
+      );
+      if (punctuation.isNotEmpty) {
+        spans.add(TextSpan(text: punctuation));
+      }
+      cursor = match.end;
+    }
+
+    if (cursor < widget.text.length) {
+      spans.add(TextSpan(text: widget.text.substring(cursor)));
+    }
+
+    return spans;
+  }
+
+  String _withoutTrailingPunctuation(String value) {
+    var end = value.length;
+    while (end > 0 && _trailingPunctuation.contains(value[end - 1])) {
+      end--;
+    }
+    return value.substring(0, end);
+  }
+
+  void _disposeRecognizers() {
+    for (final recognizer in _recognizers) {
+      recognizer.dispose();
+    }
+    _recognizers.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(
+      TextSpan(children: _spans),
+      style: _bodyStyle,
+    );
+  }
+}

--- a/test/widgets/musubi_post_content_test.dart
+++ b/test/widgets/musubi_post_content_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/musubi_post_content.dart';
+
+void main() {
+  const youtubeUrl = 'https://www.youtube.com/watch?v=ZK3JhU73W18';
+
+  testWidgets('opens a raw YouTube URL when the link is tapped',
+      (tester) async {
+    Uri? openedUri;
+
+    await tester.pumpWidget(
+      _app(
+        MusubiPostContent(
+          text: youtubeUrl,
+          urlOpener: (uri) async {
+            openedUri = uri;
+            return true;
+          },
+        ),
+      ),
+    );
+
+    final link = find.text(youtubeUrl, findRichText: true);
+    expect(link, findsOneWidget);
+
+    await tester.tap(link);
+    await tester.pump();
+
+    expect(openedUri, Uri.parse(youtubeUrl));
+  });
+
+  testWidgets('keeps surrounding post text visible', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        const MusubiPostContent(
+          text: 'この動画がおすすめです\n$youtubeUrl',
+        ),
+      ),
+    );
+
+    expect(
+      find.textContaining('この動画がおすすめです', findRichText: true),
+      findsOneWidget,
+    );
+    expect(find.textContaining(youtubeUrl, findRichText: true), findsOneWidget);
+  });
+
+  testWidgets('does not open non-web URL schemes', (tester) async {
+    Uri? openedUri;
+
+    await tester.pumpWidget(
+      _app(
+        MusubiPostContent(
+          text: 'mailto:test@example.com',
+          urlOpener: (uri) async {
+            openedUri = uri;
+            return true;
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('mailto:test@example.com', findRichText: true));
+    await tester.pump();
+
+    expect(openedUri, isNull);
+  });
+}
+
+Widget _app(Widget child) {
+  return MaterialApp(
+    theme: ThemeData.dark(useMaterial3: true),
+    home: Scaffold(body: child),
+  );
+}


### PR DESCRIPTION
## What changed
- Detect plain `http` / `https` URLs in MUSUBI post text and render them as tappable links
- Open YouTube and other web links in an external browser or new web tab
- Apply the same behavior to the feed and saved-post view
- Reject non-web URL schemes and trim trailing punctuation safely

## Why
YouTube URLs posted to MUSUBI were displayed as plain text, so users could not navigate to the linked video directly.

## Validation
- `flutter test test/widgets/musubi_post_content_test.dart test/pages/social_feed_page_test.dart test/pages/musubi_engagement_views_test.dart` (8 tests passed)
- targeted `dart analyze` for all changed Dart files (no issues)
- `flutter build web --release` (passed, including Wasm dry run)
- repository pre-push full quality gate (passed)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: External browser navigation is covered by an injected URL opener widget test with three user-visible cases; the existing Playwright public stability smoke covers the deployed route.