### PR TITLE
feat: add AI foundations video to AI University

### DIFF
--- a/supabase/migrations/20260815162113_seed_video-openai-ai-foundations_ai_university.sql
+++ b/supabase/migrations/20260815162113_seed_video-openai-ai-foundations_ai_university.sql
@@ -1,0 +1,51 @@
+-- AI大学: YouTube 公開動画を埋め込み学習コンテンツとして登録する。
+
+INSERT INTO ai_university_content (
+  provider,
+  category,
+  title,
+  content,
+  source_url,
+  published_at,
+  sort_order,
+  is_active
+)
+VALUES (
+  'openai',
+  'video_openai_ai_foundations',
+  'AIの基礎｜モデル・LLM・ChatGPTの違いをわかりやすく解説',
+  $content$# 学習目標
+
+AI、モデル、大規模言語モデル（LLM）、ChatGPTの関係と、学習方法・モデル選択・指示の基本を体系的に説明できるようになります。
+
+# 学習の要点
+
+1. AIは一つの製品名ではなく、データからパターンを学び、役に立つ出力を生み出す技術全体を表すカテゴリーです。
+2. モデルは学習したパターンを新しい状況へ応用する仕組みで、音声・画像・予測など得意分野が異なります。
+3. LLMは言葉を扱うモデルで、会話の文脈から次に続く可能性の高い言葉を組み立てます。ChatGPTは、そのモデルを使いやすく届ける製品です。
+4. 事前学習では大量の情報から基礎能力を身につけ、事後学習では人のフィードバックを通じて指示への従い方、表現、安全性を改善します。
+5. 文章整理やアイデア出しには高速なモデル、計画・分析・難しい判断にはリーズニングモデルが適しています。目的、読み手、形式、条件を具体的に伝え、重要な内容は人が確認します。
+
+# 実践演習
+
+日常や仕事からAIに任せたい作業を一つ選び、「目的」「読み手」「ほしい形式」「守る条件」を一文ずつ書いてください。高速モデルとリーズニングモデルのどちらを使うか、その理由と、人が確認すべき点も一つ挙げて実行結果を比較しましょう。
+
+# 参考・出典
+
+- 公開動画: https://www.youtube.com/watch?v=yAbco3K_TLQ
+- OpenAI Academy — AI Foundations: https://academy.openai.com/learn/ai-foundations-juzjs/lessons
+- OpenAI — AIの基礎: https://openai.com/ja-JP/academy/what-is-ai/
+
+この教材と動画は、上記のOpenAI公式コンテンツを参考に独自に再構成した日本語の要約・解説です。OpenAIによる公式翻訳・公式教材ではありません。$content$,
+  'https://www.youtube.com/watch?v=yAbco3K_TLQ',
+  '2026-08-15',
+  0,
+  true
+)
+ON CONFLICT (provider, category) DO UPDATE SET
+  title = EXCLUDED.title,
+  content = EXCLUDED.content,
+  source_url = EXCLUDED.source_url,
+  published_at = EXCLUDED.published_at,
+  sort_order = EXCLUDED.sort_order,
+  is_active = EXCLUDED.is_active;

--- a/test/services/ai_university_ai_foundations_video_seed_test.dart
+++ b/test/services/ai_university_ai_foundations_video_seed_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  const migrationPath =
+      'supabase/migrations/20260815162113_seed_video-openai-ai-foundations_ai_university.sql';
+
+  test(
+    'OpenAI AI foundations video is seeded as active AI university content',
+    () {
+      final sql = File(migrationPath).readAsStringSync();
+
+      expect(sql, contains("'openai'"));
+      expect(sql, contains("'video_openai_ai_foundations'"));
+      expect(sql, contains('https://www.youtube.com/watch?v=yAbco3K_TLQ'));
+      expect(sql, contains("'2026-08-15'"));
+      expect(sql, contains('ON CONFLICT (provider, category) DO UPDATE'));
+      expect(sql, contains('is_active = EXCLUDED.is_active'));
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Register the public YouTube lesson `yAbco3K_TLQ` in AI大学 under the existing `openai` provider.
- Use the stable category `video_openai_ai_foundations` and an idempotent `ON CONFLICT` migration so existing five published lessons remain active.
- Add a seed contract test for provider, category, canonical URL, publication date, and update behavior.

## Public lesson

- YouTube: https://www.youtube.com/watch?v=yAbco3K_TLQ
- Title: AIの基礎｜モデル・LLM・ChatGPTの違いをわかりやすく解説
- Provider: `openai`
- Category: `video_openai_ai_foundations`
- Published: `2026-08-15`
- Learning content: AI/model/LLM/ChatGPT relationships, pre-training and post-training, model selection, prompt design, human verification, and one practical exercise.

## Validation

- `ai_university_content.py check-ui --repo .` — passed; reusable iframe, provider-independent banner, and barrier-free viewer contracts exist.
- `python scripts/check_migration_timestamps.py` — passed (`1931` unique timestamps).
- Seed contract assertion — passed.
- `dart format --output=none --set-exit-if-changed test/services/ai_university_ai_foundations_video_seed_test.dart` — 0 changes.
- `git diff --check` — passed.
- Normal pre-commit hook — passed; no hook bypass was used.
- Local Flutter tests and Web build were intentionally not duplicated because free physical memory was approximately 1.1 GB in the clean worktree. GitHub Actions is the authoritative full-suite and Web-build proof for this commit.

## Minimal E2E Gate

- Implementation-detail independent: verification asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases — the active lesson appears in `公開動画で学ぶ`, the viewer uses video ID `yAbco3K_TLQ`, and `YouTubeで開く` resolves to the same public URL.
- E2E: existing Flutter viewer/route tests plus post-deployment browser playback verification cover the shared runtime path.
- E2E-Exception: no new E2E file is added because this PR changes only lesson data and its seed test; the shared UI and interaction implementation are unchanged.

## UI / visual evidence

- No Flutter UI or route code changes.
- No generated image is added to the application.
- After deployment, verify the production banner, opaque viewer route, iframe video ID, center-point iframe hit target, visible playback state change, and fallback YouTube URL.

## Security

- The migration contains only public learning content and a public YouTube URL.
- No OAuth token, credential, raw recording, local media path, or private metadata is committed.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: this is a data-only idempotent seed migration with no schema, RLS, auth, Edge Function, or runtime application-code change; deterministic checks and current-head CI cover the bounded scope.
- Security evidence: only public learning text and a canonical public YouTube URL are inserted; no secrets or personal recording artifacts are included.
- Rollback evidence: a forward-only migration can correct the row or set `is_active = false`; the squash merge can also be reverted through the normal deployment workflow.
- Prod smoke evidence: verify the active database row, production version commit, public-video banner, iframe video ID, center-point hit target, playback state change, and fallback URL.
- Observability evidence: correlate deployment by squash merge SHA and require `version.json` plus the database row and live AI大学 route to agree.
- Unresolved ultrareview findings: 0/none for this bounded migration and test scope.

## Rollback

- Data rollback: add a forward-only idempotent migration that corrects the row or sets `is_active = false` for `(openai, video_openai_ai_foundations)`.
- Code rollback if required: revert the squash merge commit and allow the normal production workflow to redeploy.
- Keep the public YouTube video unchanged if application deployment fails.

## Deployment

- Merge only after all current-head PR checks pass.
- Monitor the `Deploy to Production` run whose `headSha` equals the squash merge commit.
- Require production `version.json` to report the exact merge commit before live playback QA.
