### PR TITLE
db: add six-department KPI routing (#2480)

### DIFF
--- a/supabase/migrations/20260816040645_create_department_kpi_links.sql
+++ b/supabase/migrations/20260816040645_create_department_kpi_links.sql
@@ -1,0 +1,98 @@
+-- Issue #2480: route each of the six department views to an allowlisted KPI
+-- provider. kpi_query stores an ai-hub action identifier, never executable SQL.
+
+begin;
+
+create table if not exists public.department_kpi_links (
+  id uuid primary key default gen_random_uuid(),
+  department text not null unique,
+  feature_module text,
+  kpi_query text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint department_kpi_links_department_valid
+    check (
+      department in (
+        'accounting',
+        'hr',
+        'marketing',
+        'sales',
+        'development',
+        'legal'
+      )
+    ),
+  constraint department_kpi_links_feature_module_not_blank
+    check (feature_module is null or length(btrim(feature_module)) > 0),
+  constraint department_kpi_links_kpi_query_allowlisted_shape
+    check (
+      kpi_query is null
+      or kpi_query ~ '^ai_hub\.[a-z][a-z0-9_]*$'
+    ),
+  constraint department_kpi_links_target_pair
+    check ((feature_module is null) = (kpi_query is null))
+);
+
+comment on table public.department_kpi_links is
+  'Read-only routing from six department views to allowlisted KPI providers.';
+comment on column public.department_kpi_links.kpi_query is
+  'Allowlisted ai-hub action identifier. This value must never be executed as SQL.';
+
+alter table public.department_kpi_links enable row level security;
+
+-- RLS does not restrict TRUNCATE, REFERENCES, or TRIGGER. Remove inherited
+-- table privileges, then grant only the read path required by signed-in views.
+revoke all privileges on table public.department_kpi_links
+from public, anon, authenticated;
+
+grant all privileges on table public.department_kpi_links to service_role;
+grant select on table public.department_kpi_links to authenticated;
+
+drop policy if exists department_kpi_links_authenticated_read
+  on public.department_kpi_links;
+create policy department_kpi_links_authenticated_read
+  on public.department_kpi_links
+  for select
+  to authenticated
+  using ((select auth.uid()) is not null);
+
+create or replace function public.set_department_kpi_links_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists department_kpi_links_updated_at
+  on public.department_kpi_links;
+create trigger department_kpi_links_updated_at
+before update on public.department_kpi_links
+for each row execute function public.set_department_kpi_links_updated_at();
+
+insert into public.department_kpi_links (
+  department,
+  feature_module,
+  kpi_query
+) values
+  (
+    'accounting',
+    'asset_management',
+    'ai_hub.department_finance_summary'
+  ),
+  ('hr', null, null),
+  ('marketing', null, null),
+  ('sales', null, null),
+  ('development', null, null),
+  ('legal', null, null)
+on conflict (department) do update set
+  feature_module = excluded.feature_module,
+  kpi_query = excluded.kpi_query,
+  updated_at = now()
+where public.department_kpi_links.feature_module
+        is distinct from excluded.feature_module
+   or public.department_kpi_links.kpi_query
+        is distinct from excluded.kpi_query;
+
+commit;

--- a/test/services/department_kpi_links_schema_test.dart
+++ b/test/services/department_kpi_links_schema_test.dart
@@ -1,0 +1,175 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260816040645_create_department_kpi_links.sql';
+
+void main() {
+  group('department KPI links schema migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(_migrationPath).readAsStringSync().replaceAll('\r\n', '\n');
+    });
+
+    test('defines a single routing row per department', () {
+      final block = _createTableBlock(sql, 'department_kpi_links');
+
+      expect(block, contains('id uuid primary key default gen_random_uuid()'));
+      expect(block, contains('department text not null unique'));
+      expect(block, contains('feature_module text'));
+      expect(block, contains('kpi_query text'));
+      expect(block, contains('created_at timestamptz not null default now()'));
+      expect(block, contains('updated_at timestamptz not null default now()'));
+    });
+
+    test('locks department keys to the six supported views', () {
+      final block = _createTableBlock(sql, 'department_kpi_links');
+
+      for (final department in [
+        'accounting',
+        'hr',
+        'marketing',
+        'sales',
+        'development',
+        'legal',
+      ]) {
+        expect(block, contains("'$department'"));
+      }
+    });
+
+    test('stores allowlisted ai-hub action identifiers instead of SQL', () {
+      final block = _createTableBlock(sql, 'department_kpi_links');
+
+      expect(
+        block,
+        contains(r"kpi_query ~ '^ai_hub\.[a-z][a-z0-9_]*$'"),
+      );
+      expect(
+        block,
+        contains('check ((feature_module is null) = (kpi_query is null))'),
+      );
+      expect(
+        sql,
+        contains('This value must never be executed as SQL.'),
+      );
+    });
+
+    test('seeds accounting and five explicit placeholders', () {
+      final seedBlock = _seedBlock(sql);
+
+      expect(seedBlock, contains("'accounting',\n    'asset_management',"));
+      expect(
+        seedBlock,
+        contains("'ai_hub.department_finance_summary'"),
+      );
+      for (final department in [
+        'hr',
+        'marketing',
+        'sales',
+        'development',
+        'legal',
+      ]) {
+        expect(seedBlock, contains("('$department', null, null)"));
+      }
+      expect(
+        RegExp(r"\('(?:hr|marketing|sales|development|legal)', null, null\)")
+            .allMatches(seedBlock)
+            .length,
+        5,
+      );
+    });
+
+    test('exposes read-only rows only to authenticated clients', () {
+      expect(
+        sql,
+        contains(
+          'alter table public.department_kpi_links enable row level security;',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'revoke all privileges on table public.department_kpi_links\n'
+          'from public, anon, authenticated;',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'grant all privileges on table public.department_kpi_links to service_role;',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'grant select on table public.department_kpi_links to authenticated;',
+        ),
+      );
+      for (final operation in ['insert', 'update', 'delete', 'truncate']) {
+        expect(
+          sql,
+          isNot(
+            contains(
+              'grant $operation on table public.department_kpi_links '
+              'to authenticated;',
+            ),
+          ),
+        );
+      }
+      expect(
+        sql,
+        contains('create policy department_kpi_links_authenticated_read'),
+      );
+      expect(
+        sql,
+        contains(
+          'for select\n  to authenticated\n'
+          '  using ((select auth.uid()) is not null);',
+        ),
+      );
+      expect(sql, isNot(contains('to anon')));
+    });
+
+    test('maintains updated_at with a table-specific trigger', () {
+      expect(
+        sql,
+        contains(
+          'create or replace function public.set_department_kpi_links_updated_at()',
+        ),
+      );
+      expect(sql, contains('create trigger department_kpi_links_updated_at'));
+      expect(
+        sql,
+        contains(
+          'for each row execute function public.set_department_kpi_links_updated_at();',
+        ),
+      );
+    });
+  });
+}
+
+String _createTableBlock(String sql, String table) {
+  final start = sql.indexOf('create table if not exists public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+
+  final end = sql.indexOf('\n);', start);
+  expect(
+    end,
+    isNonNegative,
+    reason: 'missing create table terminator for $table',
+  );
+
+  return sql.substring(start, end);
+}
+
+String _seedBlock(String sql) {
+  final start = sql.indexOf('insert into public.department_kpi_links');
+  expect(start, isNonNegative, reason: 'missing department seed insert');
+
+  final end = sql.indexOf('\non conflict (department)', start);
+  expect(end, isNonNegative, reason: 'missing department seed upsert');
+
+  return sql.substring(start, end);
+}


### PR DESCRIPTION
## Summary

- create the `public.department_kpi_links` routing table for the six department views
- seed `accounting` to `asset_management` through `ai_hub.department_finance_summary`
- seed `hr / marketing / sales / development / legal` as explicit NULL placeholders
- constrain `kpi_query` to an ai-hub action identifier so it cannot hold arbitrary SQL
- expose authenticated read-only access while reserving writes for the service-role boundary
- add a deterministic migration-contract test

## Why

Issue #2480 is the database foundation for the phase E department finance summary and accounting-panel work in #2481 and #2482. A single allowlisted routing row per department keeps those consumers data-driven without letting the client supply executable query text.

## Security

- RLS is enabled on the new public table.
- Blanket privileges are revoked from `public`, `anon`, and `authenticated`.
- `authenticated` receives SELECT only and must have a non-null `auth.uid()`.
- `anon` receives no table privilege.
- Mutations remain behind `service_role`.
- `kpi_query` is constrained to `^ai_hub\.[a-z][a-z0-9_]*$` and is documented as non-SQL.

## Validation

- `flutter test test/services/department_kpi_links_schema_test.dart` — 6 tests passed
- department schema plus four existing asset-management schema suites — 24 tests passed
- `dart analyze test/services/department_kpi_links_schema_test.dart` — no issues
- PostgreSQL 17 real apply — migration committed; 6 rows seeded; 5 placeholders; RLS enabled; authenticated SELECT=true/INSERT=false; anon SELECT=false
- migration timestamp collision check — 1,938 unique timestamps
- migration time-relative and shell-quoting guards — passed
- `git diff --check` — passed

## Minimal E2E Gate

- Implementation-detail independent: the contract test and PostgreSQL apply validate the deployed database interface—columns, constraints, seed rows, privileges, and RLS.
- Minimal scope: accounting happy path, five placeholder rows, and unauthorized read/write boundaries.
- E2E: PostgreSQL 17 applied the exact migration artifact and verified catalog privileges and policy state.
- E2E-Exception: no Flutter page, browser route, Edge Function, or interactive user journey changes in this schema-only PR.

## Deployment, rollback, and observability

- Data migration: creates one new table and idempotently upserts six master rows; no existing user data is rewritten.
- Rollback: before production deployment, revert this PR; after deployment, use a follow-up migration to revoke access and drop `public.department_kpi_links` before #2481 consumers are enabled.
- Prod smoke: verify deploy-prod migration success, query the six rows, confirm the accounting action identifier, and recheck RLS/table privileges.
- Observability: deploy-prod migration logs plus catalog queries for `pg_policies`, `relrowsecurity`, and privilege checks provide deterministic evidence.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Codex #1 implemented a bounded schema-only migration with no existing-data backfill, secret change, Edge Function deployment, or client mutation path.

## Two-instance / subagent note

- Lead owner: Codex #1 Windows app.
- Guarded subagents: not used.
- Scope: Issue #2480 department KPI routing schema and contract test only.
- Validation impact: deterministic local tests and PostgreSQL 17 apply are recorded above.
- Cleanup impact: dedicated worktree and branch will be removed after merge and production verification.

Closes #2480