### PR TITLE
Add owner-scoped asset chat persistence

### DIFF
--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -3,10 +3,10 @@
 
 The smoke intentionally avoids production Supabase credentials. It starts a
 disposable Postgres container, applies a small migration/seed fixture, verifies
-the Issue #2773 fail-closed RLS migration, checks the real Edge Function import
-policy, and runs a Deno HTTP fixture against the container. Logs are written as
-artifacts so CI failures point to the migration, function, or seed boundary that
-broke.
+the Issue #2773 fail-closed RLS migration and Issue #2484 asset-chat isolation,
+checks the real Edge Function import policy, and runs a Deno HTTP fixture against
+the container. Logs are written as artifacts so CI failures point to the
+migration, function, or seed boundary that broke.
 """
 
 from __future__ import annotations
@@ -47,6 +47,13 @@ ISSUE_2773_USER_1 = "00000000-0000-4000-8000-000000002773"
 ISSUE_2773_USER_2 = "00000000-0000-4000-8000-000000002774"
 ISSUE_2773_EXPERIMENT_1 = "00000000-0000-4000-8000-000000002775"
 ISSUE_2773_EXPERIMENT_2 = "00000000-0000-4000-8000-000000002776"
+ASSET_CHAT_MIGRATION = (
+    ROOT / "supabase" / "migrations" / "20260817151738_create_asset_chat_tables.sql"
+)
+ASSET_CHAT_TABLES = ("asset_chat_messages", "asset_chat_threads")
+ASSET_CHAT_THREAD_1 = "00000000-0000-4000-8000-000000002484"
+ASSET_CHAT_THREAD_2 = "00000000-0000-4000-8000-000000002485"
+ASSET_CHAT_TEMP_THREAD = "00000000-0000-4000-8000-000000002486"
 EDGE_FIXTURE_ENV_ALLOW = (
     "DATABASE_URL",
     "PORT",
@@ -153,6 +160,14 @@ def build_plan(sql_dir: Path, edge_fixture: Path, actual_edge_function: Path) ->
             "authenticated privileges are policy-backed and least-privilege",
             "missing tenant claims see zero rows and cannot write",
             "authenticated users see only their own tenant rows",
+        ],
+        "asset_chat_migration": ASSET_CHAT_MIGRATION.relative_to(ROOT).as_posix(),
+        "asset_chat_checks": [
+            "threads and messages have owner-only RLS",
+            "anon has no table privileges",
+            "authenticated users cannot insert across tenants",
+            "message ownership follows the parent thread",
+            "deleting an owned thread cascades to its messages",
         ],
         "edge_db_fixture": edge_fixture.relative_to(ROOT).as_posix(),
         "actual_edge_checks": [
@@ -451,6 +466,221 @@ def check_issue_2773_rls(conn: Any) -> dict[str, Any]:
     }
 
 
+def seed_asset_chat_fixture(conn: Any) -> None:
+    with conn.cursor() as cur:
+        cur.executemany(
+            "insert into public.asset_chat_threads (id, user_id, title) "
+            "values (%s::uuid, %s::uuid, %s)",
+            [
+                (ASSET_CHAT_THREAD_1, ISSUE_2773_USER_1, "owner one thread"),
+                (ASSET_CHAT_THREAD_2, ISSUE_2773_USER_2, "owner two thread"),
+            ],
+        )
+        cur.executemany(
+            "insert into public.asset_chat_messages "
+            "(thread_id, role, content, tokens_in, tokens_out, model) "
+            "values (%s::uuid, %s, %s, %s, %s, %s)",
+            [
+                (ASSET_CHAT_THREAD_1, "user", "owner one message", 12, 0, None),
+                (
+                    ASSET_CHAT_THREAD_2,
+                    "assistant",
+                    "owner two response",
+                    20,
+                    8,
+                    "fixture-model",
+                ),
+            ],
+        )
+    conn.commit()
+
+
+def asset_chat_role_count(
+    conn: Any,
+    role: str,
+    user_id: str | None,
+    table: str,
+) -> int:
+    if role not in {"anon", "authenticated", "service_role"}:
+        raise ValueError(f"unexpected role for asset chat query: {role}")
+    if table not in ASSET_CHAT_TABLES:
+        raise ValueError(f"unexpected table for asset chat query: {table}")
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(f"set local role {role}")
+            cur.execute(
+                "select set_config('request.jwt.claim.sub', %s, true)",
+                (user_id or "",),
+            )
+            cur.execute(f"select count(*) from public.{table}")
+            row = cur.fetchone()
+    return int(row[0])
+
+
+def check_asset_chat_rls(conn: Any) -> dict[str, Any]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "select c.relname from pg_class c "
+            "join pg_namespace n on n.oid = c.relnamespace "
+            "where n.nspname = 'public' and c.relname = any(%s) "
+            "and c.relrowsecurity order by c.relname",
+            (list(ASSET_CHAT_TABLES),),
+        )
+        enabled_tables = [row[0] for row in cur.fetchall()]
+        cur.execute(
+            "select policyname from pg_policies where schemaname = 'public' "
+            "and tablename = any(%s) order by policyname",
+            (list(ASSET_CHAT_TABLES),),
+        )
+        policy_names = [row[0] for row in cur.fetchall()]
+    conn.commit()
+
+    if enabled_tables != sorted(ASSET_CHAT_TABLES):
+        raise AssertionError(
+            f"asset chat RLS was not enabled on every table: {enabled_tables}"
+        )
+
+    expected_policies = {
+        f"{table}_{operation}_own"
+        for table in ASSET_CHAT_TABLES
+        for operation in ("select", "insert", "update", "delete")
+    }
+    if set(policy_names) != expected_policies:
+        raise AssertionError(f"unexpected asset chat policy set: {policy_names}")
+
+    authenticated_grants = {"SELECT", "INSERT", "UPDATE", "DELETE"}
+    table_privileges = (
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "TRUNCATE",
+        "REFERENCES",
+        "TRIGGER",
+    )
+    with conn.cursor() as cur:
+        for table in ASSET_CHAT_TABLES:
+            for privilege in table_privileges:
+                cur.execute(
+                    "select has_table_privilege(%s, %s, %s)",
+                    ("anon", f"public.{table}", privilege),
+                )
+                if bool(cur.fetchone()[0]):
+                    raise AssertionError(
+                        f"anon retained {privilege} on asset chat table {table}"
+                    )
+                cur.execute(
+                    "select has_table_privilege(%s, %s, %s)",
+                    ("authenticated", f"public.{table}", privilege),
+                )
+                actual = bool(cur.fetchone()[0])
+                expected = privilege in authenticated_grants
+                if actual != expected:
+                    raise AssertionError(
+                        f"authenticated {privilege} on {table}: "
+                        f"expected {expected}, got {actual}"
+                    )
+    conn.commit()
+
+    missing_claim_counts = {
+        table: asset_chat_role_count(conn, "authenticated", None, table)
+        for table in ASSET_CHAT_TABLES
+    }
+    if any(missing_claim_counts.values()):
+        raise AssertionError(
+            f"missing tenant claim exposed asset chat rows: {missing_claim_counts}"
+        )
+
+    owner_counts = {
+        table: asset_chat_role_count(
+            conn,
+            "authenticated",
+            ISSUE_2773_USER_1,
+            table,
+        )
+        for table in ASSET_CHAT_TABLES
+    }
+    expected_owner_counts = {
+        "asset_chat_messages": 1,
+        "asset_chat_threads": 1,
+    }
+    if owner_counts != expected_owner_counts:
+        raise AssertionError(f"asset chat tenant filtering failed: {owner_counts}")
+
+    cross_thread_sqlstate = issue_2773_expect_denied(
+        conn,
+        role="authenticated",
+        user_id=ISSUE_2773_USER_1,
+        statement=(
+            "insert into public.asset_chat_messages (thread_id, role, content) "
+            "values (%s::uuid, 'user', 'cross-tenant write')"
+        ),
+        params=(ASSET_CHAT_THREAD_2,),
+    )
+    forged_owner_sqlstate = issue_2773_expect_denied(
+        conn,
+        role="authenticated",
+        user_id=ISSUE_2773_USER_1,
+        statement=(
+            "insert into public.asset_chat_threads (user_id, title) "
+            "values (%s::uuid, 'forged owner')"
+        ),
+        params=(ISSUE_2773_USER_2,),
+    )
+
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("set local role authenticated")
+            cur.execute(
+                "select set_config('request.jwt.claim.sub', %s, true)",
+                (ISSUE_2773_USER_1,),
+            )
+            cur.execute(
+                "insert into public.asset_chat_threads (id, user_id, title) "
+                "values (%s::uuid, %s::uuid, 'cascade smoke')",
+                (ASSET_CHAT_TEMP_THREAD, ISSUE_2773_USER_1),
+            )
+            cur.execute(
+                "insert into public.asset_chat_messages (thread_id, role, content) "
+                "values (%s::uuid, 'user', 'delete with thread')",
+                (ASSET_CHAT_TEMP_THREAD,),
+            )
+            cur.execute(
+                "delete from public.asset_chat_threads where id = %s::uuid",
+                (ASSET_CHAT_TEMP_THREAD,),
+            )
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "select count(*) from public.asset_chat_messages "
+            "where thread_id = %s::uuid",
+            (ASSET_CHAT_TEMP_THREAD,),
+        )
+        cascade_remaining = int(cur.fetchone()[0])
+    conn.commit()
+    if cascade_remaining != 0:
+        raise AssertionError("asset chat thread deletion left orphan messages")
+
+    for table in ASSET_CHAT_TABLES:
+        issue_2773_expect_denied(
+            conn,
+            role="anon",
+            user_id=None,
+            statement=f"select count(*) from public.{table}",
+        )
+
+    return {
+        "enabled_tables": enabled_tables,
+        "policies": policy_names,
+        "missing_claim_counts": missing_claim_counts,
+        "owner_counts": owner_counts,
+        "cross_thread_sqlstate": cross_thread_sqlstate,
+        "forged_owner_sqlstate": forged_owner_sqlstate,
+        "cascade_remaining": cascade_remaining,
+        "anon_access": "denied on both asset chat tables",
+    }
+
+
 def check_actual_edge_function(args: argparse.Namespace, artifacts_dir: Path) -> None:
     import_result = run_command(
         [sys.executable, "scripts/check_edge_function_imports.py", "--root", "supabase/functions"],
@@ -591,6 +821,9 @@ def run_smoke(args: argparse.Namespace) -> int:
             apply_sql_fixture(conn, ISSUE_2773_RLS_MIGRATION, artifacts_dir)
             seed_issue_2773_fixture(conn)
             tenant_rls = check_issue_2773_rls(conn)
+            apply_sql_fixture(conn, ASSET_CHAT_MIGRATION, artifacts_dir)
+            seed_asset_chat_fixture(conn)
+            asset_chat_rls = check_asset_chat_rls(conn)
             counts = {table: table_count(conn, table) for table in REQUIRED_TABLES}
 
         edge_result = run_edge_db_fixture(connection_url, args, artifacts_dir)
@@ -601,6 +834,7 @@ def run_smoke(args: argparse.Namespace) -> int:
             "url": redact_url(connection_url),
             "tables": counts,
             "tenant_rls": tenant_rls,
+            "asset_chat_rls": asset_chat_rls,
         },
         "edge_fixture": {
             "path": args.edge_fixture.relative_to(ROOT).as_posix(),

--- a/supabase/migrations/20260817151738_create_asset_chat_tables.sql
+++ b/supabase/migrations/20260817151738_create_asset_chat_tables.sql
@@ -1,0 +1,185 @@
+-- Issue #2484: persistence for the asset-management AI chat assistant.
+-- This migration adds storage and owner-only access. Provider calls and UI
+-- wiring remain disabled until their separately scoped follow-up issues.
+
+begin;
+
+create table if not exists public.asset_chat_threads (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title text not null,
+  created_at timestamptz not null default now(),
+  last_message_at timestamptz not null default now(),
+  constraint asset_chat_threads_title_length
+    check (length(btrim(title)) between 1 and 200),
+  constraint asset_chat_threads_last_message_not_before_created
+    check (last_message_at >= created_at)
+);
+
+create table if not exists public.asset_chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null
+    references public.asset_chat_threads(id) on delete cascade,
+  role text not null,
+  content text not null,
+  tokens_in integer not null default 0,
+  tokens_out integer not null default 0,
+  model text,
+  created_at timestamptz not null default now(),
+  constraint asset_chat_messages_role_valid
+    check (role in ('user', 'assistant')),
+  constraint asset_chat_messages_content_length
+    check (length(btrim(content)) between 1 and 50000),
+  constraint asset_chat_messages_tokens_in_non_negative
+    check (tokens_in >= 0),
+  constraint asset_chat_messages_tokens_out_non_negative
+    check (tokens_out >= 0),
+  constraint asset_chat_messages_model_length
+    check (model is null or length(btrim(model)) between 1 and 200)
+);
+
+create index if not exists asset_chat_threads_user_activity_idx
+  on public.asset_chat_threads (
+    user_id,
+    last_message_at desc,
+    id
+  );
+
+create index if not exists asset_chat_messages_thread_created_idx
+  on public.asset_chat_messages (thread_id, created_at, id);
+
+comment on table public.asset_chat_threads is
+  'Per-user conversation threads for the asset-management AI assistant. Issue #2484.';
+comment on column public.asset_chat_threads.last_message_at is
+  'Stable thread-list ordering key. The trusted writer updates it when a message is persisted.';
+comment on table public.asset_chat_messages is
+  'Ordered user and assistant messages for an asset-management chat thread.';
+comment on column public.asset_chat_messages.content is
+  'Conversation text only. Financial calculations remain deterministic outside the LLM.';
+comment on column public.asset_chat_messages.tokens_in is
+  'Provider-reported input token count. Zero when unavailable or not applicable.';
+comment on column public.asset_chat_messages.tokens_out is
+  'Provider-reported output token count. Zero when unavailable or not applicable.';
+
+alter table public.asset_chat_threads enable row level security;
+alter table public.asset_chat_messages enable row level security;
+
+-- RLS does not cover TRUNCATE, REFERENCES, or TRIGGER. Remove inherited
+-- privileges and expose only policy-backed CRUD to authenticated clients.
+revoke all privileges on table
+  public.asset_chat_threads,
+  public.asset_chat_messages
+from public, anon, authenticated;
+
+grant all privileges on table
+  public.asset_chat_threads,
+  public.asset_chat_messages
+to service_role;
+
+grant select, insert, update, delete on table
+  public.asset_chat_threads,
+  public.asset_chat_messages
+to authenticated;
+
+drop policy if exists asset_chat_threads_select_own
+  on public.asset_chat_threads;
+create policy asset_chat_threads_select_own
+  on public.asset_chat_threads
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists asset_chat_threads_insert_own
+  on public.asset_chat_threads;
+create policy asset_chat_threads_insert_own
+  on public.asset_chat_threads
+  for insert
+  to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists asset_chat_threads_update_own
+  on public.asset_chat_threads;
+create policy asset_chat_threads_update_own
+  on public.asset_chat_threads
+  for update
+  to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists asset_chat_threads_delete_own
+  on public.asset_chat_threads;
+create policy asset_chat_threads_delete_own
+  on public.asset_chat_threads
+  for delete
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists asset_chat_messages_select_own
+  on public.asset_chat_messages;
+create policy asset_chat_messages_select_own
+  on public.asset_chat_messages
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.asset_chat_threads as thread_row
+      where thread_row.id = asset_chat_messages.thread_id
+        and thread_row.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists asset_chat_messages_insert_own
+  on public.asset_chat_messages;
+create policy asset_chat_messages_insert_own
+  on public.asset_chat_messages
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from public.asset_chat_threads as thread_row
+      where thread_row.id = asset_chat_messages.thread_id
+        and thread_row.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists asset_chat_messages_update_own
+  on public.asset_chat_messages;
+create policy asset_chat_messages_update_own
+  on public.asset_chat_messages
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.asset_chat_threads as thread_row
+      where thread_row.id = asset_chat_messages.thread_id
+        and thread_row.user_id = (select auth.uid())
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.asset_chat_threads as thread_row
+      where thread_row.id = asset_chat_messages.thread_id
+        and thread_row.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists asset_chat_messages_delete_own
+  on public.asset_chat_messages;
+create policy asset_chat_messages_delete_own
+  on public.asset_chat_messages
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.asset_chat_threads as thread_row
+      where thread_row.id = asset_chat_messages.thread_id
+        and thread_row.user_id = (select auth.uid())
+    )
+  );
+
+commit;

--- a/test/scripts/test_testcontainers_supabase_smoke.py
+++ b/test/scripts/test_testcontainers_supabase_smoke.py
@@ -69,6 +69,21 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
             " ".join(plan["tenant_rls_checks"]),
         )
 
+    def test_plan_includes_asset_chat_rls_migration(self) -> None:
+        plan = module.build_plan(
+            ROOT / "test" / "fixtures" / "testcontainers" / "sql",
+            ROOT / "test" / "fixtures" / "testcontainers" / "edge-db-smoke.ts",
+            ROOT / "supabase" / "functions" / "health-check" / "index.ts",
+        )
+        self.assertEqual(
+            plan["asset_chat_migration"],
+            "supabase/migrations/20260817151738_create_asset_chat_tables.sql",
+        )
+        self.assertIn(
+            "message ownership follows the parent thread",
+            plan["asset_chat_checks"],
+        )
+
     def test_tenant_role_count_rejects_untrusted_identifiers(self) -> None:
         with self.assertRaisesRegex(ValueError, "unexpected role"):
             module.issue_2773_role_count(
@@ -79,6 +94,22 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
             )
         with self.assertRaisesRegex(ValueError, "unexpected table"):
             module.issue_2773_role_count(None, "authenticated", None, "pg_authid")
+
+    def test_asset_chat_role_count_rejects_untrusted_identifiers(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unexpected role"):
+            module.asset_chat_role_count(
+                None,
+                "postgres",
+                None,
+                "asset_chat_threads",
+            )
+        with self.assertRaisesRegex(ValueError, "unexpected table"):
+            module.asset_chat_role_count(
+                None,
+                "authenticated",
+                None,
+                "pg_authid",
+            )
 
 
 if __name__ == "__main__":

--- a/test/services/asset_chat_schema_test.dart
+++ b/test/services/asset_chat_schema_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260817151738_create_asset_chat_tables.sql';
+
+void main() {
+  group('asset chat schema migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _migrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test('defines normalized thread and message records', () {
+      final thread = _createTableBlock(sql, 'asset_chat_threads');
+      final message = _createTableBlock(sql, 'asset_chat_messages');
+
+      expect(thread, contains('id uuid primary key default gen_random_uuid()'));
+      expect(
+        thread,
+        contains(
+          'user_id uuid not null references auth.users(id) on delete cascade',
+        ),
+      );
+      expect(thread, contains('title text not null'));
+      expect(
+        thread,
+        contains('last_message_at timestamptz not null default now()'),
+      );
+
+      expect(
+        message,
+        contains('id uuid primary key default gen_random_uuid()'),
+      );
+      expect(
+        message,
+        contains('references public.asset_chat_threads(id) on delete cascade'),
+      );
+      expect(message, contains('role text not null'));
+      expect(message, contains('content text not null'));
+      expect(message, contains('tokens_in integer not null default 0'));
+      expect(message, contains('tokens_out integer not null default 0'));
+      expect(message, contains('model text'));
+    });
+
+    test('guards role, content size, timestamps, and token counts', () {
+      expect(sql, contains("check (role in ('user', 'assistant'))"));
+      expect(
+        sql,
+        contains('check (length(btrim(content)) between 1 and 50000)'),
+      );
+      expect(sql, contains('check (tokens_in >= 0)'));
+      expect(sql, contains('check (tokens_out >= 0)'));
+      expect(sql, contains('check (last_message_at >= created_at)'));
+    });
+
+    test('indexes bounded thread and ordered message reads', () {
+      expect(sql, contains('asset_chat_threads_user_activity_idx'));
+      expect(
+        sql,
+        contains(
+          'on public.asset_chat_threads (\n'
+          '    user_id,\n'
+          '    last_message_at desc,\n'
+          '    id\n'
+          '  )',
+        ),
+      );
+      expect(sql, contains('asset_chat_messages_thread_created_idx'));
+      expect(
+        sql,
+        contains('on public.asset_chat_messages (thread_id, created_at, id)'),
+      );
+    });
+
+    test('removes public grants and exposes only authenticated CRUD', () {
+      expect(
+        sql,
+        contains(
+          'revoke all privileges on table\n'
+          '  public.asset_chat_threads,\n'
+          '  public.asset_chat_messages\n'
+          'from public, anon, authenticated;',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'grant select, insert, update, delete on table\n'
+          '  public.asset_chat_threads,\n'
+          '  public.asset_chat_messages\n'
+          'to authenticated;',
+        ),
+      );
+      expect(sql, isNot(contains('to anon;')));
+    });
+
+    test('enforces owner-only RLS on threads and parent-owned messages', () {
+      for (final table in ['asset_chat_threads', 'asset_chat_messages']) {
+        expect(
+          sql,
+          contains('alter table public.$table enable row level security;'),
+        );
+        for (final operation in ['select', 'insert', 'update', 'delete']) {
+          expect(sql, contains('create policy ${table}_${operation}_own'));
+          expect(sql, contains('for $operation\n  to authenticated'));
+        }
+      }
+
+      expect(sql, contains('using ((select auth.uid()) = user_id)'));
+      expect(sql, contains('with check ((select auth.uid()) = user_id)'));
+      expect(
+        RegExp(
+          r'thread_row\.user_id = \(select auth\.uid\(\)\)',
+        ).allMatches(sql).length,
+        greaterThanOrEqualTo(5),
+      );
+    });
+  });
+}
+
+String _createTableBlock(String sql, String table) {
+  final start = sql.indexOf('create table if not exists public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+
+  final end = sql.indexOf('\n);', start);
+  expect(
+    end,
+    isNonNegative,
+    reason: 'missing create table terminator for $table',
+  );
+
+  return sql.substring(start, end);
+}


### PR DESCRIPTION
Closes #2484

WBS task: `a98dbb5a-0bd3-4dab-a1c7-9fabda48c2d5`

## What changed

- Added normalized `asset_chat_threads` and `asset_chat_messages` tables for the asset-management AI chat assistant.
- Added UUID keys, auth-user/thread cascade relationships, bounded title/content constraints, role and token-count checks, and UTC-aware timestamps.
- Added stable indexes for per-user thread activity and ordered per-thread message history.
- Extended the existing disposable Postgres Testcontainers smoke so this migration and its tenant boundary are exercised in CI.

## Data model and rollout boundary

- Thread fields: `id`, `user_id`, `title`, `created_at`, `last_message_at`.
- Message fields: `id`, `thread_id`, `role`, `content`, `tokens_in`, `tokens_out`, `model`, `created_at`.
- `role` is restricted to `user` / `assistant`; token counts cannot be negative.
- This PR is additive storage only. It does not enable provider calls, UI access, background writes, or a feature flag; #2485 and later issues own those consumers.
- Data migration/backfill: none.

## Security, privileges, and RLS

- RLS is enabled on both tables.
- `public`, `anon`, and inherited authenticated privileges are revoked first.
- `authenticated` receives policy-backed CRUD only; `TRUNCATE`, `REFERENCES`, and `TRIGGER` remain unavailable.
- Threads compare `(select auth.uid())` with `user_id`.
- Messages resolve ownership through the parent thread, including insert/update `WITH CHECK`.
- The service role remains the trusted backend boundary for the later Edge Function and is never exposed to clients.
- Real Postgres evidence: missing claims return zero rows; cross-thread and forged-owner writes fail with SQLSTATE `42501`; anon table access is denied; deleting an owned thread leaves zero child messages.

## Egress and performance

- This migration makes no network request and transfers no user data.
- No table data is seeded, rewritten, copied, or deleted.
- Thread history reads can use `(user_id, last_message_at desc, id)`.
- Message history and FK cascade lookups can use `(thread_id, created_at, id)`.
- Large text is bounded at 50,000 characters and thread titles at 200 characters. Future repositories must still select only required columns and paginate histories.

## Validation

- `python scripts/testcontainers_supabase_smoke.py --artifacts-dir <temporary>` — passed against disposable Postgres 16:
  - both tables RLS-enabled;
  - owner counts 1/1 and missing-claim counts 0/0;
  - cross-tenant writes rejected with `42501`;
  - anon denied;
  - cascade remaining 0.
- `python test/scripts/test_testcontainers_supabase_smoke.py` — 9 passed.
- Focused asset/schema Flutter regression set — 30 passed.
- `flutter analyze --no-pub` — no issues found (198.7s).
- `python scripts/check_migration_timestamps.py` — no collisions across 1,939 migrations.
- `python scripts/check_migration_time_relative_check.py` — clean.
- `git diff --check` — passed.
- Linked Supabase advisors were run. They remain non-zero because of pre-existing unrelated public security-definer/auth-user views; this PR introduces no view or advisor finding and does not broaden scope to repair those baseline objects.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: DB-only migration with no UI route; real Postgres Testcontainers covers ownership, cross-tenant denial, missing claim, anon denial, and cascade recovery.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Scoped additive schema migration with no data rewrite or destructive DDL; real Postgres RLS isolation is covered by Testcontainers and Claude Code #1 review remains the repository review owner.

## Production smoke, observability, and rollback

- Production smoke: after merge, verify the deployment workflow applies `20260817151738_create_asset_chat_tables.sql`, both tables exist with RLS enabled, all eight policies exist, and unauthenticated REST reads are rejected.
- Observability: migration deployment logs plus Supabase advisors; the tables have no runtime traffic until later issues enable a consumer.
- Rollback before consumer rollout: add a forward migration that drops messages first, then threads.
- Rollback after data exists: export/backup the two tables before a forward rollback migration; do not edit or replay an already-deployed migration.

## Coordination

- No subagents were used.
- #2485 owns the Edge Function writer/context path, #2486 the sticky chat UI, and #2487 history/search/delete UX.
