### PR TITLE
test(e2e): ランディングストーリーのロール指定を修正

### DIFF
--- a/test/e2e/landing_story_journey.spec.ts
+++ b/test/e2e/landing_story_journey.spec.ts
@@ -80,7 +80,7 @@ async function openLanding(page: Page) {
 }
 
 async function focusStory(page: Page) {
-  const story = page.getByRole('progressbar', {
+  const story = page.getByRole('group', {
     name: /自分株式会社で、迷いが今日の1件に変わるまで/,
   });
   await expect(story).toBeVisible({ timeout: 60_000 });


### PR DESCRIPTION
## 変更内容

- ランディングストーリーE2Eの対象ロールを、実際のFlutter Webセマンティクスに合わせて `progressbar` から `group` へ変更

## 原因

本番のアクセシビリティツリーでは、ストーリーは章移動ボタンを内包する `group` として公開されています。テストだけが `progressbar` を要求していたため、UIが正常に表示されていても60秒待機後に誤検知していました。

## 影響

製品UIの動作変更はありません。本番スモークが実際のアクセシビリティ構造を検証できるようになります。

## Minimal E2E Gate

- Implementation-detail independent path: LP treatment → story semantics group → chapter navigation → final CTA / no-signup trial
- Minimal scope: final chapterへ移動、登録なし導線への接続、最終章から第1章へ戻る、の3ケース
- E2E: `test/e2e/landing_story_journey.spec.ts`

## 検証

- 本番 `v1.0.1728` / commit `5b30c2fd9819bc63bc590d7ef0a02ba32fc501eb`
- Playwright: desktop 3件 + mobile 3件、計6件成功
- pre-commit fast quality gate成功