### PR TITLE
feat: complete cited research, adaptive routing, and A2A runtime

### DIFF
--- a/lib/pages/ai_company_builder_page.dart
+++ b/lib/pages/ai_company_builder_page.dart
@@ -15,6 +15,8 @@ class AiCompanyBuilderPage extends StatefulWidget {
 
 class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
   final TextEditingController _ideaController = TextEditingController();
+  final TextEditingController _researchSourceController =
+      TextEditingController();
   late final AiCompanyBuilderController _controller;
 
   double _threshold = 7;
@@ -22,6 +24,7 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
   bool get _isLoading => _controller.isLoading;
   bool get _isSubmitting => _controller.isSubmitting;
   bool get _isControlBusy => _controller.isControlBusy;
+  bool get _isResearchBusy => _controller.isResearchBusy;
   String? get _errorMessage => _controller.errorMessage;
   String? get _selectedCompanyId => _controller.selectedCompanyId;
   List<Map<String, dynamic>> get _companies => _controller.companies;
@@ -41,6 +44,7 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     _controller.removeListener(_onControllerChanged);
     _controller.dispose();
     _ideaController.dispose();
+    _researchSourceController.dispose();
     super.dispose();
   }
 
@@ -105,6 +109,22 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
 
   Future<void> _setGlobalKillSwitch(bool enabled) async {
     await _controller.setGlobalKillSwitch(enabled);
+  }
+
+  Future<void> _addResearchSource() async {
+    final added = await _controller.addResearchSource(
+      _researchSourceController.text,
+    );
+    if (added) _researchSourceController.clear();
+  }
+
+  Future<void> _copyAgentCardUrl(String url) async {
+    if (url.trim().isEmpty) return;
+    await Clipboard.setData(ClipboardData(text: url));
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Agent Card URL copied')));
   }
 
   Future<void> _copyBlueprintPost(Map<String, dynamic> blueprint) async {
@@ -338,8 +358,9 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
   }
 
   Widget _buildStatusChip(String status, bool passed) {
-    final Color tone =
-        passed ? const Color(0xFF10B981) : const Color(0xFFF59E0B);
+    final Color tone = passed
+        ? const Color(0xFF10B981)
+        : const Color(0xFFF59E0B);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
@@ -382,9 +403,9 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     final criteria = _asMapList(metadata['criteria']);
     final channels = (metadata['launch_channels'] is List)
         ? (metadata['launch_channels'] as List)
-            .map((item) => item.toString())
-            .where((item) => item.isNotEmpty)
-            .toList(growable: false)
+              .map((item) => item.toString())
+              .where((item) => item.isNotEmpty)
+              .toList(growable: false)
         : const <String>[];
     return Container(
       padding: const EdgeInsets.all(16),
@@ -499,20 +520,22 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     final passed = metadata['passed'] == true;
     final state = control['state']?.toString() ?? (passed ? 'idle' : 'blocked');
     final globalKill = master['kill_switch'] == true;
-    final completed =
-        tasks.where((task) => task['status'] == 'completed').length;
+    final completed = tasks
+        .where((task) => task['status'] == 'completed')
+        .length;
     final progress = tasks.isEmpty ? 0.0 : completed / tasks.length;
     final currentTaskId = control['current_task_id']?.toString();
     final currentTask = tasks.cast<Map<String, dynamic>?>().firstWhere(
-          (task) => task?['id']?.toString() == currentTaskId,
-          orElse: () => null,
-        );
+      (task) => task?['id']?.toString() == currentTaskId,
+      orElse: () => null,
+    );
     final totalCost = events.fold<double>(0, (sum, event) {
       return sum + ((event['estimated_cost_usd'] as num?)?.toDouble() ?? 0);
     });
     final canStart = passed && state == 'idle' && !globalKill;
     final canPause = state == 'running' && !globalKill;
-    final canResume = passed &&
+    final canResume =
+        passed &&
         <String>{'paused', 'blocked', 'cancelled'}.contains(state) &&
         !globalKill;
     final canStop = <String>{'running', 'paused', 'blocked'}.contains(state);
@@ -525,8 +548,9 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
           color: const Color(0xFF111827),
           borderRadius: BorderRadius.circular(8),
           border: Border.all(
-            color:
-                globalKill ? const Color(0xFFEF4444) : const Color(0x1FFFFFFF),
+            color: globalKill
+                ? const Color(0xFFEF4444)
+                : const Color(0x1FFFFFFF),
           ),
         ),
         child: Column(
@@ -694,8 +718,8 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
                     event['status'] == 'failed'
                         ? Icons.error_outline
                         : event['status'] == 'completed'
-                            ? Icons.check_circle_outline
-                            : Icons.bolt_outlined,
+                        ? Icons.check_circle_outline
+                        : Icons.bolt_outlined,
                     color: event['status'] == 'failed'
                         ? const Color(0xFFEF4444)
                         : const Color(0xFF22D3EE),
@@ -1027,47 +1051,49 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
       child: Wrap(
         spacing: 10,
         runSpacing: 10,
-        children: agents.map((agent) {
-          final metadata = _metadataOf(agent);
-          return Container(
-            width: 230,
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: const Color(0xFF111827),
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: const Color(0x1FFFFFFF)),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  agent['display_name']?.toString() ?? '-',
-                  style: const TextStyle(
-                    color: Color(0xFFE5E7EB),
-                    fontWeight: FontWeight.w700,
-                    height: 1.5,
-                  ),
+        children: agents
+            .map((agent) {
+              final metadata = _metadataOf(agent);
+              return Container(
+                width: 230,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF111827),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: const Color(0x1FFFFFFF)),
                 ),
-                const SizedBox(height: 4),
-                Text(
-                  agent['role_title']?.toString() ?? '-',
-                  style: const TextStyle(
-                    color: Color(0xB3E5E7EB),
-                    height: 1.5,
-                  ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      agent['display_name']?.toString() ?? '-',
+                      style: const TextStyle(
+                        color: Color(0xFFE5E7EB),
+                        fontWeight: FontWeight.w700,
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      agent['role_title']?.toString() ?? '-',
+                      style: const TextStyle(
+                        color: Color(0xB3E5E7EB),
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      metadata['focus']?.toString() ?? '',
+                      style: const TextStyle(
+                        color: Color(0x8AE5E7EB),
+                        height: 1.4,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 8),
-                Text(
-                  metadata['focus']?.toString() ?? '',
-                  style: const TextStyle(
-                    color: Color(0x8AE5E7EB),
-                    height: 1.4,
-                  ),
-                ),
-              ],
-            ),
-          );
-        }).toList(growable: false),
+              );
+            })
+            .toList(growable: false),
       ),
     );
   }
@@ -1090,61 +1116,259 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     return _buildDetailSection(
       title: 'Initial Task Graph',
       child: Column(
-        children: tasks.map((task) {
-          final metadata = _metadataOf(task);
-          return Container(
-            margin: const EdgeInsets.only(bottom: 10),
-            padding: const EdgeInsets.all(14),
-            decoration: BoxDecoration(
-              color: const Color(0xFF111827),
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: const Color(0x1FFFFFFF)),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
+        children: tasks
+            .map((task) {
+              final metadata = _metadataOf(task);
+              return Container(
+                margin: const EdgeInsets.only(bottom: 10),
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF111827),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: const Color(0x1FFFFFFF)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: Text(
-                        task['title']?.toString() ?? '-',
-                        style: const TextStyle(
-                          color: Color(0xFFE5E7EB),
-                          fontWeight: FontWeight.w700,
-                          height: 1.5,
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            task['title']?.toString() ?? '-',
+                            style: const TextStyle(
+                              color: Color(0xFFE5E7EB),
+                              fontWeight: FontWeight.w700,
+                              height: 1.5,
+                            ),
+                          ),
                         ),
+                        Text(
+                          metadata['stage']?.toString() ?? '',
+                          style: const TextStyle(
+                            color: Color(0x8AE5E7EB),
+                            height: 1.5,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      task['description']?.toString() ?? '',
+                      style: const TextStyle(
+                        color: Color(0xB3E5E7EB),
+                        height: 1.5,
                       ),
                     ),
+                    const SizedBox(height: 10),
                     Text(
-                      metadata['stage']?.toString() ?? '',
+                      '${managerNames[task['supervisor_agent_id']?.toString() ?? ''] ?? '-'} -> ${toolNames[task['assignee_agent_id']?.toString() ?? ''] ?? '-'}',
                       style: const TextStyle(
-                        color: Color(0x8AE5E7EB),
+                        color: Color(0xFFE5E7EB),
+                        fontWeight: FontWeight.w600,
                         height: 1.5,
                       ),
                     ),
                   ],
                 ),
-                const SizedBox(height: 8),
-                Text(
-                  task['description']?.toString() ?? '',
-                  style: const TextStyle(
-                    color: Color(0xB3E5E7EB),
-                    height: 1.5,
+              );
+            })
+            .toList(growable: false),
+      ),
+    );
+  }
+
+  Widget _buildResearchSection(
+    List<Map<String, dynamic>> sources,
+    List<Map<String, dynamic>> routingProfiles,
+    String agentCardUrl,
+  ) {
+    return _buildDetailSection(
+      title: 'Research & Interop',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            key: const Key('company-research-source-url'),
+            controller: _researchSourceController,
+            keyboardType: TextInputType.url,
+            autocorrect: false,
+            style: const TextStyle(color: Color(0xFFE5E7EB), height: 1.5),
+            decoration: InputDecoration(
+              labelText: 'Source URL',
+              hintText: 'https://example.com/research',
+              labelStyle: const TextStyle(color: Color(0xB3E5E7EB)),
+              hintStyle: const TextStyle(color: Color(0x61FFFFFF)),
+              filled: true,
+              fillColor: const Color(0xFF111827),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+            onSubmitted: _isResearchBusy ? null : (_) => _addResearchSource(),
+          ),
+          const SizedBox(height: 10),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              key: const Key('company-research-add'),
+              onPressed: _isResearchBusy ? null : _addResearchSource,
+              icon: _isResearchBusy
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.library_add_outlined),
+              label: Text(
+                _isResearchBusy ? 'Ingesting source...' : 'Add research source',
+              ),
+            ),
+          ),
+          if (sources.isEmpty) ...[
+            const SizedBox(height: 12),
+            const Text(
+              'Add a public source before running evidence-sensitive tasks.',
+              style: TextStyle(color: Color(0x8AE5E7EB), height: 1.5),
+            ),
+          ] else ...[
+            const SizedBox(height: 16),
+            for (final source in sources)
+              Container(
+                width: double.infinity,
+                margin: const EdgeInsets.only(bottom: 10),
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF111827),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: const Color(0x1FFFFFFF)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            source['title']?.toString().trim().isNotEmpty ==
+                                    true
+                                ? source['title'].toString()
+                                : 'Research source',
+                            style: const TextStyle(
+                              color: Color(0xFFE5E7EB),
+                              fontWeight: FontWeight.w700,
+                              height: 1.5,
+                            ),
+                          ),
+                        ),
+                        Text(
+                          source['status']?.toString() ?? 'processing',
+                          style: TextStyle(
+                            color: source['status'] == 'ready'
+                                ? const Color(0xFF34D399)
+                                : source['status'] == 'failed'
+                                ? const Color(0xFFFCA5A5)
+                                : const Color(0xFFFCD34D),
+                            fontWeight: FontWeight.w700,
+                            height: 1.5,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    SelectableText(
+                      source['source_url']?.toString() ?? '',
+                      style: const TextStyle(
+                        color: Color(0xFF93C5FD),
+                        fontSize: 12,
+                        height: 1.5,
+                      ),
+                    ),
+                    if (source['excerpt']?.toString().trim().isNotEmpty ==
+                        true) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        source['excerpt'].toString(),
+                        maxLines: 4,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Color(0xB3E5E7EB),
+                          height: 1.5,
+                        ),
+                      ),
+                    ],
+                    if (source['last_error']?.toString().trim().isNotEmpty ==
+                        true) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        source['last_error'].toString(),
+                        style: const TextStyle(
+                          color: Color(0xFFFCA5A5),
+                          height: 1.5,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+          ],
+          if (routingProfiles.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            const Text(
+              'Adaptive model routes',
+              style: TextStyle(
+                color: Color(0xFFE5E7EB),
+                fontWeight: FontWeight.w700,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: routingProfiles
+                  .map((profile) {
+                    return _buildPill(
+                      profile['routing_key']?.toString() ?? 'company_builder',
+                      '${profile['current_tier'] ?? 'free'} - ${profile['last_decision'] ?? 'baseline'}',
+                    );
+                  })
+                  .toList(growable: false),
+            ),
+          ],
+          if (agentCardUrl.trim().isNotEmpty) ...[
+            const SizedBox(height: 16),
+            const Text(
+              'A2A 1.0 Agent Card',
+              style: TextStyle(
+                color: Color(0xFFE5E7EB),
+                fontWeight: FontWeight.w700,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Row(
+              children: [
+                Expanded(
+                  child: SelectableText(
+                    agentCardUrl,
+                    key: const Key('company-a2a-agent-card-url'),
+                    style: const TextStyle(
+                      color: Color(0xFF93C5FD),
+                      fontSize: 12,
+                      height: 1.5,
+                    ),
                   ),
                 ),
-                const SizedBox(height: 10),
-                Text(
-                  '${managerNames[task['supervisor_agent_id']?.toString() ?? ''] ?? '-'} -> ${toolNames[task['assignee_agent_id']?.toString() ?? ''] ?? '-'}',
-                  style: const TextStyle(
-                    color: Color(0xFFE5E7EB),
-                    fontWeight: FontWeight.w600,
-                    height: 1.5,
-                  ),
+                IconButton(
+                  tooltip: 'Copy Agent Card URL',
+                  onPressed: () => _copyAgentCardUrl(agentCardUrl),
+                  icon: const Icon(Icons.copy_outlined),
+                  color: const Color(0xFFE5E7EB),
                 ),
               ],
             ),
-          );
-        }).toList(growable: false),
+          ],
+        ],
       ),
     );
   }
@@ -1153,50 +1377,52 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     return _buildDetailSection(
       title: 'Vault Notes',
       child: Column(
-        children: notes.map((note) {
-          final metadata = _metadataOf(note);
-          final content = metadata['content']?.toString() ?? '';
-          return Container(
-            margin: const EdgeInsets.only(bottom: 10),
-            padding: const EdgeInsets.all(14),
-            decoration: BoxDecoration(
-              color: const Color(0xFF111827),
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: const Color(0x1FFFFFFF)),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  metadata['title']?.toString() ?? 'Untitled note',
-                  style: const TextStyle(
-                    color: Color(0xFFE5E7EB),
-                    fontWeight: FontWeight.w700,
-                    height: 1.5,
-                  ),
+        children: notes
+            .map((note) {
+              final metadata = _metadataOf(note);
+              final content = metadata['content']?.toString() ?? '';
+              return Container(
+                margin: const EdgeInsets.only(bottom: 10),
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF111827),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: const Color(0x1FFFFFFF)),
                 ),
-                const SizedBox(height: 4),
-                Text(
-                  metadata['path']?.toString() ?? '',
-                  style: const TextStyle(
-                    color: Color(0x8AE5E7EB),
-                    height: 1.5,
-                  ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      metadata['title']?.toString() ?? 'Untitled note',
+                      style: const TextStyle(
+                        color: Color(0xFFE5E7EB),
+                        fontWeight: FontWeight.w700,
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      metadata['path']?.toString() ?? '',
+                      style: const TextStyle(
+                        color: Color(0x8AE5E7EB),
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Text(
+                      content.length > 220
+                          ? '${content.substring(0, 220)}...'
+                          : content,
+                      style: const TextStyle(
+                        color: Color(0xB3E5E7EB),
+                        height: 1.5,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 10),
-                Text(
-                  content.length > 220
-                      ? '${content.substring(0, 220)}...'
-                      : content,
-                  style: const TextStyle(
-                    color: Color(0xB3E5E7EB),
-                    height: 1.5,
-                  ),
-                ),
-              ],
-            ),
-          );
-        }).toList(growable: false),
+              );
+            })
+            .toList(growable: false),
       ),
     );
   }
@@ -1205,50 +1431,52 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     return _buildDetailSection(
       title: 'Audit Trail',
       child: Column(
-        children: entries.map((entry) {
-          final metadata = _metadataOf(entry);
-          final details = _asMap(metadata['details']);
-          return Container(
-            margin: const EdgeInsets.only(bottom: 10),
-            padding: const EdgeInsets.all(14),
-            decoration: BoxDecoration(
-              color: const Color(0xFF111827),
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: const Color(0x1FFFFFFF)),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  metadata['resource']?.toString() ?? 'event',
-                  style: const TextStyle(
-                    color: Color(0xFFE5E7EB),
-                    fontWeight: FontWeight.w700,
-                    height: 1.5,
-                  ),
+        children: entries
+            .map((entry) {
+              final metadata = _metadataOf(entry);
+              final details = _asMap(metadata['details']);
+              return Container(
+                margin: const EdgeInsets.only(bottom: 10),
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF111827),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: const Color(0x1FFFFFFF)),
                 ),
-                const SizedBox(height: 6),
-                Text(
-                  _shortDate(metadata['timestamp'] ?? entry['created_at']),
-                  style: const TextStyle(
-                    color: Color(0x8AE5E7EB),
-                    height: 1.5,
-                  ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      metadata['resource']?.toString() ?? 'event',
+                      style: const TextStyle(
+                        color: Color(0xFFE5E7EB),
+                        fontWeight: FontWeight.w700,
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      _shortDate(metadata['timestamp'] ?? entry['created_at']),
+                      style: const TextStyle(
+                        color: Color(0x8AE5E7EB),
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      details.entries
+                          .map((item) => '${item.key}: ${item.value}')
+                          .join('\n'),
+                      style: const TextStyle(
+                        color: Color(0xB3E5E7EB),
+                        height: 1.5,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 8),
-                Text(
-                  details.entries
-                      .map((item) => '${item.key}: ${item.value}')
-                      .join('\n'),
-                  style: const TextStyle(
-                    color: Color(0xB3E5E7EB),
-                    height: 1.5,
-                  ),
-                ),
-              ],
-            ),
-          );
-        }).toList(growable: false),
+              );
+            })
+            .toList(growable: false),
       ),
     );
   }
@@ -1276,6 +1504,9 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     final notes = _asMapList(_detail!['vault_notes']);
     final auditEntries = _asMapList(_detail!['audit_entries']);
     final runtimeEvents = _asMapList(_detail!['runtime_events']);
+    final researchSources = _asMapList(_detail!['research_sources']);
+    final routingProfiles = _asMapList(_detail!['routing_profiles']);
+    final agentCardUrl = _detail!['a2a_agent_card_url']?.toString() ?? '';
     final blueprint = _asMap(_metadataOf(company)['thirty_day_saas_blueprint']);
 
     return Column(
@@ -1286,6 +1517,8 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
         _buildRuntimeControl(company),
         const SizedBox(height: 24),
         _buildRuntimeEventsSection(runtimeEvents),
+        const SizedBox(height: 24),
+        _buildResearchSection(researchSources, routingProfiles, agentCardUrl),
         const SizedBox(height: 24),
         if (blueprint.isNotEmpty) ...[
           _buildThirtyDayBlueprint(company),

--- a/lib/pages/ai_company_builder_page.dart
+++ b/lib/pages/ai_company_builder_page.dart
@@ -358,9 +358,8 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
   }
 
   Widget _buildStatusChip(String status, bool passed) {
-    final Color tone = passed
-        ? const Color(0xFF10B981)
-        : const Color(0xFFF59E0B);
+    final Color tone =
+        passed ? const Color(0xFF10B981) : const Color(0xFFF59E0B);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
@@ -403,9 +402,9 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     final criteria = _asMapList(metadata['criteria']);
     final channels = (metadata['launch_channels'] is List)
         ? (metadata['launch_channels'] as List)
-              .map((item) => item.toString())
-              .where((item) => item.isNotEmpty)
-              .toList(growable: false)
+            .map((item) => item.toString())
+            .where((item) => item.isNotEmpty)
+            .toList(growable: false)
         : const <String>[];
     return Container(
       padding: const EdgeInsets.all(16),
@@ -520,22 +519,20 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     final passed = metadata['passed'] == true;
     final state = control['state']?.toString() ?? (passed ? 'idle' : 'blocked');
     final globalKill = master['kill_switch'] == true;
-    final completed = tasks
-        .where((task) => task['status'] == 'completed')
-        .length;
+    final completed =
+        tasks.where((task) => task['status'] == 'completed').length;
     final progress = tasks.isEmpty ? 0.0 : completed / tasks.length;
     final currentTaskId = control['current_task_id']?.toString();
     final currentTask = tasks.cast<Map<String, dynamic>?>().firstWhere(
-      (task) => task?['id']?.toString() == currentTaskId,
-      orElse: () => null,
-    );
+          (task) => task?['id']?.toString() == currentTaskId,
+          orElse: () => null,
+        );
     final totalCost = events.fold<double>(0, (sum, event) {
       return sum + ((event['estimated_cost_usd'] as num?)?.toDouble() ?? 0);
     });
     final canStart = passed && state == 'idle' && !globalKill;
     final canPause = state == 'running' && !globalKill;
-    final canResume =
-        passed &&
+    final canResume = passed &&
         <String>{'paused', 'blocked', 'cancelled'}.contains(state) &&
         !globalKill;
     final canStop = <String>{'running', 'paused', 'blocked'}.contains(state);
@@ -548,9 +545,8 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
           color: const Color(0xFF111827),
           borderRadius: BorderRadius.circular(8),
           border: Border.all(
-            color: globalKill
-                ? const Color(0xFFEF4444)
-                : const Color(0x1FFFFFFF),
+            color:
+                globalKill ? const Color(0xFFEF4444) : const Color(0x1FFFFFFF),
           ),
         ),
         child: Column(
@@ -718,8 +714,8 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
                     event['status'] == 'failed'
                         ? Icons.error_outline
                         : event['status'] == 'completed'
-                        ? Icons.check_circle_outline
-                        : Icons.bolt_outlined,
+                            ? Icons.check_circle_outline
+                            : Icons.bolt_outlined,
                     color: event['status'] == 'failed'
                         ? const Color(0xFFEF4444)
                         : const Color(0xFF22D3EE),
@@ -1051,49 +1047,47 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
       child: Wrap(
         spacing: 10,
         runSpacing: 10,
-        children: agents
-            .map((agent) {
-              final metadata = _metadataOf(agent);
-              return Container(
-                width: 230,
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF111827),
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: const Color(0x1FFFFFFF)),
+        children: agents.map((agent) {
+          final metadata = _metadataOf(agent);
+          return Container(
+            width: 230,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: const Color(0xFF111827),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: const Color(0x1FFFFFFF)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  agent['display_name']?.toString() ?? '-',
+                  style: const TextStyle(
+                    color: Color(0xFFE5E7EB),
+                    fontWeight: FontWeight.w700,
+                    height: 1.5,
+                  ),
                 ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      agent['display_name']?.toString() ?? '-',
-                      style: const TextStyle(
-                        color: Color(0xFFE5E7EB),
-                        fontWeight: FontWeight.w700,
-                        height: 1.5,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      agent['role_title']?.toString() ?? '-',
-                      style: const TextStyle(
-                        color: Color(0xB3E5E7EB),
-                        height: 1.5,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      metadata['focus']?.toString() ?? '',
-                      style: const TextStyle(
-                        color: Color(0x8AE5E7EB),
-                        height: 1.4,
-                      ),
-                    ),
-                  ],
+                const SizedBox(height: 4),
+                Text(
+                  agent['role_title']?.toString() ?? '-',
+                  style: const TextStyle(
+                    color: Color(0xB3E5E7EB),
+                    height: 1.5,
+                  ),
                 ),
-              );
-            })
-            .toList(growable: false),
+                const SizedBox(height: 8),
+                Text(
+                  metadata['focus']?.toString() ?? '',
+                  style: const TextStyle(
+                    color: Color(0x8AE5E7EB),
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }).toList(growable: false),
       ),
     );
   }
@@ -1116,63 +1110,61 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     return _buildDetailSection(
       title: 'Initial Task Graph',
       child: Column(
-        children: tasks
-            .map((task) {
-              final metadata = _metadataOf(task);
-              return Container(
-                margin: const EdgeInsets.only(bottom: 10),
-                padding: const EdgeInsets.all(14),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF111827),
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: const Color(0x1FFFFFFF)),
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+        children: tasks.map((task) {
+          final metadata = _metadataOf(task);
+          return Container(
+            margin: const EdgeInsets.only(bottom: 10),
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: const Color(0xFF111827),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: const Color(0x1FFFFFFF)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
                   children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            task['title']?.toString() ?? '-',
-                            style: const TextStyle(
-                              color: Color(0xFFE5E7EB),
-                              fontWeight: FontWeight.w700,
-                              height: 1.5,
-                            ),
-                          ),
+                    Expanded(
+                      child: Text(
+                        task['title']?.toString() ?? '-',
+                        style: const TextStyle(
+                          color: Color(0xFFE5E7EB),
+                          fontWeight: FontWeight.w700,
+                          height: 1.5,
                         ),
-                        Text(
-                          metadata['stage']?.toString() ?? '',
-                          style: const TextStyle(
-                            color: Color(0x8AE5E7EB),
-                            height: 1.5,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      task['description']?.toString() ?? '',
-                      style: const TextStyle(
-                        color: Color(0xB3E5E7EB),
-                        height: 1.5,
                       ),
                     ),
-                    const SizedBox(height: 10),
                     Text(
-                      '${managerNames[task['supervisor_agent_id']?.toString() ?? ''] ?? '-'} -> ${toolNames[task['assignee_agent_id']?.toString() ?? ''] ?? '-'}',
+                      metadata['stage']?.toString() ?? '',
                       style: const TextStyle(
-                        color: Color(0xFFE5E7EB),
-                        fontWeight: FontWeight.w600,
+                        color: Color(0x8AE5E7EB),
                         height: 1.5,
                       ),
                     ),
                   ],
                 ),
-              );
-            })
-            .toList(growable: false),
+                const SizedBox(height: 8),
+                Text(
+                  task['description']?.toString() ?? '',
+                  style: const TextStyle(
+                    color: Color(0xB3E5E7EB),
+                    height: 1.5,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  '${managerNames[task['supervisor_agent_id']?.toString() ?? ''] ?? '-'} -> ${toolNames[task['assignee_agent_id']?.toString() ?? ''] ?? '-'}',
+                  style: const TextStyle(
+                    color: Color(0xFFE5E7EB),
+                    fontWeight: FontWeight.w600,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }).toList(growable: false),
       ),
     );
   }
@@ -1266,8 +1258,8 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
                             color: source['status'] == 'ready'
                                 ? const Color(0xFF34D399)
                                 : source['status'] == 'failed'
-                                ? const Color(0xFFFCA5A5)
-                                : const Color(0xFFFCD34D),
+                                    ? const Color(0xFFFCA5A5)
+                                    : const Color(0xFFFCD34D),
                             fontWeight: FontWeight.w700,
                             height: 1.5,
                           ),
@@ -1325,14 +1317,12 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
             Wrap(
               spacing: 8,
               runSpacing: 8,
-              children: routingProfiles
-                  .map((profile) {
-                    return _buildPill(
-                      profile['routing_key']?.toString() ?? 'company_builder',
-                      '${profile['current_tier'] ?? 'free'} - ${profile['last_decision'] ?? 'baseline'}',
-                    );
-                  })
-                  .toList(growable: false),
+              children: routingProfiles.map((profile) {
+                return _buildPill(
+                  profile['routing_key']?.toString() ?? 'company_builder',
+                  '${profile['current_tier'] ?? 'free'} - ${profile['last_decision'] ?? 'baseline'}',
+                );
+              }).toList(growable: false),
             ),
           ],
           if (agentCardUrl.trim().isNotEmpty) ...[
@@ -1377,52 +1367,50 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     return _buildDetailSection(
       title: 'Vault Notes',
       child: Column(
-        children: notes
-            .map((note) {
-              final metadata = _metadataOf(note);
-              final content = metadata['content']?.toString() ?? '';
-              return Container(
-                margin: const EdgeInsets.only(bottom: 10),
-                padding: const EdgeInsets.all(14),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF111827),
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: const Color(0x1FFFFFFF)),
+        children: notes.map((note) {
+          final metadata = _metadataOf(note);
+          final content = metadata['content']?.toString() ?? '';
+          return Container(
+            margin: const EdgeInsets.only(bottom: 10),
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: const Color(0xFF111827),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: const Color(0x1FFFFFFF)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  metadata['title']?.toString() ?? 'Untitled note',
+                  style: const TextStyle(
+                    color: Color(0xFFE5E7EB),
+                    fontWeight: FontWeight.w700,
+                    height: 1.5,
+                  ),
                 ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      metadata['title']?.toString() ?? 'Untitled note',
-                      style: const TextStyle(
-                        color: Color(0xFFE5E7EB),
-                        fontWeight: FontWeight.w700,
-                        height: 1.5,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      metadata['path']?.toString() ?? '',
-                      style: const TextStyle(
-                        color: Color(0x8AE5E7EB),
-                        height: 1.5,
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    Text(
-                      content.length > 220
-                          ? '${content.substring(0, 220)}...'
-                          : content,
-                      style: const TextStyle(
-                        color: Color(0xB3E5E7EB),
-                        height: 1.5,
-                      ),
-                    ),
-                  ],
+                const SizedBox(height: 4),
+                Text(
+                  metadata['path']?.toString() ?? '',
+                  style: const TextStyle(
+                    color: Color(0x8AE5E7EB),
+                    height: 1.5,
+                  ),
                 ),
-              );
-            })
-            .toList(growable: false),
+                const SizedBox(height: 10),
+                Text(
+                  content.length > 220
+                      ? '${content.substring(0, 220)}...'
+                      : content,
+                  style: const TextStyle(
+                    color: Color(0xB3E5E7EB),
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }).toList(growable: false),
       ),
     );
   }
@@ -1431,52 +1419,50 @@ class _AiCompanyBuilderPageState extends State<AiCompanyBuilderPage> {
     return _buildDetailSection(
       title: 'Audit Trail',
       child: Column(
-        children: entries
-            .map((entry) {
-              final metadata = _metadataOf(entry);
-              final details = _asMap(metadata['details']);
-              return Container(
-                margin: const EdgeInsets.only(bottom: 10),
-                padding: const EdgeInsets.all(14),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF111827),
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: const Color(0x1FFFFFFF)),
+        children: entries.map((entry) {
+          final metadata = _metadataOf(entry);
+          final details = _asMap(metadata['details']);
+          return Container(
+            margin: const EdgeInsets.only(bottom: 10),
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: const Color(0xFF111827),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: const Color(0x1FFFFFFF)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  metadata['resource']?.toString() ?? 'event',
+                  style: const TextStyle(
+                    color: Color(0xFFE5E7EB),
+                    fontWeight: FontWeight.w700,
+                    height: 1.5,
+                  ),
                 ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      metadata['resource']?.toString() ?? 'event',
-                      style: const TextStyle(
-                        color: Color(0xFFE5E7EB),
-                        fontWeight: FontWeight.w700,
-                        height: 1.5,
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      _shortDate(metadata['timestamp'] ?? entry['created_at']),
-                      style: const TextStyle(
-                        color: Color(0x8AE5E7EB),
-                        height: 1.5,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      details.entries
-                          .map((item) => '${item.key}: ${item.value}')
-                          .join('\n'),
-                      style: const TextStyle(
-                        color: Color(0xB3E5E7EB),
-                        height: 1.5,
-                      ),
-                    ),
-                  ],
+                const SizedBox(height: 6),
+                Text(
+                  _shortDate(metadata['timestamp'] ?? entry['created_at']),
+                  style: const TextStyle(
+                    color: Color(0x8AE5E7EB),
+                    height: 1.5,
+                  ),
                 ),
-              );
-            })
-            .toList(growable: false),
+                const SizedBox(height: 8),
+                Text(
+                  details.entries
+                      .map((item) => '${item.key}: ${item.value}')
+                      .join('\n'),
+                  style: const TextStyle(
+                    color: Color(0xB3E5E7EB),
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }).toList(growable: false),
       ),
     );
   }

--- a/lib/services/ai_company_builder_controller.dart
+++ b/lib/services/ai_company_builder_controller.dart
@@ -13,6 +13,7 @@ class AiCompanyBuilderController extends ChangeNotifier {
   bool _isLoading = true;
   bool _isSubmitting = false;
   bool _isControlBusy = false;
+  bool _isResearchBusy = false;
   bool _disposed = false;
   String? _errorMessage;
   String? _selectedCompanyId;
@@ -23,6 +24,7 @@ class AiCompanyBuilderController extends ChangeNotifier {
   bool get isLoading => _isLoading;
   bool get isSubmitting => _isSubmitting;
   bool get isControlBusy => _isControlBusy;
+  bool get isResearchBusy => _isResearchBusy;
   String? get errorMessage => _errorMessage;
   String? get selectedCompanyId => _selectedCompanyId;
   List<Map<String, dynamic>> get companies => _companies;
@@ -136,6 +138,38 @@ class AiCompanyBuilderController extends ChangeNotifier {
       _errorMessage = 'Global kill switch failed: $error';
     } finally {
       _isControlBusy = false;
+      _notify();
+    }
+  }
+
+  Future<bool> addResearchSource(String sourceUrl) async {
+    final companyId = _selectedCompanyId;
+    if (companyId == null || companyId.isEmpty) return false;
+    final trimmed = sourceUrl.trim();
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null ||
+        !uri.hasScheme ||
+        uri.host.isEmpty ||
+        !const {'http', 'https'}.contains(uri.scheme)) {
+      _errorMessage = 'Enter a valid HTTP or HTTPS source URL.';
+      _notify();
+      return false;
+    }
+    _isResearchBusy = true;
+    _errorMessage = null;
+    _notify();
+    try {
+      await _service.addResearchSource(
+        companyId: companyId,
+        sourceUrl: trimmed,
+      );
+      await _refreshSelectedDetail();
+      return true;
+    } catch (error) {
+      _errorMessage = 'Research ingestion failed: $error';
+      return false;
+    } finally {
+      _isResearchBusy = false;
       _notify();
     }
   }

--- a/lib/services/ai_company_builder_service.dart
+++ b/lib/services/ai_company_builder_service.dart
@@ -58,6 +58,21 @@ class AiCompanyBuilderService {
     return _asMap(response.data);
   }
 
+  Future<Map<String, dynamic>> addResearchSource({
+    required String companyId,
+    required String sourceUrl,
+  }) async {
+    final response = await _client.functions.invoke(
+      'ai-hub',
+      body: {
+        'action': 'company_builder.research.add',
+        'company_id': companyId,
+        'source_url': sourceUrl,
+      },
+    );
+    return _asMap(response.data);
+  }
+
   Future<Map<String, dynamic>> setGlobalKillSwitch({
     required bool enabled,
   }) async {

--- a/supabase/functions/ai-hub/company_a2a.ts
+++ b/supabase/functions/ai-hub/company_a2a.ts
@@ -1,0 +1,269 @@
+export const COMPANY_A2A_PROTOCOL_VERSION = "1.0";
+export const COMPANY_A2A_CONTENT_TYPE = "application/a2a+json";
+
+type A2AMessageInput = {
+  messageId: string;
+  contextId: string;
+  companyId: string;
+  skillId: string;
+  text: string;
+  rawMessage: Record<string, unknown>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function boundedString(value: unknown, max: number): string {
+  return asString(value).slice(0, max);
+}
+
+export function buildCompanyAgentCard(endpoint: string) {
+  const baseUrl = endpoint.replace(/\/+$/, "");
+  return {
+    name: "AI Company Builder",
+    description:
+      "Durable manager and shared-tool agents for company operations, cited research, and launch execution.",
+    supportedInterfaces: [{
+      url: `${baseUrl}/a2a`,
+      protocolBinding: "HTTP+JSON",
+      protocolVersion: COMPANY_A2A_PROTOCOL_VERSION,
+    }],
+    provider: {
+      organization: "my_web_app",
+      url: "https://my-web-app-b67f4.web.app/ai-company-builder",
+    },
+    version: "1.0.0",
+    documentationUrl: "https://github.com/kanta13jp1/my_web_app",
+    capabilities: {
+      streaming: false,
+      pushNotifications: false,
+      extendedAgentCard: false,
+      extensions: [{
+        uri: "https://standards.org/extensions/citations/v1",
+        description: "Task artifacts include owner-scoped source citations.",
+        required: false,
+      }],
+    },
+    securitySchemes: {
+      bearerAuth: {
+        httpAuthSecurityScheme: {
+          description: "Supabase user access token",
+          scheme: "Bearer",
+          bearerFormat: "JWT",
+        },
+      },
+    },
+    securityRequirements: [{ schemes: { bearerAuth: { list: [] } } }],
+    defaultInputModes: ["text/plain", "application/json"],
+    defaultOutputModes: ["text/plain", "application/json"],
+    skills: [
+      {
+        id: "company-operations",
+        name: "Company Operations",
+        description:
+          "Delegates an operating request through a dedicated manager and reusable tool agent.",
+        tags: ["company", "operations", "delegation"],
+        examples: ["Create the next paid-pilot outreach experiment."],
+        inputModes: ["text/plain"],
+        outputModes: ["text/plain", "application/json"],
+      },
+      {
+        id: "cited-research",
+        name: "Cited Research",
+        description:
+          "Uses the selected company's private research corpus and returns source-addressable evidence.",
+        tags: ["research", "citations", "rag"],
+        examples: ["Compare this offer with the cited competitor pages."],
+        inputModes: ["text/plain"],
+        outputModes: ["text/plain", "application/json"],
+      },
+      {
+        id: "launch-execution",
+        name: "Launch Execution",
+        description:
+          "Runs a durable launch task with retries, cost telemetry, and kill-switch controls.",
+        tags: ["launch", "saas", "durable-task"],
+        examples: [
+          "Draft the week-one launch brief and measurable exit signal.",
+        ],
+        inputModes: ["text/plain"],
+        outputModes: ["text/plain", "application/json"],
+      },
+    ],
+  };
+}
+
+export function requestedA2AVersion(req: Request): string {
+  const url = new URL(req.url);
+  return asString(req.headers.get("A2A-Version")) ||
+    asString(url.searchParams.get("A2A-Version")) || "0.3";
+}
+
+export function assertA2AVersion(req: Request): void {
+  const version = requestedA2AVersion(req);
+  if (version !== COMPANY_A2A_PROTOCOL_VERSION) {
+    throw new Error(
+      `VersionNotSupportedError: requested ${version}; supported ${COMPANY_A2A_PROTOCOL_VERSION}`,
+    );
+  }
+}
+
+export function parseA2ASendMessage(value: unknown): A2AMessageInput {
+  const body = asRecord(value);
+  const message = asRecord(body?.message);
+  if (!body || !message) throw new Error("message is required");
+  if (message.role !== "ROLE_USER") {
+    throw new Error("message.role must be ROLE_USER");
+  }
+
+  const messageId = boundedString(message.messageId, 200);
+  if (!messageId) throw new Error("message.messageId is required");
+  const parts = Array.isArray(message.parts) ? message.parts.slice(0, 20) : [];
+  const text = parts.map(asRecord).filter((
+    part,
+  ): part is Record<string, unknown> => part !== null)
+    .map((part) => boundedString(part.text, 12_000)).filter(Boolean).join(
+      "\n\n",
+    )
+    .slice(0, 12_000)
+    .trim();
+  if (!text) throw new Error("At least one text part is required");
+
+  const requestMetadata = asRecord(body.metadata) ?? {};
+  const messageMetadata = asRecord(message.metadata) ?? {};
+  const companyId = boundedString(
+    requestMetadata.companyId ?? requestMetadata.company_id ??
+      messageMetadata.companyId ?? messageMetadata.company_id,
+    100,
+  );
+  if (!companyId) throw new Error("metadata.companyId is required");
+  const contextId = boundedString(message.contextId, 200) ||
+    crypto.randomUUID();
+  const skillId = boundedString(
+    requestMetadata.skillId ?? requestMetadata.skill_id,
+    100,
+  ) || "company-operations";
+  if (
+    !["company-operations", "cited-research", "launch-execution"].includes(
+      skillId,
+    )
+  ) {
+    throw new Error("Unsupported A2A skill");
+  }
+
+  return {
+    messageId,
+    contextId,
+    companyId,
+    skillId,
+    text,
+    rawMessage: {
+      messageId,
+      contextId,
+      role: "ROLE_USER",
+      parts: [{ text }],
+    },
+  };
+}
+
+export function agentTaskStatusToA2A(value: unknown): string {
+  switch (asString(value)) {
+    case "queued":
+      return "TASK_STATE_SUBMITTED";
+    case "in_progress":
+      return "TASK_STATE_WORKING";
+    case "completed":
+      return "TASK_STATE_COMPLETED";
+    case "failed":
+      return "TASK_STATE_FAILED";
+    case "cancelled":
+      return "TASK_STATE_CANCELED";
+    case "blocked":
+      return "TASK_STATE_INPUT_REQUIRED";
+    default:
+      return "TASK_STATE_UNSPECIFIED";
+  }
+}
+
+export function companyTaskToA2A(
+  task: Record<string, unknown>,
+  includeArtifacts = true,
+): Record<string, unknown> {
+  const metadata = asRecord(task.metadata) ?? {};
+  const result = asRecord(task.result) ?? {};
+  const resultText = asString(result.text);
+  const contextId = boundedString(metadata.a2a_context_id, 200);
+  const taskId = asString(task.id);
+  const mapped: Record<string, unknown> = {
+    id: taskId,
+    contextId,
+    status: {
+      state: agentTaskStatusToA2A(task.status),
+      timestamp: asString(task.updated_at) || asString(task.created_at) ||
+        new Date().toISOString(),
+    },
+    metadata: {
+      companyId: asString(metadata.company_id),
+      skillId: asString(metadata.a2a_skill_id) || "company-operations",
+      source: "ai-company-builder",
+    },
+  };
+  if (
+    includeArtifacts && resultText && asString(task.status) === "completed"
+  ) {
+    mapped.artifacts = [{
+      artifactId: `${taskId}-result`,
+      name: asString(task.title) || "Company task result",
+      parts: [{ text: resultText, mediaType: "text/plain" }],
+      metadata: {
+        citations: Array.isArray(result.citations) ? result.citations : [],
+      },
+      extensions: ["https://standards.org/extensions/citations/v1"],
+    }];
+  }
+  const inputMessage = asRecord(metadata.a2a_message);
+  if (inputMessage) mapped.history = [inputMessage];
+  return mapped;
+}
+
+export function encodeA2APageToken(task: Record<string, unknown>): string {
+  const payload = JSON.stringify({
+    updatedAt: asString(task.updated_at),
+    id: asString(task.id),
+  });
+  return btoa(payload).replace(/\+/g, "-").replace(/\//g, "_").replace(
+    /=+$/,
+    "",
+  );
+}
+
+export function decodeA2APageToken(
+  value: unknown,
+): { updatedAt: string; id: string } | null {
+  const token = asString(value);
+  if (!token || token.length > 1000) return null;
+  try {
+    const base64 = token.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    const parsed = asRecord(JSON.parse(atob(padded)));
+    const updatedAt = asString(parsed?.updatedAt);
+    const id = asString(parsed?.id);
+    const parsedDate = new Date(updatedAt);
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+        .test(id) || Number.isNaN(parsedDate.getTime())
+    ) {
+      return null;
+    }
+    return { updatedAt: parsedDate.toISOString(), id };
+  } catch {
+    return null;
+  }
+}

--- a/supabase/functions/ai-hub/company_a2a_test.ts
+++ b/supabase/functions/ai-hub/company_a2a_test.ts
@@ -1,0 +1,125 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  assertA2AVersion,
+  buildCompanyAgentCard,
+  companyTaskToA2A,
+  decodeA2APageToken,
+  encodeA2APageToken,
+  parseA2ASendMessage,
+} from "./company_a2a.ts";
+
+Deno.test("A2A card declares version 1.0 HTTP+JSON and bearer auth", () => {
+  const card = buildCompanyAgentCard("https://example.com/functions/v1/ai-hub");
+  assertEquals(card.supportedInterfaces[0].protocolBinding, "HTTP+JSON");
+  assertEquals(card.supportedInterfaces[0].protocolVersion, "1.0");
+  assertEquals(
+    card.securitySchemes.bearerAuth.httpAuthSecurityScheme.scheme,
+    "Bearer",
+  );
+  assertEquals(
+    card.skills.some((skill) => skill.id === "cited-research"),
+    true,
+  );
+});
+
+Deno.test("A2A version negotiation rejects missing legacy and unknown versions", () => {
+  assertThrows(
+    () => assertA2AVersion(new Request("https://example.com/a2a/tasks")),
+    Error,
+    "requested 0.3",
+  );
+  assertThrows(
+    () =>
+      assertA2AVersion(
+        new Request("https://example.com/a2a/tasks", {
+          headers: { "A2A-Version": "2.0" },
+        }),
+      ),
+    Error,
+    "requested 2.0",
+  );
+  assertA2AVersion(
+    new Request("https://example.com/a2a/tasks", {
+      headers: { "A2A-Version": "1.0" },
+    }),
+  );
+});
+
+Deno.test("A2A message parser requires scoped text and supported skills", () => {
+  const parsed = parseA2ASendMessage({
+    message: {
+      messageId: "message-1",
+      contextId: "context-1",
+      role: "ROLE_USER",
+      parts: [{ text: "Build the pilot brief" }],
+    },
+    metadata: { companyId: "company-1", skillId: "launch-execution" },
+  });
+  assertEquals(parsed.companyId, "company-1");
+  assertEquals(parsed.skillId, "launch-execution");
+  assertEquals(parsed.text, "Build the pilot brief");
+  const bounded = parseA2ASendMessage({
+    message: {
+      messageId: "message-2",
+      role: "ROLE_USER",
+      parts: Array.from({ length: 20 }, () => ({ text: "x".repeat(2000) })),
+    },
+    metadata: { companyId: "company-1" },
+  });
+  assertEquals(bounded.text.length, 12_000);
+  assertEquals(
+    (bounded.rawMessage.parts as Array<Record<string, unknown>>).length,
+    1,
+  );
+  assertThrows(() =>
+    parseA2ASendMessage({ message: { role: "ROLE_USER", parts: [] } })
+  );
+});
+
+Deno.test("agent tasks map to A2A lifecycle and citation artifacts", () => {
+  const task = {
+    id: "10000000-0000-4000-8000-000000000001",
+    title: "Pilot brief",
+    status: "completed",
+    updated_at: "2026-08-15T00:00:00.000Z",
+    metadata: {
+      company_id: "company-1",
+      a2a_context_id: "context-1",
+      a2a_skill_id: "cited-research",
+      a2a_message: {
+        messageId: "message-1",
+        role: "ROLE_USER",
+        parts: [{ text: "Research" }],
+      },
+    },
+    result: {
+      text: "Evidence [1]",
+      citations: [{ sourceUrl: "https://example.com" }],
+    },
+  };
+  const mapped = companyTaskToA2A(task);
+  assertEquals(
+    (mapped.status as Record<string, unknown>).state,
+    "TASK_STATE_COMPLETED",
+  );
+  assertEquals(Array.isArray(mapped.artifacts), true);
+  assertStringIncludes(JSON.stringify(mapped), "https://example.com");
+  assertEquals(
+    companyTaskToA2A({ ...task, status: "cancelled" }).artifacts,
+    undefined,
+  );
+  const token = encodeA2APageToken(task);
+  assertEquals(decodeA2APageToken(token), {
+    updatedAt: "2026-08-15T00:00:00.000Z",
+    id: "10000000-0000-4000-8000-000000000001",
+  });
+  const unsafeToken = btoa(JSON.stringify({
+    updatedAt: "2026-08-15T00:00:00.000Z,id.gt.0",
+    id: "not-a-uuid",
+  }));
+  assertEquals(decodeA2APageToken(unsafeToken), null);
+});

--- a/supabase/functions/ai-hub/company_builder_runtime.ts
+++ b/supabase/functions/ai-hub/company_builder_runtime.ts
@@ -1,5 +1,22 @@
 export const COMPANY_RUNTIME_QUEUE = "company_agent_runtime";
 
+export type CompanyRuntimeTier = "free" | "budget" | "performance" | "premium";
+
+export type CompanyRuntimeRoutingDecision = {
+  routingKey: string;
+  baseTier: CompanyRuntimeTier;
+  tier: CompanyRuntimeTier;
+  reason: string;
+  retryBoost: number;
+};
+
+const COMPANY_RUNTIME_TIERS: CompanyRuntimeTier[] = [
+  "free",
+  "budget",
+  "performance",
+  "premium",
+];
+
 export type CompanyRuntimeQueueMessage = {
   msgId: number;
   userId: string;
@@ -50,13 +67,14 @@ export function buildCompanyRuntimePrompt(
   task: Record<string, unknown>,
   manager: Record<string, unknown> | null,
   tool: Record<string, unknown> | null,
+  citationContext = "",
 ): string {
   const companyMetadata = asRecord(company.metadata) ?? {};
   const taskMetadata = asRecord(task.metadata) ?? {};
   const managerMetadata = asRecord(manager?.metadata) ?? {};
   const toolMetadata = asRecord(tool?.metadata) ?? {};
 
-  return [
+  const prompt = [
     "You are executing one durable task in an AI company operating system.",
     "Return a concrete work product, not a discussion of how you would work.",
     "Stay within the assigned role and avoid irreversible external actions.",
@@ -87,15 +105,142 @@ export function buildCompanyRuntimePrompt(
     "1. Deliverable",
     "2. Evidence or assumptions",
     "3. Next action for the manager",
-  ].join("\n");
+  ];
+  if (citationContext.trim()) {
+    prompt.push(
+      "",
+      "Company research sources:",
+      citationContext.trim(),
+      "",
+      "Use only the sources above for factual claims. Cite concrete claims with bracket references such as [1]. If the sources are insufficient, say so explicitly.",
+    );
+  }
+  return prompt.join("\n");
 }
 
 export function companyRuntimeRoutingTier(
   task: Record<string, unknown>,
-): "free" | "budget" | "performance" {
+): CompanyRuntimeTier {
   const metadata = asRecord(task.metadata) ?? {};
   const stage = asNonEmptyString(metadata.stage)?.toLowerCase();
   if (["legal", "gate"].includes(stage ?? "")) return "performance";
   if (stage === "finance") return "budget";
   return "free";
+}
+
+function tierIndex(value: unknown): number {
+  return COMPANY_RUNTIME_TIERS.indexOf(value as CompanyRuntimeTier);
+}
+
+function boundedTier(index: number): CompanyRuntimeTier {
+  return COMPANY_RUNTIME_TIERS[
+    Math.max(0, Math.min(index, COMPANY_RUNTIME_TIERS.length - 1))
+  ];
+}
+
+function companyRuntimeRoutingKey(task: Record<string, unknown>): string {
+  const metadata = asRecord(task.metadata) ?? {};
+  const stage = asNonEmptyString(metadata.stage)?.toLowerCase().replace(
+    /[^a-z0-9_-]/g,
+    "-",
+  ) ||
+    "general";
+  return `company_builder.${stage}`.slice(0, 120);
+}
+
+export function selectCompanyRuntimeRouting(
+  task: Record<string, unknown>,
+  profile: Record<string, unknown> | null,
+): CompanyRuntimeRoutingDecision {
+  const baseTier = companyRuntimeRoutingTier(task);
+  const metadata = asRecord(task.metadata) ?? {};
+  const stage = asNonEmptyString(metadata.stage)?.toLowerCase() ?? "general";
+  const profileTierIndex = tierIndex(profile?.current_tier);
+  const baseIndex = tierIndex(baseTier);
+  const highRiskFloor = ["legal", "gate"].includes(stage) ? baseIndex : 0;
+  const selectedIndex = profileTierIndex >= 0 ? profileTierIndex : baseIndex;
+  const attemptCount = Math.max(0, Number(task.attempt_count) || 0);
+  const retryBoost = Math.max(0, Math.min(attemptCount - 1, 2));
+  const finalIndex = Math.max(highRiskFloor, selectedIndex + retryBoost);
+  return {
+    routingKey: companyRuntimeRoutingKey(task),
+    baseTier,
+    tier: boundedTier(finalIndex),
+    reason: [
+      profileTierIndex >= 0
+        ? "persisted_outcome_profile"
+        : "task_stage_baseline",
+      retryBoost > 0 ? `retry_escalation_${retryBoost}` : "no_retry_escalation",
+      highRiskFloor > 0 ? "high_risk_floor" : "standard_floor",
+    ].join(";"),
+    retryBoost,
+  };
+}
+
+export function nextCompanyRuntimeRoutingProfile(
+  profile: Record<string, unknown> | null,
+  decision: CompanyRuntimeRoutingDecision,
+  success: boolean,
+  usedTier: unknown,
+): Record<string, unknown> {
+  const previousSuccesses = Math.max(
+    0,
+    Number(profile?.consecutive_successes) || 0,
+  );
+  const previousFailures = Math.max(
+    0,
+    Number(profile?.consecutive_failures) || 0,
+  );
+  const previousEscalations = Math.max(
+    0,
+    Number(profile?.escalation_count) || 0,
+  );
+  const previousDowngrades = Math.max(0, Number(profile?.downgrade_count) || 0);
+  const usedIndex = tierIndex(usedTier);
+  const decisionIndex = tierIndex(decision.tier);
+  let currentIndex = usedIndex >= 0 ? usedIndex : decisionIndex;
+  let consecutiveSuccesses = success ? previousSuccesses + 1 : 0;
+  const consecutiveFailures = success ? 0 : previousFailures + 1;
+  let escalationCount = previousEscalations;
+  let downgradeCount = previousDowngrades;
+  let lastDecision: string;
+
+  if (!success) {
+    const escalatedIndex = Math.min(
+      COMPANY_RUNTIME_TIERS.length - 1,
+      currentIndex + 1,
+    );
+    if (escalatedIndex > currentIndex) escalationCount += 1;
+    currentIndex = escalatedIndex;
+    lastDecision = escalatedIndex > decisionIndex
+      ? "escalated_after_failure"
+      : "failure_at_max_tier";
+  } else if (consecutiveSuccesses >= 5) {
+    const metadataStage = decision.routingKey.split(".").pop() ?? "general";
+    const minimumIndex = ["legal", "gate"].includes(metadataStage)
+      ? tierIndex(decision.baseTier)
+      : 0;
+    const downgradedIndex = Math.max(minimumIndex, currentIndex - 1);
+    if (downgradedIndex < currentIndex) {
+      currentIndex = downgradedIndex;
+      downgradeCount += 1;
+      consecutiveSuccesses = 0;
+      lastDecision = "downgraded_after_5_successes";
+    } else {
+      lastDecision = "success_floor_retained";
+    }
+  } else {
+    lastDecision = `success_streak_${consecutiveSuccesses}`;
+  }
+
+  return {
+    routing_key: decision.routingKey,
+    base_tier: decision.baseTier,
+    current_tier: boundedTier(currentIndex),
+    consecutive_successes: consecutiveSuccesses,
+    consecutive_failures: consecutiveFailures,
+    escalation_count: escalationCount,
+    downgrade_count: downgradeCount,
+    last_decision: lastDecision,
+  };
 }

--- a/supabase/functions/ai-hub/company_builder_runtime_test.ts
+++ b/supabase/functions/ai-hub/company_builder_runtime_test.ts
@@ -5,7 +5,9 @@ import {
 import {
   buildCompanyRuntimePrompt,
   companyRuntimeRoutingTier,
+  nextCompanyRuntimeRoutingProfile,
   parseCompanyRuntimeQueueMessages,
+  selectCompanyRuntimeRouting,
 } from "./company_builder_runtime.ts";
 
 Deno.test("queue parser rejects malformed or unscoped messages", () => {
@@ -60,6 +62,18 @@ Deno.test("runtime prompt binds company, manager, tool, and task context", () =>
   assertStringIncludes(prompt, "Return a concrete work product");
 });
 
+Deno.test("runtime prompt requires bracket citations when research is available", () => {
+  const prompt = buildCompanyRuntimePrompt(
+    { metadata: { company_name: "Signal School" } },
+    { title: "Review pricing", metadata: { stage: "research" } },
+    null,
+    null,
+    "[1] Pricing page\nURL: https://example.com/pricing\nExcerpt: Pro is $20.",
+  );
+  assertStringIncludes(prompt, "Company research sources:");
+  assertStringIncludes(prompt, "Cite concrete claims with bracket references");
+});
+
 Deno.test("high-risk business stages start on stronger routing tiers", () => {
   assertEquals(
     companyRuntimeRoutingTier({ metadata: { stage: "legal" } }),
@@ -73,4 +87,53 @@ Deno.test("high-risk business stages start on stronger routing tiers", () => {
     companyRuntimeRoutingTier({ metadata: { stage: "product" } }),
     "free",
   );
+});
+
+Deno.test("adaptive routing escalates retries and failures", () => {
+  const task = { attempt_count: 2, metadata: { stage: "finance" } };
+  const decision = selectCompanyRuntimeRouting(task, {
+    current_tier: "budget",
+  });
+  assertEquals(decision.tier, "performance");
+  assertEquals(decision.retryBoost, 1);
+  const profile = nextCompanyRuntimeRoutingProfile(
+    null,
+    decision,
+    false,
+    "performance",
+  );
+  assertEquals(profile.current_tier, "premium");
+  assertEquals(profile.last_decision, "escalated_after_failure");
+});
+
+Deno.test("adaptive routing downgrades after five consecutive successes", () => {
+  const decision = selectCompanyRuntimeRouting(
+    { attempt_count: 1, metadata: { stage: "finance" } },
+    { current_tier: "performance" },
+  );
+  const profile = nextCompanyRuntimeRoutingProfile(
+    { consecutive_successes: 4, current_tier: "performance" },
+    decision,
+    true,
+    "performance",
+  );
+  assertEquals(profile.current_tier, "budget");
+  assertEquals(profile.consecutive_successes, 0);
+  assertEquals(profile.downgrade_count, 1);
+  assertEquals(profile.last_decision, "downgraded_after_5_successes");
+});
+
+Deno.test("adaptive routing never downgrades legal tasks below performance", () => {
+  const decision = selectCompanyRuntimeRouting(
+    { attempt_count: 1, metadata: { stage: "legal" } },
+    { current_tier: "performance" },
+  );
+  const profile = nextCompanyRuntimeRoutingProfile(
+    { consecutive_successes: 4, current_tier: "performance" },
+    decision,
+    true,
+    "performance",
+  );
+  assertEquals(profile.current_tier, "performance");
+  assertEquals(profile.last_decision, "success_floor_retained");
 });

--- a/supabase/functions/ai-hub/company_research.ts
+++ b/supabase/functions/ai-hub/company_research.ts
@@ -1,0 +1,489 @@
+import { DOMParser } from "jsr:@b-fuze/deno-dom@0.1.56";
+
+const MAX_SOURCE_BYTES = 1_000_000;
+const MAX_REDIRECTS = 3;
+const FETCH_TIMEOUT_MS = 12_000;
+const TRACKING_PARAMS = new Set([
+  "fbclid",
+  "gclid",
+  "mc_cid",
+  "mc_eid",
+  "ref",
+]);
+
+export type ResearchDocument = {
+  sourceUrl: string;
+  canonicalUrl: string;
+  title: string;
+  markdown: string;
+  excerpt: string;
+  contentType: string;
+  httpStatus: number;
+};
+
+export type ResearchChunk = {
+  chunkIndex: number;
+  heading: string;
+  location: string;
+  content: string;
+};
+
+export type ResearchCitation = {
+  index: number;
+  sourceId: string;
+  sourceUrl: string;
+  title: string;
+  heading: string;
+  location: string;
+  excerpt: string;
+  score: number;
+  fetchedAt: string | null;
+};
+
+type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+function normalizedHostname(url: URL): string {
+  return url.hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+}
+
+function parseIpv4(host: string): number[] | null {
+  if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)) return null;
+  const octets = host.split(".").map(Number);
+  return octets.every((part) => part >= 0 && part <= 255) ? octets : null;
+}
+
+function isPrivateIpv4(octets: number[]): boolean {
+  const [a, b] = octets;
+  return a === 0 || a === 10 || a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224;
+}
+
+function isPrivateIpv6(host: string): boolean {
+  const value = host.toLowerCase();
+  if (!value.includes(":")) return false;
+  if (value.startsWith("::") || value.startsWith("0:0:0:0:0:ffff:")) {
+    return true;
+  }
+  if (value.startsWith("fc") || value.startsWith("fd")) return true;
+  if (/^fe[89ab]/.test(value)) return true;
+  if (value.startsWith("ff") || value.startsWith("64:ff9b:")) return true;
+  if (value.startsWith("100:") || value.startsWith("2001:db8:")) return true;
+  return false;
+}
+
+export function isPrivateNetworkHost(host: string): boolean {
+  const normalized = host.toLowerCase().replace(/^\[|\]$/g, "").replace(
+    /\.$/,
+    "",
+  );
+  if (
+    normalized === "localhost" || normalized.endsWith(".localhost") ||
+    normalized.endsWith(".local") || normalized.endsWith(".internal") ||
+    normalized.endsWith(".home") || normalized.endsWith(".lan")
+  ) {
+    return true;
+  }
+  const ipv4 = parseIpv4(normalized);
+  return ipv4 ? isPrivateIpv4(ipv4) : isPrivateIpv6(normalized);
+}
+
+export function normalizePublicResearchUrl(raw: unknown): URL {
+  const value = typeof raw === "string" ? raw.trim() : "";
+  if (value.length === 0 || value.length > 2048) {
+    throw new Error("A source URL between 1 and 2048 characters is required");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Source URL is invalid");
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("Only HTTP and HTTPS sources are supported");
+  }
+  if (url.username || url.password) {
+    throw new Error("Source URLs must not contain credentials");
+  }
+  if (url.port && !["80", "443"].includes(url.port)) {
+    throw new Error("Source URL port is not allowed");
+  }
+  if (isPrivateNetworkHost(normalizedHostname(url))) {
+    throw new Error("Private or local network sources are not allowed");
+  }
+  return url;
+}
+
+export function canonicalResearchUrl(raw: unknown): string {
+  const url = normalizePublicResearchUrl(raw);
+  url.hash = "";
+  url.hostname = normalizedHostname(url);
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
+  for (const key of [...url.searchParams.keys()]) {
+    if (
+      key.toLowerCase().startsWith("utm_") ||
+      TRACKING_PARAMS.has(key.toLowerCase())
+    ) {
+      url.searchParams.delete(key);
+    }
+  }
+  url.searchParams.sort();
+  return url.toString();
+}
+
+function cleanInlineText(value: string): string {
+  return value.replace(/\u00a0/g, " ").replace(/[ \t]+/g, " ")
+    .replace(/\s*\n\s*/g, " ").trim();
+}
+
+function textExcerpt(markdown: string): string {
+  return markdown.replace(/^#{1,6}\s+/gm, "").replace(/^[-*>]\s+/gm, "")
+    .replace(/\s+/g, " ").trim().slice(0, 600);
+}
+
+export function htmlToResearchMarkdown(
+  html: string,
+  fallbackTitle = "",
+): { title: string; markdown: string; excerpt: string } {
+  const document = new DOMParser().parseFromString(html, "text/html");
+  if (!document) throw new Error("HTML could not be parsed");
+
+  document.querySelectorAll(
+    "script,style,noscript,svg,canvas,nav,footer,header,form,dialog,template,iframe,object,embed",
+  ).forEach((node) => node.remove());
+  const root = document.querySelector("article,main,[role='main']") ??
+    document.body;
+  const title = cleanInlineText(
+    document.querySelector("title")?.textContent ??
+      document.querySelector("h1")?.textContent ?? fallbackTitle,
+  ).slice(0, 500);
+  const lines: string[] = [];
+  root.querySelectorAll("h1,h2,h3,h4,h5,h6,p,li,blockquote,pre,tr").forEach(
+    (node) => {
+      const text = cleanInlineText(node.textContent ?? "");
+      if (text.length === 0) return;
+      const tag = node.localName.toLowerCase();
+      if (/^h[1-6]$/.test(tag)) {
+        lines.push(`${"#".repeat(Number(tag[1]))} ${text}`);
+      } else if (tag === "li") {
+        lines.push(`- ${text}`);
+      } else if (tag === "blockquote") {
+        lines.push(`> ${text}`);
+      } else if (tag === "pre") {
+        lines.push(`\`\`\`\n${text.slice(0, 6000)}\n\`\`\``);
+      } else {
+        lines.push(text);
+      }
+    },
+  );
+
+  const markdown = lines.join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
+  if (markdown.length < 40) {
+    throw new Error("Source did not contain enough readable text");
+  }
+  return { title, markdown, excerpt: textExcerpt(markdown) };
+}
+
+export function plainTextToResearchMarkdown(
+  text: string,
+  fallbackTitle = "",
+): { title: string; markdown: string; excerpt: string } {
+  const markdown = text.replace(/\r\n?/g, "\n").replace(/[ \t]+$/gm, "")
+    .replace(/\n{4,}/g, "\n\n\n").trim();
+  if (markdown.length < 40) {
+    throw new Error("Source did not contain enough readable text");
+  }
+  return {
+    title: fallbackTitle.trim().slice(0, 500),
+    markdown,
+    excerpt: textExcerpt(markdown),
+  };
+}
+
+async function readResponseBody(response: Response): Promise<string> {
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (Number.isFinite(declared) && declared > MAX_SOURCE_BYTES) {
+    throw new Error("Source exceeds the 1 MB ingestion limit");
+  }
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const parts: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_SOURCE_BYTES) {
+      await reader.cancel();
+      throw new Error("Source exceeds the 1 MB ingestion limit");
+    }
+    parts.push(value);
+  }
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    joined.set(part, offset);
+    offset += part.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}
+
+async function assertPublicDns(
+  host: string,
+  fetcher: FetchLike,
+): Promise<void> {
+  if (parseIpv4(host) || host.includes(":")) return;
+  const addresses = new Set<string>();
+  for (const type of ["A", "AAAA"]) {
+    const lookup = new URL("https://cloudflare-dns.com/dns-query");
+    lookup.searchParams.set("name", host);
+    lookup.searchParams.set("type", type);
+    const response = await fetcher(lookup, {
+      headers: { Accept: "application/dns-json" },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) throw new Error("Public DNS validation is unavailable");
+    const payload = await response.json() as {
+      Answer?: Array<{ type?: number; data?: string }>;
+    };
+    for (const answer of payload.Answer ?? []) {
+      if ((answer.type === 1 || answer.type === 28) && answer.data) {
+        addresses.add(answer.data.replace(/^\[|\]$/g, ""));
+      }
+    }
+  }
+  if (addresses.size === 0) {
+    throw new Error("Source hostname did not resolve publicly");
+  }
+  if ([...addresses].some(isPrivateNetworkHost)) {
+    throw new Error("Source hostname resolves to a private network");
+  }
+}
+
+export async function fetchPublicResearchDocument(
+  rawUrl: unknown,
+  fetcher: FetchLike = fetch,
+): Promise<ResearchDocument> {
+  let current = normalizePublicResearchUrl(rawUrl);
+  const sourceUrl = current.toString();
+
+  for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
+    await assertPublicDns(normalizedHostname(current), fetcher);
+    const response = await fetcher(current, {
+      method: "GET",
+      redirect: "manual",
+      headers: {
+        Accept: "text/html,text/plain,text/markdown;q=0.9",
+        "User-Agent": "my-web-app-company-research/1.0",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location || redirect === MAX_REDIRECTS) {
+        throw new Error("Source redirect limit exceeded");
+      }
+      current = normalizePublicResearchUrl(
+        new URL(location, current).toString(),
+      );
+      continue;
+    }
+    if (!response.ok) {
+      throw new Error(`Source returned HTTP ${response.status}`);
+    }
+
+    const contentType = (response.headers.get("content-type") ?? "text/plain")
+      .split(";", 1)[0].trim().toLowerCase();
+    if (
+      !["text/html", "application/xhtml+xml", "text/plain", "text/markdown"]
+        .includes(contentType)
+    ) {
+      throw new Error(`Unsupported source content type: ${contentType}`);
+    }
+    const raw = await readResponseBody(response);
+    const parsed = contentType.includes("html")
+      ? htmlToResearchMarkdown(raw, current.hostname)
+      : plainTextToResearchMarkdown(raw, current.hostname);
+    return {
+      sourceUrl,
+      canonicalUrl: canonicalResearchUrl(current.toString()),
+      title: parsed.title || current.hostname,
+      markdown: parsed.markdown,
+      excerpt: parsed.excerpt,
+      contentType,
+      httpStatus: response.status,
+    };
+  }
+  throw new Error("Source redirect limit exceeded");
+}
+
+function splitLongParagraph(value: string, maxChars: number): string[] {
+  const parts: string[] = [];
+  let remaining = value.trim();
+  while (remaining.length > maxChars) {
+    const candidates = [
+      remaining.lastIndexOf("\n", maxChars),
+      remaining.lastIndexOf("。", maxChars),
+      remaining.lastIndexOf(". ", maxChars),
+      remaining.lastIndexOf(" ", maxChars),
+    ];
+    const splitAt = Math.max(...candidates, Math.floor(maxChars * 0.6));
+    parts.push(remaining.slice(0, splitAt + 1).trim());
+    remaining = remaining.slice(splitAt + 1).trim();
+  }
+  if (remaining) parts.push(remaining);
+  return parts;
+}
+
+export function chunkResearchMarkdown(
+  markdown: string,
+  maxChars = 2800,
+): ResearchChunk[] {
+  const paragraphs = markdown.split(/\n{2,}/).map((part) => part.trim())
+    .filter(Boolean).flatMap((part) => splitLongParagraph(part, maxChars));
+  const chunks: ResearchChunk[] = [];
+  let current: string[] = [];
+  let currentLength = 0;
+  let heading = "";
+  let startParagraph = 1;
+
+  const flush = (endParagraph: number) => {
+    const content = current.join("\n\n").trim();
+    if (!content) return;
+    chunks.push({
+      chunkIndex: chunks.length,
+      heading,
+      location: `paragraphs ${startParagraph}-${endParagraph}`,
+      content,
+    });
+    current = [];
+    currentLength = 0;
+  };
+
+  paragraphs.forEach((paragraph, index) => {
+    const headingMatch = paragraph.match(/^#{1,6}\s+(.+)$/);
+    if (headingMatch) heading = headingMatch[1].trim().slice(0, 500);
+    const projected = currentLength + (current.length === 0 ? 0 : 2) +
+      paragraph.length;
+    if (current.length > 0 && projected > maxChars) {
+      flush(index);
+      startParagraph = index + 1;
+    }
+    current.push(paragraph);
+    currentLength += (current.length === 1 ? 0 : 2) + paragraph.length;
+  });
+  flush(paragraphs.length);
+  return chunks.slice(0, 200);
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)].map((byte) =>
+    byte.toString(16).padStart(2, "0")
+  )
+    .join("");
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asNumber(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function normalizeResearchCitations(
+  rows: Array<Record<string, unknown>>,
+  limit = 6,
+): ResearchCitation[] {
+  const seen = new Set<string>();
+  const citations: ResearchCitation[] = [];
+  for (const row of rows) {
+    const sourceId = asString(row.source_id);
+    const sourceUrl = asString(row.source_url);
+    const location = asString(row.location);
+    const key = `${sourceId}:${location}`;
+    if (!sourceId || !sourceUrl || seen.has(key)) continue;
+    seen.add(key);
+    citations.push({
+      index: citations.length + 1,
+      sourceId,
+      sourceUrl,
+      title: asString(row.title) || sourceUrl,
+      heading: asString(row.heading),
+      location,
+      excerpt: asString(row.content).replace(/\s+/g, " ").slice(0, 700),
+      score: Math.max(0, asNumber(row.score)),
+      fetchedAt: asString(row.fetched_at) || null,
+    });
+    if (citations.length >= Math.max(1, Math.min(limit, 10))) break;
+  }
+  return citations;
+}
+
+export function buildResearchCitationContext(
+  citations: ResearchCitation[],
+): string {
+  if (citations.length === 0) return "";
+  return citations.map((citation) =>
+    [
+      `[${citation.index}] ${citation.title}`,
+      `URL: ${citation.sourceUrl}`,
+      `Location: ${citation.heading || citation.location || "source excerpt"}`,
+      `Excerpt: ${citation.excerpt}`,
+    ].join("\n")
+  ).join("\n\n");
+}
+
+export function ensureCitationFooter(
+  result: string,
+  citations: ResearchCitation[],
+): string {
+  if (citations.length === 0) return result.trim();
+  const footer = citations.map((citation) =>
+    `[${citation.index}] ${citation.title} - ${citation.sourceUrl} (${
+      citation.heading || citation.location
+    })`
+  ).join("\n");
+  return `${result.trim()}\n\nSources\n${footer}`;
+}
+
+export function buildExtractiveResearchFallback(
+  taskTitle: string,
+  citations: ResearchCitation[],
+): string {
+  const evidence = citations.slice(0, 3).map((citation) =>
+    `- ${citation.excerpt} [${citation.index}]`
+  ).join("\n");
+  return ensureCitationFooter(
+    [
+      `# ${taskTitle || "Research deliverable"}`,
+      "",
+      "The model provider was unavailable, so this is an extractive evidence fallback.",
+      "",
+      evidence,
+      "",
+      "Next action: review the cited passages before making an irreversible decision.",
+    ].join("\n"),
+    citations,
+  );
+}

--- a/supabase/functions/ai-hub/company_research_test.ts
+++ b/supabase/functions/ai-hub/company_research_test.ts
@@ -1,0 +1,138 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildExtractiveResearchFallback,
+  buildResearchCitationContext,
+  canonicalResearchUrl,
+  chunkResearchMarkdown,
+  ensureCitationFooter,
+  fetchPublicResearchDocument,
+  htmlToResearchMarkdown,
+  isPrivateNetworkHost,
+  normalizePublicResearchUrl,
+  normalizeResearchCitations,
+} from "./company_research.ts";
+
+Deno.test("research URLs reject private networks and unsafe schemes", () => {
+  for (
+    const host of [
+      "localhost",
+      "127.0.0.1",
+      "10.2.3.4",
+      "169.254.1.1",
+      "::1",
+      "fd00::1",
+      "::ffff:7f00:1",
+      "0:0:0:0:0:ffff:7f00:1",
+      "64:ff9b::7f00:1",
+      "ff02::1",
+    ]
+  ) {
+    assertEquals(isPrivateNetworkHost(host), true);
+  }
+  assertThrows(() => normalizePublicResearchUrl("file:///etc/passwd"));
+  assertThrows(() =>
+    normalizePublicResearchUrl("http://user:pass@example.com")
+  );
+  assertThrows(() => normalizePublicResearchUrl("http://localhost/admin"));
+  assertThrows(() =>
+    normalizePublicResearchUrl("http://[::ffff:127.0.0.1]/admin")
+  );
+  assertThrows(() => normalizePublicResearchUrl("https://example.com:8443/a"));
+  assertEquals(
+    canonicalResearchUrl("HTTPS://Example.com:443/a?utm_source=x&b=2&a=1#top"),
+    "https://example.com/a?a=1&b=2",
+  );
+});
+
+Deno.test("structured HTML extraction removes scripts and keeps readable sections", () => {
+  const result = htmlToResearchMarkdown(`
+    <html><head><title>Market facts</title><script>steal()</script></head>
+    <body><nav>Skip me</nav><main>
+      <h1>Pricing</h1><p>The paid plan is $20 each month.</p>
+      <ul><li>Includes exports</li><li>Includes support</li></ul>
+    </main></body></html>
+  `);
+  assertEquals(result.title, "Market facts");
+  assertStringIncludes(result.markdown, "# Pricing");
+  assertStringIncludes(result.markdown, "- Includes exports");
+  assertEquals(result.markdown.includes("steal"), false);
+  assertEquals(result.markdown.includes("Skip me"), false);
+});
+
+Deno.test("markdown chunks retain citation locations and bounded content", () => {
+  const chunks = chunkResearchMarkdown(
+    `# Market\n\n${"Demand signal. ".repeat(90)}\n\n## Pricing\n\n${
+      "Price evidence. ".repeat(90)
+    }`,
+    500,
+  );
+  assertEquals(chunks.length > 2, true);
+  assertEquals(chunks.every((chunk) => chunk.content.length <= 500), true);
+  assertEquals(chunks[0].location.startsWith("paragraphs "), true);
+  assertEquals(chunks.some((chunk) => chunk.heading === "Pricing"), true);
+});
+
+Deno.test("citations are deduplicated and appended deterministically", () => {
+  const citations = normalizeResearchCitations([
+    {
+      source_id: "source-1",
+      source_url: "https://example.com/pricing",
+      title: "Pricing",
+      heading: "Pro plan",
+      location: "paragraphs 2-3",
+      content: "The pro plan costs $20.",
+      score: 0.8,
+    },
+    {
+      source_id: "source-1",
+      source_url: "https://example.com/pricing",
+      title: "Pricing",
+      heading: "Pro plan",
+      location: "paragraphs 2-3",
+      content: "duplicate",
+      score: 0.7,
+    },
+  ]);
+  assertEquals(citations.length, 1);
+  assertStringIncludes(buildResearchCitationContext(citations), "[1] Pricing");
+  assertStringIncludes(
+    ensureCitationFooter("Decision [1]", citations),
+    "Sources",
+  );
+  assertStringIncludes(
+    buildExtractiveResearchFallback("Review pricing", citations),
+    "extractive evidence fallback",
+  );
+});
+
+Deno.test("fetch rejects redirects into private networks before the second request", async () => {
+  const calls: string[] = [];
+  const fakeFetch = (
+    input: string | URL | Request,
+  ): Promise<Response> => {
+    const url = input instanceof Request ? input.url : input.toString();
+    calls.push(url);
+    if (url.startsWith("https://cloudflare-dns.com/")) {
+      return Promise.resolve(
+        Response.json({ Answer: [{ type: 1, data: "93.184.216.34" }] }),
+      );
+    }
+    return Promise.resolve(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://127.0.0.1/private" },
+      }),
+    );
+  };
+  await assertRejects(
+    () => fetchPublicResearchDocument("https://example.com/start", fakeFetch),
+    Error,
+    "Private or local network",
+  );
+  assertEquals(calls.some((url) => url.includes("127.0.0.1")), false);
+});

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -84,14 +84,39 @@ import {
 import { applyProviderGenerationOptions } from "./provider_generation_options.ts";
 import {
   buildCompanyRuntimePrompt,
-  companyRuntimeRoutingTier,
+  nextCompanyRuntimeRoutingProfile,
   parseCompanyRuntimeQueueMessages,
+  selectCompanyRuntimeRouting,
 } from "./company_builder_runtime.ts";
+import {
+  buildExtractiveResearchFallback,
+  buildResearchCitationContext,
+  canonicalResearchUrl,
+  chunkResearchMarkdown,
+  ensureCitationFooter,
+  fetchPublicResearchDocument,
+  normalizeResearchCitations,
+  type ResearchCitation,
+  sha256Hex,
+} from "./company_research.ts";
+import {
+  assertA2AVersion,
+  buildCompanyAgentCard,
+  COMPANY_A2A_CONTENT_TYPE,
+  COMPANY_A2A_PROTOCOL_VERSION,
+  companyTaskToA2A,
+  decodeA2APageToken,
+  encodeA2APageToken,
+  parseA2ASendMessage,
+} from "./company_a2a.ts";
+import { rankBm25 } from "../memory-search-hub/search/bm25.ts";
+import { embedTextWithGemini } from "../memory-search-hub/search/vector.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type",
+    "authorization, x-client-info, apikey, content-type, a2a-version, a2a-extensions",
+  "Access-Control-Expose-Headers": "A2A-Version, WWW-Authenticate",
   "Access-Control-Max-Age": "86400",
 };
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
@@ -115,6 +140,22 @@ function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function a2aJson(
+  data: unknown,
+  status = 200,
+  extraHeaders: HeadersInit = {},
+): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      ...corsHeaders,
+      "A2A-Version": COMPANY_A2A_PROTOCOL_VERSION,
+      "Content-Type": COMPANY_A2A_CONTENT_TYPE,
+      ...Object.fromEntries(new Headers(extraHeaders)),
+    },
   });
 }
 
@@ -1990,6 +2031,8 @@ async function getCompanyBuilderDetail(
     runtimeControlResult,
     runtimeMasterResult,
     runtimeEventsResult,
+    researchSourcesResult,
+    routingProfilesResult,
   ] = await Promise.all([
     admin.from("agents").select("*")
       .eq("user_id", userId)
@@ -2034,6 +2077,17 @@ async function getCompanyBuilderDetail(
       .eq("company_id", companyId)
       .order("occurred_at", { ascending: false })
       .limit(100),
+    admin.from("company_research_sources").select(
+      "id, source_url, canonical_url, title, excerpt, status, http_status, content_type, last_error, metadata, fetched_at, created_at, updated_at",
+    )
+      .eq("user_id", userId)
+      .eq("company_id", companyId)
+      .order("updated_at", { ascending: false })
+      .limit(100),
+    admin.from("company_runtime_routing_profiles").select("*")
+      .eq("user_id", userId)
+      .eq("company_id", companyId)
+      .order("updated_at", { ascending: false }),
   ]);
 
   if (managerAgentsResult.error) {
@@ -2054,6 +2108,12 @@ async function getCompanyBuilderDetail(
   if (runtimeEventsResult.error) {
     throw new Error(runtimeEventsResult.error.message);
   }
+  if (researchSourcesResult.error) {
+    throw new Error(researchSourcesResult.error.message);
+  }
+  if (routingProfilesResult.error) {
+    throw new Error(routingProfilesResult.error.message);
+  }
 
   return {
     company,
@@ -2067,6 +2127,10 @@ async function getCompanyBuilderDetail(
     runtime_control: runtimeControlResult.data,
     runtime_master_control: runtimeMasterResult.data,
     runtime_events: runtimeEventsResult.data ?? [],
+    research_sources: researchSourcesResult.data ?? [],
+    routing_profiles: routingProfilesResult.data ?? [],
+    a2a_agent_card_url:
+      `${SUPABASE_URL}/functions/v1/ai-hub/.well-known/agent-card.json`,
   };
 }
 
@@ -2191,6 +2255,373 @@ async function archiveCompanyRuntimeMessage(
   if (error) throw new Error(error.message);
 }
 
+async function getOwnedCompany(
+  admin: SupabaseClient,
+  userId: string,
+  companyId: string,
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await admin.from("hub_data")
+    .select("id, metadata, created_at")
+    .eq("id", companyId)
+    .eq("source", "company_builder_company")
+    .filter("metadata->>user_id", "eq", userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return data as Record<string, unknown> | null;
+}
+
+async function embedCompanyResearchDocuments(
+  texts: string[],
+  apiKey: string,
+): Promise<Array<number[] | null>> {
+  if (!apiKey || texts.length === 0) return texts.map(() => null);
+  const embeddings: Array<number[] | null> = [];
+  for (let offset = 0; offset < texts.length; offset += 20) {
+    const batch = texts.slice(offset, offset + 20);
+    const response = await fetch(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-goog-api-key": apiKey,
+        },
+        body: JSON.stringify({
+          requests: batch.map((text) => ({
+            model: "models/gemini-embedding-001",
+            content: { parts: [{ text: text.slice(0, 3500) }] },
+            taskType: "RETRIEVAL_DOCUMENT",
+            outputDimensionality: 768,
+          })),
+        }),
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Gemini document embedding returned ${response.status}`);
+    }
+    const payload = await response.json() as {
+      embeddings?: Array<{ values?: number[] }>;
+    };
+    const values = payload.embeddings ?? [];
+    if (values.length !== batch.length) {
+      throw new Error("Gemini document embedding count mismatch");
+    }
+    embeddings.push(
+      ...values.map((item) =>
+        Array.isArray(item.values) && item.values.length === 768
+          ? item.values
+          : null
+      ),
+    );
+  }
+  return embeddings;
+}
+
+const COMPANY_RESEARCH_EMBEDDING_CHUNK_LIMIT = 60;
+
+async function ingestCompanyResearchSource(
+  admin: SupabaseClient,
+  userId: string,
+  companyId: string,
+  rawUrl: unknown,
+): Promise<Record<string, unknown>> {
+  if (!await getOwnedCompany(admin, userId, companyId)) {
+    throw new Error("Company not found");
+  }
+  const canonicalUrl = canonicalResearchUrl(rawUrl);
+  const sourceUrl = String(rawUrl).trim();
+  const { data: source, error: sourceError } = await admin
+    .from("company_research_sources")
+    .upsert({
+      user_id: userId,
+      company_id: companyId,
+      source_url: sourceUrl,
+      canonical_url: canonicalUrl,
+      status: "processing",
+      last_error: null,
+      metadata: { ingestion: "company_builder" },
+    }, { onConflict: "user_id,company_id,canonical_url" })
+    .select("*")
+    .single();
+  if (sourceError) throw new Error(sourceError.message);
+  const sourceId = asString(source.id);
+
+  try {
+    const document = await fetchPublicResearchDocument(sourceUrl);
+    const chunks = chunkResearchMarkdown(document.markdown);
+    if (chunks.length === 0) {
+      throw new Error("Source produced no research chunks");
+    }
+    const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
+    let embeddings = chunks.map(() => null as number[] | null);
+    let embeddingStatus = geminiKey ? "failed" : "unavailable";
+    if (geminiKey) {
+      try {
+        const generated = await embedCompanyResearchDocuments(
+          chunks.slice(0, COMPANY_RESEARCH_EMBEDDING_CHUNK_LIMIT).map((chunk) =>
+            chunk.content
+          ),
+          geminiKey,
+        );
+        embeddings = chunks.map((_, index) => generated[index] ?? null);
+        embeddingStatus = generated.some(Boolean)
+          ? chunks.length > COMPANY_RESEARCH_EMBEDDING_CHUNK_LIMIT
+            ? "partial"
+            : "ready"
+          : "failed";
+      } catch (error) {
+        console.warn("company research embedding fallback", error);
+      }
+    }
+
+    const { error: deleteError } = await admin.from("company_research_chunks")
+      .delete().eq("source_id", sourceId).eq("user_id", userId)
+      .eq("company_id", companyId);
+    if (deleteError) throw new Error(deleteError.message);
+    const chunkRows = chunks.map((chunk, index) => ({
+      source_id: sourceId,
+      user_id: userId,
+      company_id: companyId,
+      chunk_index: chunk.chunkIndex,
+      heading: chunk.heading,
+      location: chunk.location,
+      content: chunk.content,
+      embedding: embeddings[index],
+      metadata: { source_title: document.title },
+    }));
+    const { error: chunkError } = await admin.from("company_research_chunks")
+      .insert(chunkRows);
+    if (chunkError) throw new Error(chunkError.message);
+
+    const { data: ready, error: updateError } = await admin
+      .from("company_research_sources")
+      .update({
+        source_url: document.sourceUrl,
+        title: document.title,
+        content_markdown: document.markdown,
+        excerpt: document.excerpt,
+        content_hash: await sha256Hex(document.markdown),
+        status: "ready",
+        http_status: document.httpStatus,
+        content_type: document.contentType,
+        last_error: null,
+        fetched_at: new Date().toISOString(),
+        metadata: {
+          ingestion: "company_builder",
+          final_canonical_url: document.canonicalUrl,
+          chunk_count: chunks.length,
+          embedding_status: embeddingStatus,
+        },
+      })
+      .eq("id", sourceId).eq("user_id", userId).eq("company_id", companyId)
+      .select("*")
+      .single();
+    if (updateError) throw new Error(updateError.message);
+    await addCompanyEvent(
+      admin,
+      userId,
+      companyId,
+      "research_source_ready",
+      "ready",
+      {
+        source_id: sourceId,
+        chunk_count: chunks.length,
+        embedding_status: embeddingStatus,
+      },
+    );
+    return ready as Record<string, unknown>;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await admin.from("company_research_sources").update({
+      status: "failed",
+      last_error: message.slice(0, 1000),
+      metadata: {
+        ingestion: "company_builder",
+        fallback: "source_failure_recorded",
+      },
+    }).eq("id", sourceId).eq("user_id", userId).eq("company_id", companyId);
+    await addCompanyEvent(
+      admin,
+      userId,
+      companyId,
+      "research_source_failed",
+      "failed",
+      { source_id: sourceId, error: message.slice(0, 500) },
+    );
+    throw error;
+  }
+}
+
+async function searchCompanyResearch(
+  admin: SupabaseClient,
+  userId: string,
+  companyId: string,
+  query: string,
+): Promise<ResearchCitation[]> {
+  const { data: sources, error: sourcesError } = await admin
+    .from("company_research_sources")
+    .select("id, source_url, title, fetched_at")
+    .eq("user_id", userId).eq("company_id", companyId).eq("status", "ready")
+    .order("updated_at", { ascending: false }).limit(100);
+  if (sourcesError) throw new Error(sourcesError.message);
+  const sourceMap = new Map(
+    ((sources ?? []) as Record<string, unknown>[]).map((
+      source,
+    ) => [asString(source.id), source]),
+  );
+  if (sourceMap.size === 0) return [];
+
+  const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
+  let queryEmbedding: number[] | null = null;
+  if (geminiKey) {
+    try {
+      queryEmbedding = await embedTextWithGemini(query, geminiKey);
+    } catch (error) {
+      console.warn("company research query embedding fallback", error);
+    }
+  }
+
+  const merged = new Map<string, Record<string, unknown>>();
+  const { data: hybridRows, error: hybridError } = await admin.rpc(
+    "match_company_research_chunks",
+    {
+      p_user_id: userId,
+      p_company_id: companyId,
+      p_query_text: query,
+      p_query_embedding: queryEmbedding,
+      p_match_count: 12,
+      p_match_threshold: 0.05,
+    },
+  );
+  if (hybridError) {
+    console.warn("company research database search fallback", hybridError);
+  } else {
+    for (const row of (hybridRows ?? []) as Record<string, unknown>[]) {
+      merged.set(asString(row.chunk_id), row);
+    }
+  }
+
+  const { data: chunks, error: chunksError } = await admin
+    .from("company_research_chunks")
+    .select("id, source_id, heading, location, content, updated_at")
+    .eq("user_id", userId).eq("company_id", companyId)
+    .in("source_id", [...sourceMap.keys()]).limit(300);
+  if (chunksError) throw new Error(chunksError.message);
+  const documents = ((chunks ?? []) as Record<string, unknown>[]).map(
+    (chunk) => {
+      const source = sourceMap.get(asString(chunk.source_id)) ?? {};
+      return {
+        file_path: asString(chunk.id),
+        title: asString(source.title),
+        content: asString(chunk.content),
+        snippet: asString(chunk.content).slice(0, 700),
+        updated_at: asString(chunk.updated_at),
+        metadata: { chunk, source },
+      };
+    },
+  );
+  const lexicalRows = rankBm25(query, documents, 12);
+  const maxLexical = Math.max(1, ...lexicalRows.map((row) => row.score));
+  for (const lexical of lexicalRows) {
+    const metadata = asRecord(lexical.metadata) ?? {};
+    const chunk = asRecord(metadata.chunk) ?? {};
+    const source = asRecord(metadata.source) ?? {};
+    const chunkId = asString(chunk.id);
+    const candidate: Record<string, unknown> = {
+      chunk_id: chunkId,
+      source_id: asString(chunk.source_id),
+      source_url: asString(source.source_url),
+      title: asString(source.title),
+      heading: asString(chunk.heading),
+      location: asString(chunk.location),
+      content: asString(chunk.content),
+      fetched_at: asString(source.fetched_at),
+      score: lexical.score / maxLexical,
+    };
+    const existing = merged.get(chunkId);
+    if (!existing || Number(existing.score ?? 0) < Number(candidate.score)) {
+      merged.set(chunkId, candidate);
+    }
+  }
+
+  const ranked = [...merged.values()].sort((left, right) =>
+    Number(right.score ?? 0) - Number(left.score ?? 0)
+  );
+  return normalizeResearchCitations(ranked, 6);
+}
+
+async function persistCompanyRoutingOutcome(
+  admin: SupabaseClient,
+  userId: string,
+  companyId: string,
+  profile: Record<string, unknown>,
+  success: boolean,
+  provider: string,
+  model: string,
+) {
+  const timestampField = success ? "last_success_at" : "last_failure_at";
+  const { data, error } = await admin.from("company_runtime_routing_profiles")
+    .upsert({
+      user_id: userId,
+      company_id: companyId,
+      ...profile,
+      last_provider: provider || null,
+      last_model: model || null,
+      [timestampField]: new Date().toISOString(),
+    }, { onConflict: "user_id,company_id,routing_key" })
+    .select("*")
+    .single();
+  if (error) throw new Error(error.message);
+  return data as Record<string, unknown>;
+}
+
+async function consolidateCompanyTaskResult(
+  admin: SupabaseClient,
+  userId: string,
+  companyId: string,
+  task: Record<string, unknown>,
+  resultText: string,
+  citations: ResearchCitation[],
+  routingProfile: Record<string, unknown>,
+) {
+  const metadata = asRecord(task.metadata) ?? {};
+  const taskId = asString(task.id);
+  const agentId = asString(task.assignee_agent_id);
+  const { error: memoryError } = await admin.from("agent_memories").insert({
+    user_id: userId,
+    agent_id: agentId,
+    memory_layer: "knowledge",
+    content: resultText,
+    source: "company_builder_runtime",
+    metadata: {
+      system: "company_builder",
+      company_id: companyId,
+      task_id: taskId,
+      stage: metadata.stage,
+      citations,
+      routing: routingProfile,
+    },
+  });
+  if (memoryError) throw new Error(memoryError.message);
+  await addItem(admin, "wiki_page", userId, {
+    title: `${asString(task.title) || "Company task"} Result`,
+    content: resultText,
+    category: "company_builder",
+    tags: [
+      "ai-company-builder",
+      "runtime-result",
+      asString(metadata.stage) || "general",
+    ],
+    system: "company_builder",
+    company_id: companyId,
+    task_id: taskId,
+    note_type: "runtime_result",
+    citations,
+    routing: routingProfile,
+  });
+}
+
 async function runCompanyRuntimeWorker(
   admin: SupabaseClient,
 ): Promise<Record<string, unknown>> {
@@ -2230,16 +2661,21 @@ async function runCompanyRuntimeWorker(
   const supervisorId = asString(task.supervisor_agent_id);
   const assigneeId = asString(task.assignee_agent_id);
   let success = false;
+  let routingSuccess = false;
   let resultText = "";
   let errorMessage: string | null = null;
   let provider = "";
   let model = "";
   let tier = "";
   let prompt = "";
+  let fallbackReason: string | null = null;
+  let citations: ResearchCitation[] = [];
+  let currentRoutingProfile: Record<string, unknown> | null = null;
+  let routingDecision = selectCompanyRuntimeRouting(task, null);
   const startedAt = performance.now();
 
   try {
-    const [companyResult, agentsResult] = await Promise.all([
+    const [companyResult, agentsResult, routingResult] = await Promise.all([
       admin.from("hub_data").select("id, metadata, created_at")
         .eq("id", message.companyId)
         .eq("source", "company_builder_company")
@@ -2248,41 +2684,75 @@ async function runCompanyRuntimeWorker(
       admin.from("agents").select("*")
         .eq("user_id", message.userId)
         .in("id", [supervisorId, assigneeId]),
+      admin.from("company_runtime_routing_profiles").select("*")
+        .eq("user_id", message.userId)
+        .eq("company_id", message.companyId)
+        .eq("routing_key", routingDecision.routingKey)
+        .maybeSingle(),
     ]);
     if (companyResult.error) throw new Error(companyResult.error.message);
     if (agentsResult.error) throw new Error(agentsResult.error.message);
+    if (routingResult.error) throw new Error(routingResult.error.message);
 
     const agents = (agentsResult.data ?? []) as Record<string, unknown>[];
     const manager = agents.find((agent) => agent.id === supervisorId) ?? null;
     const tool = agents.find((agent) => agent.id === assigneeId) ?? null;
+    currentRoutingProfile = routingResult.data as
+      | Record<string, unknown>
+      | null;
+    routingDecision = selectCompanyRuntimeRouting(task, currentRoutingProfile);
+    citations = await searchCompanyResearch(
+      admin,
+      message.userId,
+      message.companyId,
+      [asString(task.title), asString(task.description)].filter(Boolean).join(
+        "\n",
+      ),
+    );
     prompt = buildCompanyRuntimePrompt(
       companyResult.data as Record<string, unknown>,
       task,
       manager,
       tool,
+      buildResearchCitationContext(citations),
     );
 
     const providerResponse = await invokeAiHubInternal({
       action: "provider.chat_auto",
       internal_user_id: message.userId,
       message: prompt,
-      tier: companyRuntimeRoutingTier(task),
+      tier: routingDecision.tier,
       max_tokens: 1800,
       session_id: message.companyId,
       trace_id: crypto.randomUUID(),
-      routing_use_case: "company_builder.runtime",
-      provider_choice_reason: "durable company task routing",
+      routing_use_case: routingDecision.routingKey,
+      provider_choice_reason: routingDecision.reason,
     });
     resultText = asString(providerResponse.payload.text);
     success = providerResponse.ok &&
       providerResponse.payload.success === true && resultText !== "";
+    routingSuccess = success;
     provider = asString(providerResponse.payload.provider);
     model = asString(providerResponse.payload.model);
     tier = asString(providerResponse.payload.tier);
-    if (!success) {
+    if (success) {
+      resultText = ensureCitationFooter(resultText, citations);
+    } else {
       errorMessage = asString(
         providerResponse.payload.message ?? providerResponse.payload.status,
       ) || `provider.chat_auto returned ${providerResponse.status}`;
+      if (citations.length > 0) {
+        fallbackReason = errorMessage;
+        resultText = buildExtractiveResearchFallback(
+          asString(task.title),
+          citations,
+        );
+        success = true;
+        provider = "extractive";
+        model = "deterministic-citation-fallback";
+        tier = routingDecision.tier;
+        errorMessage = null;
+      }
     }
   } catch (error) {
     errorMessage = error instanceof Error ? error.message : String(error);
@@ -2298,6 +2768,12 @@ async function runCompanyRuntimeWorker(
       estimateTokensFromChars(outputChars),
     )
     : 0;
+  const nextRoutingProfile = nextCompanyRuntimeRoutingProfile(
+    currentRoutingProfile,
+    routingDecision,
+    routingSuccess,
+    tier,
+  );
   const { data: rawFinish, error: finishError } = await admin.rpc(
     "finish_company_agent_task",
     {
@@ -2305,7 +2781,18 @@ async function runCompanyRuntimeWorker(
       p_company_id: message.companyId,
       p_task_id: taskId,
       p_success: success,
-      p_result: success ? { text: resultText, provider, model, tier } : {},
+      p_result: success
+        ? {
+          text: resultText,
+          provider,
+          model,
+          tier,
+          citations,
+          routing: nextRoutingProfile,
+          routing_provider_success: routingSuccess,
+          fallback_reason: fallbackReason,
+        }
+        : {},
       p_error: errorMessage,
       p_metrics: {
         provider,
@@ -2315,13 +2802,71 @@ async function runCompanyRuntimeWorker(
         output_chars: outputChars,
         estimated_cost_usd: estimatedCost,
         duration_ms: durationMs,
+        routing_provider_success: routingSuccess,
       },
     },
   );
   if (finishError) throw new Error(finishError.message);
+  const finish = asRecord(rawFinish) ?? {};
+  const finalTaskStatus = asString(finish.task_status);
+  const taskCancelled = finalTaskStatus === "cancelled";
+
+  let persistedRoutingProfile = nextRoutingProfile;
+  if (!taskCancelled) {
+    try {
+      persistedRoutingProfile = await persistCompanyRoutingOutcome(
+        admin,
+        message.userId,
+        message.companyId,
+        nextRoutingProfile,
+        routingSuccess,
+        provider,
+        model,
+      );
+      await addCompanyEvent(
+        admin,
+        message.userId,
+        message.companyId,
+        "routing_outcome_recorded",
+        routingSuccess ? "completed" : "failed",
+        {
+          task_id: taskId,
+          requested_tier: routingDecision.tier,
+          used_tier: tier,
+          reason: routingDecision.reason,
+          decision: persistedRoutingProfile.last_decision,
+          next_tier: persistedRoutingProfile.current_tier,
+        },
+      );
+    } catch (error) {
+      console.error("company routing profile persistence failed", error);
+    }
+  }
+  if (success && finalTaskStatus === "completed") {
+    try {
+      await consolidateCompanyTaskResult(
+        admin,
+        message.userId,
+        message.companyId,
+        task,
+        resultText,
+        citations,
+        persistedRoutingProfile,
+      );
+    } catch (error) {
+      console.error("company result consolidation failed", error);
+      await addCompanyEvent(
+        admin,
+        message.userId,
+        message.companyId,
+        "memory_consolidation_failed",
+        "failed",
+        { task_id: taskId, error: String(error).slice(0, 500) },
+      ).catch(() => undefined);
+    }
+  }
 
   await archiveCompanyRuntimeMessage(admin, message.msgId);
-  const finish = asRecord(rawFinish) ?? {};
   const shouldContinue = finish.continue === true;
   if (shouldContinue) {
     await enqueueCompanyRuntime(
@@ -2351,6 +2896,290 @@ async function getUserId(req: Request): Promise<string | null> {
   });
   const { data: { user } } = await c.auth.getUser();
   return user?.id ?? null;
+}
+
+function companyA2ARelativePath(req: Request): string | null {
+  const pathname = new URL(req.url).pathname;
+  const match = pathname.match(/\/a2a(?=\/|$)/);
+  if (!match || match.index === undefined) return null;
+  return pathname.slice(match.index + match[0].length) || "/";
+}
+
+async function activateCompanyA2ATaskRuntime(
+  admin: SupabaseClient,
+  userId: string,
+  companyId: string,
+) {
+  const { error: controlError } = await admin.rpc(
+    "set_company_agent_runtime_state",
+    {
+      p_user_id: userId,
+      p_company_id: companyId,
+      p_command: "start",
+    },
+  );
+  if (controlError) throw new Error(controlError.message);
+  await enqueueCompanyRuntime(admin, userId, companyId, "a2a_message");
+  scheduleCompanyRuntimeWorker();
+}
+
+async function createCompanyA2ATask(
+  admin: SupabaseClient,
+  userId: string,
+  value: unknown,
+): Promise<Record<string, unknown>> {
+  const input = parseA2ASendMessage(value);
+  const company = await getOwnedCompany(admin, userId, input.companyId);
+  if (!company) throw new Error("TaskNotFoundError: company not found");
+  const companyMetadata = asRecord(company.metadata) ?? {};
+  if (companyMetadata.passed !== true) {
+    throw new Error("UnsupportedOperationError: company gate is not approved");
+  }
+
+  const { data: existing, error: existingError } = await admin
+    .from("agent_tasks").select("*")
+    .eq("user_id", userId)
+    .eq("task_type", "company_builder_a2a")
+    .filter("metadata->>company_id", "eq", input.companyId)
+    .filter("metadata->>a2a_message_id", "eq", input.messageId)
+    .maybeSingle();
+  if (existingError) throw new Error(existingError.message);
+  if (existing) {
+    if (asString(existing.status) === "queued") {
+      await activateCompanyA2ATaskRuntime(admin, userId, input.companyId);
+    }
+    return existing as Record<string, unknown>;
+  }
+
+  const route = input.skillId === "cited-research"
+    ? { managerKey: "chief", toolKey: "nova", stage: "research" }
+    : input.skillId === "launch-execution"
+    ? { managerKey: "ivy", toolKey: "piper", stage: "growth" }
+    : { managerKey: "chief", toolKey: "sage", stage: "operations" };
+  const [managerResult, toolResult] = await Promise.all([
+    admin.from("agents").select("id").eq("user_id", userId)
+      .filter("metadata->>company_id", "eq", input.companyId)
+      .filter("metadata->>manager_key", "eq", route.managerKey)
+      .maybeSingle(),
+    admin.from("agents").select("id").eq("user_id", userId)
+      .filter("metadata->>system", "eq", "company_builder")
+      .filter("metadata->>shared_pool", "eq", "true")
+      .filter("metadata->>tool_key", "eq", route.toolKey)
+      .maybeSingle(),
+  ]);
+  if (managerResult.error) throw new Error(managerResult.error.message);
+  if (toolResult.error) throw new Error(toolResult.error.message);
+  if (!managerResult.data || !toolResult.data) {
+    throw new Error(
+      "UnsupportedOperationError: company agents are unavailable",
+    );
+  }
+
+  const { data: task, error: taskError } = await admin.from("agent_tasks")
+    .insert({
+      user_id: userId,
+      supervisor_agent_id: managerResult.data.id,
+      assignee_agent_id: toolResult.data.id,
+      title: `${input.skillId}: ${
+        input.text.replace(/\s+/g, " ").slice(0, 120)
+      }`,
+      description: input.text,
+      status: "queued",
+      priority: "normal",
+      task_type: "company_builder_a2a",
+      source: "company_builder_bootstrap",
+      metadata: {
+        system: "company_builder",
+        company_id: input.companyId,
+        company_name: asString(companyMetadata.company_name),
+        manager_key: route.managerKey,
+        tool_key: route.toolKey,
+        stage: route.stage,
+        a2a_message_id: input.messageId,
+        a2a_context_id: input.contextId,
+        a2a_skill_id: input.skillId,
+        a2a_message: input.rawMessage,
+      },
+    }).select("*").single();
+  if (taskError) {
+    if (taskError.code === "23505") {
+      const { data: duplicate, error: duplicateError } = await admin
+        .from("agent_tasks").select("*")
+        .eq("user_id", userId)
+        .eq("task_type", "company_builder_a2a")
+        .filter("metadata->>company_id", "eq", input.companyId)
+        .filter("metadata->>a2a_message_id", "eq", input.messageId)
+        .single();
+      if (duplicateError) throw new Error(duplicateError.message);
+      if (asString(duplicate.status) === "queued") {
+        await activateCompanyA2ATaskRuntime(admin, userId, input.companyId);
+      }
+      return duplicate as Record<string, unknown>;
+    }
+    throw new Error(taskError.message);
+  }
+
+  await activateCompanyA2ATaskRuntime(admin, userId, input.companyId);
+  await addCompanyEvent(
+    admin,
+    userId,
+    input.companyId,
+    "a2a_task_submitted",
+    "queued",
+    { task_id: task.id, message_id: input.messageId, skill_id: input.skillId },
+  );
+  return task as Record<string, unknown>;
+}
+
+async function handleCompanyA2ARequest(
+  req: Request,
+  body: Record<string, unknown>,
+  admin: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  try {
+    assertA2AVersion(req);
+  } catch (error) {
+    return a2aJson({
+      error: { code: "VersionNotSupportedError", message: String(error) },
+    }, 400);
+  }
+  const relative = companyA2ARelativePath(req) ?? "/";
+
+  try {
+    if (req.method === "POST" && relative === "/message:send") {
+      const task = await createCompanyA2ATask(admin, userId, body);
+      return a2aJson({ task: companyTaskToA2A(task) }, 202);
+    }
+
+    if (req.method === "GET" && relative === "/tasks") {
+      const url = new URL(req.url);
+      const requestedPageSize = Number(url.searchParams.get("pageSize"));
+      const pageSize = Math.max(
+        1,
+        Math.min(
+          Number.isFinite(requestedPageSize) && requestedPageSize > 0
+            ? Math.trunc(requestedPageSize)
+            : 50,
+          100,
+        ),
+      );
+      const includeArtifacts =
+        url.searchParams.get("includeArtifacts") === "true";
+      const cursor = decodeA2APageToken(url.searchParams.get("pageToken"));
+      if (url.searchParams.has("pageToken") && !cursor) {
+        return a2aJson({
+          error: { code: "InvalidArgumentError", message: "Invalid pageToken" },
+        }, 400);
+      }
+      let query = admin.from("agent_tasks").select("*")
+        .eq("user_id", userId).eq("task_type", "company_builder_a2a")
+        .order("updated_at", { ascending: false })
+        .order("id", { ascending: false }).limit(pageSize + 1);
+      const contextId = asString(url.searchParams.get("contextId"));
+      if (contextId.length > 200) {
+        return a2aJson({
+          error: {
+            code: "InvalidArgumentError",
+            message: "contextId exceeds 200 characters",
+          },
+        }, 400);
+      }
+      if (contextId) {
+        query = query.filter("metadata->>a2a_context_id", "eq", contextId);
+      }
+      if (cursor) {
+        query = query.or(
+          `updated_at.lt.${cursor.updatedAt},and(updated_at.eq.${cursor.updatedAt},id.lt.${cursor.id})`,
+        );
+      }
+      const { data, error } = await query;
+      if (error) throw new Error(error.message);
+      const rows = (data ?? []) as Record<string, unknown>[];
+      const hasNext = rows.length > pageSize;
+      const page = rows.slice(0, pageSize);
+      return a2aJson({
+        tasks: page.map((task) => companyTaskToA2A(task, includeArtifacts)),
+        nextPageToken: hasNext && page.length > 0
+          ? encodeA2APageToken(page[page.length - 1])
+          : "",
+      });
+    }
+
+    const cancelMatch = relative.match(/^\/tasks\/([0-9a-f-]{36}):cancel$/i);
+    if (req.method === "POST" && cancelMatch) {
+      const { data: current, error: currentError } = await admin.from(
+        "agent_tasks",
+      )
+        .select("*").eq("id", cancelMatch[1]).eq("user_id", userId)
+        .eq("task_type", "company_builder_a2a").maybeSingle();
+      if (currentError) throw new Error(currentError.message);
+      if (!current) {
+        return a2aJson({
+          error: { code: "TaskNotFoundError", message: "Task not found" },
+        }, 404);
+      }
+      if (
+        ["completed", "failed", "cancelled"].includes(asString(current.status))
+      ) {
+        return a2aJson({
+          error: {
+            code: "TaskNotCancelableError",
+            message: "Task is already terminal",
+          },
+        }, 409);
+      }
+      const { data: cancelled, error: cancelError } = await admin.from(
+        "agent_tasks",
+      )
+        .update({ status: "cancelled", last_error: "Cancelled through A2A" })
+        .eq("id", cancelMatch[1]).eq("user_id", userId)
+        .eq("task_type", "company_builder_a2a").select("*").single();
+      if (cancelError) throw new Error(cancelError.message);
+      const metadata = asRecord(cancelled.metadata) ?? {};
+      await addCompanyEvent(
+        admin,
+        userId,
+        asString(metadata.company_id),
+        "a2a_task_cancelled",
+        "cancelled",
+        { task_id: cancelled.id },
+      );
+      return a2aJson({ task: companyTaskToA2A(cancelled) });
+    }
+
+    const getMatch = relative.match(/^\/tasks\/([0-9a-f-]{36})$/i);
+    if (req.method === "GET" && getMatch) {
+      const { data, error } = await admin.from("agent_tasks").select("*")
+        .eq("id", getMatch[1]).eq("user_id", userId)
+        .eq("task_type", "company_builder_a2a").maybeSingle();
+      if (error) throw new Error(error.message);
+      if (!data) {
+        return a2aJson({
+          error: { code: "TaskNotFoundError", message: "Task not found" },
+        }, 404);
+      }
+      return a2aJson({
+        task: companyTaskToA2A(data as Record<string, unknown>),
+      });
+    }
+
+    return a2aJson({
+      error: {
+        code: "UnsupportedOperationError",
+        message: "A2A operation is not supported",
+      },
+    }, 404);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const code = message.split(":", 1)[0];
+    const status = code === "TaskNotFoundError"
+      ? 404
+      : code === "UnsupportedOperationError"
+      ? 409
+      : 400;
+    return a2aJson({ error: { code, message } }, status);
+  }
 }
 
 async function evaluateUniversityQuizMaster(
@@ -3322,14 +4151,45 @@ serve(async (req: Request) => {
   }
 
   try {
+    const requestUrl = new URL(req.url);
+    if (
+      req.method === "GET" &&
+      requestUrl.pathname.endsWith("/.well-known/agent-card.json")
+    ) {
+      return a2aJson(
+        buildCompanyAgentCard(`${SUPABASE_URL}/functions/v1/ai-hub`),
+        200,
+        { "Cache-Control": "public, max-age=3600" },
+      );
+    }
     const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+    const userId = await getUserId(req);
+    const a2aPath = companyA2ARelativePath(req);
+    if (a2aPath !== null) {
+      if (!userId) {
+        return a2aJson(
+          {
+            error: {
+              code: "UnauthenticatedError",
+              message: "Bearer authentication is required",
+            },
+          },
+          401,
+          { "WWW-Authenticate": 'Bearer realm="ai-company-builder"' },
+        );
+      }
+      const body = req.method === "POST"
+        ? await req.json() as Record<string, unknown>
+        : {};
+      return await handleCompanyA2ARequest(req, body, admin, userId);
+    }
+
     const body = req.method === "POST"
       ? await req.json() as Record<string, unknown>
       : {};
     const action = String(
-      body.action ?? new URL(req.url).searchParams.get("action") ?? "",
+      body.action ?? requestUrl.searchParams.get("action") ?? "",
     );
-    const userId = await getUserId(req);
 
     // Actions that require authentication
     const authRequired = [
@@ -3350,6 +4210,7 @@ serve(async (req: Request) => {
       "company_builder.list",
       "company_builder.get",
       "company_builder.bootstrap",
+      "company_builder.research.add",
       "company_builder.start",
       "company_builder.pause",
       "company_builder.resume",
@@ -4023,6 +4884,38 @@ serve(async (req: Request) => {
         const detail = await getCompanyBuilderDetail(admin, userId!, companyId);
         if (!detail) return json({ error: "Company not found" }, 404);
         return json({ success: true, ...detail });
+      }
+
+      case "company_builder.research.add": {
+        const companyId = asString(body.company_id);
+        const sourceUrl = asString(body.source_url ?? body.url);
+        if (!companyId) return json({ error: "company_id required" }, 400);
+        if (!sourceUrl) return json({ error: "source_url required" }, 400);
+        try {
+          const source = await ingestCompanyResearchSource(
+            admin,
+            userId!,
+            companyId,
+            sourceUrl,
+          );
+          return json({ success: true, source });
+        } catch (error) {
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          const status = message === "Company not found"
+            ? 404
+            : message.toLowerCase().includes("private") ||
+                message.toLowerCase().includes("source url") ||
+                message.toLowerCase().includes("unsupported")
+            ? 400
+            : 422;
+          return json({
+            success: false,
+            status: "research_ingestion_failed",
+            message,
+          }, status);
+        }
       }
 
       case "company_builder.bootstrap": {

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1,7 +1,13 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@b-fuze/deno-dom@0.1.56": "0.1.56",
     "npm:@supabase/supabase-js@2": "2.105.1"
+  },
+  "jsr": {
+    "@b-fuze/deno-dom@0.1.56": {
+      "integrity": "8030e2dc1d8750f1682b53462ab893d9c3470f2287feecbe22f44a88c54ab148"
+    }
   },
   "npm": {
     "@supabase/auth-js@2.105.1": {

--- a/supabase/migrations/20260815202000_company_research_a2a_routing.sql
+++ b/supabase/migrations/20260815202000_company_research_a2a_routing.sql
@@ -1,0 +1,313 @@
+-- Company-scoped research corpus and adaptive model routing for AI Company Builder.
+
+create extension if not exists vector;
+
+create table if not exists public.company_research_sources (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  company_id uuid not null references public.hub_data(id) on delete cascade,
+  source_url text not null check (
+    char_length(source_url) between 1 and 2048
+  ),
+  canonical_url text not null check (
+    char_length(canonical_url) between 1 and 1500
+  ),
+  title text not null default '' check (char_length(title) <= 500),
+  content_markdown text not null default '' check (
+    char_length(content_markdown) <= 1000000
+  ),
+  excerpt text not null default '' check (char_length(excerpt) <= 1200),
+  content_hash text not null default '' check (char_length(content_hash) <= 128),
+  status text not null default 'processing' check (
+    status in ('processing', 'ready', 'failed')
+  ),
+  http_status integer check (
+    http_status is null or http_status between 100 and 599
+  ),
+  content_type text check (content_type is null or char_length(content_type) <= 200),
+  last_error text check (last_error is null or char_length(last_error) <= 1000),
+  metadata jsonb not null default '{}'::jsonb,
+  fetched_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, company_id, canonical_url),
+  unique (id, user_id, company_id)
+);
+
+create table if not exists public.company_research_chunks (
+  id uuid primary key default gen_random_uuid(),
+  source_id uuid not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  company_id uuid not null references public.hub_data(id) on delete cascade,
+  chunk_index integer not null check (chunk_index between 0 and 9999),
+  heading text not null default '' check (char_length(heading) <= 500),
+  location text not null default '' check (char_length(location) <= 500),
+  content text not null check (char_length(content) between 1 and 12000),
+  embedding vector(768),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  search_vector tsvector generated always as (
+    setweight(to_tsvector('simple', coalesce(heading, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(location, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(content, '')), 'C')
+  ) stored,
+  unique (source_id, chunk_index),
+  foreign key (source_id, user_id, company_id)
+    references public.company_research_sources(id, user_id, company_id)
+    on delete cascade
+);
+
+create table if not exists public.company_runtime_routing_profiles (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  company_id uuid not null references public.hub_data(id) on delete cascade,
+  routing_key text not null check (char_length(routing_key) between 1 and 120),
+  base_tier text not null default 'free' check (
+    base_tier in ('free', 'budget', 'performance', 'premium')
+  ),
+  current_tier text not null default 'free' check (
+    current_tier in ('free', 'budget', 'performance', 'premium')
+  ),
+  consecutive_successes integer not null default 0 check (
+    consecutive_successes between 0 and 1000000
+  ),
+  consecutive_failures integer not null default 0 check (
+    consecutive_failures between 0 and 1000000
+  ),
+  escalation_count integer not null default 0 check (escalation_count >= 0),
+  downgrade_count integer not null default 0 check (downgrade_count >= 0),
+  last_provider text,
+  last_model text,
+  last_decision text,
+  last_success_at timestamptz,
+  last_failure_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, company_id, routing_key)
+);
+
+create index if not exists company_research_sources_owner_status_idx
+  on public.company_research_sources (user_id, company_id, status, updated_at desc);
+
+create index if not exists company_research_sources_company_fk_idx
+  on public.company_research_sources (company_id);
+
+create index if not exists company_research_chunks_owner_idx
+  on public.company_research_chunks (user_id, company_id, updated_at desc);
+
+create index if not exists company_research_chunks_source_fk_idx
+  on public.company_research_chunks (source_id, chunk_index);
+
+create index if not exists company_research_chunks_search_idx
+  on public.company_research_chunks using gin (search_vector);
+
+create index if not exists company_research_chunks_embedding_idx
+  on public.company_research_chunks
+  using ivfflat (embedding vector_cosine_ops)
+  with (lists = 100)
+  where embedding is not null;
+
+create index if not exists company_runtime_routing_profiles_company_idx
+  on public.company_runtime_routing_profiles (company_id, updated_at desc);
+
+create unique index if not exists agent_tasks_company_a2a_message_uidx
+  on public.agent_tasks (
+    user_id,
+    task_type,
+    (metadata ->> 'company_id'),
+    (metadata ->> 'a2a_message_id')
+  )
+  where task_type = 'company_builder_a2a'
+    and metadata ->> 'company_id' is not null
+    and metadata ->> 'a2a_message_id' is not null;
+
+drop trigger if exists trg_company_research_sources_updated_at
+  on public.company_research_sources;
+create trigger trg_company_research_sources_updated_at
+  before update on public.company_research_sources
+  for each row execute function public.set_agent_org_updated_at();
+
+drop trigger if exists trg_company_research_chunks_updated_at
+  on public.company_research_chunks;
+create trigger trg_company_research_chunks_updated_at
+  before update on public.company_research_chunks
+  for each row execute function public.set_agent_org_updated_at();
+
+drop trigger if exists trg_company_runtime_routing_profiles_updated_at
+  on public.company_runtime_routing_profiles;
+create trigger trg_company_runtime_routing_profiles_updated_at
+  before update on public.company_runtime_routing_profiles
+  for each row execute function public.set_agent_org_updated_at();
+
+alter table public.company_research_sources enable row level security;
+alter table public.company_research_chunks enable row level security;
+alter table public.company_runtime_routing_profiles enable row level security;
+
+drop policy if exists company_research_sources_select_own
+  on public.company_research_sources;
+create policy company_research_sources_select_own
+  on public.company_research_sources
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists company_research_chunks_select_own
+  on public.company_research_chunks;
+create policy company_research_chunks_select_own
+  on public.company_research_chunks
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists company_runtime_routing_profiles_select_own
+  on public.company_runtime_routing_profiles;
+create policy company_runtime_routing_profiles_select_own
+  on public.company_runtime_routing_profiles
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+revoke all on public.company_research_sources from public, anon, authenticated;
+revoke all on public.company_research_chunks from public, anon, authenticated;
+revoke all on public.company_runtime_routing_profiles from public, anon, authenticated;
+grant select on public.company_research_sources to authenticated;
+grant select on public.company_research_chunks to authenticated;
+grant select on public.company_runtime_routing_profiles to authenticated;
+grant all on public.company_research_sources to service_role;
+grant all on public.company_research_chunks to service_role;
+grant all on public.company_runtime_routing_profiles to service_role;
+
+do $migration$
+declare
+  vector_schema text;
+begin
+  select namespace.nspname
+    into vector_schema
+  from pg_catalog.pg_extension as extension
+  join pg_catalog.pg_namespace as namespace
+    on namespace.oid = extension.extnamespace
+  where extension.extname = 'vector';
+
+  if vector_schema is null then
+    raise exception 'vector extension schema was not found';
+  end if;
+
+  execute format($function$
+    create or replace function public.company_vector_cosine_similarity(
+      p_left text,
+      p_right text
+    )
+    returns double precision
+    language sql
+    immutable
+    strict
+    parallel safe
+    set search_path = ''
+    as $body$
+      select greatest(
+        0::double precision,
+        1 - (
+          p_left::%1$I.vector operator(%1$I.<=>) p_right::%1$I.vector
+        )
+      );
+    $body$;
+  $function$, vector_schema);
+end;
+$migration$;
+
+revoke execute on function public.company_vector_cosine_similarity(text, text)
+  from public, anon, authenticated, service_role;
+
+create or replace function public.match_company_research_chunks(
+  p_user_id uuid,
+  p_company_id uuid,
+  p_query_text text default '',
+  p_query_embedding vector(768) default null,
+  p_match_count integer default 8,
+  p_match_threshold double precision default 0.05
+)
+returns table (
+  chunk_id uuid,
+  source_id uuid,
+  source_url text,
+  title text,
+  heading text,
+  location text,
+  content text,
+  fetched_at timestamptz,
+  lexical_score double precision,
+  vector_score double precision,
+  score double precision
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with query_input as (
+    select websearch_to_tsquery(
+      'simple',
+      left(coalesce(nullif(trim(p_query_text), ''), '__empty_query__'), 1000)
+    ) as query
+  ), ranked as (
+    select
+      chunk.id as chunk_id,
+      chunk.source_id,
+      source.source_url,
+      source.title,
+      chunk.heading,
+      chunk.location,
+      chunk.content,
+      source.fetched_at,
+      case
+        when chunk.search_vector @@ query_input.query
+          then ts_rank_cd(chunk.search_vector, query_input.query)::double precision
+        else 0::double precision
+      end as lexical_score,
+      case
+        when p_query_embedding is not null and chunk.embedding is not null
+          then public.company_vector_cosine_similarity(
+            chunk.embedding::text,
+            p_query_embedding::text
+          )
+        else 0::double precision
+      end as vector_score
+    from public.company_research_chunks as chunk
+    join public.company_research_sources as source
+      on source.id = chunk.source_id
+      and source.user_id = chunk.user_id
+      and source.company_id = chunk.company_id
+    cross join query_input
+    where chunk.user_id = p_user_id
+      and chunk.company_id = p_company_id
+      and source.status = 'ready'
+  )
+  select
+    ranked.chunk_id,
+    ranked.source_id,
+    ranked.source_url,
+    ranked.title,
+    ranked.heading,
+    ranked.location,
+    ranked.content,
+    ranked.fetched_at,
+    ranked.lexical_score,
+    ranked.vector_score,
+    (ranked.lexical_score * 0.45 + ranked.vector_score * 0.55) as score
+  from ranked
+  where ranked.lexical_score > 0
+    or ranked.vector_score >= greatest(0, least(coalesce(p_match_threshold, 0.05), 1))
+  order by score desc, ranked.fetched_at desc nulls last, ranked.chunk_id
+  limit greatest(1, least(coalesce(p_match_count, 8), 30));
+$$;
+
+revoke execute on function public.match_company_research_chunks(
+  uuid, uuid, text, vector, integer, double precision
+) from public, anon, authenticated;
+grant execute on function public.match_company_research_chunks(
+  uuid, uuid, text, vector, integer, double precision
+) to service_role;
+
+comment on table public.company_research_sources is
+  'Owner-scoped external sources ingested by AI Company Builder';
+comment on table public.company_research_chunks is
+  'Citation-addressable text chunks with full-text and pgvector indexes';
+comment on table public.company_runtime_routing_profiles is
+  'Persisted success/failure feedback for adaptive company model tiers';

--- a/test/pages/ai_company_builder_page_test.dart
+++ b/test/pages/ai_company_builder_page_test.dart
@@ -5,6 +5,7 @@ import 'package:my_web_app/services/ai_company_builder_service.dart';
 
 class _FakeCompanyBuilderService extends AiCompanyBuilderService {
   final List<String> commands = <String>[];
+  final List<String> researchUrls = <String>[];
 
   @override
   bool get isSignedIn => true;
@@ -67,6 +68,24 @@ class _FakeCompanyBuilderService extends AiCompanyBuilderService {
           'kill_switch': false,
         },
         'runtime_master_control': {'kill_switch': false},
+        'research_sources': [
+          {
+            'id': 'source-1',
+            'title': 'Pricing evidence',
+            'source_url': 'https://example.com/pricing',
+            'excerpt': 'The pro plan costs twenty dollars.',
+            'status': 'ready',
+          },
+        ],
+        'routing_profiles': [
+          {
+            'routing_key': 'company_builder.finance',
+            'current_tier': 'budget',
+            'last_decision': 'downgraded_after_5_successes',
+          },
+        ],
+        'a2a_agent_card_url':
+            'https://example.com/functions/v1/ai-hub/.well-known/agent-card.json',
       };
 
   @override
@@ -75,6 +94,15 @@ class _FakeCompanyBuilderService extends AiCompanyBuilderService {
     required String command,
   }) async {
     commands.add(command);
+    return {'success': true};
+  }
+
+  @override
+  Future<Map<String, dynamic>> addResearchSource({
+    required String companyId,
+    required String sourceUrl,
+  }) async {
+    researchUrls.add(sourceUrl);
     return {'success': true};
   }
 
@@ -125,6 +153,35 @@ void main() {
 
     expect(find.text('Company Instances'), findsOneWidget);
     expect(find.text('Signal School'), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('adds a cited research source and exposes the A2A card', (
+    tester,
+  ) async {
+    final service = _FakeCompanyBuilderService();
+    await _pumpPage(tester, service, const Size(390, 844));
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('company-research-source-url')),
+      600,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.enterText(
+      find.byKey(const Key('company-research-source-url')),
+      'https://docs.example.com/market',
+    );
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('company-research-add')),
+      120,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.byKey(const Key('company-research-add')));
+    await tester.pumpAndSettle();
+
+    expect(service.researchUrls, ['https://docs.example.com/market']);
+    expect(find.text('Pricing evidence'), findsOneWidget);
+    expect(find.byKey(const Key('company-a2a-agent-card-url')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/services/ai_company_builder_controller_test.dart
+++ b/test/services/ai_company_builder_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:my_web_app/services/ai_company_builder_service.dart';
 
 class _FakeCompanyBuilderService extends AiCompanyBuilderService {
   final List<String> commands = <String>[];
+  final List<String> researchUrls = <String>[];
   bool globalKillEnabled = false;
   bool latestPassed = true;
   void Function()? onChange;
@@ -15,10 +16,7 @@ class _FakeCompanyBuilderService extends AiCompanyBuilderService {
   Future<List<Map<String, dynamic>>> listCompanies() async => [
         {
           'id': 'company-1',
-          'metadata': {
-            'company_name': 'Signal School',
-            'passed': latestPassed,
-          },
+          'metadata': {'company_name': 'Signal School', 'passed': latestPassed},
         },
       ];
 
@@ -57,6 +55,15 @@ class _FakeCompanyBuilderService extends AiCompanyBuilderService {
   }
 
   @override
+  Future<Map<String, dynamic>> addResearchSource({
+    required String companyId,
+    required String sourceUrl,
+  }) async {
+    researchUrls.add(sourceUrl);
+    return {'success': true};
+  }
+
+  @override
   void subscribe(String companyId, void Function() onChange) {
     this.onChange = onChange;
   }
@@ -84,10 +91,7 @@ Map<String, dynamic> _companyDetail({
     'vault_notes': <Map<String, dynamic>>[],
     'audit_entries': <Map<String, dynamic>>[],
     'runtime_events': <Map<String, dynamic>>[],
-    'runtime_control': {
-      'state': state,
-      'kill_switch': false,
-    },
+    'runtime_control': {'state': state, 'kill_switch': false},
     'runtime_master_control': {'kill_switch': false},
   };
 }
@@ -98,21 +102,26 @@ Map<String, dynamic> _childMap(Map<String, dynamic>? source, String key) {
 }
 
 void main() {
-  test('loads a company and routes runtime commands through the service',
-      () async {
-    final service = _FakeCompanyBuilderService();
-    final controller = AiCompanyBuilderController(service: service);
+  test(
+    'loads a company and routes runtime commands through the service',
+    () async {
+      final service = _FakeCompanyBuilderService();
+      final controller = AiCompanyBuilderController(service: service);
 
-    await controller.loadCompanies();
-    expect(controller.selectedCompanyId, 'company-1');
-    expect(_childMap(controller.detail, 'runtime_control')['state'], 'idle');
+      await controller.loadCompanies();
+      expect(controller.selectedCompanyId, 'company-1');
+      expect(_childMap(controller.detail, 'runtime_control')['state'], 'idle');
 
-    await controller.runCommand('start');
-    expect(service.commands, ['start']);
-    expect(_childMap(controller.detail, 'runtime_control')['state'], 'running');
+      await controller.runCommand('start');
+      expect(service.commands, ['start']);
+      expect(
+        _childMap(controller.detail, 'runtime_control')['state'],
+        'running',
+      );
 
-    controller.dispose();
-  });
+      controller.dispose();
+    },
+  );
 
   test('keeps a gate rejection as a visible blocked company', () async {
     final service = _FakeCompanyBuilderService();
@@ -128,6 +137,24 @@ void main() {
     expect(_childMap(company, 'metadata')['passed'], isFalse);
     expect(_childMap(controller.detail, 'runtime_control')['state'], 'blocked');
     expect(controller.errorMessage, isNull);
+
+    controller.dispose();
+  });
+
+  test('validates and ingests a company research source', () async {
+    final service = _FakeCompanyBuilderService();
+    final controller = AiCompanyBuilderController(service: service);
+    await controller.loadCompanies();
+
+    expect(await controller.addResearchSource('file:///private'), isFalse);
+    expect(controller.errorMessage, contains('HTTP or HTTPS'));
+    expect(await controller.addResearchSource('https:missing-host'), isFalse);
+    expect(
+      await controller.addResearchSource('https://example.com/research'),
+      isTrue,
+    );
+    expect(service.researchUrls, ['https://example.com/research']);
+    expect(controller.isResearchBusy, isFalse);
 
     controller.dispose();
   });

--- a/test/services/ai_company_builder_runtime_schema_test.dart
+++ b/test/services/ai_company_builder_runtime_schema_test.dart
@@ -85,5 +85,14 @@ void main() {
         expect(aiHub, contains(action));
       }
     });
+
+    test('exposes cited research and the A2A 1.0 HTTP surface', () {
+      expect(aiHub, contains('company_builder.research.add'));
+      expect(aiHub, contains('/.well-known/agent-card.json'));
+      expect(aiHub, contains('/message:send'));
+      expect(aiHub, contains('relative === "/tasks"'));
+      expect(aiHub, contains(':cancel'));
+      expect(aiHub, contains('"WWW-Authenticate"'));
+    });
   });
 }

--- a/test/services/company_research_a2a_schema_test.dart
+++ b/test/services/company_research_a2a_schema_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260815202000_company_research_a2a_routing.sql';
+
+void main() {
+  group('AI Company Builder research and routing schema', () {
+    late String sql;
+
+    setUpAll(() {
+      sql = File(_migrationPath).readAsStringSync().toLowerCase();
+    });
+
+    test('isolates source, chunk, and routing rows by owner and company', () {
+      expect(
+        sql,
+        contains('create table if not exists public.company_research_sources'),
+      );
+      expect(
+        sql,
+        contains('create table if not exists public.company_research_chunks'),
+      );
+      expect(
+        sql,
+        contains(
+          'create table if not exists public.company_runtime_routing_profiles',
+        ),
+      );
+      expect(sql, contains('using ((select auth.uid()) = user_id)'));
+      expect(sql, contains('foreign key (source_id, user_id, company_id)'));
+    });
+
+    test('keeps writes and hybrid matching service-role only', () {
+      expect(
+        sql,
+        contains(
+          'revoke all on public.company_research_sources from public, anon, authenticated',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'revoke execute on function public.match_company_research_chunks',
+        ),
+      );
+      expect(sql, contains('to service_role'));
+      expect(sql, contains('security definer'));
+      expect(sql, contains("set search_path = ''"));
+    });
+
+    test('combines full-text and pgvector scores with supporting indexes', () {
+      expect(sql, contains('embedding vector(768)'));
+      expect(sql, contains('search_vector tsvector generated always'));
+      expect(sql, contains('using gin (search_vector)'));
+      expect(sql, contains('using ivfflat (embedding vector_cosine_ops)'));
+      expect(sql, contains('ranked.lexical_score * 0.45'));
+      expect(sql, contains('ranked.vector_score * 0.55'));
+      expect(sql, contains('company_vector_cosine_similarity'));
+      expect(sql, contains("where extension.extname = 'vector'"));
+      expect(sql, contains(r'operator(%1$i.<=>)'));
+    });
+
+    test('deduplicates concurrent A2A submissions by owner and message', () {
+      expect(sql, contains('agent_tasks_company_a2a_message_uidx'));
+      expect(sql, contains("where task_type = 'company_builder_a2a'"));
+      expect(sql, contains("(metadata ->> 'company_id')"));
+      expect(sql, contains("(metadata ->> 'a2a_message_id')"));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Ingest owner-scoped public web sources as structured text, chunks, embeddings, and stable citations.
- Ground durable AI Company Builder tasks in those sources, append deterministic source footers, and preserve an extractive fallback when model providers fail.
- Persist adaptive free/budget/performance/premium routing outcomes, escalating failures and retries while downgrading sustained success without crossing legal/gate floors.
- Expose the existing durable company queue through an authenticated A2A 1.0 HTTP+JSON Agent Card and task lifecycle API.
- Surface research sources, routing profiles, and the Agent Card URL in the responsive Flutter workspace.

Closes #1377
Closes #2786
Closes #2787

Source design references:
- https://dev.to/pavelbuild/im-building-a-platform-that-deploys-ai-companies-from-a-single-sentence-32aj
- https://a2a-protocol.org/dev/specification/

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Authenticated production company state is not available to CI or local browser automation; cover the visible add-source flow with Flutter widget tests, API authentication/error paths with HTTP smoke, and the complete owner-isolated data path with Postgres 17 integration smoke before and after deployment.

The three black-box cases are:
1. Add a valid public source and display its ready citation record plus the A2A card URL.
2. Reject invalid/private-network URLs and unauthenticated A2A/research requests without exposing owner data.
3. Complete a cited task through deterministic evidence fallback when the provider fails, while recording that provider failure for tier escalation.

## Visual E2E Evidence

- Changed route: `/ai-company-builder`.
- Mobile and desktop layout stability is covered by widget tests at 390x844 and 1280x900.
- Codex in-app browser verification is currently blocked before navigation by the local control runtime error `failed to write kernel assets: path not found`; no standalone Playwright fallback was used.
- Post-merge production checks will cover route HTTP 200, public Agent Card content, auth rejection paths, and deployed commit identity.
- No generated image was used.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 is not callable from this Codex-owned task; Codex completed a repository-grounded security, rollback, observability, cancellation, retry, and owner-isolation review with deterministic tests before requesting merge.
- Security: URL credentials, unsafe ports, private IPv4/IPv6, mapped IPv6, DNS-to-private resolution, redirects, content types, response size, and timeouts are rejected. Research writes and matching stay service-role only; reads use owner RLS. A2A operations authenticate Supabase JWTs and scope every task to the authenticated owner.
- Rollback: revert the Edge/Flutter commit to disable the feature. The migration is additive and backward-compatible; tables can remain inert during rollback and be dropped only after confirming no retained research or routing data is needed.
- Observability: source ready/failed events, routing decisions, provider/model/tier outcomes, fallback reasons, A2A task events, last errors, and durable task status are persisted.
- Unresolved findings: none.

## Implementation

- `company_research_sources` and `company_research_chunks` provide owner/company isolation, full-text ranking, pgvector similarity, and citation locations.
- `company_runtime_routing_profiles` records success/failure streaks and model-tier changes.
- The vector operator schema is discovered at migration time so both `public` and `extensions` Supabase layouts work while security-definer functions keep `search_path = ''`.
- The public Agent Card advertises A2A 1.0 HTTP+JSON and bearer auth. Authenticated endpoints implement `POST /message:send`, `GET /tasks`, `GET /tasks/{id}`, and `POST /tasks/{id}:cancel`.
- A2A message IDs are database-unique per owner/company, queued retries self-recover runtime activation, cursor inputs are strictly validated, and canceled tasks do not publish artifacts or memory.
- Research embedding is bounded to 60 chunks per source; all retained chunks remain searchable lexically.

## Validation

- [x] `flutter analyze` on 7 changed Dart/test files: no issues.
- [x] Flutter targeted suite: 16 passed.
- [x] `deno lint` on 7 changed Edge files: passed.
- [x] `deno check --node-modules-dir=auto ... ai-hub/index.ts`: passed.
- [x] Deno runtime/research/A2A suite: 16 passed.
- [x] `deno fmt --check`: passed.
- [x] Pre-commit import and migration timestamp gates: passed.
- [x] Supabase Postgres `17.6.1.157-mmlb` migration/RLS/RPC smoke: `DB_SMOKE_OK`.
- [x] Vector schema portability and helper privilege smoke: `VECTOR_SCHEMA_SMOKE_OK`.
- [x] `git diff --cached --check`: passed.

## Deployment

- Database migration required: `20260815202000_company_research_a2a_routing.sql`.
- No new environment variable is required; embeddings use the existing `GEMINI_API_KEY` when available and fall back to lexical retrieval when unavailable.
- Production deployment uses the existing `deploy-prod.yml` ordering: migrations, Edge Functions, then Flutter/Firebase.
- Production smoke after merge: `version.json` commit, `/ai-company-builder` HTTP 200, Agent Card 200 with `application/a2a+json` and protocol `1.0`, unauthenticated A2A 401 with `WWW-Authenticate`, and unauthenticated research action rejection.

## Coordination

- Subagents used: none.
- Implementation owner: Codex #1.
- Breaking changes: none.
