### PR TITLE
test: isolate landing production acquisition checks

### DIFF
--- a/test/e2e/lp_first_user_acquisition.spec.ts
+++ b/test/e2e/lp_first_user_acquisition.spec.ts
@@ -43,7 +43,7 @@ test.describe('LP first-user acquisition', () => {
     await openLanding(page, treatmentPath);
 
     await page
-      .getByRole('button', { name: '今やる1件を試す', exact: true })
+      .getByRole('button', { name: 'この例で即試す', exact: true })
       .click();
 
     await expect(
@@ -103,13 +103,14 @@ test.describe('LP first-user acquisition', () => {
     expect(authBox!.y).toBeLessThan(trialBox!.y);
 
     await page
-      .getByRole('textbox', { name: 'メールアドレス', exact: true })
+      .getByRole('textbox', { name: /メールアドレス/ })
+      .first()
       .fill('sales @example.com');
     await magicLinkAction.click();
     await expect(
       page.getByText('メールアドレスの形式を確認してください。', {
         exact: false,
-      }),
+      }).first(),
     ).toBeVisible();
     await expect(googleAction).toBeVisible();
   });
@@ -123,6 +124,24 @@ async function openLanding(page: Page, path: string) {
       contentType: 'application/json',
       headers: isRead ? { 'content-range': '0-0/0' } : undefined,
       body: isRead ? '[]' : '',
+    });
+  });
+
+  await page.route('**/functions/v1/growth-hub', async (route) => {
+    const body = JSON.parse(route.request().postData() ?? '{}') as {
+      action?: string;
+    };
+    const responseBody = body.action === 'landing.trial'
+      ? {
+          success: true,
+          action: '止まっている案件を1つ開き、確認先を1人決める',
+          reason: '10分で連絡文の下書きまで進められるためです。',
+        }
+      : { success: true, skipped: true };
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(responseBody),
     });
   });
 


### PR DESCRIPTION
## What changed
- update the H04 production test to use the current deterministic example CTA
- tolerate Flutter's merged semantics label for the email field and duplicate validation text
- intercept growth-hub calls with deterministic responses so production quota, API spend, and funnel analytics are not changed by E2E

## Revenue impact
Keeps the LP acquisition gate trustworthy without consuming anonymous trial quota or recording synthetic conversion events.

## Validation
- Playwright desktop + mobile: 6 passed (1.2m)
- git diff --check

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Test-only change; no production runtime behavior, data, secrets, billing, public action, rollback, migration, smoke, or observability path is changed.