### PR TITLE
fix: keep all published AI University videos visible

### DIFF
--- a/lib/pages/gemini_university_v2_page.dart
+++ b/lib/pages/gemini_university_v2_page.dart
@@ -6269,15 +6269,32 @@ class _AiUniversityPageState extends State<AiUniversityPage>
 
   Future<void> _fetchContent() async {
     try {
-      final rows = await _supabase
+      final contentRows = await _supabase
           .from('ai_university_content')
           .select()
           .eq('is_active', true)
           .order('sort_order')
           .timeout(const Duration(seconds: 10));
 
+      // PostgREST limits one response to 1,000 rows. Fetch video lessons
+      // separately so the provider-independent banner never loses published
+      // videos as the general AI University catalog grows.
+      final publishedVideoRows = await _supabase
+          .from('ai_university_content')
+          .select()
+          .eq('is_active', true)
+          .like('category', 'video_%')
+          .order('published_at', ascending: false)
+          .timeout(const Duration(seconds: 10));
+
+      final rows =
+          AiUniversityVideoLessonService.mergeContentRowsByProviderCategory(
+        (contentRows as List).cast<Map<String, dynamic>>(),
+        (publishedVideoRows as List).cast<Map<String, dynamic>>(),
+      );
+
       final Map<String, List<Map<String, dynamic>>> grouped = {};
-      for (final row in (rows as List).cast<Map<String, dynamic>>()) {
+      for (final row in rows) {
         final provider =
             (row['provider'] as String?) ?? (row['provider_id'] as String?);
         if (provider == null) continue;

--- a/lib/services/ai_university_video_lesson_service.dart
+++ b/lib/services/ai_university_video_lesson_service.dart
@@ -98,6 +98,27 @@ class AiUniversityVideoLessonService {
     'pika': 'Pika',
   };
 
+  static List<Map<String, dynamic>> mergeContentRowsByProviderCategory(
+    Iterable<Map<String, dynamic>> primaryRows,
+    Iterable<Map<String, dynamic>> supplementalRows,
+  ) {
+    final rowsByKey = <String, Map<String, dynamic>>{};
+    var unkeyedRowIndex = 0;
+
+    for (final row in [...primaryRows, ...supplementalRows]) {
+      final provider =
+          (row['provider'] as String? ?? row['provider_id'] as String? ?? '')
+              .trim();
+      final category = (row['category'] as String? ?? '').trim();
+      final key = provider.isNotEmpty && category.isNotEmpty
+          ? '$provider::$category'
+          : 'unkeyed::${unkeyedRowIndex++}';
+      rowsByKey[key] = row;
+    }
+
+    return rowsByKey.values.toList(growable: false);
+  }
+
   static List<AiUniversityVideoLessonTopic> topicsFromRows(
     List<Map<String, dynamic>> rows,
   ) {

--- a/test/pages/ai_university_published_video_fetch_contract_test.dart
+++ b/test/pages/ai_university_published_video_fetch_contract_test.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'published videos are fetched separately from the capped catalog query',
+    () {
+      final source = File(
+        'lib/pages/gemini_university_v2_page.dart',
+      ).readAsStringSync();
+
+      expect(source, contains(".like('category', 'video_%')"));
+      expect(source, contains('mergeContentRowsByProviderCategory'));
+    },
+  );
+}

--- a/test/services/ai_university_video_lesson_service_test.dart
+++ b/test/services/ai_university_video_lesson_service_test.dart
@@ -2,6 +2,45 @@ import 'package:my_web_app/services/ai_university_video_lesson_service.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('supplemental video rows restore every unique published lesson', () {
+    Map<String, dynamic> row(String category, {String? title}) => {
+          'provider': 'openai',
+          'category': category,
+          'title': title ?? category,
+          'content': 'lesson',
+          'source_url': 'https://www.youtube.com/watch?v=-ZxiEPqxKRY',
+        };
+
+    final merged =
+        AiUniversityVideoLessonService.mergeContentRowsByProviderCategory(
+      [
+        row('overview'),
+        row('video_codex_solution_engineering'),
+        row('video_codex_custom_code_review_rules', title: 'stale title'),
+      ],
+      [
+        row('video_codex_record_replay'),
+        row('video_codex_customer_demo'),
+        row('video_codex_ios_xcodebuildmcp'),
+        row('video_codex_solution_engineering'),
+        row('video_codex_custom_code_review_rules', title: 'current title'),
+      ],
+    );
+
+    final videoRows = merged
+        .where((item) => (item['category'] as String).startsWith('video_'))
+        .toList();
+
+    expect(videoRows, hasLength(5));
+    expect(merged, hasLength(6));
+    expect(
+      videoRows.singleWhere(
+        (item) => item['category'] == 'video_codex_custom_code_review_rules',
+      )['title'],
+      'current title',
+    );
+  });
+
   test('topicsFromRows sorts overview before api', () {
     final topics = AiUniversityVideoLessonService.topicsFromRows([
       {


### PR DESCRIPTION
## Summary

- Fix the AI大学 `公開動画で学ぶ` banner showing only 2 of 5 active YouTube lessons.
- Fetch active `video_%` rows separately from the general catalog query, which can hit PostgREST's 1,000-row response cap.
- Merge the supplemental video rows by `(provider, category)` so both the provider-independent banner and OpenAI lesson list retain every published video without duplicates.
- Add pure-logic and source-contract regression tests.

## Root cause

Production contains all five active YouTube rows. The page loaded the entire `ai_university_content` catalog with one query ordered only by `sort_order`. The catalog has reached the PostgREST 1,000-row response cap, so only two video rows were present in the page state. No YouTube lesson data was deleted.

## Validation

- Production REST check: 5 active `video_%` rows are present.
- `dart test test/services/ai_university_video_lesson_service_test.dart test/pages/ai_university_published_video_fetch_contract_test.dart --reporter expanded`: PASS (9 tests).
- Repository pre-commit quality gate: PASS.
- `git diff --check`: PASS.
- Local full Flutter analysis/build is intentionally deferred because Windows physical memory is above 95% in use. GitHub CI is the authoritative full-suite and Web-build proof.

## Minimal E2E Gate

- Implementation-detail independent: the E2E plan checks user-visible input/output, not private internals.
- Minimal scope: about 3 cases only: the banner reports `5本`; the first, middle, and last video cards can each open their matching iframe; closing the viewer returns to a usable AI大学 page.
- E2E: exact-SHA production browser smoke after deployment, including iframe video IDs, center-point hit testing, play-control state changes, and canonical `YouTubeで開く` targets.
- E2E-Exception: no new integration_test or Playwright file is included because the regression is covered by a pure merge test and a query-contract test; the existing reusable banner/viewer E2E contracts remain unchanged. Production browser verification is mandatory after deploy.

## Visual E2E Evidence

- Before: production `/ai-university?tab=openai` visibly reports `2本` although the database contains 5 active videos.
- After deployment: verify desktop production reports `5本`, all five titles are selectable, and the first/middle/last embedded players advance.
- Console errors, page errors, request failures, and HTTP 5xx responses will be reviewed during production QA.
- No generated image is used as product-state evidence.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: the change is limited to a read-only supplemental Supabase query and deterministic in-memory deduplication. It changes no schema, RLS, authentication, secret, Edge Function, or write path. GitHub CI and exact-SHA production verification remain mandatory.
- Security evidence: only active public lesson rows are selected; no credentials or user data are added.
- Rollback evidence: revert the squash commit and redeploy the previous Web build.
- Production smoke evidence: verify the five-card banner and three representative embedded players after exact-SHA deployment.
- Observability evidence: inspect browser console errors and the matching deploy workflow.
- Unresolved findings: none.

## Deployment and rollback

- Squash merge to `main` after every required check succeeds.
- Monitor only the `Deploy to Production` run whose `headSha` matches the squash commit.
- Require cache-busted `version.json.commit` to match the squash commit.
- Rollback with a reviewed `git revert`; all five public YouTube videos and DB rows remain unchanged.