### PR TITLE
feat: 資産AIチャット履歴ページを追加 (#2487)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -143,6 +143,7 @@ import 'package:my_web_app/pages/team_workspace_page.dart';
 import 'package:my_web_app/pages/ai_status_page.dart';
 import 'package:my_web_app/pages/ai_provider_status_page.dart';
 import 'package:my_web_app/pages/asset_management_page.dart';
+import 'package:my_web_app/pages/asset_chat_history_page.dart';
 import 'package:my_web_app/pages/cfo_office_page.dart';
 import 'package:my_web_app/pages/cho_office_page.dart';
 import 'package:my_web_app/pages/chro_office_page.dart';
@@ -1094,6 +1095,10 @@ Route<dynamic> generateAppRoute(
     case '/asset-management':
       return MaterialPageRoute(
         builder: (_) => const AssetManagementPage(),
+      );
+    case '/asset-chat-history':
+      return MaterialPageRoute(
+        builder: (_) => const AssetChatHistoryPage(),
       );
     case '/cfo-office':
       return MaterialPageRoute(builder: (_) => const CfoOfficePage());

--- a/lib/models/asset_chat.dart
+++ b/lib/models/asset_chat.dart
@@ -43,3 +43,106 @@ class AssetChatResponse {
     required this.usage,
   });
 }
+
+class AssetChatThreadSummary {
+  final String id;
+  final String title;
+  final DateTime createdAt;
+  final DateTime lastMessageAt;
+
+  const AssetChatThreadSummary({
+    required this.id,
+    required this.title,
+    required this.createdAt,
+    required this.lastMessageAt,
+  });
+
+  factory AssetChatThreadSummary.fromMap(Map<String, dynamic> map) {
+    return AssetChatThreadSummary(
+      id: _requiredString(map, 'id'),
+      title: _requiredString(map, 'title'),
+      createdAt: _requiredDateTime(map, 'created_at'),
+      lastMessageAt: _requiredDateTime(map, 'last_message_at'),
+    );
+  }
+}
+
+class AssetChatStoredMessage {
+  final String id;
+  final String threadId;
+  final AssetChatMessageRole role;
+  final String text;
+  final int tokensIn;
+  final int tokensOut;
+  final String? model;
+  final DateTime createdAt;
+
+  const AssetChatStoredMessage({
+    required this.id,
+    required this.threadId,
+    required this.role,
+    required this.text,
+    required this.tokensIn,
+    required this.tokensOut,
+    required this.model,
+    required this.createdAt,
+  });
+
+  factory AssetChatStoredMessage.fromMap(Map<String, dynamic> map) {
+    final roleValue = _requiredString(map, 'role');
+    final role = switch (roleValue) {
+      'user' => AssetChatMessageRole.user,
+      'assistant' => AssetChatMessageRole.assistant,
+      _ => throw FormatException('Unsupported asset chat role: $roleValue'),
+    };
+    final modelValue = map['model']?.toString().trim();
+    return AssetChatStoredMessage(
+      id: _requiredString(map, 'id'),
+      threadId: _requiredString(map, 'thread_id'),
+      role: role,
+      text: _requiredString(map, 'content'),
+      tokensIn: _nonNegativeInt(map['tokens_in']),
+      tokensOut: _nonNegativeInt(map['tokens_out']),
+      model: modelValue == null || modelValue.isEmpty ? null : modelValue,
+      createdAt: _requiredDateTime(map, 'created_at'),
+    );
+  }
+
+  bool get isUser => role == AssetChatMessageRole.user;
+}
+
+class AssetChatThreadPage {
+  final List<AssetChatThreadSummary> items;
+  final bool hasMore;
+
+  const AssetChatThreadPage({required this.items, required this.hasMore});
+}
+
+class AssetChatMessagePage {
+  final List<AssetChatStoredMessage> items;
+  final bool hasMore;
+
+  const AssetChatMessagePage({required this.items, required this.hasMore});
+}
+
+String _requiredString(Map<String, dynamic> map, String key) {
+  final value = map[key]?.toString().trim() ?? '';
+  if (value.isEmpty) {
+    throw FormatException('Asset chat $key is required');
+  }
+  return value;
+}
+
+DateTime _requiredDateTime(Map<String, dynamic> map, String key) {
+  final value = _requiredString(map, key);
+  final parsed = DateTime.tryParse(value);
+  if (parsed == null) {
+    throw FormatException('Asset chat $key must be an ISO-8601 timestamp');
+  }
+  return parsed;
+}
+
+int _nonNegativeInt(Object? value) {
+  final parsed = value is num ? value.toInt() : int.tryParse('$value') ?? 0;
+  return parsed < 0 ? 0 : parsed;
+}

--- a/lib/pages/asset_chat_history_page.dart
+++ b/lib/pages/asset_chat_history_page.dart
@@ -1,0 +1,417 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../models/asset_chat.dart';
+import '../services/asset_chat_history_repository.dart';
+import '../view_models/asset_chat_history_view_model.dart';
+
+class AssetChatHistoryPage extends StatefulWidget {
+  final AssetChatHistoryRepository? repository;
+  final AssetChatHistoryViewModel? viewModel;
+
+  const AssetChatHistoryPage({
+    super.key,
+    this.repository,
+    this.viewModel,
+  });
+
+  @override
+  State<AssetChatHistoryPage> createState() => _AssetChatHistoryPageState();
+}
+
+class _AssetChatHistoryPageState extends State<AssetChatHistoryPage> {
+  static const double _wideBreakpoint = 760;
+
+  final TextEditingController _searchController = TextEditingController();
+  late final AssetChatHistoryViewModel _viewModel;
+  late final bool _ownsViewModel;
+  bool _showMobileDetail = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _ownsViewModel = widget.viewModel == null;
+    _viewModel = widget.viewModel ??
+        AssetChatHistoryViewModel(
+          repository: widget.repository ?? SupabaseAssetChatHistoryRepository(),
+        );
+    _searchController.text = _viewModel.searchQuery;
+    _viewModel.addListener(_handleViewModelChanged);
+    if (_viewModel.threads.isEmpty && !_viewModel.isLoadingThreads) {
+      unawaited(_viewModel.initialize());
+    }
+  }
+
+  @override
+  void dispose() {
+    _viewModel.removeListener(_handleViewModelChanged);
+    if (_ownsViewModel) _viewModel.dispose();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _handleViewModelChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _selectThread(AssetChatThreadSummary thread) async {
+    setState(() => _showMobileDetail = true);
+    await _viewModel.selectThread(thread);
+  }
+
+  Future<void> _confirmDelete(AssetChatThreadSummary thread) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('チャットを削除しますか？'),
+        content: Text(
+          '「${thread.title}」のメッセージをすべて削除します。この操作は元に戻せません。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            key: const Key('asset_chat_delete_confirm_button'),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('削除する'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    final deleted = await _viewModel.deleteThread(thread);
+    if (!mounted) return;
+    if (deleted && _showMobileDetail) {
+      setState(() => _showMobileDetail = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('資産AIチャット履歴'),
+        backgroundColor: const Color(0xFF1B5E20),
+        foregroundColor: Colors.white,
+      ),
+      body: Column(
+        children: [
+          if (_viewModel.errorMessage case final error?)
+            MaterialBanner(
+              key: const Key('asset_chat_history_error'),
+              content: Text(error),
+              leading: const Icon(Icons.error_outline),
+              actions: [
+                TextButton(
+                  onPressed: _viewModel.clearError,
+                  child: const Text('閉じる'),
+                ),
+                TextButton(
+                  onPressed: () => _viewModel.loadThreads(reset: true),
+                  child: const Text('再試行'),
+                ),
+              ],
+            ),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                if (constraints.maxWidth >= _wideBreakpoint) {
+                  return Row(
+                    key: const Key('asset_chat_history_wide_layout'),
+                    children: [
+                      SizedBox(width: 360, child: _buildThreadPane()),
+                      const VerticalDivider(width: 1),
+                      Expanded(child: _buildDetailPane()),
+                    ],
+                  );
+                }
+                return KeyedSubtree(
+                  key: const Key('asset_chat_history_narrow_layout'),
+                  child: _showMobileDetail && _viewModel.selectedThread != null
+                      ? _buildDetailPane(showBackButton: true)
+                      : _buildThreadPane(),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildThreadPane() {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 10),
+          child: TextField(
+            key: const Key('asset_chat_history_search_input'),
+            controller: _searchController,
+            textInputAction: TextInputAction.search,
+            onSubmitted: _viewModel.search,
+            decoration: InputDecoration(
+              labelText: 'スレッド名を検索',
+              hintText: '例: 支払い相談',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: _viewModel.searchQuery.isEmpty
+                  ? IconButton(
+                      key: const Key('asset_chat_history_search_button'),
+                      tooltip: '検索',
+                      onPressed: () =>
+                          _viewModel.search(_searchController.text),
+                      icon: const Icon(Icons.arrow_forward),
+                    )
+                  : IconButton(
+                      key: const Key('asset_chat_history_clear_search_button'),
+                      tooltip: '検索をクリア',
+                      onPressed: () {
+                        _searchController.clear();
+                        unawaited(_viewModel.clearSearch());
+                      },
+                      icon: const Icon(Icons.clear),
+                    ),
+              border: const OutlineInputBorder(),
+            ),
+          ),
+        ),
+        if (_viewModel.searchQuery.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                '「${_viewModel.searchQuery}」の検索結果',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+          ),
+        Expanded(child: _buildThreadList()),
+      ],
+    );
+  }
+
+  Widget _buildThreadList() {
+    if (_viewModel.isLoadingThreads && _viewModel.threads.isEmpty) {
+      return const Center(
+        child: CircularProgressIndicator(
+          key: Key('asset_chat_history_loading_threads'),
+        ),
+      );
+    }
+    if (_viewModel.threads.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: () => _viewModel.loadThreads(reset: true),
+        child: ListView(
+          key: const Key('asset_chat_history_empty'),
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 96),
+            Icon(Icons.forum_outlined, size: 48, color: Colors.black38),
+            SizedBox(height: 12),
+            Text(
+              'チャット履歴はありません',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontWeight: FontWeight.w700),
+            ),
+            SizedBox(height: 6),
+            Text(
+              '資産管理画面の「資産AIに相談」から会話を始められます。',
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+    }
+
+    final itemCount = _viewModel.threads.length +
+        (_viewModel.hasMoreThreads || _viewModel.isLoadingThreads ? 1 : 0);
+    return RefreshIndicator(
+      onRefresh: () => _viewModel.loadThreads(reset: true),
+      child: ListView.separated(
+        key: const Key('asset_chat_history_thread_list'),
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: itemCount,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          if (index == _viewModel.threads.length) {
+            return Padding(
+              padding: const EdgeInsets.all(12),
+              child: Center(
+                child: _viewModel.isLoadingThreads
+                    ? const CircularProgressIndicator(strokeWidth: 2)
+                    : OutlinedButton(
+                        key: const Key('asset_chat_history_load_more_threads'),
+                        onPressed: _viewModel.loadThreads,
+                        child: const Text('さらに表示'),
+                      ),
+              ),
+            );
+          }
+          final thread = _viewModel.threads[index];
+          return ListTile(
+            key: Key('asset_chat_thread_${thread.id}'),
+            selected: _viewModel.selectedThread?.id == thread.id,
+            leading: const CircleAvatar(child: Icon(Icons.chat_bubble_outline)),
+            title: Text(
+              thread.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Text('最終更新 ${_formatDateTime(thread.lastMessageAt)}'),
+            trailing: IconButton(
+              key: Key('asset_chat_delete_${thread.id}'),
+              tooltip: 'このチャットを削除',
+              onPressed:
+                  _viewModel.isDeleting ? null : () => _confirmDelete(thread),
+              icon: const Icon(Icons.delete_outline),
+            ),
+            onTap: () => _selectThread(thread),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildDetailPane({bool showBackButton = false}) {
+    final thread = _viewModel.selectedThread;
+    if (thread == null) {
+      return const Center(
+        key: Key('asset_chat_history_no_selection'),
+        child: Text('スレッドを選択するとメッセージを表示します。'),
+      );
+    }
+    return Column(
+      key: const Key('asset_chat_history_detail'),
+      children: [
+        Material(
+          color: Theme.of(context).colorScheme.surfaceContainerLow,
+          child: ListTile(
+            leading: showBackButton
+                ? IconButton(
+                    key: const Key('asset_chat_history_back_to_list'),
+                    tooltip: '履歴一覧へ戻る',
+                    onPressed: () => setState(() => _showMobileDetail = false),
+                    icon: const Icon(Icons.arrow_back),
+                  )
+                : const Icon(Icons.chat),
+            title: Text(
+              thread.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Text('開始 ${_formatDateTime(thread.createdAt)}'),
+            trailing: IconButton(
+              key: const Key('asset_chat_history_detail_delete'),
+              tooltip: 'このチャットを削除',
+              onPressed:
+                  _viewModel.isDeleting ? null : () => _confirmDelete(thread),
+              icon: const Icon(Icons.delete_outline),
+            ),
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(child: _buildMessages()),
+      ],
+    );
+  }
+
+  Widget _buildMessages() {
+    if (_viewModel.isLoadingMessages && _viewModel.messages.isEmpty) {
+      return const Center(
+        child: CircularProgressIndicator(
+          key: Key('asset_chat_history_loading_messages'),
+        ),
+      );
+    }
+    if (_viewModel.messages.isEmpty) {
+      return const Center(
+        key: Key('asset_chat_history_empty_messages'),
+        child: Text('このスレッドにはメッセージがありません。'),
+      );
+    }
+
+    final showOlder = _viewModel.hasOlderMessages ||
+        (_viewModel.isLoadingMessages && _viewModel.messages.isNotEmpty);
+    return ListView.builder(
+      key: const Key('asset_chat_history_message_list'),
+      padding: const EdgeInsets.all(16),
+      itemCount: _viewModel.messages.length + (showOlder ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (showOlder && index == 0) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: _viewModel.isLoadingMessages
+                  ? const CircularProgressIndicator(strokeWidth: 2)
+                  : OutlinedButton.icon(
+                      key: const Key('asset_chat_history_load_older_messages'),
+                      onPressed: _viewModel.loadOlderMessages,
+                      icon: const Icon(Icons.expand_less),
+                      label: const Text('以前のメッセージを表示'),
+                    ),
+            ),
+          );
+        }
+        final messageIndex = index - (showOlder ? 1 : 0);
+        return _buildMessage(_viewModel.messages[messageIndex]);
+      },
+    );
+  }
+
+  Widget _buildMessage(AssetChatStoredMessage message) {
+    final isUser = message.isUser;
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        key: Key('asset_chat_history_message_${message.id}'),
+        constraints: const BoxConstraints(maxWidth: 640),
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+        decoration: BoxDecoration(
+          color: isUser
+              ? const Color(0xFF2E7D32)
+              : Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SelectableText(
+              message.text,
+              style: TextStyle(
+                color: isUser ? Colors.white : null,
+                height: 1.45,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              [
+                _formatDateTime(message.createdAt),
+                if (!isUser && message.model != null) message.model!,
+                if (!isUser && message.tokensIn + message.tokensOut > 0)
+                  '${message.tokensIn + message.tokensOut} tokens',
+              ].join(' · '),
+              style: TextStyle(
+                color: isUser ? Colors.white70 : Colors.black54,
+                fontSize: 10,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _formatDateTime(DateTime value) {
+  final local = value.toLocal();
+  String two(int number) => number.toString().padLeft(2, '0');
+  return '${local.year}/${two(local.month)}/${two(local.day)} '
+      '${two(local.hour)}:${two(local.minute)}';
+}

--- a/lib/services/asset_chat_history_repository.dart
+++ b/lib/services/asset_chat_history_repository.dart
@@ -1,0 +1,167 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/asset_chat.dart';
+
+abstract class AssetChatHistoryRepository {
+  const AssetChatHistoryRepository();
+
+  Future<AssetChatThreadPage> fetchThreads({
+    String searchQuery = '',
+    int offset = 0,
+    int limit = 50,
+  });
+
+  Future<AssetChatMessagePage> fetchMessages({
+    required String threadId,
+    int offset = 0,
+    int limit = 100,
+  });
+
+  Future<void> deleteThread(String threadId);
+}
+
+class AssetChatHistoryRepositoryException implements Exception {
+  final String code;
+  final String message;
+
+  const AssetChatHistoryRepositoryException(this.code, this.message);
+
+  @override
+  String toString() => message;
+}
+
+class SupabaseAssetChatHistoryRepository implements AssetChatHistoryRepository {
+  SupabaseAssetChatHistoryRepository({SupabaseClient? client})
+      : _client = client ?? Supabase.instance.client;
+
+  static const String threadTable = 'asset_chat_threads';
+  static const String messageTable = 'asset_chat_messages';
+  static const String threadColumns = 'id,title,created_at,last_message_at';
+  static const String messageColumns =
+      'id,thread_id,role,content,tokens_in,tokens_out,model,created_at';
+
+  final SupabaseClient _client;
+
+  @override
+  Future<AssetChatThreadPage> fetchThreads({
+    String searchQuery = '',
+    int offset = 0,
+    int limit = 50,
+  }) async {
+    final userId = _requiredUserId();
+    final safeOffset = offset < 0 ? 0 : offset;
+    final safeLimit = limit.clamp(1, 100);
+    var request =
+        _client.from(threadTable).select(threadColumns).eq('user_id', userId);
+    final normalizedSearch = searchQuery.trim();
+    if (normalizedSearch.isNotEmpty) {
+      request = request.ilike('title', '%${_escapeLike(normalizedSearch)}%');
+    }
+    try {
+      final rows = await request
+          .order('last_message_at', ascending: false)
+          .order('id', ascending: true)
+          .range(safeOffset, safeOffset + safeLimit);
+      final pageRows = _rows(rows);
+      return AssetChatThreadPage(
+        items: List<AssetChatThreadSummary>.unmodifiable(
+          pageRows.take(safeLimit).map(AssetChatThreadSummary.fromMap),
+        ),
+        hasMore: pageRows.length > safeLimit,
+      );
+    } on PostgrestException catch (error) {
+      throw AssetChatHistoryRepositoryException(
+        'thread_read_failed',
+        error.message,
+      );
+    }
+  }
+
+  @override
+  Future<AssetChatMessagePage> fetchMessages({
+    required String threadId,
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    _requiredUserId();
+    final normalizedThreadId = _requiredId(threadId, 'threadId');
+    final safeOffset = offset < 0 ? 0 : offset;
+    final safeLimit = limit.clamp(1, 200);
+    try {
+      final rows = await _client
+          .from(messageTable)
+          .select(messageColumns)
+          .eq('thread_id', normalizedThreadId)
+          .order('created_at', ascending: false)
+          .order('id', ascending: false)
+          .range(safeOffset, safeOffset + safeLimit);
+      final pageRows = _rows(rows);
+      return AssetChatMessagePage(
+        items: List<AssetChatStoredMessage>.unmodifiable(
+          pageRows.take(safeLimit).map(AssetChatStoredMessage.fromMap),
+        ),
+        hasMore: pageRows.length > safeLimit,
+      );
+    } on PostgrestException catch (error) {
+      throw AssetChatHistoryRepositoryException(
+        'message_read_failed',
+        error.message,
+      );
+    }
+  }
+
+  @override
+  Future<void> deleteThread(String threadId) async {
+    final userId = _requiredUserId();
+    final normalizedThreadId = _requiredId(threadId, 'threadId');
+    try {
+      final rows = await _client
+          .from(threadTable)
+          .delete()
+          .eq('id', normalizedThreadId)
+          .eq('user_id', userId)
+          .select('id');
+      if (_rows(rows).isEmpty) {
+        throw const AssetChatHistoryRepositoryException(
+          'thread_not_found',
+          'Asset chat thread not found',
+        );
+      }
+    } on PostgrestException catch (error) {
+      throw AssetChatHistoryRepositoryException(
+        'thread_delete_failed',
+        error.message,
+      );
+    }
+  }
+
+  String _requiredUserId() {
+    final userId = _client.auth.currentUser?.id.trim() ?? '';
+    if (userId.isEmpty) {
+      throw const AssetChatHistoryRepositoryException(
+        'login_required',
+        'Authenticated user required',
+      );
+    }
+    return userId;
+  }
+}
+
+List<Map<String, dynamic>> _rows(Object? value) {
+  if (value is! List) return const <Map<String, dynamic>>[];
+  return value
+      .whereType<Map>()
+      .map((row) => row.cast<String, dynamic>())
+      .toList(growable: false);
+}
+
+String _requiredId(String value, String name) {
+  final normalized = value.trim();
+  if (normalized.isEmpty) {
+    throw ArgumentError.value(value, name, 'must not be empty');
+  }
+  return normalized;
+}
+
+String _escapeLike(String value) =>
+    value.replaceAll(r'\', r'\\').replaceAll('%', r'\%').replaceAll('_', r'\_');

--- a/lib/view_models/asset_chat_history_view_model.dart
+++ b/lib/view_models/asset_chat_history_view_model.dart
@@ -1,0 +1,211 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/asset_chat.dart';
+import '../services/asset_chat_history_repository.dart';
+
+class AssetChatHistoryViewModel extends ChangeNotifier {
+  AssetChatHistoryViewModel({required AssetChatHistoryRepository repository})
+      : _repository = repository;
+
+  static const int threadPageSize = 50;
+  static const int messagePageSize = 100;
+
+  final AssetChatHistoryRepository _repository;
+  final List<AssetChatThreadSummary> _threads = [];
+  final List<AssetChatStoredMessage> _messages = [];
+
+  bool _isLoadingThreads = false;
+  bool _isLoadingMessages = false;
+  bool _isDeleting = false;
+  bool _hasMoreThreads = false;
+  bool _hasOlderMessages = false;
+  String _searchQuery = '';
+  String? _errorMessage;
+  AssetChatThreadSummary? _selectedThread;
+  int _threadRequestVersion = 0;
+  int _messageRequestVersion = 0;
+
+  UnmodifiableListView<AssetChatThreadSummary> get threads =>
+      UnmodifiableListView(_threads);
+  UnmodifiableListView<AssetChatStoredMessage> get messages =>
+      UnmodifiableListView(_messages);
+  bool get isLoadingThreads => _isLoadingThreads;
+  bool get isLoadingMessages => _isLoadingMessages;
+  bool get isDeleting => _isDeleting;
+  bool get hasMoreThreads => _hasMoreThreads;
+  bool get hasOlderMessages => _hasOlderMessages;
+  String get searchQuery => _searchQuery;
+  String? get errorMessage => _errorMessage;
+  AssetChatThreadSummary? get selectedThread => _selectedThread;
+
+  Future<void> initialize() => loadThreads(reset: true);
+
+  Future<void> search(String value) async {
+    final normalized = value.trim();
+    if (normalized == _searchQuery && _threads.isNotEmpty) return;
+    _searchQuery = normalized;
+    await loadThreads(reset: true);
+  }
+
+  Future<void> clearSearch() => search('');
+
+  Future<void> loadThreads({bool reset = false}) async {
+    if (_isLoadingThreads && !reset) return;
+    if (!reset && !_hasMoreThreads && _threads.isNotEmpty) return;
+    final requestVersion = ++_threadRequestVersion;
+    _isLoadingThreads = true;
+    _errorMessage = null;
+    if (reset) {
+      _threads.clear();
+      _hasMoreThreads = false;
+    }
+    notifyListeners();
+
+    try {
+      final page = await _repository.fetchThreads(
+        searchQuery: _searchQuery,
+        offset: reset ? 0 : _threads.length,
+        limit: threadPageSize,
+      );
+      if (requestVersion != _threadRequestVersion) return;
+      _appendUniqueThreads(page.items);
+      _hasMoreThreads = page.hasMore;
+
+      final selectedId = _selectedThread?.id;
+      final selectedStillVisible = selectedId != null &&
+          _threads.any((thread) => thread.id == selectedId);
+      if (!selectedStillVisible) {
+        _selectedThread = null;
+        _messages.clear();
+        _hasOlderMessages = false;
+      }
+    } catch (error) {
+      if (requestVersion == _threadRequestVersion) {
+        _errorMessage = _safeError(error);
+      }
+    } finally {
+      if (requestVersion == _threadRequestVersion) {
+        _isLoadingThreads = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> selectThread(AssetChatThreadSummary thread) async {
+    final requestVersion = ++_messageRequestVersion;
+    _selectedThread = thread;
+    _messages.clear();
+    _hasOlderMessages = false;
+    _isLoadingMessages = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final page = await _repository.fetchMessages(
+        threadId: thread.id,
+        limit: messagePageSize,
+      );
+      if (requestVersion != _messageRequestVersion) return;
+      _messages.addAll(page.items.reversed);
+      _hasOlderMessages = page.hasMore;
+    } catch (error) {
+      if (requestVersion == _messageRequestVersion) {
+        _errorMessage = _safeError(error);
+      }
+    } finally {
+      if (requestVersion == _messageRequestVersion) {
+        _isLoadingMessages = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> loadOlderMessages() async {
+    final thread = _selectedThread;
+    if (thread == null || _isLoadingMessages || !_hasOlderMessages) return;
+    final requestVersion = ++_messageRequestVersion;
+    _isLoadingMessages = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final page = await _repository.fetchMessages(
+        threadId: thread.id,
+        offset: _messages.length,
+        limit: messagePageSize,
+      );
+      if (requestVersion != _messageRequestVersion ||
+          _selectedThread?.id != thread.id) {
+        return;
+      }
+      final knownIds = _messages.map((message) => message.id).toSet();
+      final older = page.items
+          .where((message) => !knownIds.contains(message.id))
+          .toList(growable: false)
+          .reversed;
+      _messages.insertAll(0, older);
+      _hasOlderMessages = page.hasMore;
+    } catch (error) {
+      if (requestVersion == _messageRequestVersion) {
+        _errorMessage = _safeError(error);
+      }
+    } finally {
+      if (requestVersion == _messageRequestVersion) {
+        _isLoadingMessages = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<bool> deleteThread(AssetChatThreadSummary thread) async {
+    if (_isDeleting) return false;
+    _isDeleting = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      await _repository.deleteThread(thread.id);
+      final wasSelected = _selectedThread?.id == thread.id;
+      _threads.removeWhere((item) => item.id == thread.id);
+      if (wasSelected) {
+        ++_messageRequestVersion;
+        _selectedThread = null;
+        _messages.clear();
+        _hasOlderMessages = false;
+      }
+      return true;
+    } catch (error) {
+      _errorMessage = _safeError(error);
+      return false;
+    } finally {
+      _isDeleting = false;
+      notifyListeners();
+    }
+  }
+
+  void clearError() {
+    if (_errorMessage == null) return;
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  void _appendUniqueThreads(Iterable<AssetChatThreadSummary> items) {
+    final knownIds = _threads.map((thread) => thread.id).toSet();
+    for (final item in items) {
+      if (knownIds.add(item.id)) _threads.add(item);
+    }
+  }
+}
+
+String _safeError(Object error) {
+  if (error is AssetChatHistoryRepositoryException) {
+    return switch (error.code) {
+      'login_required' => 'チャット履歴を表示するにはログインしてください。',
+      'thread_not_found' => 'このチャットは見つからないか、既に削除されています。',
+      'thread_delete_failed' => 'チャットを削除できませんでした。時間をおいて再試行してください。',
+      _ => 'チャット履歴を読み込めませんでした。時間をおいて再試行してください。',
+    };
+  }
+  return 'チャット履歴を読み込めませんでした。時間をおいて再試行してください。';
+}

--- a/lib/widgets/asset_chat_widget.dart
+++ b/lib/widgets/asset_chat_widget.dart
@@ -9,8 +9,14 @@ import '../view_models/asset_chat_view_model.dart';
 class AssetChatWidget extends StatefulWidget {
   final AiHubChatService? service;
   final AssetChatViewModel? viewModel;
+  final VoidCallback? onOpenHistory;
 
-  const AssetChatWidget({super.key, this.service, this.viewModel});
+  const AssetChatWidget({
+    super.key,
+    this.service,
+    this.viewModel,
+    this.onOpenHistory,
+  });
 
   @override
   State<AssetChatWidget> createState() => _AssetChatWidgetState();
@@ -65,6 +71,16 @@ class _AssetChatWidgetState extends State<AssetChatWidget> {
       _inputController.clear();
     }
     await pending;
+  }
+
+  void _openHistory() {
+    setState(() => _isOpen = false);
+    final callback = widget.onOpenHistory;
+    if (callback != null) {
+      callback();
+      return;
+    }
+    Navigator.of(context).pushNamed('/asset-chat-history');
   }
 
   @override
@@ -140,6 +156,12 @@ class _AssetChatWidgetState extends State<AssetChatWidget> {
                   ),
                 ],
               ),
+            ),
+            IconButton(
+              key: const Key('asset_chat_history_button'),
+              tooltip: 'チャット履歴を開く',
+              onPressed: _openHistory,
+              icon: const Icon(Icons.history, color: Colors.white),
             ),
             IconButton(
               key: const Key('asset_chat_close_button'),

--- a/test/models/asset_chat_test.dart
+++ b/test/models/asset_chat_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_chat.dart';
+
+void main() {
+  test('parses thread summary timestamps', () {
+    final thread = AssetChatThreadSummary.fromMap(<String, dynamic>{
+      'id': 'thread-1',
+      'title': '今月の支払い',
+      'created_at': '2026-08-18T01:00:00Z',
+      'last_message_at': '2026-08-18T02:00:00Z',
+    });
+
+    expect(thread.id, 'thread-1');
+    expect(thread.title, '今月の支払い');
+    expect(thread.createdAt.toUtc().hour, 1);
+    expect(thread.lastMessageAt.toUtc().hour, 2);
+  });
+
+  test('parses stored assistant message usage', () {
+    final message = AssetChatStoredMessage.fromMap(<String, dynamic>{
+      'id': 'message-1',
+      'thread_id': 'thread-1',
+      'role': 'assistant',
+      'content': '未払い予定を確認してください。',
+      'tokens_in': 120,
+      'tokens_out': 24,
+      'model': 'gemini-2.5-flash',
+      'created_at': '2026-08-18T02:00:00Z',
+    });
+
+    expect(message.isUser, isFalse);
+    expect(message.tokensIn, 120);
+    expect(message.tokensOut, 24);
+    expect(message.model, 'gemini-2.5-flash');
+  });
+
+  test('rejects unsupported stored message roles', () {
+    expect(
+      () => AssetChatStoredMessage.fromMap(<String, dynamic>{
+        'id': 'message-1',
+        'thread_id': 'thread-1',
+        'role': 'system',
+        'content': 'secret',
+        'created_at': '2026-08-18T02:00:00Z',
+      }),
+      throwsFormatException,
+    );
+  });
+}

--- a/test/pages/asset_chat_history_page_test.dart
+++ b/test/pages/asset_chat_history_page_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_chat.dart';
+import 'package:my_web_app/pages/asset_chat_history_page.dart';
+import 'package:my_web_app/services/asset_chat_history_repository.dart';
+
+class _FakeHistoryRepository implements AssetChatHistoryRepository {
+  _FakeHistoryRepository({required List<AssetChatThreadSummary> threads})
+      : _threads = List.of(threads);
+
+  final List<AssetChatThreadSummary> _threads;
+  final List<String> deletedIds = [];
+
+  @override
+  Future<AssetChatThreadPage> fetchThreads({
+    String searchQuery = '',
+    int offset = 0,
+    int limit = 50,
+  }) async {
+    final normalized = searchQuery.trim().toLowerCase();
+    final filtered = normalized.isEmpty
+        ? _threads
+        : _threads
+            .where((thread) => thread.title.toLowerCase().contains(normalized))
+            .toList(growable: false);
+    final end = (offset + limit).clamp(0, filtered.length);
+    return AssetChatThreadPage(
+      items:
+          offset >= filtered.length ? const [] : filtered.sublist(offset, end),
+      hasMore: end < filtered.length,
+    );
+  }
+
+  @override
+  Future<AssetChatMessagePage> fetchMessages({
+    required String threadId,
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    return AssetChatMessagePage(
+      items: [
+        AssetChatStoredMessage(
+          id: 'assistant-1',
+          threadId: threadId,
+          role: AssetChatMessageRole.assistant,
+          text: '未払い予定を先に確認してください。',
+          tokensIn: 100,
+          tokensOut: 20,
+          model: 'gemini-2.5-flash',
+          createdAt: DateTime.utc(2026, 8, 18, 2),
+        ),
+        AssetChatStoredMessage(
+          id: 'user-1',
+          threadId: threadId,
+          role: AssetChatMessageRole.user,
+          text: '今月の支払いを確認して',
+          tokensIn: 0,
+          tokensOut: 0,
+          model: null,
+          createdAt: DateTime.utc(2026, 8, 18, 1),
+        ),
+      ],
+      hasMore: false,
+    );
+  }
+
+  @override
+  Future<void> deleteThread(String threadId) async {
+    deletedIds.add(threadId);
+    _threads.removeWhere((thread) => thread.id == threadId);
+  }
+}
+
+AssetChatThreadSummary _thread(String id, String title) {
+  return AssetChatThreadSummary(
+    id: id,
+    title: title,
+    createdAt: DateTime.utc(2026, 8, 18, 1),
+    lastMessageAt: DateTime.utc(2026, 8, 18, 2),
+  );
+}
+
+Widget _app(_FakeHistoryRepository repository) {
+  return MaterialApp(
+    home: AssetChatHistoryPage(repository: repository),
+  );
+}
+
+void main() {
+  testWidgets('shows thread list and message detail in a wide layout', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1000, 720));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final repository = _FakeHistoryRepository(
+      threads: [_thread('thread-1', '今月の支払い相談')],
+    );
+
+    await tester.pumpWidget(_app(repository));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('asset_chat_history_wide_layout')), findsOne);
+    expect(find.text('今月の支払い相談'), findsOneWidget);
+    expect(
+      find.byKey(const Key('asset_chat_history_no_selection')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('asset_chat_thread_thread-1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('asset_chat_history_detail')), findsOneWidget);
+    expect(find.text('今月の支払いを確認して'), findsOneWidget);
+    expect(find.text('未払い予定を先に確認してください。'), findsOneWidget);
+    expect(find.textContaining('120 tokens'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('searches by title and clears the result', (tester) async {
+    final repository = _FakeHistoryRepository(
+      threads: [
+        _thread('thread-1', '支払い相談'),
+        _thread('thread-2', '資産配分相談'),
+      ],
+    );
+
+    await tester.pumpWidget(_app(repository));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('asset_chat_history_search_input')),
+      '支払い',
+    );
+    await tester.tap(
+      find.byKey(const Key('asset_chat_history_search_button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('支払い相談'), findsOneWidget);
+    expect(find.text('資産配分相談'), findsNothing);
+    expect(find.textContaining('検索結果'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const Key('asset_chat_history_clear_search_button')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('資産配分相談'), findsOneWidget);
+  });
+
+  testWidgets('confirms deletion and removes the whole thread', (tester) async {
+    final repository = _FakeHistoryRepository(
+      threads: [_thread('thread-1', '削除対象の相談')],
+    );
+
+    await tester.pumpWidget(_app(repository));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('asset_chat_delete_thread-1')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('チャットを削除しますか？'), findsOneWidget);
+    await tester.tap(
+      find.byKey(const Key('asset_chat_delete_confirm_button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(repository.deletedIds, ['thread-1']);
+    expect(find.byKey(const Key('asset_chat_history_empty')), findsOneWidget);
+  });
+
+  testWidgets('uses list-detail navigation without overflow on a narrow screen',
+      (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 640));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final repository = _FakeHistoryRepository(
+      threads: [_thread('thread-1', 'モバイル相談')],
+    );
+
+    await tester.pumpWidget(_app(repository));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('asset_chat_history_narrow_layout')), findsOne);
+
+    await tester.tap(find.byKey(const Key('asset_chat_thread_thread-1')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('asset_chat_history_detail')), findsOneWidget);
+    expect(
+      find.byKey(const Key('asset_chat_history_back_to_list')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(
+      find.byKey(const Key('asset_chat_history_back_to_list')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('asset_chat_history_thread_list')), findsOne);
+  });
+}

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -52,6 +52,7 @@ const List<String> kAllAppRoutes = <String>[
   '/app-hub',
   '/appointment-scheduler',
   '/ar-navigation',
+  '/asset-chat-history',
   '/asset-management',
   '/auction-marketplace',
   '/audio-effects-processor',

--- a/test/services/asset_chat_history_repository_contract_test.dart
+++ b/test/services/asset_chat_history_repository_contract_test.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final source = File(
+    'lib/services/asset_chat_history_repository.dart',
+  ).readAsStringSync();
+
+  test('list query is owner-scoped, column-bounded, and paginated', () {
+    expect(source, contains('.select(threadColumns)'));
+    expect(source, contains('.eq(\'user_id\', userId)'));
+    expect(source, contains('.ilike(\'title\''));
+    expect(source, contains('.range(safeOffset, safeOffset + safeLimit)'));
+    expect(source, isNot(contains('.select(\'*\')')));
+  });
+
+  test('message detail is lazy and thread deletion is doubly scoped', () {
+    expect(source, contains('.select(messageColumns)'));
+    expect(source, contains('.eq(\'thread_id\', normalizedThreadId)'));
+    expect(source, contains('.delete()'));
+    expect(source, contains('.eq(\'id\', normalizedThreadId)'));
+    expect(source, contains('.eq(\'user_id\', userId)'));
+    expect(source, contains('.select(\'id\')'));
+  });
+}

--- a/test/view_models/asset_chat_history_view_model_test.dart
+++ b/test/view_models/asset_chat_history_view_model_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_chat.dart';
+import 'package:my_web_app/services/asset_chat_history_repository.dart';
+import 'package:my_web_app/view_models/asset_chat_history_view_model.dart';
+
+typedef ThreadLoader = Future<AssetChatThreadPage> Function(
+  String searchQuery,
+  int offset,
+  int limit,
+);
+typedef MessageLoader = Future<AssetChatMessagePage> Function(
+  String threadId,
+  int offset,
+  int limit,
+);
+
+class _FakeRepository implements AssetChatHistoryRepository {
+  _FakeRepository({
+    required this.threadLoader,
+    required this.messageLoader,
+    this.onDelete,
+  });
+
+  final ThreadLoader threadLoader;
+  final MessageLoader messageLoader;
+  final Future<void> Function(String threadId)? onDelete;
+
+  @override
+  Future<AssetChatThreadPage> fetchThreads({
+    String searchQuery = '',
+    int offset = 0,
+    int limit = 50,
+  }) =>
+      threadLoader(searchQuery, offset, limit);
+
+  @override
+  Future<AssetChatMessagePage> fetchMessages({
+    required String threadId,
+    int offset = 0,
+    int limit = 100,
+  }) =>
+      messageLoader(threadId, offset, limit);
+
+  @override
+  Future<void> deleteThread(String threadId) async {
+    await onDelete?.call(threadId);
+  }
+}
+
+AssetChatThreadSummary _thread(int index, {String? title}) {
+  final time = DateTime.utc(2026, 8, 18, 0, index % 60);
+  return AssetChatThreadSummary(
+    id: 'thread-$index',
+    title: title ?? '相談 $index',
+    createdAt: time,
+    lastMessageAt: time,
+  );
+}
+
+AssetChatStoredMessage _message(int index) {
+  return AssetChatStoredMessage(
+    id: 'message-$index',
+    threadId: 'thread-1',
+    role: index.isEven
+        ? AssetChatMessageRole.user
+        : AssetChatMessageRole.assistant,
+    text: 'message $index',
+    tokensIn: 0,
+    tokensOut: 0,
+    model: null,
+    createdAt: DateTime.utc(2026, 8, 18, 0, index),
+  );
+}
+
+void main() {
+  test('loads thread pages and applies server-side title search', () async {
+    final calls = <String>[];
+    final allThreads = List.generate(51, _thread);
+    final repository = _FakeRepository(
+      threadLoader: (search, offset, limit) async {
+        calls.add('$search:$offset:$limit');
+        if (search == '支払い') {
+          return AssetChatThreadPage(
+            items: [_thread(99, title: '支払い相談')],
+            hasMore: false,
+          );
+        }
+        final end = (offset + limit).clamp(0, allThreads.length);
+        return AssetChatThreadPage(
+          items: allThreads.sublist(offset, end),
+          hasMore: end < allThreads.length,
+        );
+      },
+      messageLoader: (_, __, ___) async =>
+          const AssetChatMessagePage(items: [], hasMore: false),
+    );
+    final viewModel = AssetChatHistoryViewModel(repository: repository);
+    addTearDown(viewModel.dispose);
+
+    await viewModel.initialize();
+    expect(viewModel.threads, hasLength(50));
+    expect(viewModel.hasMoreThreads, isTrue);
+
+    await viewModel.loadThreads();
+    expect(viewModel.threads, hasLength(51));
+    expect(viewModel.hasMoreThreads, isFalse);
+
+    await viewModel.search('  支払い  ');
+    expect(viewModel.searchQuery, '支払い');
+    expect(viewModel.threads.single.title, '支払い相談');
+    expect(calls, contains('支払い:0:50'));
+  });
+
+  test('loads newest page then prepends older messages chronologically',
+      () async {
+    final thread = _thread(1);
+    final repository = _FakeRepository(
+      threadLoader: (_, __, ___) async =>
+          AssetChatThreadPage(items: [thread], hasMore: false),
+      messageLoader: (_, offset, __) async {
+        if (offset == 0) {
+          return AssetChatMessagePage(
+            items: [_message(4), _message(3)],
+            hasMore: true,
+          );
+        }
+        return AssetChatMessagePage(
+          items: [_message(2), _message(1)],
+          hasMore: false,
+        );
+      },
+    );
+    final viewModel = AssetChatHistoryViewModel(repository: repository);
+    addTearDown(viewModel.dispose);
+
+    await viewModel.selectThread(thread);
+    expect(viewModel.messages.map((message) => message.id), [
+      'message-3',
+      'message-4',
+    ]);
+    expect(viewModel.hasOlderMessages, isTrue);
+
+    await viewModel.loadOlderMessages();
+    expect(viewModel.messages.map((message) => message.id), [
+      'message-1',
+      'message-2',
+      'message-3',
+      'message-4',
+    ]);
+    expect(viewModel.hasOlderMessages, isFalse);
+  });
+
+  test('deletes the selected thread and clears its messages', () async {
+    final deletedIds = <String>[];
+    final thread = _thread(1);
+    final repository = _FakeRepository(
+      threadLoader: (_, __, ___) async =>
+          AssetChatThreadPage(items: [thread], hasMore: false),
+      messageLoader: (_, __, ___) async => AssetChatMessagePage(
+        items: [_message(1)],
+        hasMore: false,
+      ),
+      onDelete: (id) async => deletedIds.add(id),
+    );
+    final viewModel = AssetChatHistoryViewModel(repository: repository);
+    addTearDown(viewModel.dispose);
+
+    await viewModel.initialize();
+    await viewModel.selectThread(thread);
+    expect(await viewModel.deleteThread(thread), isTrue);
+
+    expect(deletedIds, ['thread-1']);
+    expect(viewModel.threads, isEmpty);
+    expect(viewModel.selectedThread, isNull);
+    expect(viewModel.messages, isEmpty);
+  });
+
+  test('maps an unauthenticated repository error to a safe login message',
+      () async {
+    final repository = _FakeRepository(
+      threadLoader: (_, __, ___) async =>
+          throw const AssetChatHistoryRepositoryException(
+        'login_required',
+        'jwt detail must not leak',
+      ),
+      messageLoader: (_, __, ___) async =>
+          const AssetChatMessagePage(items: [], hasMore: false),
+    );
+    final viewModel = AssetChatHistoryViewModel(repository: repository);
+    addTearDown(viewModel.dispose);
+
+    await viewModel.initialize();
+
+    expect(viewModel.errorMessage, contains('ログイン'));
+    expect(viewModel.errorMessage, isNot(contains('jwt')));
+  });
+}

--- a/test/widgets/asset_chat_widget_test.dart
+++ b/test/widgets/asset_chat_widget_test.dart
@@ -103,4 +103,30 @@ void main() {
     expect(panelSize.width, lessThanOrEqualTo(320));
     expect(panelSize.height, lessThanOrEqualTo(568));
   });
+
+  testWidgets('opens the registered chat history route from the header', (
+    tester,
+  ) async {
+    final service = AiHubChatService(invoker: (_) async => _successResponse());
+    await tester.pumpWidget(
+      MaterialApp(
+        routes: {
+          '/asset-chat-history': (_) => const Scaffold(
+                body: Text('履歴ページ'),
+              ),
+        },
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          floatingActionButton: AssetChatWidget(service: service),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('asset_chat_open_button')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('asset_chat_history_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('履歴ページ'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## 概要

Issue #2487 の資産AIチャット履歴ページを追加します。

- 全スレッドの一覧、タイトル検索、追加ページ読込
- スレッド選択後の全メッセージ表示、過去ページ読込
- 確認ダイアログ付きのスレッド削除
- デスクトップの2ペイン表示とモバイルの一覧・詳細遷移
- 既存の資産AIチャットから履歴ページを開く導線

## データアクセスと安全性

- 既存の `asset_chat_threads` / `asset_chat_messages` と #2484 のRLS・cascade delete契約を利用し、migrationやfeature flagは追加しません。
- 一覧は認証ユーザーの `user_id` で絞り、明示した4列だけを取得します。初回は1リクエスト、最大51行を取得して50件を表示します。
- 詳細はスレッド選択後だけ取得します。1リクエストで最大101行を取得して100件を表示し、それ以前は利用者の操作時だけ追加取得します。
- 未認証時はDBリクエストを送らず、安全なログイン案内を表示します。
- 削除は `id` と `user_id` の両方で絞った1リクエストで、戻り値も `id` のみに限定します。
- Widget再buildでは重複読込を行いません。エラー文にはバックエンド詳細を露出しません。

## 検証

- `flutter analyze --no-pub` — 0 issues
- `flutter test --no-pub` — 2359 tests passed
- 対象モデル・Repository契約・ViewModel・Widget・routeテスト — 30 tests passed
- `flutter build web --release --pwa-strategy=none` — success
- `git diff --check` — success
- 実ブラウザーQA
  - 1280x800: 2ペイン、検索、空状態、ログイン案内、横overflowなし
  - 390x844: 1カラム、一覧・詳細導線、横overflowなし
  - browser errors / warnings: 0

## Minimal E2E Gate

- Implementation-detail independent: 一覧・検索・詳細・削除確認という利用者に見える入出力を検証しています。
- Minimal scope: 正常系、未認証エラー、空状態・レスポンシブ復旧を重点テストしています。
- E2E: route登録テスト、Widget操作テスト、release Webの実ブラウザーQAで画面遷移と表示を確認しました。
- E2E-Exception: 履歴CRUDは既存RLSと認証セッションに依存するため、Repository契約・ViewModel・Widgetの重点テストと実ブラウザーQAで代替しました。

Closes #2487
