### PR TITLE
test: keep endorsement validator in sync with generated asset

### DIFF
--- a/supabase/functions/local-election-intelligence/election_mode_test.ts
+++ b/supabase/functions/local-election-intelligence/election_mode_test.ts
@@ -156,12 +156,12 @@ Deno.test("local snapshot resolves goal progress and official achievements", () 
 Deno.test("generated endorsement asset passes the shared validator", () => {
   const snapshot = normalizeOfficialEndorsementSnapshot(endorsementAsset);
 
-  assertEquals(snapshot.totalCount, endorsementAsset.totalCount);
-  assertEquals(snapshot.incumbentCount, endorsementAsset.incumbentCount);
-  assertEquals(snapshot.newcomerCount, endorsementAsset.newcomerCount);
-  assertEquals(snapshot.formerCount, endorsementAsset.formerCount);
-  assertEquals(snapshot.recommendationCount, endorsementAsset.recommendationCount);
-  assertEquals(snapshot.prefectureCount, endorsementAsset.prefectureCount);
+  assertEquals(snapshot.totalCount, endorsementAsset.officialEndorsements.totalCount);
+  assertEquals(snapshot.incumbentCount, endorsementAsset.officialEndorsements.incumbentCount);
+  assertEquals(snapshot.newcomerCount, endorsementAsset.officialEndorsements.newcomerCount);
+  assertEquals(snapshot.formerCount, endorsementAsset.officialEndorsements.formerCount);
+  assertEquals(snapshot.recommendationCount, endorsementAsset.recommendations.totalCount);
+  assertEquals(snapshot.prefectureCount, endorsementAsset.prefectures.length);
   assertEquals(
     snapshot.totalCount,
     snapshot.incumbentCount + snapshot.newcomerCount + snapshot.formerCount,

--- a/supabase/functions/local-election-intelligence/election_mode_test.ts
+++ b/supabase/functions/local-election-intelligence/election_mode_test.ts
@@ -156,10 +156,14 @@ Deno.test("local snapshot resolves goal progress and official achievements", () 
 Deno.test("generated endorsement asset passes the shared validator", () => {
   const snapshot = normalizeOfficialEndorsementSnapshot(endorsementAsset);
 
-  assertEquals(snapshot.totalCount, 218);
-  assertEquals(snapshot.incumbentCount, 102);
-  assertEquals(snapshot.newcomerCount, 107);
-  assertEquals(snapshot.formerCount, 9);
-  assertEquals(snapshot.recommendationCount, 9);
-  assertEquals(snapshot.prefectureCount, 33);
+  assertEquals(snapshot.totalCount, endorsementAsset.totalCount);
+  assertEquals(snapshot.incumbentCount, endorsementAsset.incumbentCount);
+  assertEquals(snapshot.newcomerCount, endorsementAsset.newcomerCount);
+  assertEquals(snapshot.formerCount, endorsementAsset.formerCount);
+  assertEquals(snapshot.recommendationCount, endorsementAsset.recommendationCount);
+  assertEquals(snapshot.prefectureCount, endorsementAsset.prefectureCount);
+  assertEquals(
+    snapshot.totalCount,
+    snapshot.incumbentCount + snapshot.newcomerCount + snapshot.formerCount,
+  );
 });

--- a/supabase/functions/local-election-intelligence/election_mode_test.ts
+++ b/supabase/functions/local-election-intelligence/election_mode_test.ts
@@ -156,6 +156,7 @@ Deno.test("local snapshot resolves goal progress and official achievements", () 
 Deno.test("generated endorsement asset passes the shared validator", () => {
   const snapshot = normalizeOfficialEndorsementSnapshot(endorsementAsset);
 
+  // Counts change when the generated asset refreshes; validate the data contract.
   assertEquals(snapshot.totalCount, endorsementAsset.officialEndorsements.totalCount);
   assertEquals(snapshot.incumbentCount, endorsementAsset.officialEndorsements.incumbentCount);
   assertEquals(snapshot.newcomerCount, endorsementAsset.officialEndorsements.newcomerCount);


### PR DESCRIPTION
## Summary
- remove stale hard-coded endorsement totals from the shared Deno validator test
- compare normalized values with the generated endorsement asset
- preserve an independent invariant that category counts add up to the total

## Validation
- `deno eval` against the branch's raw asset and normalizer: `[221,103,109,9,9,33]`, category total `221`

## Minimal E2E Gate
- Implementation-detail independent: the test checks the generated public data contract through the shared normalizer, not private implementation steps.
- E2E-Exception: Test-only assertion maintenance; no application route or runtime behavior changes. The repository Deno test job exercises the affected contract.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Test-only assertion change mechanically matched by the supabase/functions path; production code, security, data migration, rollback behavior, prod smoke, and observability are unchanged.