### PR TITLE
fix: note editor console errors and conveni report payload

### DIFF
--- a/lib/pages/conveni_store_page.dart
+++ b/lib/pages/conveni_store_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:intl/intl.dart';
 
+import '../services/conveni_daily_report_payload.dart';
+
 class ConveniStorePage extends StatefulWidget {
   const ConveniStorePage({super.key});
 
@@ -168,26 +170,27 @@ class _ConveniStorePageState extends State<ConveniStorePage> {
       final revenue = baseRevenue -
           variance +
           (DateTime.now().millisecond % (variance * 2));
-      final expenses = (revenue * 0.6).toInt();
-      final profit = revenue - expenses;
+      final costOfGoods = (revenue * 0.6).toInt();
+      final profit = revenue - costOfGoods;
       final newCash = cash + profit;
       final newReputation = (reputation + (profit > 0 ? 1 : -1)).clamp(0, 100);
 
-      await _supabase.from('conveni_daily_reports').insert({
-        'store_id': storeId,
-        'game_day': currentDay,
-        'revenue': revenue,
-        'expense': expenses,
-        'profit': profit,
-        'customer_count': (revenue / 600).toInt(),
-        'weather': 'sunny',
-      });
+      await _supabase.from('conveni_daily_reports').insert(
+            buildConveniDailyReportPayload(
+              storeId: storeId,
+              gameDay: currentDay,
+              revenue: revenue,
+              costOfGoods: costOfGoods,
+              profit: profit,
+              customerCount: (revenue / 600).toInt(),
+            ),
+          );
 
       await _supabase.from('conveni_stores').update({
         'current_day': currentDay + 1,
         'cash': newCash,
         'total_revenue': (_store!['total_revenue'] as int? ?? 0) + revenue,
-        'total_expense': (_store!['total_expense'] as int? ?? 0) + expenses,
+        'total_expense': (_store!['total_expense'] as int? ?? 0) + costOfGoods,
         'total_profit': (_store!['total_profit'] as int? ?? 0) + profit,
         'reputation': newReputation,
         'experience_points': (_store!['experience_points'] as int? ?? 0) + 10,

--- a/lib/pages/note_editor_page.dart
+++ b/lib/pages/note_editor_page.dart
@@ -144,7 +144,6 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
   late final AIService _aiService;
   late final NoteCommentsService _noteCommentsService;
   NoteImagePasteRegistration? _imagePasteRegistration;
-  StreamSubscription<void>? _commentSubscription;
 
   String? _currentNoteId;
   DateTime? _reminderDate;
@@ -241,7 +240,6 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     await _loadPromptTemplates();
     if (_currentNoteId != null) {
       await _loadNote(_currentNoteId!);
-      _startCommentCountSubscription();
       unawaited(_loadCommentCount());
     }
     await _loadAttachments();
@@ -564,7 +562,6 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     }
 
     _currentNoteId = createdNoteId.toString();
-    _startCommentCountSubscription();
     unawaited(_loadCommentCount());
     _autoSaveService.markAsSaved();
     await _clearDraftFromLocal();
@@ -1429,7 +1426,6 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
 
       if (inserted is Map && inserted['id'] != null) {
         _currentNoteId = inserted['id'].toString();
-        _startCommentCountSubscription();
         unawaited(_loadCommentCount());
         if (mounted) {
           setState(() {});
@@ -1555,19 +1551,6 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
         const SnackBar(content: Text('公開に失敗しました')),
       );
     }
-  }
-
-  void _startCommentCountSubscription() {
-    final noteId = int.tryParse(_currentNoteId ?? '');
-    if (noteId == null) return;
-    _commentSubscription?.cancel();
-    _commentSubscription =
-        _noteCommentsService.watchCommentChanges(noteId: noteId).listen(
-      (_) => unawaited(_loadCommentCount()),
-      onError: (Object error) {
-        debugPrint('Note comment realtime stream error: $error');
-      },
-    );
   }
 
   Future<void> _loadCommentCount() async {
@@ -2416,7 +2399,6 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
   @override
   void dispose() {
     _flushPendingSaveOnExit();
-    _commentSubscription?.cancel();
     _imagePasteRegistration?.dispose();
     _contentFocusNode.dispose();
     _detachTextListeners();
@@ -2601,334 +2583,4 @@ class _RedoIntent extends Intent {
 
 class _SaveIntent extends Intent {
   const _SaveIntent();
-}
-
-// ── Note Comments Bottom Sheet ────────────────────────────────────────────────
-
-class _NoteCommentsSheet extends StatefulWidget {
-  final int noteId;
-  final SupabaseClient supabase;
-  final String commentsUrl;
-  final void Function(int count) onCountChanged;
-
-  const _NoteCommentsSheet({
-    required this.noteId,
-    required this.supabase,
-    required this.commentsUrl,
-    required this.onCountChanged,
-  });
-
-  @override
-  State<_NoteCommentsSheet> createState() => _NoteCommentsSheetState();
-}
-
-class _NoteCommentsSheetState extends State<_NoteCommentsSheet> {
-  final _inputController = TextEditingController();
-  List<Map<String, dynamic>> _comments = [];
-  bool _loading = true;
-  bool _submitting = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _load();
-  }
-
-  @override
-  void dispose() {
-    _inputController.dispose();
-    super.dispose();
-  }
-
-  Future<String?> _getToken() async {
-    return widget.supabase.auth.currentSession?.accessToken;
-  }
-
-  Future<void> _load() async {
-    setState(() => _loading = true);
-    try {
-      final res = await widget.supabase
-          .from('note_comments')
-          .select('id, content, created_at')
-          .eq('note_id', widget.noteId)
-          .order('created_at', ascending: true);
-      final list = List<Map<String, dynamic>>.from(
-        (res as List).map((e) => Map<String, dynamic>.from(e as Map)),
-      );
-      if (mounted) {
-        setState(() {
-          _comments = list;
-          _loading = false;
-        });
-        widget.onCountChanged(list.length);
-      }
-    } catch (_) {
-      if (mounted) setState(() => _loading = false);
-    }
-  }
-
-  Future<void> _submit() async {
-    final content = _inputController.text.trim();
-    if (content.isEmpty || _submitting) return;
-
-    final token = await _getToken();
-    if (token == null) return;
-
-    if (!mounted) return;
-    setState(() => _submitting = true);
-    try {
-      final response = await widget.supabase
-          .from('note_comments')
-          .insert({
-            'note_id': widget.noteId,
-            'user_id': widget.supabase.auth.currentUser?.id ?? '',
-            'content': content,
-          })
-          .select('id, content, created_at')
-          .single();
-      final newComment = Map<String, dynamic>.from(response as Map);
-      if (mounted) {
-        setState(() {
-          _comments.add(newComment);
-          _inputController.clear();
-        });
-        widget.onCountChanged(_comments.length);
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('送信に失敗しました: $e')),
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _submitting = false);
-    }
-  }
-
-  Future<void> _delete(String commentId) async {
-    try {
-      await widget.supabase
-          .from('note_comments')
-          .delete()
-          .eq('id', commentId)
-          .eq('user_id', widget.supabase.auth.currentUser?.id ?? '')
-          .select();
-      if (mounted) {
-        setState(() => _comments.removeWhere((c) => c['id'] == commentId));
-        widget.onCountChanged(_comments.length);
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('削除に失敗しました: $e')),
-        );
-      }
-    }
-  }
-
-  String _formatDate(String? isoString) {
-    final dt = DateTime.tryParse(isoString ?? '')?.toLocal();
-    if (dt == null) return '';
-    return '${dt.month}/${dt.day} ${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return DraggableScrollableSheet(
-      expand: false,
-      initialChildSize: 0.55,
-      maxChildSize: 0.9,
-      minChildSize: 0.3,
-      builder: (_, scrollCtrl) => Column(
-        children: [
-          const SizedBox(height: 8),
-          Container(
-            width: 40,
-            height: 4,
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(2),
-            ),
-          ),
-          const SizedBox(height: 12),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              children: [
-                const Icon(Icons.comment_outlined, size: 18),
-                const SizedBox(width: 8),
-                const Text(
-                  'コメント',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    height: 1.5,
-                  ),
-                ),
-                const Spacer(),
-                Text(
-                  '${_comments.length}件',
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    height: 1.5,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const Divider(),
-          Expanded(
-            child: _loading
-                ? const Center(child: CircularProgressIndicator())
-                : _comments.isEmpty
-                    ? Center(
-                        child: Text(
-                          'コメントはまだありません\n最初のメモを追加しましょう',
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                            height: 1.5,
-                          ),
-                        ),
-                      )
-                    : ListView.separated(
-                        controller: scrollCtrl,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 8,
-                        ),
-                        itemCount: _comments.length,
-                        separatorBuilder: (_, __) => const SizedBox(height: 8),
-                        itemBuilder: (_, i) {
-                          final c = _comments[i];
-                          return Container(
-                            decoration: BoxDecoration(
-                              color: const Color(0xFF6366F1)
-                                  .withValues(alpha: 0.05),
-                              borderRadius: BorderRadius.circular(8),
-                              border: Border.all(
-                                color: const Color(0xFF6366F1)
-                                    .withValues(alpha: 0.15),
-                              ),
-                            ),
-                            child: ListTile(
-                              dense: true,
-                              leading: const CircleAvatar(
-                                radius: 14,
-                                backgroundColor: Color(0xFF6366F1),
-                                child: Icon(
-                                  Icons.person,
-                                  size: 16,
-                                  color: Colors.white,
-                                ),
-                              ),
-                              title: Text(
-                                c['content'] as String? ?? '',
-                                style: const TextStyle(
-                                  fontSize: 14,
-                                  height: 1.5,
-                                ),
-                              ),
-                              subtitle: Text(
-                                _formatDate(c['created_at']?.toString()),
-                                style: TextStyle(
-                                  fontSize: 11,
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurfaceVariant,
-                                  height: 1.5,
-                                ),
-                              ),
-                              trailing: IconButton(
-                                icon: const Icon(
-                                  Icons.delete_outline,
-                                  size: 18,
-                                  color: Color(0xFFB91C1C),
-                                ),
-                                tooltip: '削除',
-                                onPressed: () async {
-                                  final id = c['id']?.toString() ?? '';
-                                  if (id.isEmpty) return;
-                                  final ok = await showDialog<bool>(
-                                    context: context,
-                                    builder: (_) => AlertDialog(
-                                      title: const Text('コメントを削除しますか？'),
-                                      actions: [
-                                        TextButton(
-                                          onPressed: () =>
-                                              Navigator.pop(context, false),
-                                          child: const Text('キャンセル'),
-                                        ),
-                                        TextButton(
-                                          onPressed: () =>
-                                              Navigator.pop(context, true),
-                                          child: const Text(
-                                            '削除',
-                                            style: TextStyle(
-                                              color: Color(0xFFB91C1C),
-                                              height: 1.5,
-                                            ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  );
-                                  if (ok == true) await _delete(id);
-                                },
-                              ),
-                            ),
-                          );
-                        },
-                      ),
-          ),
-          const Divider(height: 1),
-          Padding(
-            padding: EdgeInsets.only(
-              left: 12,
-              right: 12,
-              top: 8,
-              bottom: MediaQuery.of(context).viewInsets.bottom + 12,
-            ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _inputController,
-                    maxLength: 2000,
-                    maxLines: null,
-                    textInputAction: TextInputAction.newline,
-                    decoration: InputDecoration(
-                      hintText: 'コメントを追加…',
-                      counterText: '',
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
-                      ),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                _submitting
-                    ? const SizedBox(
-                        width: 36,
-                        height: 36,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : IconButton(
-                        icon: const Icon(Icons.send, color: Color(0xFF6366F1)),
-                        tooltip: '送信',
-                        onPressed: _submit,
-                      ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 }

--- a/lib/services/conveni_daily_report_payload.dart
+++ b/lib/services/conveni_daily_report_payload.dart
@@ -1,0 +1,21 @@
+Map<String, Object> buildConveniDailyReportPayload({
+  required String storeId,
+  required int gameDay,
+  required int revenue,
+  required int costOfGoods,
+  required int profit,
+  required int customerCount,
+  String weather = 'sunny',
+}) {
+  return <String, Object>{
+    'store_id': storeId,
+    'game_day': gameDay,
+    'revenue': revenue,
+    'cost_of_goods': costOfGoods,
+    'staff_cost': 0,
+    'waste_loss': 0,
+    'profit': profit,
+    'customer_count': customerCount,
+    'weather': weather,
+  };
+}

--- a/lib/services/note_comments_service.dart
+++ b/lib/services/note_comments_service.dart
@@ -19,6 +19,16 @@ abstract class NoteCommentsService {
   Stream<void> watchCommentChanges({required int noteId});
 }
 
+bool isExpectedNoteCommentRealtimeDisconnect(Object error) {
+  final message = error.toString();
+  if (!message.contains('RealtimeSubscribeException') ||
+      !message.contains('RealtimeSubscribeStatus.channelError')) {
+    return false;
+  }
+  return message.contains('RealtimeCloseEvent(code: 1000') ||
+      message.contains('details: null');
+}
+
 class SupabaseNoteCommentsService implements NoteCommentsService {
   SupabaseNoteCommentsService(this._supabase);
 

--- a/lib/widgets/note_comments_panel.dart
+++ b/lib/widgets/note_comments_panel.dart
@@ -73,6 +73,7 @@ class _NoteCommentsPanelState extends State<NoteCommentsPanel> {
   List<NoteComment> _comments = const <NoteComment>[];
   bool _isLoading = true;
   bool _isSubmitting = false;
+  bool _isRealtimeAvailable = true;
   String? _errorMessage;
 
   ScrollController get _effectiveScrollController =>
@@ -119,9 +120,21 @@ class _NoteCommentsPanelState extends State<NoteCommentsPanel> {
   void _attachRealtime() {
     _watchSubscription =
         _service.watchCommentChanges(noteId: widget.noteId).listen(
-      (_) => unawaited(_loadComments(showSpinner: false)),
+      (_) {
+        if (mounted && !_isRealtimeAvailable) {
+          setState(() => _isRealtimeAvailable = true);
+        }
+        unawaited(_loadComments(showSpinner: false));
+      },
       onError: (Object error) {
-        debugPrint('Note comment realtime stream error: $error');
+        if (!mounted) return;
+        if (_isRealtimeAvailable) {
+          setState(() => _isRealtimeAvailable = false);
+        }
+        unawaited(_loadComments(showSpinner: false));
+        if (!isExpectedNoteCommentRealtimeDisconnect(error)) {
+          debugPrint('Note comment realtime stream error: $error');
+        }
       },
     );
   }
@@ -297,12 +310,25 @@ class _NoteCommentsPanelState extends State<NoteCommentsPanel> {
                   ),
                 ),
                 const Spacer(),
-                Text(
-                  'リアルタイム',
-                  style: theme.textTheme.labelMedium?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
+                if (_isRealtimeAvailable)
+                  Text(
+                    'リアルタイム',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  )
+                else
+                  TextButton.icon(
+                    onPressed: () => unawaited(
+                      _loadComments(showSpinner: false),
+                    ),
+                    icon: const Icon(Icons.refresh, size: 16),
+                    label: const Text('手動更新'),
+                    style: TextButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                    ),
                   ),
-                ),
               ],
             ),
           ),

--- a/test/services/conveni_daily_report_payload_test.dart
+++ b/test/services/conveni_daily_report_payload_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/conveni_daily_report_payload.dart';
+
+void main() {
+  test('daily report payload matches the conveni_daily_reports schema', () {
+    final payload = buildConveniDailyReportPayload(
+      storeId: 'store-1',
+      gameDay: 3,
+      revenue: 15000,
+      costOfGoods: 9000,
+      profit: 6000,
+      customerCount: 25,
+    );
+
+    expect(payload, <String, Object>{
+      'store_id': 'store-1',
+      'game_day': 3,
+      'revenue': 15000,
+      'cost_of_goods': 9000,
+      'staff_cost': 0,
+      'waste_loss': 0,
+      'profit': 6000,
+      'customer_count': 25,
+      'weather': 'sunny',
+    });
+    expect(payload, isNot(contains('expense')));
+  });
+}

--- a/test/services/note_comments_service_test.dart
+++ b/test/services/note_comments_service_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/note_comments_service.dart';
+
+void main() {
+  group('isExpectedNoteCommentRealtimeDisconnect', () {
+    test('accepts a normal websocket close', () {
+      const error = 'RealtimeSubscribeException(status: '
+          'RealtimeSubscribeStatus.channelError, details: '
+          'RealtimeCloseEvent(code: 1000, reason: ))';
+
+      expect(isExpectedNoteCommentRealtimeDisconnect(error), isTrue);
+    });
+
+    test('accepts a channel close without details', () {
+      const error = 'RealtimeSubscribeException(status: '
+          'RealtimeSubscribeStatus.channelError, details: null)';
+
+      expect(isExpectedNoteCommentRealtimeDisconnect(error), isTrue);
+    });
+
+    test('keeps unexpected realtime failures visible', () {
+      const error = 'RealtimeSubscribeException(status: '
+          'RealtimeSubscribeStatus.timedOut, details: timeout)';
+
+      expect(isExpectedNoteCommentRealtimeDisconnect(error), isFalse);
+    });
+  });
+}

--- a/test/widgets/note_comments_panel_test.dart
+++ b/test/widgets/note_comments_panel_test.dart
@@ -134,4 +134,37 @@ void main() {
     expect(find.text('Realtime comment'), findsOneWidget);
     expect(latestCount, 4);
   });
+
+  testWidgets('falls back to manual refresh after a realtime disconnect', (
+    tester,
+  ) async {
+    final service = _FakeNoteCommentsService(<NoteComment>[]);
+    addTearDown(service.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 640,
+            child: NoteCommentsPanel(
+              noteId: 1,
+              service: service,
+              currentUserId: 'user-1',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    service.controller.addError(
+      'RealtimeSubscribeException(status: '
+      'RealtimeSubscribeStatus.channelError, details: '
+      'RealtimeCloseEvent(code: 1000, reason: ))',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('手動更新'), findsOneWidget);
+    expect(find.text('リアルタイム'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary

- send `conveni_daily_reports` inserts with the real schema columns (`cost_of_goods`, `staff_cost`, `waste_loss`) instead of the nonexistent `expense` column
- remove the redundant page-level note comment Realtime subscription and dead duplicate comments sheet
- degrade the active comments panel to manual refresh when Realtime is unavailable while keeping unexpected failures visible
- add focused service and widget regression tests

## Root cause

The convenience-store simulator posted an `expense` key that does not exist in the production table. The note editor also kept Realtime subscriptions open for `note_comments`, although that table is not in the production `supabase_realtime` publication, so normal channel closes surfaced as console errors.

## Validation

- production Supabase schema queried read-only: expected columns present and `expense` absent
- production Realtime publication queried read-only: `note_comments` is not published
- repository pre-commit quality gate passed: 195 files checked, full Flutter analyze clean, Deno lint and deterministic CI policy checks passed
- focused Flutter tests: 6 passed before and after rebasing onto latest `main`
- `flutter build web --release`: passed
- local `/note-editor` QA: desktop and 390×844 mobile layouts loaded; browser error/warn logs were empty

## Deployment verification

No production data was written during local QA. After merge, verify the Firebase Hosting deployment SHA and smoke-test `/note-editor` in production.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Console error handling only; no auth, RLS, data migration, or deployment workflow changes.
- Unresolved ultrareview findings: none

## Minimal E2E Gate

- Implementation-detail independent: the checks assert user-visible input/output rather than private implementation details.
- Minimal scope: about 3 cases covering the successful report payload, Realtime disconnect error, and manual-refresh recovery.
- E2E: Playwright local route smoke for `/note-editor`, plus focused Flutter widget and service tests.
- E2E-Exception: No new integration_test or test/e2e file because this fixes an existing route; focused regression tests and local Playwright smoke cover the changed behavior.