### PR TITLE
fix: preserve philosophy document title

### DIFF
--- a/lib/pages/philosophy_page.dart
+++ b/lib/pages/philosophy_page.dart
@@ -3,6 +3,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../utils/platform_view.dart' as platform_view;
+import '../utils/document_title.dart' as document_title;
+
+const philosophyDocumentTitle = '自分株式会社とは？人生を経営する9原則と実践方法';
+const homepageDocumentTitle = '自分株式会社とは？ | 人生を経営するAIライフマネジメントアプリ';
 
 /// 自分株式会社 — 基本理念ページ
 ///
@@ -21,6 +25,11 @@ class _PhilosophyPageState extends State<PhilosophyPage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        document_title.setDocumentTitle(philosophyDocumentTitle);
+      }
+    });
     for (final v in _videos) {
       final src = v.mp4Url ?? 'https://www.youtube.com/embed/${v.id}';
       platform_view.registerIframeViewFactory(
@@ -31,11 +40,17 @@ class _PhilosophyPageState extends State<PhilosophyPage> {
   }
 
   @override
+  void dispose() {
+    document_title.setDocumentTitle(homepageDocumentTitle);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final video = _videos[_selectedVideoIdx];
     return Title(
       key: const Key('philosophy_document_title'),
-      title: '自分株式会社とは？人生を経営する9原則と実践方法',
+      title: philosophyDocumentTitle,
       color: const Color(0xFF7986CB),
       child: Scaffold(
         backgroundColor: const Color(0xFF0A0A0A),

--- a/lib/utils/document_title.dart
+++ b/lib/utils/document_title.dart
@@ -1,0 +1,2 @@
+export 'document_title_stub.dart'
+    if (dart.library.js_interop) 'document_title_web.dart';

--- a/lib/utils/document_title_stub.dart
+++ b/lib/utils/document_title_stub.dart
@@ -1,0 +1,1 @@
+void setDocumentTitle(String title) {}

--- a/lib/utils/document_title_web.dart
+++ b/lib/utils/document_title_web.dart
@@ -1,0 +1,5 @@
+import 'package:web/web.dart' as web;
+
+void setDocumentTitle(String title) {
+  web.document.title = title;
+}

--- a/test/pages/philosophy_page_test.dart
+++ b/test/pages/philosophy_page_test.dart
@@ -29,7 +29,12 @@ void main() {
     expect(find.text('財務'), findsOneWidget);
     expect(find.text('マーケ営業'), findsOneWidget);
     expect(find.text('横断'), findsOneWidget);
-    expect(find.byKey(const Key('philosophy_document_title')), findsOneWidget);
+    final documentTitle = find.byKey(const Key('philosophy_document_title'));
+    expect(documentTitle, findsOneWidget);
+    expect(
+      tester.widget<Title>(documentTitle).title,
+      philosophyDocumentTitle,
+    );
     expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
## 概要

PR #4573 のproduction smokeで、`/philosophy`のFlutter本文・canonical・FAQPageは正しく配信された一方、Flutter起動後のdocument titleがホーム用へ戻ることを検出しました。このhotfixはWebで理念ページtitleを明示設定し、ページ離脱時にホームtitleへ戻します。

## 原因と変更

- Flutterの`Title`ウィジェットだけではproduction Webのdocument titleが保持されませんでした。
- `dart.library.js_interop`条件付きのdocument titleヘルパーを追加しました。
- `/philosophy`表示後のpost-frameで理念ページ固有titleを設定します。
- 非Webではno-opとし、既存のiOS/Android/VMテストを壊しません。
- widgetテストで`Title.title`が同じ定数を使うことを固定しました。

## 検証

- `flutter test test/pages/philosophy_page_test.dart`: 合格
- 対象5ファイルの`flutter analyze`: 問題なし
- `flutter build web --release`: 成功
- production smokeで修正前のcanonical、本文、FAQPage 1件／4問は正常で、titleだけが不一致であることを確認

## ロールバック

このPRをrevertすれば条件付きtitleヘルパーと理念ページの明示設定だけを戻せます。DB、認証、決済、デプロイ設定は変更しません。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: This scoped document-title fix has no interactive flow; focused widget tests, targeted analysis, release Web build, and production browser verification cover it.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Document title lifecycle only; no authentication, payment, database, deployment configuration, or other high-risk path changed.

## リリース

ユーザーの明示承認に基づき、required CI合格後にマージし、通常のproduction deploy workflowで再公開して実ブラウザ確認します。