### PR TITLE
feat: streamline landing pricing disclosure

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -3879,15 +3879,25 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   Widget _buildPricingComparisonSection() {
     return Container(
       key: const Key('landing_pricing_disclosure'),
-      padding: const EdgeInsets.all(20),
+      padding: const EdgeInsets.fromLTRB(20, 22, 20, 20),
       decoration: BoxDecoration(
-        color: const Color(0xFFFFFBF0),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0xFFF4DFA7)),
+        color: const Color(0xFFE9E2D8),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: const Color(0xFFD6CFC4)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          const Text(
+            'PRICE & CONTINUITY',
+            style: TextStyle(
+              color: Color(0xFFB45F42),
+              fontSize: 10,
+              fontWeight: FontWeight.w900,
+              letterSpacing: 1.8,
+            ),
+          ),
+          const SizedBox(height: 10),
           const Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -3915,8 +3925,40 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
             '登録前のAI提案と無料登録では、カード情報を求めません。有料プランは別画面で内容と料金を確認し、同意した場合だけ申し込めます。',
             style: TextStyle(
               fontSize: 13,
-              color: Color(0xFF6F5530),
-              height: 1.6,
+              color: Color(0xFF52606D),
+              height: 1.65,
+            ),
+          ),
+          const SizedBox(height: 14),
+          Container(
+            key: const Key('landing_pricing_trust_summary'),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 11),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF7F1E7),
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: const Color(0xFFD6CFC4)),
+            ),
+            child: const Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  Icons.verified_user_outlined,
+                  size: 18,
+                  color: Color(0xFFB45F42),
+                ),
+                SizedBox(width: 9),
+                Expanded(
+                  child: Text(
+                    '無料登録: カード不要 / 有料プラン: 内容・料金を事前確認',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: Color(0xFF111D2B),
+                      height: 1.55,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
           const SizedBox(height: 14),

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -1009,6 +1009,35 @@ void main() {
     expect(find.textContaining('21サービス分'), findsNothing);
   });
 
+  testWidgets(
+    'pricing disclosure keeps verified trust essentials visible',
+    (tester) async {
+      await pumpLanding(
+        tester,
+        assignment: _assignment('h01', LandingExperimentVariant.treatment),
+      );
+
+      expect(
+        find.byKey(const Key('landing_pricing_trust_summary')),
+        findsOneWidget,
+      );
+      expect(
+        find.text(
+          '無料登録: カード不要 / 有料プラン: 内容・料金を事前確認',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('landing_pricing_disclosure_link')),
+        findsOneWidget,
+      );
+      expect(
+        find.text('競合サービスとの料金比較を見る'),
+        findsNothing,
+      );
+    },
+  );
+
   testWidgets('hero media keeps a readable fallback contract', (tester) async {
     await pumpLanding(
       tester,


### PR DESCRIPTION
## What changed

- restyle the verified pricing/card disclosure as a warm editorial section that continues the cinematic LP story
- add a compact trust summary: free registration needs no card, while paid-plan content and pricing are confirmed before signup
- keep the existing billing-detail link and route
- add regression coverage that keeps the verified trust essentials visible and prevents the removed competitor comparison from returning

## Why

Latest `main` removed unsupported competitor price and count claims. This phase preserves that trust boundary while improving the visual hierarchy and the transition into Chapter 4.

## User impact

Visitors can understand card and payment expectations at a glance without unsupported comparison claims. CTA behavior, authentication, analytics, experiment allocation, SEO, deep links, story behavior, billing behavior, and the mobile sticky CTA are unchanged.

## Validation

- `flutter analyze lib/pages/landing_page.dart test/pages/landing_page_conversion_test.dart` — no issues
- `flutter test test/pages/landing_page_conversion_test.dart test/widgets/landing_story_journey_test.dart` — 47 tests passed
- required GitHub Actions CI must pass before merge
- production responsive browser QA will run after the protected deployment

## Minimal E2E Gate

- Implementation-detail independent: verification asserts user-visible trust-summary, billing-link, absence of unsupported comparison copy, and responsive output rather than private internals.
- Minimal scope: about 3 cases (trust summary, billing link, and absence of the removed competitor comparison).
- E2E: Playwright responsive browser QA covers the public landing-page route at desktop and mobile viewports.
- E2E-Exception: This disclosure-only landing-page change is covered by focused widget regression and responsive browser QA; it changes no route, backend, authentication, payment, or data flow.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: The production-deploy wording below documents the repository's standard merge trigger only; changed files are landing-page UI and its widget test, with no security, auth, payment, migration, workflow, secret, or other high-risk path touched.

## Deployment

This is an application-only landing-page change. Merging to `main` triggers the repository's protected `Deploy to Production` workflow and Firebase Hosting verification.