### PR TITLE
fix: enforce fail-closed RLS for exposed tables (#2773)

### DIFF
--- a/docs/testing/testcontainers_supabase_smoke.md
+++ b/docs/testing/testcontainers_supabase_smoke.md
@@ -9,6 +9,11 @@ Function work without using production Supabase credentials.
   `testcontainers-python`.
 - Applies the fixture migrations in `test/fixtures/testcontainers/sql/`.
 - Seeds representative `profiles`, `wbs_tasks`, and `ai_circuit_breaker` rows.
+- Applies the real Issue #2773 migration and verifies fail-closed RLS for the
+  six production tables identified by Supabase Security Advisor.
+- Impersonates `anon` and `authenticated` roles to prove that a missing tenant
+  claim returns no rows, cross-tenant writes fail with SQLSTATE `42501`, and an
+  authenticated user sees only their own rows.
 - Runs `scripts/check_edge_function_imports.py` so real Edge Functions keep the
   ADR-required `npm:@supabase/supabase-js@2` import rule.
 - Runs `deno check` for `supabase/functions/health-check/index.ts`.

--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -2,10 +2,11 @@
 """Run a deterministic Testcontainers smoke for DB + Edge runtime work.
 
 The smoke intentionally avoids production Supabase credentials. It starts a
-disposable Postgres container, applies a small migration/seed fixture, checks
-the real Edge Function import policy, and runs a Deno HTTP fixture against the
-container. Logs are written as artifacts so CI failures point to the migration,
-function, or seed boundary that broke.
+disposable Postgres container, applies a small migration/seed fixture, verifies
+the Issue #2773 fail-closed RLS migration, checks the real Edge Function import
+policy, and runs a Deno HTTP fixture against the container. Logs are written as
+artifacts so CI failures point to the migration, function, or seed boundary that
+broke.
 """
 
 from __future__ import annotations
@@ -31,6 +32,21 @@ DEFAULT_EDGE_FIXTURE = ROOT / "test" / "fixtures" / "testcontainers" / "edge-db-
 DEFAULT_ARTIFACTS_DIR = ROOT / ".testcontainers-logs"
 DEFAULT_ACTUAL_EDGE_FUNCTION = ROOT / "supabase" / "functions" / "health-check" / "index.ts"
 REQUIRED_TABLES = ("profiles", "wbs_tasks", "ai_circuit_breaker")
+ISSUE_2773_RLS_MIGRATION = (
+    ROOT / "supabase" / "migrations" / "20260815124052_fail_closed_rls_issue_2773.sql"
+)
+ISSUE_2773_RLS_TABLES = (
+    "ab_assignments",
+    "ab_experiments",
+    "ai_benchmark_results",
+    "competitor_feature_status",
+    "referral_tracking",
+    "viral_ad_generations",
+)
+ISSUE_2773_USER_1 = "00000000-0000-4000-8000-000000002773"
+ISSUE_2773_USER_2 = "00000000-0000-4000-8000-000000002774"
+ISSUE_2773_EXPERIMENT_1 = "00000000-0000-4000-8000-000000002775"
+ISSUE_2773_EXPERIMENT_2 = "00000000-0000-4000-8000-000000002776"
 EDGE_FIXTURE_ENV_ALLOW = (
     "DATABASE_URL",
     "PORT",
@@ -130,6 +146,14 @@ def build_plan(sql_dir: Path, edge_fixture: Path, actual_edge_function: Path) ->
         "container": "postgres:16-alpine via testcontainers-python",
         "production_credentials_required": False,
         "sql_fixtures": [path.relative_to(ROOT).as_posix() for path in sql_files(sql_dir)],
+        "tenant_rls_migration": ISSUE_2773_RLS_MIGRATION.relative_to(ROOT).as_posix(),
+        "tenant_rls_checks": [
+            "all six audited public tables have RLS enabled",
+            "anon keeps no table privileges",
+            "authenticated privileges are policy-backed and least-privilege",
+            "missing tenant claims see zero rows and cannot write",
+            "authenticated users see only their own tenant rows",
+        ],
         "edge_db_fixture": edge_fixture.relative_to(ROOT).as_posix(),
         "actual_edge_checks": [
             "scripts/check_edge_function_imports.py --root supabase/functions",
@@ -166,6 +190,265 @@ def table_count(conn: Any, table_name: str) -> int:
         cur.execute(f"select count(*) from {table_name}")
         row = cur.fetchone()
     return int(row[0])
+
+
+def seed_issue_2773_fixture(conn: Any) -> None:
+    with conn.cursor() as cur:
+        cur.executemany(
+            "insert into auth.users (id) values (%s::uuid)",
+            [(ISSUE_2773_USER_1,), (ISSUE_2773_USER_2,)],
+        )
+        cur.executemany(
+            "insert into public.ab_experiments (id, name, status) "
+            "values (%s::uuid, %s, 'active')",
+            [
+                (ISSUE_2773_EXPERIMENT_1, "tenant isolation one"),
+                (ISSUE_2773_EXPERIMENT_2, "tenant isolation two"),
+            ],
+        )
+        cur.executemany(
+            "insert into public.ab_assignments "
+            "(experiment_id, user_id, variant) values (%s::uuid, %s::uuid, %s)",
+            [
+                (ISSUE_2773_EXPERIMENT_1, ISSUE_2773_USER_1, "control"),
+                (ISSUE_2773_EXPERIMENT_1, ISSUE_2773_USER_2, "variant_a"),
+            ],
+        )
+        cur.executemany(
+            "insert into public.ai_benchmark_results "
+            "(user_id, model_name, provider, vision_score, latency_ms) "
+            "values (%s::uuid, %s, 'fixture', 90, 100)",
+            [
+                (ISSUE_2773_USER_1, "tenant-model-one"),
+                (ISSUE_2773_USER_2, "tenant-model-two"),
+            ],
+        )
+        cur.execute(
+            "insert into public.referral_tracking "
+            "(referrer_user_id, referred_user_id, referral_code) values (%s, %s, %s)",
+            (ISSUE_2773_USER_1, ISSUE_2773_USER_2, "ISSUE2773"),
+        )
+        cur.execute(
+            "insert into public.competitor_feature_status "
+            "(competitor_id, feature_name) values ('fixture', 'tenant isolation')"
+        )
+        cur.execute(
+            "insert into public.viral_ad_generations (template_key) values ('fixture')"
+        )
+    conn.commit()
+
+
+def issue_2773_role_count(
+    conn: Any,
+    role: str,
+    user_id: str | None,
+    table: str,
+) -> int:
+    if role not in {"anon", "authenticated", "service_role"}:
+        raise ValueError(f"unexpected role for tenant RLS query: {role}")
+    if table not in ISSUE_2773_RLS_TABLES:
+        raise ValueError(f"unexpected table for tenant RLS query: {table}")
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(f"set local role {role}")
+            cur.execute(
+                "select set_config('request.jwt.claim.sub', %s, true)",
+                (user_id or "",),
+            )
+            cur.execute(f"select count(*) from public.{table}")
+            row = cur.fetchone()
+    return int(row[0])
+
+
+def issue_2773_expect_denied(
+    conn: Any,
+    *,
+    role: str,
+    user_id: str | None,
+    statement: str,
+    params: tuple[Any, ...] = (),
+) -> str:
+    try:
+        with conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(f"set local role {role}")
+                cur.execute(
+                    "select set_config('request.jwt.claim.sub', %s, true)",
+                    (user_id or "",),
+                )
+                cur.execute(statement, params)
+    except Exception as exc:  # psycopg is loaded only for the integration run.
+        sqlstate = getattr(exc, "sqlstate", None)
+        if sqlstate != "42501":
+            raise AssertionError(
+                f"expected SQLSTATE 42501, got {sqlstate}: {exc}"
+            ) from exc
+        return sqlstate
+    raise AssertionError("tenant RLS operation unexpectedly succeeded")
+
+
+def check_issue_2773_rls(conn: Any) -> dict[str, Any]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "select c.relname from pg_class c "
+            "join pg_namespace n on n.oid = c.relnamespace "
+            "where n.nspname = 'public' and c.relname = any(%s) "
+            "and c.relrowsecurity order by c.relname",
+            (list(ISSUE_2773_RLS_TABLES),),
+        )
+        enabled_tables = [row[0] for row in cur.fetchall()]
+        cur.execute(
+            "select policyname from pg_policies where schemaname = 'public' "
+            "and tablename = any(%s) order by policyname",
+            (list(ISSUE_2773_RLS_TABLES),),
+        )
+        policy_names = [row[0] for row in cur.fetchall()]
+    conn.commit()
+
+    if enabled_tables != sorted(ISSUE_2773_RLS_TABLES):
+        raise AssertionError(
+            f"RLS was not enabled on every audited table: {enabled_tables}"
+        )
+
+    expected_policies = {
+        "ab_assignments_delete_own",
+        "ab_assignments_insert_own",
+        "ab_assignments_select_own",
+        "ab_assignments_update_own",
+        "ab_experiments_authenticated_read",
+        "ai_benchmark_results_select_own",
+        "referral_tracking_select_participant",
+    }
+    if set(policy_names) != expected_policies:
+        raise AssertionError(f"unexpected tenant RLS policy set: {policy_names}")
+
+    authenticated_grants = {
+        "ab_assignments": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+        "ab_experiments": {"SELECT"},
+        "ai_benchmark_results": {"SELECT"},
+        "competitor_feature_status": set(),
+        "referral_tracking": {"SELECT"},
+        "viral_ad_generations": set(),
+    }
+    table_privileges = (
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "TRUNCATE",
+        "REFERENCES",
+        "TRIGGER",
+    )
+    with conn.cursor() as cur:
+        for table in ISSUE_2773_RLS_TABLES:
+            for privilege in table_privileges:
+                cur.execute(
+                    "select has_table_privilege(%s, %s, %s)",
+                    ("anon", f"public.{table}", privilege),
+                )
+                if bool(cur.fetchone()[0]):
+                    raise AssertionError(f"anon retained {privilege} on {table}")
+                cur.execute(
+                    "select has_table_privilege(%s, %s, %s)",
+                    ("authenticated", f"public.{table}", privilege),
+                )
+                actual = bool(cur.fetchone()[0])
+                expected = privilege in authenticated_grants[table]
+                if actual != expected:
+                    raise AssertionError(
+                        f"authenticated {privilege} on {table}: "
+                        f"expected {expected}, got {actual}"
+                    )
+    conn.commit()
+
+    missing_claim_counts = {
+        table: issue_2773_role_count(conn, "authenticated", None, table)
+        for table in (
+            "ab_assignments",
+            "ab_experiments",
+            "ai_benchmark_results",
+            "referral_tracking",
+        )
+    }
+    if any(missing_claim_counts.values()):
+        raise AssertionError(f"missing tenant claim exposed rows: {missing_claim_counts}")
+
+    owner_counts = {
+        table: issue_2773_role_count(
+            conn,
+            "authenticated",
+            ISSUE_2773_USER_1,
+            table,
+        )
+        for table in (
+            "ab_assignments",
+            "ab_experiments",
+            "ai_benchmark_results",
+            "referral_tracking",
+        )
+    }
+    expected_owner_counts = {
+        "ab_assignments": 1,
+        "ab_experiments": 2,
+        "ai_benchmark_results": 1,
+        "referral_tracking": 1,
+    }
+    if owner_counts != expected_owner_counts:
+        raise AssertionError(
+            f"tenant filtering returned unexpected counts: {owner_counts}"
+        )
+
+    missing_write_sqlstate = issue_2773_expect_denied(
+        conn,
+        role="authenticated",
+        user_id=None,
+        statement=(
+            "insert into public.ab_assignments "
+            "(experiment_id, user_id, variant) values (%s::uuid, %s::uuid, 'control')"
+        ),
+        params=(ISSUE_2773_EXPERIMENT_2, ISSUE_2773_USER_1),
+    )
+    cross_tenant_sqlstate = issue_2773_expect_denied(
+        conn,
+        role="authenticated",
+        user_id=ISSUE_2773_USER_2,
+        statement=(
+            "insert into public.ab_assignments "
+            "(experiment_id, user_id, variant) values (%s::uuid, %s::uuid, 'control')"
+        ),
+        params=(ISSUE_2773_EXPERIMENT_2, ISSUE_2773_USER_1),
+    )
+
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("set local role authenticated")
+            cur.execute(
+                "select set_config('request.jwt.claim.sub', %s, true)",
+                (ISSUE_2773_USER_1,),
+            )
+            cur.execute(
+                "insert into public.ab_assignments "
+                "(experiment_id, user_id, variant) values (%s::uuid, %s::uuid, 'control')",
+                (ISSUE_2773_EXPERIMENT_2, ISSUE_2773_USER_1),
+            )
+
+    for table in ISSUE_2773_RLS_TABLES:
+        issue_2773_expect_denied(
+            conn,
+            role="anon",
+            user_id=None,
+            statement=f"select count(*) from public.{table}",
+        )
+
+    return {
+        "enabled_tables": enabled_tables,
+        "policies": policy_names,
+        "missing_claim_counts": missing_claim_counts,
+        "owner_counts": owner_counts,
+        "missing_write_sqlstate": missing_write_sqlstate,
+        "cross_tenant_sqlstate": cross_tenant_sqlstate,
+        "anon_access": "denied on all audited tables",
+    }
 
 
 def check_actual_edge_function(args: argparse.Namespace, artifacts_dir: Path) -> None:
@@ -305,6 +588,9 @@ def run_smoke(args: argparse.Namespace) -> int:
         with psycopg.connect(connection_url) as conn:
             for fixture in sql_files(args.sql_dir):
                 apply_sql_fixture(conn, fixture, artifacts_dir)
+            apply_sql_fixture(conn, ISSUE_2773_RLS_MIGRATION, artifacts_dir)
+            seed_issue_2773_fixture(conn)
+            tenant_rls = check_issue_2773_rls(conn)
             counts = {table: table_count(conn, table) for table in REQUIRED_TABLES}
 
         edge_result = run_edge_db_fixture(connection_url, args, artifacts_dir)
@@ -314,6 +600,7 @@ def run_smoke(args: argparse.Namespace) -> int:
         "database": {
             "url": redact_url(connection_url),
             "tables": counts,
+            "tenant_rls": tenant_rls,
         },
         "edge_fixture": {
             "path": args.edge_fixture.relative_to(ROOT).as_posix(),

--- a/supabase/migrations/20260815124052_fail_closed_rls_issue_2773.sql
+++ b/supabase/migrations/20260815124052_fail_closed_rls_issue_2773.sql
@@ -1,0 +1,117 @@
+-- Issue #2773: fail closed at the database boundary for tables that were
+-- reachable from the Data API without row-level security.
+
+-- This table existed in production without a matching migration. Capture the
+-- production shape so a clean migration replay can apply the RLS hardening.
+create table if not exists public.ai_benchmark_results (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id),
+  model_name text not null,
+  provider text not null,
+  vision_score integer not null,
+  latency_ms integer not null,
+  detail text,
+  tested_at timestamptz default now()
+);
+
+create index if not exists idx_model_tested_at
+  on public.ai_benchmark_results (model_name, tested_at desc);
+
+create index if not exists idx_ai_benchmark_results_user_id
+  on public.ai_benchmark_results (user_id);
+
+alter table public.ai_benchmark_results enable row level security;
+alter table public.referral_tracking enable row level security;
+alter table public.competitor_feature_status enable row level security;
+alter table public.ab_experiments enable row level security;
+alter table public.ab_assignments enable row level security;
+alter table public.viral_ad_generations enable row level security;
+
+-- RLS does not protect TRUNCATE, REFERENCES, or TRIGGER privileges. Remove the
+-- historical blanket grants first, then grant only operations backed by an
+-- explicit policy. Service-role callers remain the trusted backend boundary.
+revoke all privileges on table
+  public.ai_benchmark_results,
+  public.referral_tracking,
+  public.competitor_feature_status,
+  public.ab_experiments,
+  public.ab_assignments,
+  public.viral_ad_generations
+from public, anon, authenticated;
+
+grant all privileges on table
+  public.ai_benchmark_results,
+  public.referral_tracking,
+  public.competitor_feature_status,
+  public.ab_experiments,
+  public.ab_assignments,
+  public.viral_ad_generations
+to service_role;
+
+grant select on table public.ai_benchmark_results to authenticated;
+grant select on table public.referral_tracking to authenticated;
+grant select on table public.ab_experiments to authenticated;
+grant select, insert, update, delete on table public.ab_assignments
+  to authenticated;
+
+drop policy if exists ai_benchmark_results_select_own
+  on public.ai_benchmark_results;
+create policy ai_benchmark_results_select_own
+  on public.ai_benchmark_results
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists referral_tracking_select_participant
+  on public.referral_tracking;
+create policy referral_tracking_select_participant
+  on public.referral_tracking
+  for select
+  to authenticated
+  using (
+    (select auth.uid())::text = referrer_user_id
+    or (select auth.uid())::text = referred_user_id
+  );
+
+-- Experiment definitions are shared configuration, but only a request with a
+-- real authenticated subject may read them.
+drop policy if exists ab_experiments_authenticated_read
+  on public.ab_experiments;
+create policy ab_experiments_authenticated_read
+  on public.ab_experiments
+  for select
+  to authenticated
+  using ((select auth.uid()) is not null);
+
+drop policy if exists ab_assignments_select_own
+  on public.ab_assignments;
+create policy ab_assignments_select_own
+  on public.ab_assignments
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists ab_assignments_insert_own
+  on public.ab_assignments;
+create policy ab_assignments_insert_own
+  on public.ab_assignments
+  for insert
+  to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists ab_assignments_update_own
+  on public.ab_assignments;
+create policy ab_assignments_update_own
+  on public.ab_assignments
+  for update
+  to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists ab_assignments_delete_own
+  on public.ab_assignments;
+create policy ab_assignments_delete_own
+  on public.ab_assignments
+  for delete
+  to authenticated
+  using ((select auth.uid()) = user_id);

--- a/test/fixtures/testcontainers/sql/003_issue_2773_rls_base.sql
+++ b/test/fixtures/testcontainers/sql/003_issue_2773_rls_base.sql
@@ -1,0 +1,65 @@
+create role anon nologin;
+create role authenticated nologin;
+create role service_role nologin bypassrls;
+
+create schema auth;
+create table auth.users (
+  id uuid primary key
+);
+
+create function auth.uid()
+returns uuid
+language sql
+stable
+set search_path = ''
+as $$
+  select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid
+$$;
+
+grant usage on schema public, auth to anon, authenticated, service_role;
+grant execute on function auth.uid() to anon, authenticated, service_role;
+
+create table ab_experiments (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  status text not null default 'draft'
+);
+
+create table ab_assignments (
+  id uuid primary key default gen_random_uuid(),
+  experiment_id uuid not null references ab_experiments(id),
+  user_id uuid not null,
+  variant text not null,
+  converted boolean default false,
+  unique (experiment_id, user_id)
+);
+
+create table competitor_feature_status (
+  id uuid primary key default gen_random_uuid(),
+  competitor_id text not null,
+  feature_name text not null,
+  status text not null default 'notYet'
+);
+
+create table referral_tracking (
+  id uuid primary key default gen_random_uuid(),
+  referrer_user_id text not null,
+  referred_user_id text not null,
+  referral_code text not null,
+  registered_at timestamptz not null default now()
+);
+
+create table viral_ad_generations (
+  id uuid primary key default gen_random_uuid(),
+  template_key text not null,
+  status text not null default 'draft',
+  created_at timestamptz not null default now()
+);
+
+grant all privileges on table
+  public.ab_experiments,
+  public.ab_assignments,
+  public.competitor_feature_status,
+  public.referral_tracking,
+  public.viral_ad_generations
+to anon, authenticated, service_role;

--- a/test/scripts/test_testcontainers_supabase_smoke.py
+++ b/test/scripts/test_testcontainers_supabase_smoke.py
@@ -54,6 +54,32 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
         self.assertFalse(plan["production_credentials_required"])
         self.assertIn("summary.json", " ".join(plan["artifacts"]))
 
+    def test_plan_includes_fail_closed_rls_migration(self) -> None:
+        plan = module.build_plan(
+            ROOT / "test" / "fixtures" / "testcontainers" / "sql",
+            ROOT / "test" / "fixtures" / "testcontainers" / "edge-db-smoke.ts",
+            ROOT / "supabase" / "functions" / "health-check" / "index.ts",
+        )
+        self.assertEqual(
+            plan["tenant_rls_migration"],
+            "supabase/migrations/20260815124052_fail_closed_rls_issue_2773.sql",
+        )
+        self.assertIn(
+            "missing tenant claims see zero rows",
+            " ".join(plan["tenant_rls_checks"]),
+        )
+
+    def test_tenant_role_count_rejects_untrusted_identifiers(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unexpected role"):
+            module.issue_2773_role_count(
+                None,
+                "postgres",
+                None,
+                "ab_assignments",
+            )
+        with self.assertRaisesRegex(ValueError, "unexpected table"):
+            module.issue_2773_role_count(None, "authenticated", None, "pg_authid")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Closes #2773.
- Enables RLS on all six `public` tables reported by the production Supabase Security Advisor as `rls_disabled_in_public`.
- Replaces historical blanket `anon` / `authenticated` grants with policy-backed least privileges.
- Adds a deterministic Testcontainers check that applies the real migration and impersonates database roles.

## Production audit evidence

Before this change, Supabase Security Advisor reported six external-facing errors:

- `ai_benchmark_results`
- `referral_tracking`
- `competitor_feature_status`
- `ab_experiments`
- `ab_assignments`
- `viral_ad_generations`

Five of the tables granted `anon` and `authenticated` every table privilege, including `TRUNCATE`, while RLS was disabled. The application schema has no first-party `business_id` / `tenant_id`; its actual tenant boundary is the authenticated `user_id` from `auth.uid()`.

## Access model after migration

| Table | Authenticated access | Tenant rule |
| --- | --- | --- |
| `ai_benchmark_results` | SELECT | own `user_id` only |
| `referral_tracking` | SELECT | referrer or referred participant only |
| `ab_experiments` | SELECT | valid non-null authenticated subject |
| `ab_assignments` | SELECT/INSERT/UPDATE/DELETE | own `user_id`; UPDATE uses both USING and WITH CHECK |
| `competitor_feature_status` | none | service-role only |
| `viral_ad_generations` | none | service-role only |

`service_role` remains the trusted backend boundary. The migration also captures the production-only `ai_benchmark_results` table in version control and adds the missing `user_id` index used by its RLS policy.

## Validation

- `python test/scripts/test_testcontainers_supabase_smoke.py` — 7 tests passed.
- `python scripts/check_migration_timestamps.py` — 1,934 unique timestamps, no collisions.
- Pre-commit fast quality gate — passed.
- `python scripts/testcontainers_supabase_smoke.py --artifacts-dir .testcontainers-logs-issue2773` — passed against disposable PostgreSQL 16 with the real migration:
  - all six tables reported `relrowsecurity=true`;
  - `anon` was denied on every audited table;
  - missing tenant claims returned zero rows;
  - missing-claim and cross-tenant writes failed with SQLSTATE `42501`;
  - authenticated fixtures saw only their own tenant rows.

## Data migration

No existing rows are rewritten or deleted. The only new data structure is `idx_ai_benchmark_results_user_id`; all policy and privilege changes are transactional migration DDL.

## Rollback

Prefer a forward fix if an intended client access path is discovered. Emergency rollback requires a dedicated migration that drops these named policies, restores only the confirmed required grants, and disables RLS only on the affected table; restoring the previous blanket grants would intentionally reintroduce the security defect and is not an acceptable default rollback.

## Production smoke and observability

After merge/deploy, rerun `supabase db advisors --linked --type security --level warn` and verify the six `rls_disabled_in_public` findings are gone. Then query `pg_class.relrowsecurity`, `pg_policies`, and role grants for the six tables. Monitor Data API `42501` responses for an unintended client path; service-role Edge Function access should remain operational.

## Minimal E2E Gate

- Implementation-detail independent: the disposable database test asserts role-level input/output rather than private helper behavior.
- Minimal scope: three cases cover missing tenant context, cross-tenant access, and valid owner access.
- E2E: the existing Testcontainers integration workflow is the database black-box mechanism; no Flutter runtime route changed.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 の `/ultrareview` 実行環境がこのCodexタスクに無いため。security、rollback、data migration、prod smoke、observability は上記の決定的検証と手動レビュー項目で明示した。
