### PR TITLE
fix: derive document title from active route

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:my_web_app/data/home_tool_catalog.dart';
 import 'package:my_web_app/utils/feature_route_labels.dart';
 import 'package:my_web_app/utils/route_url_sync.dart';
+import 'package:my_web_app/utils/route_document_title.dart';
 import 'package:my_web_app/models/site_guide_catalog_item.dart';
 import 'package:my_web_app/pages/abstinence_guard_page.dart';
 import 'package:my_web_app/pages/self_touch_tracker_page.dart';
@@ -1856,60 +1857,63 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     final themeService = Provider.of<ThemeService>(context);
 
-    return MaterialApp(
-      title: '自分株式会社', //  旧: マイメモ -> 新: 自分株式会社
-      debugShowCheckedModeBanner: false,
-      scaffoldMessengerKey: _scaffoldMessengerKey,
-      navigatorKey: _navigatorKey,
-      initialRoute: _initialRouteName(),
-      theme: themeService.overrideTheme ?? themeService.getLightTheme(),
-      darkTheme: themeService.overrideTheme ?? themeService.getDarkTheme(),
-      themeMode: themeService.overrideTheme != null
-          ? ThemeMode.light
-          : themeService.getFlutterThemeMode(),
-      builder: (context, child) {
-        return GlobalHeaderClockShell(
-          navigatorKey: _navigatorKey,
-          child: UniversalAiShareShell(
+    return ValueListenableBuilder(
+      valueListenable: universalAiShareRouteObserver.currentPage,
+      builder: (context, currentPage, _) => MaterialApp(
+        title: documentTitleForRoute(currentPage.routePath),
+        debugShowCheckedModeBanner: false,
+        scaffoldMessengerKey: _scaffoldMessengerKey,
+        navigatorKey: _navigatorKey,
+        initialRoute: _initialRouteName(),
+        theme: themeService.overrideTheme ?? themeService.getLightTheme(),
+        darkTheme: themeService.overrideTheme ?? themeService.getDarkTheme(),
+        themeMode: themeService.overrideTheme != null
+            ? ThemeMode.light
+            : themeService.getFlutterThemeMode(),
+        builder: (context, child) {
+          return GlobalHeaderClockShell(
             navigatorKey: _navigatorKey,
-            child: MaintenanceShell(
-              routeListenable: universalAiShareRouteObserver.currentPage,
-              child: Column(
-                children: [
-                  if (_showUpdateBanner)
-                    UpdateBanner(
-                      onDismiss: () =>
-                          setState(() => _showUpdateBanner = false),
-                    ),
-                  Expanded(child: child ?? const SizedBox.shrink()),
-                ],
+            child: UniversalAiShareShell(
+              navigatorKey: _navigatorKey,
+              child: MaintenanceShell(
+                routeListenable: universalAiShareRouteObserver.currentPage,
+                child: Column(
+                  children: [
+                    if (_showUpdateBanner)
+                      UpdateBanner(
+                        onDismiss: () =>
+                            setState(() => _showUpdateBanner = false),
+                      ),
+                    Expanded(child: child ?? const SizedBox.shrink()),
+                  ],
+                ),
               ),
             ),
+          );
+        },
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('ja'), Locale('en')],
+        locale: const Locale('ja'),
+        navigatorObservers: <NavigatorObserver>[
+          _growthPresenceObserver,
+          universalAiShareRouteObserver,
+          // deep link 直開き時に下へ積まれた HomePage / LandingPage の fetch・
+          // LP View 計測を可視化まで遅延させる (可視化ゲート)。
+          deepLinkVisibilityRouteObserver,
+          if (MyApp._sentryNavigatorObserver != null)
+            MyApp._sentryNavigatorObserver!,
+        ],
+        onGenerateRoute: (settings) => ensureRouteAnnouncesUrl(
+          generateAppRoute(
+            settings,
+            signupCompletionService: widget.signupCompletionService,
           ),
-        );
-      },
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [Locale('ja'), Locale('en')],
-      locale: const Locale('ja'),
-      navigatorObservers: <NavigatorObserver>[
-        _growthPresenceObserver,
-        universalAiShareRouteObserver,
-        // deep link 直開き時に下へ積まれた HomePage / LandingPage の fetch・
-        // LP View 計測を可視化まで遅延させる (可視化ゲート)。
-        deepLinkVisibilityRouteObserver,
-        if (MyApp._sentryNavigatorObserver != null)
-          MyApp._sentryNavigatorObserver!,
-      ],
-      onGenerateRoute: (settings) => ensureRouteAnnouncesUrl(
-        generateAppRoute(
           settings,
-          signupCompletionService: widget.signupCompletionService,
         ),
-        settings,
       ),
     );
   }

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -14,6 +14,7 @@ import '../services/landing_page_adapter.dart';
 import '../services/landing_signup_completion_service.dart';
 import '../services/pending_landing_trial_service.dart';
 import '../services/route_visibility_observer.dart';
+import '../utils/route_document_title.dart';
 import '../widgets/live_growth_banner.dart';
 import '../widgets/landing_story_journey.dart';
 
@@ -5194,7 +5195,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   if (ModalRoute.of(context)?.isCurrent ?? true)
                     Title(
                       key: const Key('landing_document_title'),
-                      title: '自分株式会社とは？ | 人生を経営するAIライフマネジメントアプリ',
+                      title: landingDocumentTitle,
                       color: const Color(0xFF1F7AE0),
                       child: const SizedBox.shrink(),
                     ),

--- a/lib/pages/philosophy_page.dart
+++ b/lib/pages/philosophy_page.dart
@@ -3,8 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../utils/platform_view.dart' as platform_view;
-
-const philosophyDocumentTitle = '自分株式会社とは？人生を経営する9原則と実践方法';
+import '../utils/route_document_title.dart';
 
 /// 自分株式会社 — 基本理念ページ
 ///

--- a/lib/utils/route_document_title.dart
+++ b/lib/utils/route_document_title.dart
@@ -1,0 +1,10 @@
+const landingDocumentTitle = '自分株式会社とは？ | 人生を経営するAIライフマネジメントアプリ';
+const philosophyDocumentTitle = '自分株式会社とは？人生を経営する9原則と実践方法';
+
+String documentTitleForRoute(String routePath) {
+  return switch (routePath) {
+    '/philosophy' => philosophyDocumentTitle,
+    '/' => landingDocumentTitle,
+    _ => '自分株式会社',
+  };
+}

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -10,6 +10,7 @@ import 'package:my_web_app/services/landing_page_adapter.dart';
 import 'package:my_web_app/services/landing_signup_completion_service.dart';
 import 'package:my_web_app/services/pending_landing_trial_service.dart';
 import 'package:my_web_app/services/route_visibility_observer.dart';
+import 'package:my_web_app/utils/route_document_title.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -315,7 +316,7 @@ void main() {
     );
     expect(
       documentTitle.title,
-      '自分株式会社とは？ | 人生を経営するAIライフマネジメントアプリ',
+      landingDocumentTitle,
     );
   });
 

--- a/test/pages/philosophy_page_test.dart
+++ b/test/pages/philosophy_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/pages/philosophy_page.dart';
+import 'package:my_web_app/utils/route_document_title.dart';
 
 void main() {
   testWidgets('philosophy page explains the self-management operating model',

--- a/test/utils/route_document_title_test.dart
+++ b/test/utils/route_document_title_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/utils/route_document_title.dart';
+
+void main() {
+  test('public SEO routes keep their canonical document titles', () {
+    expect(documentTitleForRoute('/'), landingDocumentTitle);
+    expect(documentTitleForRoute('/philosophy'), philosophyDocumentTitle);
+    expect(documentTitleForRoute('/settings'), '自分株式会社');
+  });
+}


### PR DESCRIPTION
## 調査根拠

本番 `/philosophy` のブラウザタイトルを10秒追跡したところ、背面LPの上書き修正後も最上位 `MaterialApp` の既定タイトル「自分株式会社」が残りました。ページ単位の `Title` では、アプリ最上位の再描画を恒久的に上書きできないことが原因です。

## 変更内容

- 最上位 `MaterialApp` を既存の現在ルート通知へ接続
- `/` と `/philosophy` の正式タイトルを共通ユーティリティで一元管理
- ページ内 `Title` と最上位タイトルで同じ定数を利用
- ルート別タイトル判定の専用テストを追加

## 検証結果

- 対象Flutterテスト29件成功
- 対象6ファイルの `flutter analyze` 成功
- SEO生成テスト16件成功
- `flutter build web --release --no-wasm-dry-run` 成功
- `git diff --check` 問題なし

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Route-title ownership is covered by unit, widget, release-build, and post-deploy browser timing checks.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Production verification wording is descriptive only; no security, data, infrastructure, secret, or deployment workflow path changed.

## ロールバック

このPRのマージコミットをrevertすると、直前のページ単位タイトル処理に戻せます。