### PR TITLE
[Issue #2486] 資産管理に固定AIチャットを追加

### DIFF
--- a/lib/models/asset_chat.dart
+++ b/lib/models/asset_chat.dart
@@ -1,0 +1,45 @@
+enum AssetChatMessageRole { user, assistant }
+
+class AssetChatUsage {
+  final int tokensIn;
+  final int tokensOut;
+  final double estimatedCostUsd;
+  final String provider;
+  final String model;
+
+  const AssetChatUsage({
+    required this.tokensIn,
+    required this.tokensOut,
+    required this.estimatedCostUsd,
+    required this.provider,
+    required this.model,
+  });
+
+  int get totalTokens => tokensIn + tokensOut;
+}
+
+class AssetChatMessage {
+  final AssetChatMessageRole role;
+  final String text;
+  final AssetChatUsage? usage;
+
+  const AssetChatMessage({required this.role, required this.text, this.usage});
+
+  bool get isUser => role == AssetChatMessageRole.user;
+}
+
+class AssetChatResponse {
+  final String threadId;
+  final String threadTitle;
+  final bool threadCreated;
+  final String reply;
+  final AssetChatUsage usage;
+
+  const AssetChatResponse({
+    required this.threadId,
+    required this.threadTitle,
+    required this.threadCreated,
+    required this.reply,
+    required this.usage,
+  });
+}

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -100,6 +100,7 @@ import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
+import 'package:my_web_app/widgets/asset_chat_widget.dart';
 import 'package:my_web_app/widgets/debt_progress_share_dialog.dart';
 import 'package:my_web_app/widgets/asset_alert_center_card.dart';
 import 'package:my_web_app/widgets/asset_cashflow_statement_card.dart';
@@ -9482,6 +9483,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ],
       ),
       backgroundColor: const Color(0xFF64748B),
+      floatingActionButton: AssetChatWidget(service: _aiHubChatService),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       body: SingleChildScrollView(
         controller: _scrollController,
         padding: EdgeInsets.all(isCompact ? 12.0 : 16.0),

--- a/lib/services/ai_hub_chat_service.dart
+++ b/lib/services/ai_hub_chat_service.dart
@@ -1,5 +1,6 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/asset_chat.dart';
 import 'offline_secure_mode_settings_service.dart';
 
 typedef AiHubChatInvoker = Future<Map<String, dynamic>> Function(
@@ -156,6 +157,82 @@ class AiHubChatService {
   })  : _supabase = supabase,
         _invoker = invoker,
         _offlineSettingsService = offlineSettingsService;
+
+  Future<AssetChatResponse> sendAssetChat({
+    required String message,
+    String? threadId,
+    int snapshotMonths = 3,
+    int historyMessages = 8,
+    String piiMode = 'off',
+  }) async {
+    final normalizedMessage = message.trim();
+    if (normalizedMessage.isEmpty) {
+      throw const AiHubChatException('message required');
+    }
+    if (normalizedMessage.length > 4000) {
+      throw const AiHubChatException('message must be at most 4000 characters');
+    }
+    if (_invoker == null) {
+      final client = _supabase ?? Supabase.instance.client;
+      if (client.auth.currentUser == null) {
+        throw const AiHubChatException('login_required');
+      }
+    }
+    if (AiHubChatQuotaGuard.isCoolingDown()) {
+      throw const AiHubChatException('AI quota cooldown');
+    }
+
+    try {
+      final data = await _invoke(
+        await _withOfflinePolicy({
+          'action': 'ai_hub.asset_chat',
+          'message': normalizedMessage,
+          if (threadId != null && threadId.trim().isNotEmpty)
+            'thread_id': threadId.trim(),
+          'snapshot_months': snapshotMonths.clamp(1, 12),
+          'history_messages': historyMessages.clamp(0, 20),
+          'pii_mode': piiMode,
+        }),
+      );
+      final reply = data['reply']?.toString().trim();
+      final responseThreadId = data['thread_id']?.toString().trim();
+      if (data['success'] == true &&
+          reply != null &&
+          reply.isNotEmpty &&
+          responseThreadId != null &&
+          responseThreadId.isNotEmpty) {
+        return AssetChatResponse(
+          threadId: responseThreadId,
+          threadTitle: data['thread_title']?.toString().trim() ?? '',
+          threadCreated: data['thread_created'] == true,
+          reply: reply,
+          usage: AssetChatUsage(
+            tokensIn: _asInt(data['tokens_in']) ?? 0,
+            tokensOut: _asInt(data['tokens_out']) ?? 0,
+            estimatedCostUsd: _asDouble(data['estimated_cost_usd']) ?? 0,
+            provider: data['provider']?.toString().trim() ?? '',
+            model: data['model']?.toString().trim() ?? '',
+          ),
+        );
+      }
+      throw _buildAiHubFailureException(
+        data,
+        fallbackMessage: 'Asset chat response was empty',
+      );
+    } catch (error) {
+      final detail = error.toString();
+      if (RegExp(
+        r'429|quota|rate.?limit',
+        caseSensitive: false,
+      ).hasMatch(detail)) {
+        AiHubChatQuotaGuard.markQuotaExceeded();
+      }
+      if (error is AiHubChatException) {
+        rethrow;
+      }
+      throw AiHubChatException(detail);
+    }
+  }
 
   Future<AiHubChatResponse> sendProviderChat({
     required String message,

--- a/lib/view_models/asset_chat_view_model.dart
+++ b/lib/view_models/asset_chat_view_model.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/asset_chat.dart';
+import '../services/ai_hub_chat_service.dart';
+
+class AssetChatViewModel extends ChangeNotifier {
+  AssetChatViewModel({required AiHubChatService service}) : _service = service;
+
+  final AiHubChatService _service;
+  final List<AssetChatMessage> _messages = <AssetChatMessage>[];
+
+  String? _threadId;
+  String? _threadTitle;
+  String? _errorMessage;
+  bool _isSending = false;
+
+  List<AssetChatMessage> get messages =>
+      List<AssetChatMessage>.unmodifiable(_messages);
+  String? get threadId => _threadId;
+  String? get threadTitle => _threadTitle;
+  String? get errorMessage => _errorMessage;
+  bool get isSending => _isSending;
+
+  Future<bool> sendMessage(String message) async {
+    final normalized = message.trim();
+    if (normalized.isEmpty || _isSending) {
+      return false;
+    }
+
+    _messages.add(
+      AssetChatMessage(role: AssetChatMessageRole.user, text: normalized),
+    );
+    _errorMessage = null;
+    _isSending = true;
+    notifyListeners();
+
+    try {
+      final response = await _service.sendAssetChat(
+        message: normalized,
+        threadId: _threadId,
+      );
+      _threadId = response.threadId;
+      _threadTitle = response.threadTitle;
+      _messages.add(
+        AssetChatMessage(
+          role: AssetChatMessageRole.assistant,
+          text: response.reply,
+          usage: response.usage,
+        ),
+      );
+      return true;
+    } catch (error) {
+      _errorMessage = _friendlyError(error);
+      return false;
+    } finally {
+      _isSending = false;
+      notifyListeners();
+    }
+  }
+
+  String _friendlyError(Object error) {
+    final detail = error.toString().toLowerCase();
+    if (detail.contains('login_required') ||
+        detail.contains('unauthorized') ||
+        detail.contains('jwt')) {
+      return 'このAIチャットを使うにはログインしてください。';
+    }
+    if (detail.contains('quota') ||
+        detail.contains('rate limit') ||
+        detail.contains('429')) {
+      return 'AIが混み合っています。1分ほど待ってからもう一度お試しください。';
+    }
+    if (detail.contains('offline')) {
+      return 'オフライン保護設定によりAI送信が停止されています。設定を確認してください。';
+    }
+    return 'AIとの通信に失敗しました。時間をおいてもう一度お試しください。';
+  }
+}

--- a/lib/widgets/asset_chat_widget.dart
+++ b/lib/widgets/asset_chat_widget.dart
@@ -28,8 +28,7 @@ class _AssetChatWidgetState extends State<AssetChatWidget> {
   void initState() {
     super.initState();
     _ownsViewModel = widget.viewModel == null;
-    _viewModel =
-        widget.viewModel ??
+    _viewModel = widget.viewModel ??
         AssetChatViewModel(service: widget.service ?? const AiHubChatService());
     _viewModel.addListener(_handleViewModelChanged);
   }
@@ -292,13 +291,13 @@ class _AssetChatWidgetState extends State<AssetChatWidget> {
                 minLines: 1,
                 maxLines: 4,
                 maxLength: 4000,
-                buildCounter:
-                    (
-                      _, {
-                      required currentLength,
-                      required isFocused,
-                      maxLength,
-                    }) => null,
+                buildCounter: (
+                  _, {
+                  required currentLength,
+                  required isFocused,
+                  maxLength,
+                }) =>
+                    null,
                 textInputAction: TextInputAction.send,
                 onSubmitted: (_) => _sendCurrentMessage(),
                 decoration: const InputDecoration(

--- a/lib/widgets/asset_chat_widget.dart
+++ b/lib/widgets/asset_chat_widget.dart
@@ -1,0 +1,323 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../models/asset_chat.dart';
+import '../services/ai_hub_chat_service.dart';
+import '../view_models/asset_chat_view_model.dart';
+
+class AssetChatWidget extends StatefulWidget {
+  final AiHubChatService? service;
+  final AssetChatViewModel? viewModel;
+
+  const AssetChatWidget({super.key, this.service, this.viewModel});
+
+  @override
+  State<AssetChatWidget> createState() => _AssetChatWidgetState();
+}
+
+class _AssetChatWidgetState extends State<AssetChatWidget> {
+  final TextEditingController _inputController = TextEditingController();
+  final ScrollController _messageScrollController = ScrollController();
+
+  late final AssetChatViewModel _viewModel;
+  late final bool _ownsViewModel;
+  bool _isOpen = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _ownsViewModel = widget.viewModel == null;
+    _viewModel =
+        widget.viewModel ??
+        AssetChatViewModel(service: widget.service ?? const AiHubChatService());
+    _viewModel.addListener(_handleViewModelChanged);
+  }
+
+  @override
+  void dispose() {
+    _viewModel.removeListener(_handleViewModelChanged);
+    if (_ownsViewModel) {
+      _viewModel.dispose();
+    }
+    _inputController.dispose();
+    _messageScrollController.dispose();
+    super.dispose();
+  }
+
+  void _handleViewModelChanged() {
+    if (!mounted) return;
+    setState(() {});
+    WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToLatest());
+  }
+
+  void _scrollToLatest() {
+    if (!_messageScrollController.hasClients) return;
+    _messageScrollController.jumpTo(
+      _messageScrollController.position.maxScrollExtent,
+    );
+  }
+
+  Future<void> _sendCurrentMessage() async {
+    final message = _inputController.text.trim();
+    if (message.isEmpty || _viewModel.isSending) return;
+    final pending = _viewModel.sendMessage(message);
+    if (_viewModel.isSending) {
+      _inputController.clear();
+    }
+    await pending;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isOpen) {
+      return FloatingActionButton.extended(
+        key: const Key('asset_chat_open_button'),
+        heroTag: null,
+        backgroundColor: const Color(0xFF1B5E20),
+        foregroundColor: Colors.white,
+        tooltip: '資産AIチャットを開く',
+        onPressed: () => setState(() => _isOpen = true),
+        icon: const Icon(Icons.auto_awesome),
+        label: const Text('資産AIに相談'),
+      );
+    }
+
+    final screenSize = MediaQuery.sizeOf(context);
+    final panelWidth = math.min(400.0, math.max(240.0, screenSize.width - 32));
+    final panelHeight = math.min(
+      560.0,
+      math.max(260.0, screenSize.height * 0.72),
+    );
+    final theme = Theme.of(context);
+
+    return Material(
+      key: const Key('asset_chat_panel'),
+      color: theme.colorScheme.surface,
+      elevation: 16,
+      shadowColor: Colors.black54,
+      borderRadius: BorderRadius.circular(20),
+      clipBehavior: Clip.antiAlias,
+      child: SizedBox(
+        width: panelWidth,
+        height: panelHeight,
+        child: Column(
+          children: [
+            _buildHeader(),
+            Expanded(child: _buildConversation()),
+            if (_viewModel.errorMessage case final error?) _buildError(error),
+            _buildInput(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return ColoredBox(
+      color: const Color(0xFF1B5E20),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 10, 8, 10),
+        child: Row(
+          children: [
+            const Icon(Icons.auto_awesome, color: Colors.white, size: 20),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '資産AIチャット',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  Text(
+                    _viewModel.threadTitle ?? '資産スナップショットをもとに回答',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(color: Colors.white70, fontSize: 11),
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              key: const Key('asset_chat_close_button'),
+              tooltip: '閉じる',
+              onPressed: () => setState(() => _isOpen = false),
+              icon: const Icon(Icons.close, color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildConversation() {
+    final messages = _viewModel.messages;
+    if (messages.isEmpty && !_viewModel.isSending) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.account_balance_wallet_outlined,
+                size: 38,
+                color: Color(0xFF2E7D32),
+              ),
+              SizedBox(height: 12),
+              Text(
+                '資産・負債・支払い予定について相談できます。',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontWeight: FontWeight.w700, height: 1.45),
+              ),
+              SizedBox(height: 8),
+              Text(
+                '入力内容と資産スナップショットをAIへ送信します。',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 12, color: Colors.black54),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      key: const Key('asset_chat_message_list'),
+      controller: _messageScrollController,
+      padding: const EdgeInsets.all(12),
+      itemCount: messages.length + (_viewModel.isSending ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (index == messages.length) {
+          return const Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: SizedBox(
+                key: Key('asset_chat_sending_indicator'),
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+          );
+        }
+        return _buildMessageBubble(messages[index], index);
+      },
+    );
+  }
+
+  Widget _buildMessageBubble(AssetChatMessage message, int index) {
+    final isUser = message.isUser;
+    final usage = message.usage;
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        key: Key('asset_chat_message_$index'),
+        constraints: const BoxConstraints(maxWidth: 320),
+        margin: const EdgeInsets.only(bottom: 10),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: isUser ? const Color(0xFF2E7D32) : const Color(0xFFF1F5F9),
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SelectableText(
+              message.text,
+              style: TextStyle(
+                color: isUser ? Colors.white : const Color(0xFF0F172A),
+                height: 1.45,
+              ),
+            ),
+            if (usage != null) ...[
+              const SizedBox(height: 7),
+              Text(
+                '入力 ${usage.tokensIn} / 出力 ${usage.tokensOut} tokens'
+                ' · ${_formatCost(usage.estimatedCostUsd)}',
+                key: Key('asset_chat_usage_$index'),
+                style: const TextStyle(
+                  color: Color(0xFF64748B),
+                  fontSize: 10,
+                  height: 1.3,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatCost(double cost) {
+    if (cost == 0) return r'$0.00';
+    if (cost < 0.01) return '\$${cost.toStringAsFixed(6)}';
+    return '\$${cost.toStringAsFixed(4)}';
+  }
+
+  Widget _buildError(String error) {
+    return Container(
+      key: const Key('asset_chat_error'),
+      width: double.infinity,
+      color: const Color(0xFFFEF2F2),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Text(
+        error,
+        style: const TextStyle(color: Color(0xFFB91C1C), fontSize: 12),
+      ),
+    );
+  }
+
+  Widget _buildInput() {
+    return SafeArea(
+      top: false,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(12, 8, 8, 10),
+        decoration: const BoxDecoration(
+          border: Border(top: BorderSide(color: Color(0xFFE2E8F0))),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(
+              child: TextField(
+                key: const Key('asset_chat_input'),
+                controller: _inputController,
+                enabled: !_viewModel.isSending,
+                minLines: 1,
+                maxLines: 4,
+                maxLength: 4000,
+                buildCounter:
+                    (
+                      _, {
+                      required currentLength,
+                      required isFocused,
+                      maxLength,
+                    }) => null,
+                textInputAction: TextInputAction.send,
+                onSubmitted: (_) => _sendCurrentMessage(),
+                decoration: const InputDecoration(
+                  hintText: '例: 今月の支払いで注意すべき点は？',
+                  isDense: true,
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ),
+            const SizedBox(width: 6),
+            IconButton.filled(
+              key: const Key('asset_chat_send_button'),
+              tooltip: '送信',
+              onPressed: _viewModel.isSending ? null : _sendCurrentMessage,
+              icon: const Icon(Icons.send),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/ai_hub_chat_service_test.dart
+++ b/test/services/ai_hub_chat_service_test.dart
@@ -9,6 +9,68 @@ void main() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
   });
 
+  test('sendAssetChat maps the backend thread and usage contract', () async {
+    final service = AiHubChatService(
+      invoker: (body) async {
+        expect(body['action'], 'ai_hub.asset_chat');
+        expect(body['message'], '今月の支払いを確認して');
+        expect(body['thread_id'], '11111111-1111-4111-8111-111111111111');
+        expect(body['snapshot_months'], 3);
+        expect(body['history_messages'], 8);
+        expect(body['pii_mode'], 'off');
+        return <String, dynamic>{
+          'success': true,
+          'thread_id': '11111111-1111-4111-8111-111111111111',
+          'thread_title': '今月の支払い',
+          'thread_created': false,
+          'reply': '未払い予定を先に確認してください。',
+          'provider': 'google',
+          'model': 'gemini-2.5-flash',
+          'tokens_in': 123,
+          'tokens_out': 45,
+          'estimated_cost_usd': 0.000321,
+        };
+      },
+    );
+
+    final response = await service.sendAssetChat(
+      message: '  今月の支払いを確認して  ',
+      threadId: '11111111-1111-4111-8111-111111111111',
+    );
+
+    expect(response.threadId, '11111111-1111-4111-8111-111111111111');
+    expect(response.threadTitle, '今月の支払い');
+    expect(response.threadCreated, isFalse);
+    expect(response.reply, '未払い予定を先に確認してください。');
+    expect(response.usage.tokensIn, 123);
+    expect(response.usage.tokensOut, 45);
+    expect(response.usage.totalTokens, 168);
+    expect(response.usage.estimatedCostUsd, 0.000321);
+    expect(response.usage.provider, 'google');
+    expect(response.usage.model, 'gemini-2.5-flash');
+  });
+
+  test('sendAssetChat rejects an incomplete successful response', () async {
+    final service = AiHubChatService(
+      invoker: (_) async => <String, dynamic>{
+        'success': true,
+        'thread_id': '11111111-1111-4111-8111-111111111111',
+        'reply': '',
+      },
+    );
+
+    await expectLater(
+      () => service.sendAssetChat(message: 'hello'),
+      throwsA(
+        isA<AiHubChatException>().having(
+          (error) => error.message,
+          'message',
+          contains('Asset chat response was empty'),
+        ),
+      ),
+    );
+  });
+
   test('sendProviderChat returns normalized provider text', () async {
     final service = AiHubChatService(
       invoker: (body) async {

--- a/test/view_models/asset_chat_view_model_test.dart
+++ b/test/view_models/asset_chat_view_model_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_chat.dart';
+import 'package:my_web_app/services/ai_hub_chat_service.dart';
+import 'package:my_web_app/view_models/asset_chat_view_model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    AiHubChatQuotaGuard.resetForTesting();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test(
+    'keeps current-session history and reuses the returned thread id',
+    () async {
+      final requests = <Map<String, dynamic>>[];
+      var call = 0;
+      final service = AiHubChatService(
+        invoker: (body) async {
+          requests.add(Map<String, dynamic>.from(body));
+          call += 1;
+          return <String, dynamic>{
+            'success': true,
+            'thread_id': '11111111-1111-4111-8111-111111111111',
+            'thread_title': '資産相談',
+            'thread_created': call == 1,
+            'reply': call == 1 ? '最初の回答' : '続きの回答',
+            'provider': 'google',
+            'model': 'gemini-2.5-flash',
+            'tokens_in': 100 + call,
+            'tokens_out': 20 + call,
+            'estimated_cost_usd': 0.0002 * call,
+          };
+        },
+      );
+      final viewModel = AssetChatViewModel(service: service);
+      addTearDown(viewModel.dispose);
+
+      expect(await viewModel.sendMessage('最初の質問'), isTrue);
+      expect(await viewModel.sendMessage('続きの質問'), isTrue);
+
+      expect(requests.first.containsKey('thread_id'), isFalse);
+      expect(
+        requests.last['thread_id'],
+        '11111111-1111-4111-8111-111111111111',
+      );
+      expect(viewModel.messages, hasLength(4));
+      expect(viewModel.messages[0].role, AssetChatMessageRole.user);
+      expect(viewModel.messages[1].role, AssetChatMessageRole.assistant);
+      expect(viewModel.messages[3].text, '続きの回答');
+      expect(viewModel.messages[3].usage?.tokensIn, 102);
+      expect(viewModel.threadTitle, '資産相談');
+      expect(viewModel.errorMessage, isNull);
+      expect(viewModel.isSending, isFalse);
+    },
+  );
+
+  test('keeps the user message and exposes a safe login error', () async {
+    final service = AiHubChatService(
+      invoker: (_) async => throw const AiHubChatException('unauthorized'),
+    );
+    final viewModel = AssetChatViewModel(service: service);
+    addTearDown(viewModel.dispose);
+
+    expect(await viewModel.sendMessage('相談したい'), isFalse);
+
+    expect(viewModel.messages, hasLength(1));
+    expect(viewModel.messages.single.text, '相談したい');
+    expect(viewModel.errorMessage, contains('ログイン'));
+    expect(viewModel.isSending, isFalse);
+  });
+
+  test('ignores empty messages', () async {
+    var invoked = false;
+    final service = AiHubChatService(
+      invoker: (_) async {
+        invoked = true;
+        return <String, dynamic>{};
+      },
+    );
+    final viewModel = AssetChatViewModel(service: service);
+    addTearDown(viewModel.dispose);
+
+    expect(await viewModel.sendMessage('   '), isFalse);
+    expect(invoked, isFalse);
+    expect(viewModel.messages, isEmpty);
+  });
+}

--- a/test/widgets/asset_chat_widget_test.dart
+++ b/test/widgets/asset_chat_widget_test.dart
@@ -14,17 +14,17 @@ Widget _testApp(AiHubChatService service) {
 }
 
 Map<String, dynamic> _successResponse() => <String, dynamic>{
-  'success': true,
-  'thread_id': '11111111-1111-4111-8111-111111111111',
-  'thread_title': '今月の支払い相談',
-  'thread_created': true,
-  'reply': '口座残高と未払い予定を確認してください。',
-  'provider': 'google',
-  'model': 'gemini-2.5-flash',
-  'tokens_in': 128,
-  'tokens_out': 42,
-  'estimated_cost_usd': 0.000321,
-};
+      'success': true,
+      'thread_id': '11111111-1111-4111-8111-111111111111',
+      'thread_title': '今月の支払い相談',
+      'thread_created': true,
+      'reply': '口座残高と未払い予定を確認してください。',
+      'provider': 'google',
+      'model': 'gemini-2.5-flash',
+      'tokens_in': 128,
+      'tokens_out': 42,
+      'estimated_cost_usd': 0.000321,
+    };
 
 void main() {
   setUp(() {

--- a/test/widgets/asset_chat_widget_test.dart
+++ b/test/widgets/asset_chat_widget_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/ai_hub_chat_service.dart';
+import 'package:my_web_app/widgets/asset_chat_widget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _testApp(AiHubChatService service) {
+  return MaterialApp(
+    home: Scaffold(
+      body: const SizedBox.expand(),
+      floatingActionButton: AssetChatWidget(service: service),
+    ),
+  );
+}
+
+Map<String, dynamic> _successResponse() => <String, dynamic>{
+  'success': true,
+  'thread_id': '11111111-1111-4111-8111-111111111111',
+  'thread_title': '今月の支払い相談',
+  'thread_created': true,
+  'reply': '口座残高と未払い予定を確認してください。',
+  'provider': 'google',
+  'model': 'gemini-2.5-flash',
+  'tokens_in': 128,
+  'tokens_out': 42,
+  'estimated_cost_usd': 0.000321,
+};
+
+void main() {
+  setUp(() {
+    AiHubChatQuotaGuard.resetForTesting();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('opens, sends, and displays reply with token cost', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(900, 720));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final service = AiHubChatService(invoker: (_) async => _successResponse());
+
+    await tester.pumpWidget(_testApp(service));
+    expect(find.byKey(const Key('asset_chat_open_button')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('asset_chat_open_button')));
+    await tester.pump();
+    expect(find.byKey(const Key('asset_chat_panel')), findsOneWidget);
+    expect(find.textContaining('資産スナップショットをAIへ送信'), findsOne);
+
+    await tester.enterText(
+      find.byKey(const Key('asset_chat_input')),
+      '今月の支払いを確認して',
+    );
+    await tester.tap(find.byKey(const Key('asset_chat_send_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('今月の支払いを確認して'), findsOneWidget);
+    expect(find.text('口座残高と未払い予定を確認してください。'), findsOneWidget);
+    expect(find.textContaining('入力 128 / 出力 42 tokens'), findsOneWidget);
+    expect(find.textContaining(r'$0.000321'), findsOneWidget);
+    expect(find.text('今月の支払い相談'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('asset_chat_close_button')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('asset_chat_open_button')));
+    await tester.pump();
+    expect(find.text('口座残高と未払い予定を確認してください。'), findsOneWidget);
+  });
+
+  testWidgets('shows a safe error and re-enables input after failure', (
+    tester,
+  ) async {
+    final service = AiHubChatService(
+      invoker: (_) async => throw const AiHubChatException('unauthorized'),
+    );
+    await tester.pumpWidget(_testApp(service));
+    await tester.tap(find.byKey(const Key('asset_chat_open_button')));
+    await tester.pump();
+    await tester.enterText(find.byKey(const Key('asset_chat_input')), '相談したい');
+    await tester.tap(find.byKey(const Key('asset_chat_send_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('asset_chat_error')), findsOneWidget);
+    expect(find.textContaining('ログイン'), findsOneWidget);
+    final input = tester.widget<TextField>(
+      find.byKey(const Key('asset_chat_input')),
+    );
+    expect(input.enabled, isTrue);
+  });
+
+  testWidgets('fits a narrow mobile viewport without overflow', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(320, 568));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final service = AiHubChatService(invoker: (_) async => _successResponse());
+
+    await tester.pumpWidget(_testApp(service));
+    await tester.tap(find.byKey(const Key('asset_chat_open_button')));
+    await tester.pump();
+
+    expect(find.byKey(const Key('asset_chat_panel')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+    final panelSize = tester.getSize(find.byKey(const Key('asset_chat_panel')));
+    expect(panelSize.width, lessThanOrEqualTo(320));
+    expect(panelSize.height, lessThanOrEqualTo(568));
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -102,6 +102,26 @@ void main() {
   });
 
   group('AssetManagementPage smoke', () {
+    testWidgets('sticky asset chat entry opens and closes the panel', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+
+      expect(find.byKey(const Key('asset_chat_open_button')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('asset_chat_open_button')));
+      await tester.pump();
+      expect(find.byKey(const Key('asset_chat_panel')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('asset_chat_close_button')));
+      await tester.pump();
+      expect(find.byKey(const Key('asset_chat_panel')), findsNothing);
+
+      await _unmount(tester);
+    });
+
     testWidgets('display mode chips reduce visible sections', (tester) async {
       await tester.binding.setSurfaceSize(const Size(1200, 2400));
       addTearDown(() => tester.binding.setSurfaceSize(null));


### PR DESCRIPTION
## 変更内容

- 資産管理ページ右下に開閉可能な「資産AIに相談」固定ウィジェットを追加
- 既存 `AiHubChatService` に `ai_hub.asset_chat` のリクエスト/レスポンス契約を追加
- ページ滞在中の会話履歴を ViewModel で保持し、2通目以降は返却済み `thread_id` を再利用
- 各AI回答に入出力トークン数と推定USDコストを表示
- 未ログイン、クォータ、オフライン、一般通信失敗を安全な日本語メッセージへ変換
- デスクトップ最大幅400px、狭幅320pxでも収まるレスポンシブパネルを追加

## スコープ境界

- 永続スレッド一覧・検索・詳細・削除は #2487 に残しています
- PII設定/変換UIは #2488 に残し、本Issueではバックエンド既定の `pii_mode: off` を使用します

## 検証

- `dart analyze --fatal-infos` — No issues found
- `flutter test --no-pub test/services/ai_hub_chat_service_test.dart test/view_models/asset_chat_view_model_test.dart test/widgets/asset_chat_widget_test.dart` — 15 passed
- `flutter test --no-pub test/widgets/asset_management_page_smoke_test.dart` — 既存64件 passed
- 追加したページ内開閉スモーク — 1 passed
- 320x568 viewport の無オーバーフロー、開閉後の履歴保持、送信失敗後の入力再有効化をWidgetテストで確認
- ローカルWebビルドは起動成功。in-app Browserの自動接続は環境側のパス初期化エラーで未実施

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: This floating authenticated widget needs seeded Supabase user data for a stable route E2E; the three user-visible paths are covered by isolated widget and page smoke tests.

Closes #2486