### PR TITLE
fix: hide internal clock on public pages

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1880,6 +1880,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         builder: (context, child) {
           return GlobalHeaderClockShell(
             navigatorKey: _navigatorKey,
+            // 時計とビルド番号はログイン後の業務用クロームに限定する。
+            // 公開LPに内部ステータス風の帯を出すと、未完成・デバッグ中に
+            // 見えるうえ、狭幅ではラベルが切れて信頼を損なう。
+            showClockBar: supabase.auth.currentSession != null,
             child: UniversalAiShareShell(
               navigatorKey: _navigatorKey,
               child: MaintenanceShell(

--- a/lib/widgets/global_header_clock_bar.dart
+++ b/lib/widgets/global_header_clock_bar.dart
@@ -9,6 +9,12 @@ import '../pages/release_notes_page.dart';
 class GlobalHeaderClockShell extends StatelessWidget {
   final Widget child;
 
+  /// 公開ページでは内部アプリ向けの時計・ビルド情報を表示しない。
+  ///
+  /// 既定値は既存の認証済み画面と単体利用を壊さないため `true` のままにし、
+  /// アプリ直下で認証状態に応じて明示的に切り替える。
+  final bool showClockBar;
+
   /// アプリ直下の Navigator を指す key。本シェルは `MaterialApp.builder` で
   /// Navigator より上に置かれるため、`Navigator.of(context)` は祖先 Navigator を
   /// 見つけられず release ビルドで null-check 例外になる。バージョンバッジ等の
@@ -19,6 +25,7 @@ class GlobalHeaderClockShell extends StatelessWidget {
     super.key,
     required this.child,
     this.navigatorKey,
+    this.showClockBar = true,
   });
 
   @override
@@ -27,7 +34,7 @@ class GlobalHeaderClockShell extends StatelessWidget {
       color: Theme.of(context).scaffoldBackgroundColor,
       child: Column(
         children: [
-          GlobalHeaderClockBar(navigatorKey: navigatorKey),
+          if (showClockBar) GlobalHeaderClockBar(navigatorKey: navigatorKey),
           Expanded(
             child: MediaQuery.removePadding(
               context: context,

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -113,6 +113,7 @@ void main() {
       // Assert
       expect(find.byType(LandingPage), findsOneWidget);
       expect(find.byType(HomePage), findsNothing);
+      expect(find.byKey(const Key('global_header_clock_bar')), findsNothing);
     });
 
     testWidgets('ログイン済みでオンボーディング未完了時は OnboardingPage が表示されること',
@@ -207,6 +208,7 @@ void main() {
 
       // Assert
       expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byKey(const Key('global_header_clock_bar')), findsOneWidget);
     });
 
     testWidgets('オンボーディングは保存済みページから再開できること', (WidgetTester tester) async {

--- a/test/widgets/global_header_clock_bar_test.dart
+++ b/test/widgets/global_header_clock_bar_test.dart
@@ -22,6 +22,25 @@ void main() {
     expect(find.text('dummy page'), findsOneWidget);
   });
 
+  testWidgets('public shell omits internal clock and build chrome', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: GlobalHeaderClockShell(
+          showClockBar: false,
+          child: Scaffold(
+            body: Center(child: Text('public landing page')),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('global_header_clock_bar')), findsNothing);
+    expect(find.byKey(const Key('global_header_clock_text')), findsNothing);
+    expect(find.text('public landing page'), findsOneWidget);
+  });
+
   testWidgets(
     'version badge opens the release notes dialog via navigatorKey when the '
     'header is mounted above the Navigator (MaterialApp.builder)',


### PR DESCRIPTION
## What changed

- Hide the internal date/time and build-number bar on unauthenticated public pages.
- Keep the bar unchanged for authenticated app users.
- Add regression coverage for both public and authenticated shell behavior.

## Why

The production landing page exposed internal operational chrome at the top of the public experience. On mobile, its label was clipped, making the site look unfinished or like a debug build and reducing user trust.

## Protected behavior

CTA behavior, analytics keys, experiments, deep links, SEO semantics, and the authenticated app header remain unchanged.

## Validation

- `flutter analyze --no-pub lib/main.dart lib/widgets/global_header_clock_bar.dart test/main_test.dart test/widgets/global_header_clock_bar_test.dart`
- 46 landing-page and header widget tests passed
- Production Flutter Web release build succeeded
- Browser QA: 1280×720 and 390×844
- No internal clock/build bar, no horizontal overflow, primary CTA visible, no browser warnings/errors

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: This shell visibility change adds no new route or interaction flow; direct widget regression tests and desktop/mobile browser QA cover the user-visible result.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: The trigger is release-validation prose only; no security, auth, payment, database, migration, secret, workflow, or infrastructure path changed.

## Rollback

Revert this PR to restore the previous global clock-bar behavior.