### PR TITLE
fix: restore AI University YouTube playback

### DIFF
--- a/.agents/skills/youtube-video-pipeline/SKILL.md
+++ b/.agents/skills/youtube-video-pipeline/SKILL.md
@@ -190,7 +190,7 @@ Use the shared `AiUniversityPublishedVideoBanner` contract from [references/ai-u
 
 - Show the published title, provider, and total public-video count.
 - Use the design-system orange primary CTA `今すぐ見る` with a minimum 44 px target.
-- Open the reusable embedded player in-place without requiring a provider-tab change.
+- Open the reusable embedded player in a barrier-free opaque viewer route without requiring a provider-tab change. Do not place an interactive Web iframe behind a `DialogRoute` or `ModalBarrier`.
 - Switch the CTA below 620 px to a full-width layout and add a narrow-width overflow test.
 - Keep the app-bar video-generation action distinct, such as `AI動画レッスンを生成`.
 - Derive lessons from database rows; never hard-code one video ID into the banner.
@@ -242,9 +242,10 @@ After deployment:
 
 1. Poll `https://my-web-app-b67f4.web.app/version.json` until `commit` equals the squash merge commit.
 2. Open `/ai-university` without relying on a particular provider tab.
-3. Confirm `公開動画で学ぶ` shows the published title and `今すぐ見る` opens the player.
+3. Confirm `公開動画で学ぶ` shows the published title and `今すぐ見る` opens the barrier-free viewer.
 4. Confirm the iframe URL or player contains the published video ID and `YouTubeで開く` resolves to the same public URL.
-5. Report separately: YouTube privacy state, database lesson state, deployed commit, workflow URL, banner visibility, and embedded-player state.
+5. Confirm the iframe is the browser hit-test target at its center, click the YouTube play control, and verify playback time advances.
+6. Report separately: YouTube privacy state, database lesson state, deployed commit, workflow URL, banner visibility, and embedded-player state.
 
 Do not claim completion until the active database lesson, production version, discoverability banner, and visible embedded player are all confirmed.
 

--- a/.agents/skills/youtube-video-pipeline/references/ai-university-embedding.md
+++ b/.agents/skills/youtube-video-pipeline/references/ai-university-embedding.md
@@ -53,10 +53,14 @@ Expected components:
   - Use the orange primary `今すぐ見る` CTA with a minimum 44 px target.
   - Switch to a full-width CTA below 620 px using `LayoutBuilder`.
   - Receive title, provider, count, and callback as data; never hard-code a video ID.
+- `lib/widgets/ai_university_youtube_viewer_route.dart`
+  - Open the embedded lesson through a regular opaque `MaterialPageRoute`.
+  - Do not render an interactive iframe behind a `DialogRoute` or `ModalBarrier`; Flutter Web can place the barrier above the iframe in browser hit testing.
+  - Keep an explicit visible close action and prevent interaction with the previous page while the viewer is open.
 - `lib/pages/gemini_university_v2_page.dart`
   - Detect a YouTube `source_url` and embed the player inside the expanded lesson card.
   - Derive active public-video topics from database rows and show the banner regardless of the selected provider.
-  - Open the embedded lesson in a constrained in-place dialog and keep the generation action labeled separately.
+  - Open the embedded lesson in a constrained barrier-free viewer and keep the generation action labeled separately.
 - `lib/pages/ai_university_video_page.dart`
   - Embed the selected published lesson before the generated-video controls.
 
@@ -89,12 +93,14 @@ python "$skillDir\scripts\ai_university_content.py" check-ui --repo "<worktree>"
 dart analyze lib/services/ai_university_video_lesson_service.dart
 dart analyze lib/widgets/ai_university_youtube_embed.dart
 dart analyze lib/widgets/ai_university_published_video_banner.dart
+dart analyze lib/widgets/ai_university_youtube_viewer_route.dart
 dart analyze lib/pages/ai_university_video_page.dart
 dart analyze lib/pages/gemini_university_v2_page.dart
 flutter test --no-pub test/services/ai_university_video_lesson_service_test.dart
 flutter test --no-pub test/services/ai_university_published_video_seed_test.dart
 flutter test --no-pub test/widgets/ai_university_youtube_embed_test.dart
 flutter test --no-pub test/widgets/ai_university_published_video_banner_test.dart
+flutter test --no-pub test/widgets/ai_university_youtube_viewer_route_test.dart
 git diff --check
 ```
 
@@ -112,7 +118,7 @@ After the separate AI大学 confirmation:
 6. Watch the matching run through migration, Flutter Web build, Firebase deploy, and version verification.
 7. Confirm `https://my-web-app-b67f4.web.app/version.json` reports the squash merge commit.
 8. Open production `/ai-university` without selecting a provider and verify the public-video banner shows the title.
-9. Use `今すぐ見る`, verify the iframe contains the published video ID, and confirm `YouTubeで開く` resolves to the same public video.
+9. Use `今すぐ見る`, verify the iframe contains the published video ID, confirm the iframe is the browser hit-test target, click play and verify playback advances, and confirm `YouTubeで開く` resolves to the same public video.
 
 Report separately: YouTube state, database lesson state, deployed commit, workflow URL, banner state, and visible embed state.
 

--- a/.agents/skills/youtube-video-pipeline/scripts/ai_university_content.py
+++ b/.agents/skills/youtube-video-pipeline/scripts/ai_university_content.py
@@ -190,9 +190,15 @@ def check_ui(args: argparse.Namespace) -> int:
             "今すぐ見る",
             "LayoutBuilder",
         ],
+        "lib/widgets/ai_university_youtube_viewer_route.dart": [
+            "AiUniversityYoutubeViewerRoute",
+            "MaterialPageRoute",
+            "showAiUniversityYoutubeViewer",
+        ],
         "lib/pages/gemini_university_v2_page.dart": [
             "AiUniversityYoutubeEmbed",
             "AiUniversityPublishedVideoBanner",
+            "showAiUniversityYoutubeViewer",
             "_buildPublishedVideoBanner",
             "AI動画レッスンを生成",
         ],

--- a/lib/pages/gemini_university_v2_page.dart
+++ b/lib/pages/gemini_university_v2_page.dart
@@ -22,6 +22,7 @@ import '../services/theme_service.dart';
 import '../services/user_data_finetune_readiness_service.dart';
 import '../widgets/ai_university_published_video_banner.dart';
 import '../widgets/ai_university_youtube_embed.dart';
+import '../widgets/ai_university_youtube_viewer_route.dart';
 import 'ai_university_ranking_page.dart';
 import 'api_playground_page.dart';
 import 'package:my_web_app/utils/tab_route_url_sync.dart';
@@ -6365,9 +6366,9 @@ class _AiUniversityPageState extends State<AiUniversityPage>
     if (videoId == null) return;
     final provider = _meta(topic.provider);
 
-    await showDialog<void>(
+    await showAiUniversityYoutubeViewer<void>(
       context: context,
-      builder: (dialogContext) {
+      viewerBuilder: (dialogContext) {
         final windowHeight = MediaQuery.sizeOf(dialogContext).height;
         return Dialog(
           backgroundColor: const Color(0xFF1A1A1A),

--- a/lib/widgets/ai_university_youtube_viewer_route.dart
+++ b/lib/widgets/ai_university_youtube_viewer_route.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+/// Opens an embedded YouTube lesson without a modal barrier.
+///
+/// Flutter Web represents a dialog's modal barrier as a full-screen hit-test
+/// element. That element can sit above an [HtmlElementView] in the browser and
+/// prevent the YouTube iframe from receiving pointer events. A regular opaque
+/// page route has no modal barrier, keeps the previous page non-interactive,
+/// and lets the embedded player receive clicks directly.
+class AiUniversityYoutubeViewerRoute<T> extends MaterialPageRoute<T> {
+  AiUniversityYoutubeViewerRoute({
+    required WidgetBuilder viewerBuilder,
+    super.settings,
+  }) : super(
+          fullscreenDialog: true,
+          builder: (routeContext) => ColoredBox(
+            color: const Color(0xFF0A0A0A),
+            child: SafeArea(child: Center(child: viewerBuilder(routeContext))),
+          ),
+        );
+}
+
+Future<T?> showAiUniversityYoutubeViewer<T>({
+  required BuildContext context,
+  required WidgetBuilder viewerBuilder,
+  bool useRootNavigator = true,
+}) {
+  return Navigator.of(context, rootNavigator: useRootNavigator).push<T>(
+    AiUniversityYoutubeViewerRoute<T>(
+      viewerBuilder: viewerBuilder,
+      settings: const RouteSettings(name: '/ai-university?tab=openai'),
+    ),
+  );
+}

--- a/test/widgets/ai_university_youtube_viewer_route_test.dart
+++ b/test/widgets/ai_university_youtube_viewer_route_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/ai_university_youtube_viewer_route.dart';
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  Route<dynamic>? lastPushedRoute;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    lastPushedRoute = route;
+  }
+}
+
+void main() {
+  testWidgets('YouTubeビューアーはモーダル障壁のない不透明ルートで開く', (tester) async {
+    final observer = _RecordingNavigatorObserver();
+    var backgroundTapCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorObservers: [observer],
+        home: Scaffold(
+          body: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => backgroundTapCount++,
+            child: Center(
+              child: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () => showAiUniversityYoutubeViewer<void>(
+                    context: context,
+                    viewerBuilder: (viewerContext) => Dialog(
+                      child: TextButton(
+                        onPressed: () => Navigator.of(viewerContext).pop(),
+                        child: const Text('閉じる'),
+                      ),
+                    ),
+                  ),
+                  child: const Text('動画を見る'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('動画を見る'));
+    await tester.pumpAndSettle();
+
+    final route = observer.lastPushedRoute;
+    expect(route, isA<AiUniversityYoutubeViewerRoute<void>>());
+    final viewerRoute = route! as AiUniversityYoutubeViewerRoute<void>;
+    expect(viewerRoute.opaque, isTrue);
+    expect(viewerRoute.barrierColor, isNull);
+
+    final backgroundTapsBeforeOutsideClick = backgroundTapCount;
+    await tester.tapAt(const Offset(4, 4));
+    await tester.pumpAndSettle();
+    expect(backgroundTapCount, backgroundTapsBeforeOutsideClick);
+    expect(find.text('閉じる'), findsOneWidget);
+
+    await tester.tap(find.text('閉じる'));
+    await tester.pumpAndSettle();
+    expect(find.text('閉じる'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Replaces the YouTube lesson modal route with an opaque barrier-free viewer route.
- Adds a widget regression test covering route opacity, background isolation, and explicit close behavior.
- Updates the reusable pipeline contract so future lessons verify iframe hit testing and playback.

## Root cause
Flutter Web’s full-screen modal barrier was the browser hit-test target above the YouTube iframe, so the player could render but not receive clicks.

## Validation
- AI大学 reusable UI contract: PASS
- Python syntax check: PASS
- Fast quality gate: PASS
- flutter analyze: No issues found
- New viewer widget test: PASS
- Manual Playwright reproduction: disabling the blocking barrier made playback advance.

## Rollback
Revert this PR to restore the previous dialog route.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Focused route regression is covered by a widget test and manual Playwright reproduction.