### PR TITLE
feat: add privacy-safe LP conversion analytics

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -741,10 +741,14 @@ jobs:
             --dart-define=ASSET_LIABILITY_SUPABASE_PRODUCTION_WRITES_ENABLED=true \
             --dart-define=ASSET_MANAGEMENT_AI_SUMMARY_ENABLED=true \
             --dart-define=ASSET_MANAGEMENT_AI_PROVIDER_ROUTING_ENABLED=true \
+            --dart-define=POSTHOG_PROJECT_TOKEN=$POSTHOG_PROJECT_TOKEN \
+            --dart-define=POSTHOG_HOST=$POSTHOG_HOST \
             --dart-define=LANDING_GOOGLE_LOGIN_ENABLED=${{ env.LANDING_GOOGLE_LOGIN_ENABLED }}
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_PROD }}
+          POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://us.i.posthog.com' }}
 
       - name: Write version.json
         if: steps.changes.outputs.web == 'true'

--- a/docs/LP_CONVERSION_ANALYTICS.md
+++ b/docs/LP_CONVERSION_ANALYTICS.md
@@ -1,0 +1,47 @@
+# LP Conversion Analytics
+
+The landing page keeps Supabase as the source of truth for experiment events,
+LP views, and completed registrations. `LandingConversionAnalytics` mirrors the
+same anonymous experiment event to PostHog when a production token is present.
+
+## Production Configuration
+
+Add `POSTHOG_PROJECT_TOKEN` as a GitHub Actions repository secret. Optionally
+set the `POSTHOG_HOST` repository variable for EU Cloud or self-hosting. The
+default host is `https://us.i.posthog.com`.
+
+```bash
+flutter build web \
+  --dart-define=POSTHOG_PROJECT_TOKEN=phc_xxx \
+  --dart-define=POSTHOG_HOST=https://us.i.posthog.com
+```
+
+An absent token, blocked script, or PostHog outage makes the adapter a no-op.
+It does not block the LP, authentication, or Supabase measurement.
+
+## Event Model
+
+PostHog receives one event, `landing_conversion_stage`. Its generated fields
+are `hypothesis_id`, `variant`, and `stage`, parsed from the validated existing
+`lp_exp_hXX_{control|treatment}_{stage}` event key. Supported stages are owned
+by `LandingConversionExperimentService`.
+
+Only these optional properties can pass through the adapter:
+
+- `path`
+- `viewport`
+- `utm_source`
+- `utm_medium`
+- `utm_campaign`
+- `referral_present`
+
+Email, visitor UUID, user ID, prompt text, proposed tasks, and arbitrary
+properties are never sent. Autocapture, automatic page views, page leaves,
+session replay, surveys, lifecycle capture, push capture, feature-flag events,
+and person profiles are disabled. The app never calls `identify`.
+
+## Analysis
+
+Build funnels with the same hypothesis and variant filters. Use
+`signup_complete` as the outcome, segment mobile and desktop separately, and
+confirm the result against Supabase before selecting a winning treatment.

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../services/growth_acquisition_service.dart';
 import '../services/growth_mission_service.dart';
+import '../services/landing_conversion_analytics.dart';
 import '../services/landing_conversion_experiment_service.dart';
 import '../services/landing_page_adapter.dart';
 import '../services/landing_signup_completion_service.dart';
@@ -20,6 +21,7 @@ enum _LandingIntent { work, learning, money }
 class LandingPage extends StatefulWidget {
   final LandingPageAdapter adapter;
   final GrowthMissionService growthService;
+  final LandingConversionAnalytics conversionAnalytics;
   final LandingConversionExperimentService conversionExperimentService;
   final LandingSignupCompletionService signupCompletionService;
   final PendingLandingTrialService pendingTrialService;
@@ -32,6 +34,7 @@ class LandingPage extends StatefulWidget {
     super.key,
     LandingPageAdapter? adapter,
     GrowthMissionService? growthService,
+    LandingConversionAnalytics? conversionAnalytics,
     LandingConversionExperimentService? conversionExperimentService,
     LandingSignupCompletionService? signupCompletionService,
     PendingLandingTrialService? pendingTrialService,
@@ -41,6 +44,8 @@ class LandingPage extends StatefulWidget {
     this.landingUri,
   })  : adapter = adapter ?? const SupabaseLandingPageAdapter(),
         growthService = growthService ?? const GrowthMissionService(),
+        conversionAnalytics =
+            conversionAnalytics ?? const PostHogLandingConversionAnalytics(),
         pendingTrialService =
             pendingTrialService ?? const PendingLandingTrialService(),
         signupCompletionService =
@@ -203,8 +208,15 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       if (!_recordedExperimentStages.add(stage)) {
         return;
       }
+      final eventKey = assignment.eventKey(stage);
+      unawaited(
+        widget.conversionAnalytics.captureExperimentEvent(
+          eventKey: eventKey,
+          properties: _conversionAnalyticsProperties(),
+        ),
+      );
       await widget.adapter.recordConversionEvent(
-        eventKey: assignment.eventKey(stage),
+        eventKey: eventKey,
         visitorId: visitorId,
       );
     } catch (error) {
@@ -223,6 +235,32 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     } catch (error) {
       debugPrint('First-user LP funnel event failed ($stage): $error');
     }
+  }
+
+  Map<String, Object> _conversionAnalyticsProperties() {
+    final uri = _landingUri;
+    final width = MediaQuery.maybeSizeOf(context)?.width;
+    final properties = <String, Object>{
+      'path': uri?.path.isNotEmpty == true ? uri!.path : '/',
+      'viewport': width != null && width < 600 ? 'mobile' : 'desktop',
+    };
+    for (final key in const <String>[
+      'utm_source',
+      'utm_medium',
+      'utm_campaign',
+    ]) {
+      final value = uri?.queryParameters[key]?.trim();
+      if (value != null && value.isNotEmpty) {
+        properties[key] = value;
+      }
+    }
+    properties['referral_present'] = _pendingReferralCode != null ||
+        const <String>{
+          'ref',
+          'referral',
+          'referral_code',
+        }.any((key) => uri?.queryParameters[key]?.trim().isNotEmpty == true);
+    return properties;
   }
 
   @override

--- a/lib/services/landing_conversion_analytics.dart
+++ b/lib/services/landing_conversion_analytics.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/foundation.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+import 'landing_conversion_experiment_service.dart';
+import 'posthog_web_initializer_stub.dart'
+    if (dart.library.js_interop) 'posthog_web_initializer_web.dart';
+
+abstract interface class LandingConversionAnalytics {
+  Future<void> captureExperimentEvent({
+    required String eventKey,
+    Map<String, Object> properties = const <String, Object>{},
+  });
+}
+
+/// Privacy-limited, best-effort mirror of the existing Supabase LP funnel.
+///
+/// Supabase remains the source of truth. This adapter never identifies a user
+/// and drops events or properties outside its explicit allowlists.
+class PostHogLandingConversionAnalytics implements LandingConversionAnalytics {
+  const PostHogLandingConversionAnalytics();
+
+  static const String _projectToken = String.fromEnvironment(
+    'POSTHOG_PROJECT_TOKEN',
+  );
+  static const String _host = String.fromEnvironment(
+    'POSTHOG_HOST',
+    defaultValue: 'https://us.i.posthog.com',
+  );
+  static const String _eventName = 'landing_conversion_stage';
+
+  static const Set<String> _allowedProperties = <String>{
+    'path',
+    'viewport',
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'referral_present',
+  };
+
+  static final RegExp _eventParts = RegExp(
+    r'^lp_exp_(h(?:0[1-9]|10))_(control|treatment)_(.+)$',
+  );
+  static Future<void>? _initialization;
+  static bool _enabled = false;
+
+  Future<void> _initialize() {
+    return _initialization ??= _initializeOnce();
+  }
+
+  Future<void> _initializeOnce() async {
+    if (_projectToken.isEmpty) return;
+
+    try {
+      await initializePostHogWeb(projectToken: _projectToken, host: _host);
+      final config = PostHogConfig(_projectToken)
+        ..host = _host
+        ..captureApplicationLifecycleEvents = false
+        ..capturePushNotificationOpened = false
+        ..capturePushNotificationSubscriptions = false
+        ..personProfiles = PostHogPersonProfiles.never
+        ..sendFeatureFlagEvents = false
+        ..sessionReplay = false
+        ..surveys = false;
+      await Posthog().setup(config);
+      _enabled = true;
+    } catch (error) {
+      _enabled = false;
+      debugPrint('Landing conversion analytics disabled: $error');
+    }
+  }
+
+  @override
+  Future<void> captureExperimentEvent({
+    required String eventKey,
+    Map<String, Object> properties = const <String, Object>{},
+  }) async {
+    if (!LandingConversionExperimentService.isExperimentEventKey(eventKey)) {
+      debugPrint('Dropped unapproved landing event: $eventKey');
+      return;
+    }
+
+    final match = _eventParts.firstMatch(eventKey);
+    if (match == null) return;
+
+    await _initialize();
+    if (!_enabled) return;
+
+    final stage = match.group(3)!;
+    if (!LandingConversionExperimentService.supportedStages.contains(stage)) {
+      return;
+    }
+    final safeProperties = <String, Object>{
+      'hypothesis_id': match.group(1)!,
+      'variant': match.group(2)!,
+      'stage': stage,
+      for (final entry in properties.entries)
+        if (_allowedProperties.contains(entry.key)) entry.key: entry.value,
+    };
+
+    try {
+      await Posthog().capture(
+        eventName: _eventName,
+        properties: safeProperties,
+      );
+    } catch (error) {
+      debugPrint('Landing conversion event failed: $error');
+    }
+  }
+}

--- a/lib/services/landing_signup_completion_service.dart
+++ b/lib/services/landing_signup_completion_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'growth_acquisition_service.dart';
+import 'landing_conversion_analytics.dart';
 import 'landing_conversion_experiment_service.dart';
 import 'landing_page_adapter.dart';
 
@@ -68,10 +69,13 @@ class LandingSignupCompletionService {
   const LandingSignupCompletionService({
     this.ttl = const Duration(hours: 48),
     LandingPageAdapter? landingPageAdapter,
+    LandingConversionAnalytics? conversionAnalytics,
     GrowthAcquisitionService? acquisitionService,
     DateTime Function()? clock,
   })  : _landingPageAdapter =
             landingPageAdapter ?? const SupabaseLandingPageAdapter(),
+        _conversionAnalytics =
+            conversionAnalytics ?? const PostHogLandingConversionAnalytics(),
         _acquisitionService =
             acquisitionService ?? const GrowthAcquisitionService(),
         _clock = clock;
@@ -82,6 +86,7 @@ class LandingSignupCompletionService {
 
   final Duration ttl;
   final LandingPageAdapter _landingPageAdapter;
+  final LandingConversionAnalytics _conversionAnalytics;
   final GrowthAcquisitionService _acquisitionService;
   final DateTime Function()? _clock;
 
@@ -184,6 +189,11 @@ class LandingSignupCompletionService {
       await _landingPageAdapter.recordConversionEvent(
         eventKey: pending.eventKey,
         visitorId: pending.visitorId,
+      );
+      unawaited(
+        _conversionAnalytics.captureExperimentEvent(
+          eventKey: pending.eventKey,
+        ),
       );
       try {
         await _acquisitionService.recordFirstUserFunnelStage(

--- a/lib/services/posthog_web_initializer_stub.dart
+++ b/lib/services/posthog_web_initializer_stub.dart
@@ -1,0 +1,4 @@
+Future<void> initializePostHogWeb({
+  required String projectToken,
+  required String host,
+}) async {}

--- a/lib/services/posthog_web_initializer_web.dart
+++ b/lib/services/posthog_web_initializer_web.dart
@@ -1,0 +1,14 @@
+import 'dart:js_interop';
+
+@JS('initializePostHogForFlutter')
+external JSPromise<JSAny?> _initializePostHogForFlutter(
+  JSString projectToken,
+  JSString host,
+);
+
+Future<void> initializePostHogWeb({
+  required String projectToken,
+  required String host,
+}) async {
+  await _initializePostHogForFlutter(projectToken.toJS, host.toJS).toDart;
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import file_selector_macos
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import package_info_plus
+import posthog_flutter
 import printing
 import sentry_flutter
 import share_plus
@@ -26,6 +27,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PosthogFlutterPlugin.register(with: registry.registrar(forPlugin: "PosthogFlutterPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -844,6 +844,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -928,18 +936,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1541,26 +1549,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -844,14 +844,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -936,18 +928,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1549,26 +1541,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   time:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -844,14 +844,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -936,18 +928,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1172,6 +1164,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.1"
+  posthog_flutter:
+    dependency: "direct main"
+    description:
+      name: posthog_flutter
+      sha256: "3f95dc662e4acc017d0c72374046dd96d4a5c2efa8f3f1608d757ceb4bdf55cc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.36.2"
   printing:
     dependency: "direct main"
     description:
@@ -1541,26 +1541,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.4.1 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -15,6 +15,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   supabase_flutter: ^2.0.0
+  posthog_flutter: ^5.36.1
   crypto: ^3.0.7
   cupertino_icons: ^1.0.6
   web: ^1.1.0

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/pages/landing_page.dart';
 import 'package:my_web_app/services/growth_acquisition_service.dart';
+import 'package:my_web_app/services/landing_conversion_analytics.dart';
 import 'package:my_web_app/services/landing_conversion_experiment_service.dart';
 import 'package:my_web_app/services/landing_page_adapter.dart';
 import 'package:my_web_app/services/landing_signup_completion_service.dart';
@@ -121,6 +122,20 @@ class _RecordingAcquisitionService extends GrowthAcquisitionService {
   }
 }
 
+class _RecordingConversionAnalytics implements LandingConversionAnalytics {
+  final List<String> eventKeys = <String>[];
+  final List<Map<String, Object>> properties = <Map<String, Object>>[];
+
+  @override
+  Future<void> captureExperimentEvent({
+    required String eventKey,
+    Map<String, Object> properties = const <String, Object>{},
+  }) async {
+    eventKeys.add(eventKey);
+    this.properties.add(Map<String, Object>.from(properties));
+  }
+}
+
 LandingConversionHypothesis _hypothesis(String id) {
   return LandingConversionExperimentService.hypotheses.firstWhere(
     (hypothesis) => hypothesis.id == id,
@@ -159,6 +174,7 @@ void main() {
     bool? analyticsEnabled,
     Uri? landingUri,
     LandingConversionExperimentService? conversionExperimentService,
+    LandingConversionAnalytics? conversionAnalytics,
     GrowthAcquisitionService? acquisitionService,
   }) async {
     tester.view.devicePixelRatio = 1;
@@ -177,6 +193,7 @@ void main() {
           adapter: adapter,
           experimentAssignment: assignment,
           conversionExperimentService: conversionExperimentService,
+          conversionAnalytics: conversionAnalytics,
           acquisitionService: acquisitionService,
           analyticsEnabled: analyticsEnabled,
           landingUri: landingUri,
@@ -224,6 +241,45 @@ void main() {
       isFalse,
     );
     expect(LandingPage.shouldFocusTrialForUri(null), isFalse);
+  });
+
+  testWidgets('mirrors an anonymous experiment view with safe attribution', (
+    tester,
+  ) async {
+    final analytics = _RecordingConversionAnalytics();
+    await pumpLanding(
+      tester,
+      assignment: _assignment('h01', LandingExperimentVariant.treatment),
+      conversionAnalytics: analytics,
+      size: const Size(390, 844),
+      landingUri: Uri.parse(
+        'https://example.com/start?utm_source=x&utm_medium=organic'
+        '&utm_campaign=first_user&ref=invite-code',
+      ),
+    );
+
+    expect(analytics.eventKeys, contains('lp_exp_h01_treatment_view'));
+    final viewIndex = analytics.eventKeys.indexOf('lp_exp_h01_treatment_view');
+    expect(analytics.properties[viewIndex], <String, Object>{
+      'path': '/start',
+      'viewport': 'mobile',
+      'utm_source': 'x',
+      'utm_medium': 'organic',
+      'utm_campaign': 'first_user',
+      'referral_present': true,
+    });
+  });
+
+  testWidgets('QA traffic does not reach conversion analytics', (tester) async {
+    final analytics = _RecordingConversionAnalytics();
+    await pumpLanding(
+      tester,
+      assignment: _assignment('h01', LandingExperimentVariant.control),
+      conversionAnalytics: analytics,
+      landingUri: Uri.parse('https://example.com/?lp_qa=1'),
+    );
+
+    expect(analytics.eventKeys, isEmpty);
   });
 
   testWidgets('brand search intent is visible and exposed as headings', (

--- a/test/services/landing_signup_completion_service_test.dart
+++ b/test/services/landing_signup_completion_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/growth_acquisition_service.dart';
+import 'package:my_web_app/services/landing_conversion_analytics.dart';
 import 'package:my_web_app/services/landing_page_adapter.dart';
 import 'package:my_web_app/services/landing_signup_completion_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -46,6 +47,18 @@ class _RecordingAcquisitionService extends GrowthAcquisitionService {
   }
 }
 
+class _RecordingConversionAnalytics implements LandingConversionAnalytics {
+  final List<String> eventKeys = <String>[];
+
+  @override
+  Future<void> captureExperimentEvent({
+    required String eventKey,
+    Map<String, Object> properties = const <String, Object>{},
+  }) async {
+    eventKeys.add(eventKey);
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -53,6 +66,7 @@ void main() {
   const visitorId = '00000000-0000-4000-8000-000000000001';
   late _RecordingLandingAdapter adapter;
   late _RecordingAcquisitionService acquisitionService;
+  late _RecordingConversionAnalytics conversionAnalytics;
   late DateTime now;
   late LandingSignupCompletionService service;
 
@@ -60,9 +74,11 @@ void main() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
     adapter = _RecordingLandingAdapter();
     acquisitionService = _RecordingAcquisitionService();
+    conversionAnalytics = _RecordingConversionAnalytics();
     now = DateTime.utc(2026, 7, 23, 1);
     service = LandingSignupCompletionService(
       landingPageAdapter: adapter,
+      conversionAnalytics: conversionAnalytics,
       acquisitionService: acquisitionService,
       clock: () => now,
     );
@@ -88,6 +104,7 @@ void main() {
 
       expect(adapter.eventKeys, <String>[eventKey]);
       expect(adapter.visitorIds, <String>[visitorId]);
+      expect(conversionAnalytics.eventKeys, <String>[eventKey]);
       expect(acquisitionService.funnelStages, <String>[
         'signup_complete:$visitorId',
       ]);

--- a/web/index.html
+++ b/web/index.html
@@ -518,6 +518,36 @@
       }
     }
   </style>
+  <script>
+    window.initializePostHogForFlutter = async function(projectToken, host) {
+      if (!projectToken || window.__posthogFlutterInitialized) return;
+
+      const normalizedHost = (host || 'https://us.i.posthog.com').replace(/\/$/, '');
+      if (!window.posthog || typeof window.posthog.init !== 'function') {
+        const assetHost = normalizedHost.replace('.i.posthog.com', '-assets.i.posthog.com');
+        await new Promise((resolve, reject) => {
+          const script = document.createElement('script');
+          script.async = true;
+          script.crossOrigin = 'anonymous';
+          script.src = `${assetHost}/static/array.js`;
+          script.onload = resolve;
+          script.onerror = () => reject(new Error('PostHog script failed to load'));
+          document.head.appendChild(script);
+        });
+      }
+
+      window.posthog.init(projectToken, {
+        api_host: normalizedHost,
+        autocapture: false,
+        capture_pageview: false,
+        capture_pageleave: false,
+        disable_session_recording: true,
+        person_profiles: 'never',
+        advanced_disable_feature_flags_on_first_load: true
+      });
+      window.__posthogFlutterInitialized = true;
+    };
+  </script>
 </head>
 <body>
   <div id="seo-shell">

--- a/web/release-notes.json
+++ b/web/release-notes.json
@@ -2,7 +2,7 @@
   "current": {
     "build": "1",
     "category": "release",
-    "date": "2026-07-04",
+    "date": "2026-08-15",
     "links": [
       {
         "title": "GitHub Release v1.0.0",
@@ -13,7 +13,7 @@
     "summary": "Release 1.0.0",
     "version": "1.0.0"
   },
-  "generatedAt": "2026-07-04T00:00:00Z",
+  "generatedAt": "2026-08-15T00:00:00Z",
   "schemaVersion": 1,
   "source": {
     "aiToolWatch": "docs/ai-tool-watch/latest-report.json",
@@ -26,406 +26,405 @@
       "category": "release",
       "changeCategories": [
         "automation",
-        "docs",
         "feature",
         "fix"
       ],
       "changes": [
         {
-          "category": "fix",
-          "id": "pr-3766",
+          "category": "feature",
+          "id": "pr-4475",
           "links": [
             {
-              "title": "PR #3766",
+              "title": "PR #4475",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3766"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4475"
             }
           ],
-          "mergedAt": "2026-07-04T04:06:04Z",
-          "summary": "#3766 fix(x-share): URLをリプライへ回す + 動画をトレンド反映で毎回変化 (#3764)"
+          "mergedAt": "2026-08-15T08:46:35Z",
+          "summary": "#4475 feat(asset): import Rakuten and SBI holdings CSV"
         },
         {
           "category": "fix",
-          "id": "pr-3763",
+          "id": "pr-4546",
           "links": [
             {
-              "title": "PR #3763",
+              "title": "PR #4546",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3763"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4546"
             }
           ],
-          "mergedAt": "2026-07-04T02:47:42Z",
-          "summary": "#3763 fix(viral-video): Hedra音声アセット(audio_id)復活+ゲート非依存化+診断常時付記 (#3751)"
+          "mergedAt": "2026-08-15T08:22:50Z",
+          "summary": "#4546 fix(wbs): avoid duplicate issue links in revenue migration"
         },
         {
           "category": "feature",
-          "id": "pr-3760",
+          "id": "pr-4461",
           "links": [
             {
-              "title": "PR #3760",
+              "title": "PR #4461",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3760"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4461"
             }
           ],
-          "mergedAt": "2026-07-03T14:37:21Z",
-          "summary": "#3760 [CI/CD自動最適化] 2026-07-03 (concurrency追加 + cron 6h削減)"
+          "mergedAt": "2026-08-15T07:48:44Z",
+          "summary": "#4461 feat: automate Stripe revenue readiness gate"
         },
         {
-          "category": "fix",
-          "id": "pr-3752",
+          "category": "feature",
+          "id": "pr-4543",
           "links": [
             {
-              "title": "PR #3752",
+              "title": "PR #4543",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3752"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4543"
             }
           ],
-          "mergedAt": "2026-07-02T18:51:31Z",
-          "summary": "#3752 fix(viral-video): OpenAI TTS無条件フォールバック + speech_chain診断 (#3751)"
+          "mergedAt": "2026-08-15T07:40:24Z",
+          "summary": "#4543 feat: add AI foundations video to AI University"
         },
         {
           "category": "automation",
-          "id": "pr-3703",
+          "id": "pr-4544",
           "links": [
             {
-              "title": "PR #3703",
+              "title": "PR #4544",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3703"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4544"
             }
           ],
-          "mergedAt": "2026-07-02T17:01:39Z",
-          "summary": "#3703 ci: bump the github-actions group across 2 directories with 2 updates"
+          "mergedAt": "2026-08-15T07:37:22Z",
+          "summary": "#4544 test: keep endorsement validator in sync with generated asset"
+        },
+        {
+          "category": "feature",
+          "id": "pr-4537",
+          "links": [
+            {
+              "title": "PR #4537",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4537"
+            }
+          ],
+          "mergedAt": "2026-08-15T06:14:51Z",
+          "summary": "#4537 feat: publish AGI Fireworks video page"
+        },
+        {
+          "category": "feature",
+          "id": "pr-4540",
+          "links": [
+            {
+              "title": "PR #4540",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4540"
+            }
+          ],
+          "mergedAt": "2026-08-15T05:55:59Z",
+          "summary": "#4540 feat: optimize homepage for 自分株式会社 brand search"
         },
         {
           "category": "fix",
-          "id": "pr-3738",
+          "id": "pr-4536",
           "links": [
             {
-              "title": "PR #3738",
+              "title": "PR #4536",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3738"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4536"
             }
           ],
-          "mergedAt": "2026-07-02T16:48:42Z",
-          "summary": "#3738 fix: keep hedra video generation after speech failures"
-        },
-        {
-          "category": "fix",
-          "id": "pr-3735",
-          "links": [
-            {
-              "title": "PR #3735",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3735"
-            }
-          ],
-          "mergedAt": "2026-07-01T18:28:55Z",
-          "summary": "#3735 fix: recover hedra presenter video tts"
-        },
-        {
-          "category": "fix",
-          "id": "pr-3733",
-          "links": [
-            {
-              "title": "PR #3733",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3733"
-            }
-          ],
-          "mergedAt": "2026-07-01T11:53:03Z",
-          "summary": "#3733 fix: allow generated audio uploads for viral videos"
-        },
-        {
-          "category": "fix",
-          "id": "pr-3712",
-          "links": [
-            {
-              "title": "PR #3712",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3712"
-            }
-          ],
-          "mergedAt": "2026-06-29T14:48:12Z",
-          "summary": "#3712 fix: fall back to OpenAI TTS for AI secretary videos"
-        },
-        {
-          "category": "fix",
-          "id": "pr-3711",
-          "links": [
-            {
-              "title": "PR #3711",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3711"
-            }
-          ],
-          "mergedAt": "2026-06-29T11:19:23Z",
-          "summary": "#3711 fix: route AI secretary videos through ElevenLabs audio"
+          "mergedAt": "2026-08-14T16:20:01Z",
+          "summary": "#4536 fix: keep all published AI University videos visible"
         },
         {
           "category": "feature",
-          "id": "pr-3704",
+          "id": "pr-4534",
           "links": [
             {
-              "title": "PR #3704",
+              "title": "PR #4534",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3704"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4534"
             }
           ],
-          "mergedAt": "2026-06-29T09:38:53Z",
-          "summary": "#3704 deps: update google-genai requirement from <3.0.0,>=2.9.0 to >=2.10.0,<3.0.0 in the python-dependencies group"
+          "mergedAt": "2026-08-14T14:15:28Z",
+          "summary": "#4534 feat: publish custom review rules lesson in AI University"
         },
         {
           "category": "feature",
-          "id": "pr-3702",
+          "id": "pr-4525",
           "links": [
             {
-              "title": "PR #3702",
+              "title": "PR #4525",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3702"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4525"
             }
           ],
-          "mergedAt": "2026-06-29T09:38:36Z",
-          "summary": "#3702 deps: bump @playwright/test from 1.61.0 to 1.61.1 in the npm-dev-dependencies group"
+          "mergedAt": "2026-08-14T06:01:29Z",
+          "summary": "#4525 feat: add daily progressive guitar course"
         },
         {
           "category": "feature",
-          "id": "pr-3694",
+          "id": "pr-4533",
           "links": [
             {
-              "title": "PR #3694",
+              "title": "PR #4533",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3694"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4533"
             }
           ],
-          "mergedAt": "2026-06-29T01:31:01Z",
-          "summary": "#3694 Add paid conversion metrics to admin analytics"
-        },
-        {
-          "category": "fix",
-          "id": "pr-3701",
-          "links": [
-            {
-              "title": "PR #3701",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3701"
-            }
-          ],
-          "mergedAt": "2026-06-29T01:21:15Z",
-          "summary": "#3701 Fix AI secretary share video template"
-        },
-        {
-          "category": "feature",
-          "id": "pr-3692",
-          "links": [
-            {
-              "title": "PR #3692",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3692"
-            }
-          ],
-          "mergedAt": "2026-06-27T13:20:42Z",
-          "summary": "#3692 Add revenue funnel attribution for supporter checkout"
-        },
-        {
-          "category": "feature",
-          "id": "pr-3691",
-          "links": [
-            {
-              "title": "PR #3691",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3691"
-            }
-          ],
-          "mergedAt": "2026-06-27T11:43:05Z",
-          "summary": "#3691 Show upgrade dialog on free AI limit"
-        },
-        {
-          "category": "feature",
-          "id": "pr-3690",
-          "links": [
-            {
-              "title": "PR #3690",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3690"
-            }
-          ],
-          "mergedAt": "2026-06-27T11:15:25Z",
-          "summary": "#3690 Add X post metrics optimizer"
-        },
-        {
-          "category": "fix",
-          "id": "pr-3689",
-          "links": [
-            {
-              "title": "PR #3689",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3689"
-            }
-          ],
-          "mergedAt": "2026-06-27T06:53:30Z",
-          "summary": "#3689 Fix freemium landing pricing copy"
-        },
-        {
-          "category": "feature",
-          "id": "pr-3686",
-          "links": [
-            {
-              "title": "PR #3686",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3686"
-            }
-          ],
-          "mergedAt": "2026-06-27T03:47:12Z",
-          "summary": "#3686 feat: handle billing checkout return state"
-        },
-        {
-          "category": "fix",
-          "id": "pr-3682",
-          "links": [
-            {
-              "title": "PR #3682",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3682"
-            }
-          ],
-          "mergedAt": "2026-06-27T01:34:50Z",
-          "summary": "#3682 fix: finish monetization terms landing links"
-        },
-        {
-          "category": "feature",
-          "id": "pr-3679",
-          "links": [
-            {
-              "title": "PR #3679",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3679"
-            }
-          ],
-          "mergedAt": "2026-06-26T10:12:45Z",
-          "summary": "#3679 docs(legal): 特定商取引法ページに運営者情報を記入 (#3640)"
-        },
-        {
-          "category": "fix",
-          "id": "pr-3661",
-          "links": [
-            {
-              "title": "PR #3661",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3661"
-            }
-          ],
-          "mergedAt": "2026-06-25T18:36:58Z",
-          "summary": "#3661 fix(billing): Edge Function の env値を .trim() でコピペ空白事故から防御"
-        },
-        {
-          "category": "feature",
-          "id": "pr-3659",
-          "links": [
-            {
-              "title": "PR #3659",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3659"
-            }
-          ],
-          "mergedAt": "2026-06-25T14:51:46Z",
-          "summary": "#3659 feat(billing): AI使用量メータリング + フリーミアム上限ゲート (#3645 #3646)"
-        },
-        {
-          "category": "feature",
-          "id": "pr-3652",
-          "links": [
-            {
-              "title": "PR #3652",
-              "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3652"
-            }
-          ],
-          "mergedAt": "2026-06-25T14:35:32Z",
-          "summary": "#3652 feat(billing): 特商法・利用規約ページ追加 + 課金導線/返却URL整備 (収益化P0 #3639)"
+          "mergedAt": "2026-08-14T05:57:34Z",
+          "summary": "#4533 feat: add Codex solution engineering lesson"
         },
         {
           "category": "automation",
-          "id": "pr-3657",
+          "id": "pr-4529",
           "links": [
             {
-              "title": "PR #3657",
+              "title": "PR #4529",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3657"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4529"
             }
           ],
-          "mergedAt": "2026-06-25T14:31:26Z",
-          "summary": "#3657 ci: deploy-prod.yml に Flutter pub キャッシュ追加 (2026-06-25 ci-audit)"
+          "mergedAt": "2026-08-14T05:36:35Z",
+          "summary": "#4529 ci: keep generated endorsement data format-compatible"
         },
         {
-          "category": "docs",
-          "id": "pr-3650",
+          "category": "feature",
+          "id": "pr-4527",
           "links": [
             {
-              "title": "PR #3650",
+              "title": "PR #4527",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3650"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4527"
             }
           ],
-          "mergedAt": "2026-06-25T11:46:54Z",
-          "summary": "#3650 docs: add VS Code terminal troubleshooting guide"
+          "mergedAt": "2026-08-14T04:51:19Z",
+          "summary": "#4527 Add asset management WBS release skill"
         },
         {
-          "category": "docs",
-          "id": "pr-3638",
+          "category": "feature",
+          "id": "pr-4522",
           "links": [
             {
-              "title": "PR #3638",
+              "title": "PR #4522",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3638"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4522"
             }
           ],
-          "mergedAt": "2026-06-25T11:29:26Z",
-          "summary": "#3638 docs: update AI character principles"
+          "mergedAt": "2026-08-13T20:11:31Z",
+          "summary": "#4522 feat: add Codex iOS lesson to AI University"
+        },
+        {
+          "category": "fix",
+          "id": "pr-4520",
+          "links": [
+            {
+              "title": "PR #4520",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4520"
+            }
+          ],
+          "mergedAt": "2026-08-13T17:19:38Z",
+          "summary": "#4520 fix: make every AI University video selectable"
         },
         {
           "category": "automation",
-          "id": "pr-3637",
+          "id": "pr-4519",
           "links": [
             {
-              "title": "PR #3637",
+              "title": "PR #4519",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3637"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4519"
             }
           ],
-          "mergedAt": "2026-06-25T09:29:55Z",
-          "summary": "#3637 ci: disambiguate monthly AI tool watch"
+          "mergedAt": "2026-08-13T16:17:23Z",
+          "summary": "#4519 ci: skip redundant validation and deploy work"
         },
         {
           "category": "feature",
-          "id": "pr-3633",
+          "id": "pr-4517",
           "links": [
             {
-              "title": "PR #3633",
+              "title": "PR #4517",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3633"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4517"
             }
           ],
-          "mergedAt": "2026-06-24T14:20:07Z",
-          "summary": "#3633 [CI/CD自動最適化] cancel-in-progress 修正 2 本 2026-06-24"
+          "mergedAt": "2026-08-13T15:48:17Z",
+          "summary": "#4517 feat: publish Codex customer demo lesson in AI University"
+        },
+        {
+          "category": "fix",
+          "id": "pr-4513",
+          "links": [
+            {
+              "title": "PR #4513",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4513"
+            }
+          ],
+          "mergedAt": "2026-08-13T12:11:46Z",
+          "summary": "#4513 fix: restore AI University YouTube playback"
         },
         {
           "category": "feature",
-          "id": "pr-3631",
+          "id": "pr-4512",
           "links": [
             {
-              "title": "PR #3631",
+              "title": "PR #4512",
               "type": "pull_request",
-              "url": "https://github.com/kanta13jp1/my_web_app/pull/3631"
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4512"
             }
           ],
-          "mergedAt": "2026-06-24T05:47:17Z",
-          "summary": "#3631 feat(election): 公開ノートの立憲ベンチマークを週次cronバッチ値へ同期"
+          "mergedAt": "2026-08-13T10:26:54Z",
+          "summary": "#4512 feat: publish YouTube lesson in AI University"
+        },
+        {
+          "category": "feature",
+          "id": "pr-4510",
+          "links": [
+            {
+              "title": "PR #4510",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4510"
+            }
+          ],
+          "mergedAt": "2026-08-13T07:48:25Z",
+          "summary": "#4510 MUSUBIの投稿リンクをクリック可能にする"
+        },
+        {
+          "category": "fix",
+          "id": "pr-4509",
+          "links": [
+            {
+              "title": "PR #4509",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4509"
+            }
+          ],
+          "mergedAt": "2026-08-13T03:55:40Z",
+          "summary": "#4509 fix(musubi): support existing pg_trgm extension schemas"
+        },
+        {
+          "category": "feature",
+          "id": "pr-4506",
+          "links": [
+            {
+              "title": "PR #4506",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4506"
+            }
+          ],
+          "mergedAt": "2026-08-13T02:53:37Z",
+          "summary": "#4506 feat: launch MUSUBI social MVP"
+        },
+        {
+          "category": "feature",
+          "id": "pr-4503",
+          "links": [
+            {
+              "title": "PR #4503",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4503"
+            }
+          ],
+          "mergedAt": "2026-08-12T18:15:26Z",
+          "summary": "#4503 feat: add guided Blackbird guitar lesson"
+        },
+        {
+          "category": "feature",
+          "id": "pr-4500",
+          "links": [
+            {
+              "title": "PR #4500",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4500"
+            }
+          ],
+          "mergedAt": "2026-08-12T11:21:37Z",
+          "summary": "#4500 feat: add Beatles guitar practice tabs"
+        },
+        {
+          "category": "feature",
+          "id": "pr-4481",
+          "links": [
+            {
+              "title": "PR #4481",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4481"
+            }
+          ],
+          "mergedAt": "2026-08-10T09:47:21Z",
+          "summary": "#4481 feat: 国民民主党の選挙インテリジェンスを自動更新"
+        },
+        {
+          "category": "automation",
+          "id": "pr-4465",
+          "links": [
+            {
+              "title": "PR #4465",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4465"
+            }
+          ],
+          "mergedAt": "2026-08-05T01:08:50Z",
+          "summary": "#4465 ci: handle disposed tools-hub error responses"
+        },
+        {
+          "category": "automation",
+          "id": "pr-4457",
+          "links": [
+            {
+              "title": "PR #4457",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4457"
+            }
+          ],
+          "mergedAt": "2026-08-03T14:48:02Z",
+          "summary": "#4457 ci: support PowerShell 7 smoke error responses"
+        },
+        {
+          "category": "fix",
+          "id": "pr-4423",
+          "links": [
+            {
+              "title": "PR #4423",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4423"
+            }
+          ],
+          "mergedAt": "2026-07-31T03:10:48Z",
+          "summary": "#4423 ci: fix tools-hub MCP smoke parameter binding"
+        },
+        {
+          "category": "automation",
+          "id": "pr-4422",
+          "links": [
+            {
+              "title": "PR #4422",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4422"
+            }
+          ],
+          "mergedAt": "2026-07-31T01:18:35Z",
+          "summary": "#4422 ci: restore tools-hub MCP smoke workflow"
+        },
+        {
+          "category": "feature",
+          "id": "pr-4421",
+          "links": [
+            {
+              "title": "PR #4421",
+              "type": "pull_request",
+              "url": "https://github.com/kanta13jp1/my_web_app/pull/4421"
+            }
+          ],
+          "mergedAt": "2026-07-31T00:30:48Z",
+          "summary": "#4421 feat: prepare first-user Hook B candidate"
         }
       ],
-      "date": "2026-07-04",
+      "date": "2026-08-15",
       "extensions": {
         "aiToolWatch": {
-          "changedSourceCount": 4,
+          "changedSourceCount": 5,
           "signalCount": 0,
           "source": "docs/ai-tool-watch/latest-report.json"
         }


### PR DESCRIPTION
## Summary
- mirror the existing Supabase LP experiment funnel to an injectable, privacy-limited PostHog adapter
- include auth-redirect signup completion without blocking registration when analytics is unavailable
- initialize PostHog safely on Flutter Web and pass optional production build configuration
- document the event/privacy contract and add stable adapter-backed tests

## Privacy and rollout
- Supabase remains the source of truth
- no email, visitor UUID, user ID, prompt, task content, identify call, autocapture, or session replay is sent
- `POSTHOG_PROJECT_TOKEN` is currently absent, so production behavior is a no-op until that secret is configured

## Validation
- `flutter analyze --no-pub` (no issues)
- `flutter test test/pages/landing_page_conversion_test.dart test/services/landing_signup_completion_service_test.dart` (32 passed)
- `flutter build web --release --no-pub --pwa-strategy=none --no-tree-shake-icons --dart-define=POSTHOG_PROJECT_TOKEN= --dart-define=POSTHOG_HOST=https://us.i.posthog.com`
- `flutter pub get --offline --enforce-lockfile`

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: The workflow change only passes optional no-op analytics defines; deploy targets, credentials, migrations, and release commands are unchanged.

## Minimal E2E Gate
- Implementation-detail independent: the tests assert visible landing input/output and emitted conversion outcomes, not private implementation details.
- Minimal scope: about 3 cases (anonymous view attribution, QA exclusion, signup completion recovery across auth redirect).
- E2E: Flutter `integration_test/` or Playwright `test/e2e/` would duplicate the stable injected-adapter contract for this analytics-only change.
- E2E-Exception: Existing Flutter widget and service tests cover the three user-observable outcomes without introducing browser-provider flakiness.
