### PR TITLE
feat: add asset chat money range privacy mode

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -54,6 +54,7 @@ import 'package:my_web_app/services/asset_subscription_audit_store.dart';
 import 'package:my_web_app/services/asset_subscription_catalog.dart';
 import 'package:my_web_app/services/asset_subscription_duplicate_detector.dart';
 import 'package:my_web_app/services/ai_hub_chat_service.dart';
+import 'package:my_web_app/services/asset_chat_privacy_settings_service.dart';
 import 'package:my_web_app/services/asset_payment_check_guide_service.dart';
 import 'package:my_web_app/services/asset_salary_amount_store.dart';
 import 'package:my_web_app/services/asset_salary_day_store.dart';
@@ -407,8 +408,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // 支払確認手順(決定論ベース)と、ネット検索対応プロバイダ経由の AI 詳細手順。
   final AssetPaymentCheckGuideService _paymentCheckGuideService =
       const AssetPaymentCheckGuideService();
+  final AssetChatPrivacySettingsService _assetChatPrivacySettingsService =
+      const AssetChatPrivacySettingsService();
   late final AiHubChatService _aiHubChatService = AiHubChatService(
     supabase: _supabase,
+    assetChatPrivacySettingsService: _assetChatPrivacySettingsService,
   );
   final ProfileService _profileService = ProfileService();
 
@@ -874,6 +878,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetManagementDisplayModeStore();
   AssetManagementDisplayMode _displayMode =
       AssetManagementDisplayModeStore.defaultMode;
+  bool _assetChatMaskMoneyAmounts = false;
   final AssetManagementMainAccountStore _mainAccountStore =
       const AssetManagementMainAccountStore();
   // 月をまたいだ負債トレンド(リボ複利・残高増加)判定のための口座別残高履歴。
@@ -1100,6 +1105,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchMustTasks();
     unawaited(_loadDailyTodos());
     _loadDisplayMode();
+    unawaited(_loadAssetChatPrivacySettings());
     _loadMainAccount();
     unawaited(_loadHouseholdTrackerPublishing());
     unawaited(_loadSalaryAmount());
@@ -12195,6 +12201,27 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  Future<void> _loadAssetChatPrivacySettings() async {
+    final enabled =
+        await _assetChatPrivacySettingsService.loadMaskMoneyAmounts();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _assetChatMaskMoneyAmounts = enabled;
+    });
+  }
+
+  Future<void> _setAssetChatMaskMoneyAmounts(bool enabled) async {
+    await _assetChatPrivacySettingsService.saveMaskMoneyAmounts(enabled);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _assetChatMaskMoneyAmounts = enabled;
+    });
+  }
+
   Future<void> _loadDisplayMode() async {
     final mode = await _displayModeStore.load();
     final overrides = await _displayModeStore.loadOverrides();
@@ -13991,6 +14018,50 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      color: Theme.of(
+                        dialogContext,
+                      ).colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: SwitchListTile.adaptive(
+                      key: const Key('asset_chat_money_range_toggle'),
+                      value: _assetChatMaskMoneyAmounts,
+                      secondary: const Icon(Icons.privacy_tip_outlined),
+                      title: const Text(
+                        'AIチャットの金額をレンジ化',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      subtitle: const Text(
+                        'ONではAIへ送る直前に金額を「¥100k-500k」などへ変換します。'
+                        '入力原文はチャット履歴に残ります（既定OFF）。',
+                        style: TextStyle(fontSize: 11, height: 1.4),
+                      ),
+                      onChanged: (enabled) async {
+                        try {
+                          await _setAssetChatMaskMoneyAmounts(enabled);
+                          if (!dialogContext.mounted) {
+                            return;
+                          }
+                          setDialogState(() {});
+                        } catch (_) {
+                          if (!dialogContext.mounted) {
+                            return;
+                          }
+                          ScaffoldMessenger.of(dialogContext).showSnackBar(
+                            const SnackBar(
+                              content: Text('AIチャットのプライバシー設定を保存できませんでした'),
+                            ),
+                          );
+                        }
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 12),
                   if (_displayModeStatsLabel != null) ...[
                     Text(
                       '実験ログ: $_displayModeStatsLabel',

--- a/lib/services/ai_hub_chat_service.dart
+++ b/lib/services/ai_hub_chat_service.dart
@@ -1,6 +1,7 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/asset_chat.dart';
+import 'asset_chat_privacy_settings_service.dart';
 import 'offline_secure_mode_settings_service.dart';
 
 typedef AiHubChatInvoker = Future<Map<String, dynamic>> Function(
@@ -148,22 +149,26 @@ class AiHubChatService {
   final SupabaseClient? _supabase;
   final AiHubChatInvoker? _invoker;
   final OfflineSecureModeSettingsService _offlineSettingsService;
+  final AssetChatPrivacySettingsService _assetChatPrivacySettingsService;
 
   const AiHubChatService({
     SupabaseClient? supabase,
     AiHubChatInvoker? invoker,
     OfflineSecureModeSettingsService offlineSettingsService =
         const OfflineSecureModeSettingsService(),
+    AssetChatPrivacySettingsService assetChatPrivacySettingsService =
+        const AssetChatPrivacySettingsService(),
   })  : _supabase = supabase,
         _invoker = invoker,
-        _offlineSettingsService = offlineSettingsService;
+        _offlineSettingsService = offlineSettingsService,
+        _assetChatPrivacySettingsService = assetChatPrivacySettingsService;
 
   Future<AssetChatResponse> sendAssetChat({
     required String message,
     String? threadId,
     int snapshotMonths = 3,
     int historyMessages = 8,
-    String piiMode = 'off',
+    String? piiMode,
   }) async {
     final normalizedMessage = message.trim();
     if (normalizedMessage.isEmpty) {
@@ -181,6 +186,10 @@ class AiHubChatService {
     if (AiHubChatQuotaGuard.isCoolingDown()) {
       throw const AiHubChatException('AI quota cooldown');
     }
+    final resolvedPiiMode = piiMode ??
+        ((await _assetChatPrivacySettingsService.loadMaskMoneyAmounts())
+            ? 'mask'
+            : 'off');
 
     try {
       final data = await _invoke(
@@ -191,7 +200,7 @@ class AiHubChatService {
             'thread_id': threadId.trim(),
           'snapshot_months': snapshotMonths.clamp(1, 12),
           'history_messages': historyMessages.clamp(0, 20),
-          'pii_mode': piiMode,
+          'pii_mode': resolvedPiiMode,
         }),
       );
       final reply = data['reply']?.toString().trim();

--- a/lib/services/asset_chat_privacy_settings_service.dart
+++ b/lib/services/asset_chat_privacy_settings_service.dart
@@ -1,0 +1,21 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// AI 資産チャットへ送る金額のプライバシー設定。
+///
+/// 既定は OFF。ON の場合だけ Edge Function に `pii_mode=mask` を渡し、
+/// LLM 送信境界で金額を幅へ変換する。
+class AssetChatPrivacySettingsService {
+  const AssetChatPrivacySettingsService();
+
+  static const String maskMoneyAmountsKey = 'asset_chat_mask_money_amounts_v1';
+
+  Future<bool> loadMaskMoneyAmounts() async {
+    final preferences = await SharedPreferences.getInstance();
+    return preferences.getBool(maskMoneyAmountsKey) ?? false;
+  }
+
+  Future<void> saveMaskMoneyAmounts(bool enabled) async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.setBool(maskMoneyAmountsKey, enabled);
+  }
+}

--- a/supabase/functions/ai-hub/asset_chat.ts
+++ b/supabase/functions/ai-hub/asset_chat.ts
@@ -207,10 +207,58 @@ export function normalizeAssetChatPiiMode(value: unknown): AssetChatPiiMode {
   );
 }
 
+export function assetChatMoneyRange(value: number): string {
+  if (!Number.isFinite(value)) return "[masked-number]";
+  const prefix = value < 0 ? "-" : "";
+  const amount = Math.abs(value);
+  if (amount < 10_000) return `${prefix}¥0-10k`;
+  if (amount < 50_000) return `${prefix}¥10k-50k`;
+  if (amount < 100_000) return `${prefix}¥50k-100k`;
+  if (amount < 500_000) return `${prefix}¥100k-500k`;
+  if (amount < 1_000_000) return `${prefix}¥500k-1m`;
+  if (amount < 5_000_000) return `${prefix}¥1m-5m`;
+  if (amount < 10_000_000) return `${prefix}¥5m-10m`;
+  if (amount < 50_000_000) return `${prefix}¥10m-50m`;
+  if (amount < 100_000_000) return `${prefix}¥50m-100m`;
+  return `${prefix}¥100m+`;
+}
+
 export function maskAssetChatSensitiveNumbers(value: string): string {
-  return value
+  const moneyRanges: Array<{ token: string; range: string }> = [];
+  const keepRange = (range: string): string => {
+    const token = `__ASSET_CHAT_MONEY_${alphabeticToken(moneyRanges.length)}__`;
+    moneyRanges.push({ token, range });
+    return token;
+  };
+  let masked = normalizeNumericWidth(value)
     .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[masked-email]")
-    .replace(/\p{Number}+(?:[.,，．]\p{Number}+)*/gu, "[masked-number]");
+    // Keep already-bucketed values stable when a structured snapshot is serialized.
+    .replace(
+      /-?¥\s*\d+(?:\.\d+)?(?:k|m)?(?:-\d+(?:\.\d+)?(?:k|m)?)?\+?/gi,
+      (match) => keepRange(match.replace(/\s+/g, "")),
+    )
+    .replace(
+      /¥\s*([+-]?\d+(?:,\d{3})*(?:\.\d+)?)\s*(億|万|千)?(?:円)?|([+-]?\d+(?:,\d{3})*(?:\.\d+)?)\s*(億|万|千)?\s*円/gu,
+      (_match, prefixed, prefixedUnit, suffixed, suffixedUnit) => {
+        const amount = parseMoneyAmount(
+          prefixed ?? suffixed,
+          prefixedUnit ?? suffixedUnit,
+        );
+        return keepRange(assetChatMoneyRange(amount));
+      },
+    )
+    // Comma-grouped bare values are overwhelmingly monetary in this feature.
+    .replace(
+      /[+-]?\d{1,3}(?:,\d{3})+(?:\.\d+)?/g,
+      (match) => keepRange(assetChatMoneyRange(parseMoneyAmount(match))),
+    )
+    // Account numbers, dates, counts, and other raw numbers remain fully masked.
+    .replace(/\d+(?:[.,]\d+)*/g, "[masked-number]");
+
+  for (const entry of moneyRanges) {
+    masked = masked.replaceAll(entry.token, entry.range);
+  }
+  return masked;
 }
 
 export async function handleAssetChatAction(options: {
@@ -402,8 +450,11 @@ export function buildAssetChatMessages(options: {
   snapshots: AssetChatSnapshotContext[];
   piiMode: AssetChatPiiMode;
 }): AssetChatMessage[] {
+  const snapshots = options.piiMode === "mask"
+    ? options.snapshots.map(rangeSnapshotMoneyAmounts)
+    : options.snapshots;
   const contextJson = applyPiiMode(
-    JSON.stringify(options.snapshots),
+    JSON.stringify(snapshots),
     options.piiMode,
   );
   const history = options.history.map((row) => ({
@@ -419,7 +470,7 @@ export function buildAssetChatMessages(options: {
         "不明な値は不明と明示し、説明と次に確認すべき行動だけを簡潔に示してください。",
         "投資・税務・法務の断定的助言や売買指示は行わないでください。",
         options.piiMode === "mask"
-          ? "プライバシーモード中です。[masked-number] を具体値へ推測しないでください。"
+          ? "プライバシーモード中です。金額レンジ（例: ¥100k-500k）や [masked-number] を具体値へ推測しないでください。"
           : "プライバシーモードはOFFです。受け取った値を必要以上に繰り返さないでください。",
       ].join("\n"),
     },
@@ -433,6 +484,40 @@ export function buildAssetChatMessages(options: {
       content: applyPiiMode(options.message, options.piiMode),
     },
   ];
+}
+
+function rangeSnapshotMoneyAmounts(
+  snapshot: AssetChatSnapshotContext,
+): Record<string, string | number | null> {
+  const moneyRange = (value: number | null): string | null =>
+    value === null ? null : assetChatMoneyRange(value);
+  return {
+    month_key: snapshot.month_key,
+    positive_asset_total: moneyRange(snapshot.positive_asset_total),
+    liability_total: moneyRange(snapshot.liability_total),
+    net_worth: moneyRange(snapshot.net_worth),
+    cash_like_total: moneyRange(snapshot.cash_like_total),
+    monthly_received_income_total: moneyRange(
+      snapshot.monthly_received_income_total,
+    ),
+    monthly_scheduled_payment_total: moneyRange(
+      snapshot.monthly_scheduled_payment_total,
+    ),
+    monthly_paid_payment_total: moneyRange(
+      snapshot.monthly_paid_payment_total,
+    ),
+    monthly_unpaid_payment_total: moneyRange(
+      snapshot.monthly_unpaid_payment_total,
+    ),
+    monthly_actual_payment_total: moneyRange(
+      snapshot.monthly_actual_payment_total,
+    ),
+    monthly_payment_difference_total: moneyRange(
+      snapshot.monthly_payment_difference_total,
+    ),
+    overdue_payment_count: snapshot.overdue_payment_count,
+    securities_total: moneyRange(snapshot.securities_total),
+  };
 }
 
 function toSnapshotContext(
@@ -528,6 +613,41 @@ function providerFailureStatus(error: unknown): number {
 
 function applyPiiMode(value: string, mode: AssetChatPiiMode): string {
   return mode === "mask" ? maskAssetChatSensitiveNumbers(value) : value;
+}
+
+function normalizeNumericWidth(value: string): string {
+  return value
+    .replace(
+      /[０-９]/g,
+      (character) => String(character.charCodeAt(0) - "０".charCodeAt(0)),
+    )
+    .replaceAll("，", ",")
+    .replaceAll("．", ".")
+    .replaceAll("￥", "¥")
+    .replaceAll("＋", "+")
+    .replaceAll("－", "-");
+}
+
+function parseMoneyAmount(value: string, unit?: string): number {
+  const parsed = Number(value.replaceAll(",", ""));
+  const multiplier = unit === "億"
+    ? 100_000_000
+    : unit === "万"
+    ? 10_000
+    : unit === "千"
+    ? 1_000
+    : 1;
+  return parsed * multiplier;
+}
+
+function alphabeticToken(index: number): string {
+  let current = index;
+  let result = "";
+  do {
+    result = String.fromCharCode(65 + (current % 26)) + result;
+    current = Math.floor(current / 26) - 1;
+  } while (current >= 0);
+  return result;
 }
 
 function estimateTokens(characters: number): number {

--- a/supabase/functions/ai-hub/asset_chat_test.ts
+++ b/supabase/functions/ai-hub/asset_chat_test.ts
@@ -4,6 +4,7 @@ import {
   type AssetChatExchange,
   type AssetChatHistoryRow,
   type AssetChatMessage,
+  assetChatMoneyRange,
   type AssetChatProviderRequest,
   type AssetChatSnapshotRow,
   type AssetChatStore,
@@ -32,8 +33,17 @@ Deno.test("asset chat action aliases and PII defaults are stable", () => {
   const masked = maskAssetChatSensitiveNumbers(
     "口座123-456、残高1,234,567円、全角１２３万円、mail=user123@example.com",
   );
-  assert(!/\p{Number}/u.test(masked), `digits leaked: ${masked}`);
+  assert(masked.includes("[masked-number]-[masked-number]"), masked);
+  assert(masked.includes("¥1m-5m"), masked);
+  assert(!masked.includes("1,234,567"), `raw amount leaked: ${masked}`);
+  assert(!masked.includes("１２３"), `full-width amount leaked: ${masked}`);
   assert(!masked.includes("user123@example.com"), `email leaked: ${masked}`);
+
+  assertEquals(assetChatMoneyRange(0), "¥0-10k");
+  assertEquals(assetChatMoneyRange(123_456), "¥100k-500k");
+  assertEquals(assetChatMoneyRange(1_234_567), "¥1m-5m");
+  assertEquals(assetChatMoneyRange(-500_000), "-¥500k-1m");
+  assertEquals(assetChatMoneyRange(100_000_000), "¥100m+");
 });
 
 Deno.test("creates a thread, calls the provider, and persists one exchange", async () => {
@@ -186,7 +196,7 @@ Deno.test("reuses snapshot context for one hour but always reloads history", asy
   assertEquals(store.snapshotReads, 2);
 });
 
-Deno.test("mask mode hides all digits from provider input and stored reply", async () => {
+Deno.test("mask mode sends money ranges without raw sensitive values", async () => {
   const store = new FakeStore({
     snapshots: [snapshot("2026-08", 1_234_567, 456_789)],
   });
@@ -203,19 +213,37 @@ Deno.test("mask mode hides all digits from provider input and stored reply", asy
     },
   });
 
-  for (const item of providerMessages) {
+  const providerInput = providerMessages.map((item) => item.content).join("\n");
+  for (
+    const rawValue of [
+      "123456",
+      "1,234,567",
+      "1234567",
+      "456789",
+      "2026-08",
+      "user9@example.com",
+    ]
+  ) {
     assert(
-      !/\p{Number}/u.test(item.content),
-      `provider input leaked digits: ${item.content}`,
-    );
-    assert(
-      !item.content.includes("user9@example.com"),
-      `provider input leaked email: ${item.content}`,
+      !providerInput.includes(rawValue),
+      `provider input leaked ${rawValue}: ${providerInput}`,
     );
   }
-  assert(!/\d/.test(result.reply), `reply leaked digits: ${result.reply}`);
+  assert(
+    providerInput.includes('"positive_asset_total":"¥1m-5m"'),
+    providerInput,
+  );
+  assert(
+    providerInput.includes('"liability_total":"¥100k-500k"'),
+    providerInput,
+  );
+  assert(providerInput.includes("残高¥100k-500k"), providerInput);
+  assertEquals(result.reply, "残高¥500k-1mを確認しました");
   assertEquals(store.exchanges[0].exchange.user.content, rawMessage);
-  assert(!/\d/.test(store.exchanges[0].exchange.assistant.content));
+  assertEquals(
+    store.exchanges[0].exchange.assistant.content,
+    "残高¥500k-1mを確認しました",
+  );
 });
 
 Deno.test("provider failures do not create a new thread or persist messages", async () => {

--- a/test/services/ai_hub_chat_service_test.dart
+++ b/test/services/ai_hub_chat_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/ai_hub_chat_service.dart';
+import 'package:my_web_app/services/asset_chat_privacy_settings_service.dart';
 import 'package:my_web_app/services/offline_secure_mode_settings_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -48,6 +49,52 @@ void main() {
     expect(response.usage.estimatedCostUsd, 0.000321);
     expect(response.usage.provider, 'google');
     expect(response.usage.model, 'gemini-2.5-flash');
+  });
+
+  test('sendAssetChat reads persisted opt-in at the send boundary', () async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.setBool(
+      AssetChatPrivacySettingsService.maskMoneyAmountsKey,
+      true,
+    );
+    final service = AiHubChatService(
+      invoker: (body) async {
+        expect(body['pii_mode'], 'mask');
+        return <String, dynamic>{
+          'success': true,
+          'thread_id': '11111111-1111-4111-8111-111111111111',
+          'thread_title': 'プライバシー相談',
+          'thread_created': true,
+          'reply': '金額レンジで確認しました。',
+        };
+      },
+    );
+
+    final response = await service.sendAssetChat(message: '残高を確認して');
+
+    expect(response.reply, '金額レンジで確認しました。');
+  });
+
+  test('sendAssetChat explicit mode overrides persisted preference', () async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.setBool(
+      AssetChatPrivacySettingsService.maskMoneyAmountsKey,
+      true,
+    );
+    final service = AiHubChatService(
+      invoker: (body) async {
+        expect(body['pii_mode'], 'off');
+        return <String, dynamic>{
+          'success': true,
+          'thread_id': '11111111-1111-4111-8111-111111111111',
+          'thread_title': '明示設定',
+          'thread_created': true,
+          'reply': '確認しました。',
+        };
+      },
+    );
+
+    await service.sendAssetChat(message: '確認して', piiMode: 'off');
   });
 
   test('sendAssetChat rejects an incomplete successful response', () async {

--- a/test/services/asset_chat_privacy_settings_service_test.dart
+++ b/test/services/asset_chat_privacy_settings_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_chat_privacy_settings_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test(
+    'money range protection is off by default and persists opt-in',
+    () async {
+      const service = AssetChatPrivacySettingsService();
+
+      expect(await service.loadMaskMoneyAmounts(), isFalse);
+
+      await service.saveMaskMoneyAmounts(true);
+      expect(await service.loadMaskMoneyAmounts(), isTrue);
+
+      await service.saveMaskMoneyAmounts(false);
+      expect(await service.loadMaskMoneyAmounts(), isFalse);
+    },
+  );
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/pages/asset_management_page.dart';
+import 'package:my_web_app/services/asset_chat_privacy_settings_service.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
@@ -118,6 +119,37 @@ void main() {
       await tester.tap(find.byKey(const Key('asset_chat_close_button')));
       await tester.pump();
       expect(find.byKey(const Key('asset_chat_panel')), findsNothing);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('asset chat money range protection defaults off and persists', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      final customizeButton =
+          find.byKey(const Key('asset_section_customize_button'));
+      await tester.ensureVisible(customizeButton);
+      await tester.tap(customizeButton);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final toggle = find.byKey(const Key('asset_chat_money_range_toggle'));
+      expect(tester.widget<SwitchListTile>(toggle).value, isFalse);
+
+      await tester.tap(toggle);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final preferences = await SharedPreferences.getInstance();
+      expect(
+        preferences.getBool(
+          AssetChatPrivacySettingsService.maskMoneyAmountsKey,
+        ),
+        isTrue,
+      );
+      expect(tester.widget<SwitchListTile>(toggle).value, isTrue);
 
       await _unmount(tester);
     });


### PR DESCRIPTION
## Summary

- add an opt-in, default-OFF privacy setting to the existing asset-management customization dialog
- read the persisted setting at the asset-chat send boundary and pass `pii_mode=mask` only when enabled
- replace snapshot monetary fields and recognizable yen amounts with deterministic ranges such as `¥100k-500k`
- keep email addresses and non-monetary sensitive numbers masked, while preserving the raw user message in chat history as disclosed in the UI
- add Edge Function, service, persistence, and widget regression coverage

## User impact

Users can enable monetary range protection without changing the default behavior. When enabled, exact asset and liability amounts are not sent to the LLM provider; only deterministic ranges are sent. The toggle explicitly notes that the original message remains in chat history.

## Supabase egress review

- no new Supabase query, table, RPC, or storage access
- asset-chat request count remains one Edge Function invocation per send
- only one local SharedPreferences read is added per send
- provider payload shape is unchanged and exact numeric strings are replaced with similar-size or smaller range labels
- snapshot cache and selected database columns are unchanged

## Minimal E2E Gate

- Implementation-detail independent: tests assert visible settings behavior and outbound raw-value omission, not private implementation structure.
- Minimal scope: about 3 I/O cases (default OFF, opt-in range send, and explicit OFF override).
- E2E: a broader route test would use Flutter `integration_test/` or Playwright `test/e2e/`.
- E2E-Exception: The deterministic Edge boundary and existing asset-page widget harness cover this setting without sending authenticated production financial data from an end-to-end test.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Deterministic pre-provider text transformation only; no auth, schema, migration, secret, provider routing, or production data-write behavior changes. Deno boundary tests assert raw-value non-leakage, and default OFF is the immediate rollback.
- Security: raw amounts, emails, dates, counts, and account-like numbers are removed before provider invocation in mask mode.
- Rollback: leave the persisted toggle OFF (the default) or revert this isolated commit.
- Data migration: none; one local SharedPreferences boolean is optional and backward compatible.
- Prod smoke: CI DB + Edge smoke passed; post-merge smoke will verify the deployed `ai-hub` response.
- Observability: request count, cache behavior, selected DB columns, and `pii_mode` response field remain unchanged.
- Unresolved ultrareview findings: none under this exception.

## Validation

- `deno test supabase/functions/ai-hub/asset_chat_test.ts` — 8 passed
- `deno lint supabase/functions/ai-hub/asset_chat.ts supabase/functions/ai-hub/asset_chat_test.ts` — passed
- Flutter service tests — 12 passed
- asset-management privacy toggle widget test — passed
- existing asset-chat widget tests — 4 passed
- pre-commit Edge Function lint/import quality gate — passed
- full `flutter analyze` was started locally but could not complete under concurrent machine-wide memory pressure; CI remains the authoritative full analysis gate

Closes #2488