### PR TITLE
feat: add local election candidate release skill

### DIFF
--- a/.agents/skills/local-election-candidate-release/SKILL.md
+++ b/.agents/skills/local-election-candidate-release/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: local-election-candidate-release
+description: >-
+  Refresh the Kokumin Democratic Party local-election endorsement snapshot from the official PDF, regenerate the Flutter JSON and Dart fallback, preserve the repository/ViewModel architecture, validate the change, prepare a compliant pull request, monitor required checks, merge to main, and verify the Firebase production commit. Use when users ask to reflect newly announced 地方選の公認候補・推薦候補, update official candidate counts or prefecture aggregates, or complete that update through main merge and production deployment.
+---
+
+# Local Election Candidate Release
+
+公式発表を唯一の根拠として、候補データ更新を本番反映まで完遂する。
+
+## 必須資料
+
+- 編集前に [project-contract.md](references/project-contract.md) を読む。
+- PR作成、マージ、デプロイまで求められた場合は [release-monitoring.md](references/release-monitoring.md) も読む。
+
+## 1. 安全な作業場所を確保する
+
+1. リポジトリの `AGENTS.md` と適用対象の追加指示を読む。
+2. `git status -sb`、`python scripts/codex_session_check.py`、`python scripts/ai_tool_watch.py --print-only` を実行する。
+3. ルートがdirtyなら、既存変更を触らず `origin/main` から専用worktreeと `codex/` ブランチを作る。
+4. 同じ候補更新を扱う未完了PRや近接worktreeがないか確認する。
+
+## 2. 公式スナップショットを更新する
+
+1. 公式候補者一覧をインターネットで開き、公開日、PDF、ページ数を確認する。過去の件数や検索結果だけを根拠にしない。
+2. 必要なPython依存を導入し、既存ジェネレーターを実行する。
+3. 生成JSONとDart fallbackを手編集しない。差分が必要ならジェネレーターまたはパーサーテストを修正して再生成する。
+4. 更新前後について次を記録する。
+   - `sourceAsOf`
+   - `sourceDocumentSha256`
+   - 公認総数と現職・新人・元職の内訳
+   - 公認都道府県数
+   - 推薦総数
+   - 都道府県別の増減
+5. 件数合計と内訳、都道府県集計、公式PDFの代表行を照合する。
+6. 25%を超える減少を `--allow-large-drop` で通すのは、選挙サイクル切替や公式一覧の再編を人手で確認できた場合だけにする。根拠をPRへ残す。
+
+## 3. Flutterの責務分離を守る
+
+- JSON assetを正規スナップショット、生成Dartをオフラインfallbackとして維持する。
+- Data層のrepositoryでlive snapshotとfallbackを解決する。
+- UI状態と通知をViewModelへ置き、ページや共有サービスへ件数ロジックを複製しない。
+- 公式PDFの形式またはJSON schemaが変わった場合だけ、parser、model、repository、ViewModelを必要最小限で更新する。
+- UI表示や操作を変えた場合は、データ更新扱いにせずブラウザ・レスポンシブ検証を追加する。
+
+## 4. 段階的に検証する
+
+1. Pythonパーサー、生成データ、repository、ViewModel、ページ、共有サービスの対象テストを先に実行する。
+2. 変更したDartファイルのformat checkと `flutter analyze` を実行する。
+3. UI変更がなければ、ユーザー表示値と公式集計の一致を黒箱I/Oとして説明し、Minimal E2Eの例外理由をPRへ記録する。
+4. UI変更があれば、最小約3ケースのFlutter integration testまたはPlaywright E2Eと、desktop/mobileの証拠を追加する。
+5. full testまたはpre-push品質ゲートは、コミット内容が確定してから1回実行する。同じcommitに対して重いローカルテストを繰り返さない。
+
+## 5. PRを作成する
+
+1. 候補更新に関係するファイルだけをstage・commitする。
+2. PR本文に公式URL、基準日、SHA-256、更新前後の件数、都道府県差分、アーキテクチャ、検証結果、rollbackを記載する。
+3. リポジトリのスクリプトでMinimal E2EとHigh-risk Ultrareviewの合格スニペットを生成し、PR作成前に本文へ入れる。実施していないultrareviewを証拠として記載しない。
+4. CIが対象にするhead SHAを控える。
+
+## 6. CI、マージ、デプロイを完遂する
+
+1. 必須チェックを監視し、failure、cancelled、timed_outを成功扱いしない。
+2. PRが `BEHIND` ならGitHubのupdate-branchで最新mainを取り込み、新しいhead SHAのチェックを最初から待つ。
+3. CI失敗時はログから最初の実原因を特定し、利用可能なら `github:gh-fix-ci` を使って最小修正を行う。
+4. PRがready、mergeable、`CLEAN` で全必須チェック成功の場合だけsquash mergeする。
+5. merge commitに紐づく `Deploy to Production` runを特定し、terminal statusまで監視する。
+6. run成功後も本番URLを直接確認し、`version.json.commit` がmerge commitと完全一致することを確認する。
+7. 一致しない場合は、後続のmain deployに上書きされたか、Hosting工程がsoft-failしたかを調べる。正しいcommitが公開されるまで完了と報告しない。
+
+## 安全規則
+
+- 公式資料にない氏名、区分、件数を推測しない。
+- 生成物だけを直してジェネレーターとの不整合を作らない。
+- 必須CIが未完了または失敗中のPRをmergeしない。
+- 監視を依頼されたら、成功、修正可能な失敗、または外部権限による真のblockerまで継続する。
+- 監視中はGitHub APIの軽量照会を使い、ローカルのFlutter build/testを再起動しない。
+- ユーザーのdirty tree、別worktree、生成物以外の変更を削除・復元しない。
+
+## 完了報告
+
+次を簡潔に報告する。
+
+- 公式基準日と公認・推薦・都道府県数
+- 主要な都道府県差分
+- PR URL、merge commit、全必須チェック結果
+- production run URLと結論
+- 本番HTTP status、公開version、公開commit
+- 未完了事項または例外判断

--- a/.agents/skills/local-election-candidate-release/agents/openai.yaml
+++ b/.agents/skills/local-election-candidate-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Local Election Candidate Release"
+  short_description: "Safely release official local-election candidate updates"
+  default_prompt: "Use $local-election-candidate-release to refresh the official local-election candidate data, validate the Flutter changes, and monitor the release through production."

--- a/.agents/skills/local-election-candidate-release/references/project-contract.md
+++ b/.agents/skills/local-election-candidate-release/references/project-contract.md
@@ -1,0 +1,62 @@
+# Project Contract
+
+## 公式ソースと生成経路
+
+- 公式候補者一覧: `https://new-kokumin.jp/local-election-list`
+- 依存定義: `scripts/requirements-election-intelligence.txt`
+- 唯一のジェネレーター: `scripts/update_kokumin_local_endorsements.py`
+- 正規JSON asset: `assets/data/kokumin_local_endorsements.json`
+- 生成Dart fallback: `lib/data/dpj_official_endorsements.dart`
+- asset登録: `pubspec.yaml` の `assets/data/`
+
+次の順で実行する。
+
+```powershell
+python -m pip install -r scripts/requirements-election-intelligence.txt
+python scripts/update_kokumin_local_endorsements.py
+```
+
+ローカルPDFでparserを調べる場合は `--input-pdf <path>` を使う。通常更新で `--source-url` を差し替えない。
+
+## データ安全契約
+
+ジェネレーターは次を満たさない出力を拒否する。
+
+- 公認30件以上
+- 10都道府県以上
+- 現職・新人・元職の合計と公認総数が一致
+- 都道府県別内訳と各総数が一致
+- 前回から25%を超える減少がない
+
+`--allow-large-drop` は安全契約の解除である。公式資料上の理由を確認し、PR本文へ記録してから使う。
+
+## Flutterの消費経路
+
+- Data: `lib/data/repositories/official_endorsement_repository.dart`
+- Logic: `lib/ui/features/election_victory/view_models/official_endorsement_view_model.dart`
+- UI: `lib/pages/election_victory_page.dart`
+- Share: `lib/services/local_election_share_service.dart`
+
+live Edge Function snapshotが有効ならrepositoryが優先し、利用不能なら生成Dart fallbackを返す。表示側で別の公認件数を持たない。
+
+## 対象検証
+
+まず限定テストを実行する。
+
+```powershell
+python test/scripts/update_kokumin_local_endorsements_test.py
+flutter test test/data/dpj_official_endorsements_test.dart test/data/repositories/official_endorsement_repository_test.dart test/ui/features/election_victory/view_models/official_endorsement_view_model_test.dart test/pages/election_victory_page_test.dart test/services/local_election_share_service_test.dart test/services/local_election_share_payload_test.dart
+dart format --output=none --set-exit-if-changed lib/data/dpj_official_endorsements.dart lib/data/repositories/official_endorsement_repository.dart lib/ui/features/election_victory/view_models/official_endorsement_view_model.dart
+flutter analyze
+```
+
+変更内容が固まった後、リポジトリのpre-push hookまたは公式full gateを1回通す。カバレッジ生成で `coverage/lcov.info` だけが変わった場合は、今回の生成物ではないことを確認してworktree側の変更だけを戻す。
+
+## 想定差分
+
+公式PDFの通常更新なら、主差分は次の2ファイルに限定する。
+
+- `assets/data/kokumin_local_endorsements.json`
+- `lib/data/dpj_official_endorsements.dart`
+
+parser、schema、repository、ViewModel、UIの差分が出た場合は、公式形式変更または新要件の根拠をPRで説明する。

--- a/.agents/skills/local-election-candidate-release/references/release-monitoring.md
+++ b/.agents/skills/local-election-candidate-release/references/release-monitoring.md
@@ -1,0 +1,84 @@
+# Release Monitoring
+
+## PR本文のゲートを先に満たす
+
+app codeを変更しE2Eファイルを追加しない場合は、実際の理由を指定してMinimal E2E blockを生成する。
+
+```powershell
+python scripts/check_minimal_e2e_gate.py --emit-snippet --exception "公式PDF由来の集計値更新で操作フローは不変。repository・ViewModel・ページの対象テストと公開smokeで確認する。"
+```
+
+タイトルや本文の `production`、`deploy` などでhigh-risk判定され、実際のClaude ultrareviewを行っていない場合は、正直な例外blockを生成する。
+
+```powershell
+python scripts/check_high_risk_ultrareview_gate.py --emit-exception "公式候補スナップショット更新で認証・決済・migration・workflowの高リスクパスは変更しない。"
+```
+
+実際にClaude Code #1がultrareviewを完了した場合だけ `--emit-evidence` を使う。
+
+## PR状態を確認する
+
+```powershell
+gh pr view <PR> --json number,url,isDraft,state,mergeable,mergeStateStatus,reviewDecision,headRefOid,statusCheckRollup
+gh pr checks <PR>
+```
+
+`gh pr checks` のexit code 1はpendingでも発生する。出力の各statusを読んでfailureと混同しない。
+
+PRがmainより遅れている場合は、現在のhead SHAを指定して更新する。
+
+```powershell
+gh api --method PUT repos/<owner>/<repo>/pulls/<PR>/update-branch -f expected_head_sha=<HEAD_SHA>
+```
+
+更新後にhead SHAが変わったことを確認し、以前の成功チェックを流用しない。全必須チェック成功後にready化し、merge stateが `CLEAN` の場合だけmergeする。
+
+```powershell
+gh pr ready <PR>
+gh pr merge <PR> --squash --subject "feat: refresh local election endorsements (#<PR>)"
+gh pr view <PR> --json state,mergedAt,mergeCommit,url
+```
+
+リポジトリでauto-mergeが無効なら、エラーを異常と扱わず、全チェック完了後に手動mergeする。
+
+## production runを追跡する
+
+merge commitに一致するrunだけを対象にする。
+
+```powershell
+gh run list --branch main --commit <MERGE_SHA> --limit 30 --json databaseId,name,workflowName,status,conclusion,url,event,headSha,createdAt
+gh run view <RUN_ID> --json status,conclusion,jobs,url,headSha,createdAt,updatedAt
+```
+
+`Deploy to Production` の外側statusだけでなく、active job/stepも確認する。代表的な順序は次のとおり。
+
+1. Run CI Checks
+2. Run Supabase migrations
+3. Deploy Supabase Edge Functions
+4. Build Flutter Web (Production)
+5. Deploy to Firebase Hosting (Production)
+6. Verify deploy reflects current commit
+7. Notify Deployment Status
+
+Hostingとcommit verificationはworkflow上soft-failになり得るため、runの `success` だけで公開完了と判断しない。
+
+## 本番を別経路で確認する
+
+cache busterを付け、HTTP 200とcommit完全一致を確認する。
+
+```powershell
+$stamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+$site = Invoke-WebRequest -UseBasicParsing -Uri "https://my-web-app-b67f4.web.app/?verify=$stamp" -Headers @{ 'Cache-Control'='no-cache' }
+$version = Invoke-RestMethod -Uri "https://my-web-app-b67f4.web.app/version.json?verify=$stamp" -Headers @{ 'Cache-Control'='no-cache' }
+[int]$site.StatusCode
+$version | ConvertTo-Json -Compress
+```
+
+`$version.commit` がmerge SHAと一致しない場合は完了報告を止める。後続runが同じproduction concurrency groupで待機または上書きしていないかを調べ、最終的に公開されるmain commitを明示する。
+
+## 監視時の負荷制御
+
+- GitHub API照会は30〜60秒間隔にする。
+- 対話TTYを前提とする `gh pr checks --watch` が出力しない場合は、停止して単発照会へ切り替える。
+- 監視中にローカルの `flutter test`、`flutter analyze`、build、ブラウザ自動化を再実行しない。
+- 60秒以内に短い進捗を共有し、何を待っているかを示す。


### PR DESCRIPTION
## Summary

- add the repository-local `local-election-candidate-release` Agent Skill
- document the official candidate source, deterministic generator, Flutter repository/ViewModel contract, and targeted checks
- document PR checks, main synchronization, squash merge, deployment monitoring, and direct production commit verification
- add Codex UI metadata for invoking the skill

## Why

The local-election candidate refresh and release process has been performed manually across multiple tools. Capturing it as a project skill makes future official endorsement updates repeatable while preserving source verification, architecture boundaries, CI integrity, and deployment proof.

## Impact

- Agent instructions and references only
- no Flutter runtime, candidate snapshot, Supabase resource, GitHub workflow, or production configuration changes
- no user-visible behavior change

## Validation

- `python -X utf8 C:\Users\kanta\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents\skills\local-election-candidate-release`
- `python -X utf8 test\scripts\update_kokumin_local_endorsements_test.py` — 3 passed
- `git diff --check origin/main...HEAD`
- confirmed `agents/openai.yaml` is valid UTF-8 and invokes `$local-election-candidate-release`

## Minimal E2E Gate

- Implementation-detail independent: validation checks skill inputs and generated guidance, not private runtime internals.
- Minimal scope: about 3 cases (skill structure, existing generator contract, release gate snippets).
- E2E: not applicable because this PR changes only Agent Skill documentation and metadata.
- E2E-Exception: No application runtime or user-visible interaction changes; deterministic skill validation and parser tests cover the changed contract.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Documentation-only Agent Skill change; no authentication, billing, migration, workflow, secret, or production runtime path is modified.

## Risk and rollback

Risk is limited to future agent guidance. Revert the single skill commit if the workflow needs to be withdrawn or revised.
