### PR TITLE
fix: apply philosophy title after first frame

### DIFF
--- a/lib/pages/philosophy_page.dart
+++ b/lib/pages/philosophy_page.dart
@@ -26,9 +26,13 @@ class _PhilosophyPageState extends State<PhilosophyPage> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        document_title.setDocumentTitle(philosophyDocumentTitle);
-      }
+      // MaterialApp's root Title updates later in the first frame. Defer one
+      // event turn so the route-specific title is the final browser value.
+      Future<void>.delayed(Duration.zero, () {
+        if (mounted) {
+          document_title.setDocumentTitle(philosophyDocumentTitle);
+        }
+      });
     });
     for (final v in _videos) {
       final src = v.mp4Url ?? 'https://www.youtube.com/embed/${v.id}';

--- a/test/pages/philosophy_page_test.dart
+++ b/test/pages/philosophy_page_test.dart
@@ -14,6 +14,7 @@ void main() {
       const MaterialApp(home: PhilosophyPage()),
     );
     await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
 
     expect(
       find.text('自分株式会社を30日で運営する実践ガイド'),


### PR DESCRIPTION
## 概要

PR #4590 のproduction追跡で、静的HTMLの正しい`/philosophy` titleがFlutter初回frame（約2秒）でホームtitleへ上書きされることを確認しました。このfollow-upは、root `Title`のpost-frame処理が終わった次のevent turnで理念ページtitleを確定します。

## 変更

- 最初のpost-frame callback内で`Future<void>.delayed(Duration.zero, ...)`を使い、root title更新後にroute titleを設定
- `mounted`確認を維持
- widgetテストで次event turnを1ms pumpし、未処理timerが残らないことを検証

## 検証

- `flutter test test/pages/philosophy_page_test.dart`: 合格
- `flutter analyze lib/pages/philosophy_page.dart test/pages/philosophy_page_test.dart`: 問題なし
- 直前PR #4590の`flutter build web --release`とGitHub production Web build: 成功
- production title trace: 0–1秒はroute title、Flutter初回frame後の2秒でホームtitleへ上書きされる根本順序を確認

## ロールバック

このPRをrevertすればtitle設定タイミングと追加pumpだけを戻せます。DB、認証、決済、デプロイ設定は変更しません。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: This event-ordering title fix has no interactive flow; focused widget tests, targeted analysis, CI Web build, and production browser title tracing cover it.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Document title scheduling only; no authentication, payment, database, deployment configuration, or other high-risk path changed.

## リリース

ユーザーの明示承認に基づき、required CI合格後にマージし、通常のproduction deploy workflowで再公開して5秒後のtitleを実ブラウザ確認します。