### PR TITLE
feat: add owner-scoped tax records schema

### DIFF
--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -54,6 +55,12 @@ ASSET_CHAT_TABLES = ("asset_chat_messages", "asset_chat_threads")
 ASSET_CHAT_THREAD_1 = "00000000-0000-4000-8000-000000002484"
 ASSET_CHAT_THREAD_2 = "00000000-0000-4000-8000-000000002485"
 ASSET_CHAT_TEMP_THREAD = "00000000-0000-4000-8000-000000002486"
+TAX_RECORDS_MIGRATION = (
+    ROOT / "supabase" / "migrations" / "20260820023000_create_tax_records.sql"
+)
+TAX_RECORDS_TABLES = ("tax_records",)
+TAX_RECORD_1 = "00000000-0000-4000-8000-000000002489"
+TAX_RECORD_2 = "00000000-0000-4000-8000-000000002490"
 EDGE_FIXTURE_ENV_ALLOW = (
     "DATABASE_URL",
     "PORT",
@@ -101,7 +108,108 @@ def sql_files(sql_dir: Path) -> list[Path]:
 
 
 def sql_statements(sql: str) -> list[str]:
-    return [statement.strip() for statement in sql.split(";") if statement.strip()]
+    statements: list[str] = []
+    current: list[str] = []
+    index = 0
+    state = "normal"
+    dollar_tag = ""
+
+    while index < len(sql):
+        char = sql[index]
+        next_char = sql[index + 1] if index + 1 < len(sql) else ""
+
+        if state == "single_quote":
+            current.append(char)
+            if char == "'" and next_char == "'":
+                current.append(next_char)
+                index += 2
+                continue
+            if char == "'":
+                state = "normal"
+            index += 1
+            continue
+
+        if state == "double_quote":
+            current.append(char)
+            if char == '"' and next_char == '"':
+                current.append(next_char)
+                index += 2
+                continue
+            if char == '"':
+                state = "normal"
+            index += 1
+            continue
+
+        if state == "line_comment":
+            current.append(char)
+            if char == "\n":
+                state = "normal"
+            index += 1
+            continue
+
+        if state == "block_comment":
+            current.append(char)
+            if char == "*" and next_char == "/":
+                current.append(next_char)
+                index += 2
+                state = "normal"
+                continue
+            index += 1
+            continue
+
+        if state == "dollar_quote":
+            if sql.startswith(dollar_tag, index):
+                current.append(dollar_tag)
+                index += len(dollar_tag)
+                state = "normal"
+                continue
+            current.append(char)
+            index += 1
+            continue
+
+        if char == "-" and next_char == "-":
+            current.extend((char, next_char))
+            index += 2
+            state = "line_comment"
+            continue
+        if char == "/" and next_char == "*":
+            current.extend((char, next_char))
+            index += 2
+            state = "block_comment"
+            continue
+        if char == "'":
+            current.append(char)
+            index += 1
+            state = "single_quote"
+            continue
+        if char == '"':
+            current.append(char)
+            index += 1
+            state = "double_quote"
+            continue
+        if char == "$":
+            match = re.match(r"\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$", sql[index:])
+            if match:
+                dollar_tag = match.group(0)
+                current.append(dollar_tag)
+                index += len(dollar_tag)
+                state = "dollar_quote"
+                continue
+        if char == ";":
+            statement = "".join(current).strip()
+            if statement:
+                statements.append(statement)
+            current.clear()
+            index += 1
+            continue
+
+        current.append(char)
+        index += 1
+
+    trailing = "".join(current).strip()
+    if trailing:
+        statements.append(trailing)
+    return statements
 
 
 def free_tcp_port() -> int:
@@ -168,6 +276,14 @@ def build_plan(sql_dir: Path, edge_fixture: Path, actual_edge_function: Path) ->
             "authenticated users cannot insert across tenants",
             "message ownership follows the parent thread",
             "deleting an owned thread cascades to its messages",
+        ],
+        "tax_records_migration": TAX_RECORDS_MIGRATION.relative_to(ROOT).as_posix(),
+        "tax_records_checks": [
+            "tax_records has owner-only RLS",
+            "anon has no table privileges",
+            "authenticated users see only their own tax records",
+            "authenticated users cannot forge another owner",
+            "authenticated owner CRUD succeeds",
         ],
         "edge_db_fixture": edge_fixture.relative_to(ROOT).as_posix(),
         "actual_edge_checks": [
@@ -681,6 +797,191 @@ def check_asset_chat_rls(conn: Any) -> dict[str, Any]:
     }
 
 
+def seed_tax_records_fixture(conn: Any) -> None:
+    with conn.cursor() as cur:
+        cur.executemany(
+            "insert into public.tax_records "
+            "(id, user_id, year, type, amount, category, evidence_url) "
+            "values (%s::uuid, %s::uuid, %s, %s, %s, %s, %s)",
+            [
+                (
+                    TAX_RECORD_1,
+                    ISSUE_2773_USER_1,
+                    2026,
+                    "business",
+                    "120000.0000",
+                    "consulting",
+                    "https://example.invalid/evidence/owner-one",
+                ),
+                (
+                    TAX_RECORD_2,
+                    ISSUE_2773_USER_2,
+                    2026,
+                    "furusato",
+                    "20000.0000",
+                    "donation",
+                    None,
+                ),
+            ],
+        )
+    conn.commit()
+
+
+def tax_records_role_count(
+    conn: Any,
+    role: str,
+    user_id: str | None,
+    table: str,
+) -> int:
+    if role not in {"anon", "authenticated", "service_role"}:
+        raise ValueError(f"unexpected role for tax records query: {role}")
+    if table not in TAX_RECORDS_TABLES:
+        raise ValueError(f"unexpected table for tax records query: {table}")
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(f"set local role {role}")
+            cur.execute(
+                "select set_config('request.jwt.claim.sub', %s, true)",
+                (user_id or "",),
+            )
+            cur.execute(f"select count(*) from public.{table}")
+            row = cur.fetchone()
+    return int(row[0])
+
+
+def check_tax_records_rls(conn: Any) -> dict[str, Any]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "select c.relname from pg_class c "
+            "join pg_namespace n on n.oid = c.relnamespace "
+            "where n.nspname = 'public' and c.relname = any(%s) "
+            "and c.relrowsecurity order by c.relname",
+            (list(TAX_RECORDS_TABLES),),
+        )
+        enabled_tables = [row[0] for row in cur.fetchall()]
+        cur.execute(
+            "select policyname from pg_policies where schemaname = 'public' "
+            "and tablename = 'tax_records' order by policyname"
+        )
+        policy_names = [row[0] for row in cur.fetchall()]
+    conn.commit()
+
+    if enabled_tables != ["tax_records"]:
+        raise AssertionError(f"tax records RLS was not enabled: {enabled_tables}")
+
+    expected_policies = {
+        f"tax_records_{operation}_own"
+        for operation in ("select", "insert", "update", "delete")
+    }
+    if set(policy_names) != expected_policies:
+        raise AssertionError(f"unexpected tax records policy set: {policy_names}")
+
+    authenticated_grants = {"SELECT", "INSERT", "UPDATE", "DELETE"}
+    table_privileges = (
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "TRUNCATE",
+        "REFERENCES",
+        "TRIGGER",
+    )
+    with conn.cursor() as cur:
+        for privilege in table_privileges:
+            cur.execute(
+                "select has_table_privilege(%s, %s, %s)",
+                ("anon", "public.tax_records", privilege),
+            )
+            if bool(cur.fetchone()[0]):
+                raise AssertionError(f"anon retained {privilege} on tax_records")
+            cur.execute(
+                "select has_table_privilege(%s, %s, %s)",
+                ("authenticated", "public.tax_records", privilege),
+            )
+            actual = bool(cur.fetchone()[0])
+            expected = privilege in authenticated_grants
+            if actual != expected:
+                raise AssertionError(
+                    "authenticated privilege mismatch on tax_records: "
+                    f"{privilege} expected {expected}, got {actual}"
+                )
+    conn.commit()
+
+    missing_claim_count = tax_records_role_count(
+        conn,
+        "authenticated",
+        None,
+        "tax_records",
+    )
+    if missing_claim_count != 0:
+        raise AssertionError(
+            f"missing tenant claim exposed tax records: {missing_claim_count}"
+        )
+
+    owner_count = tax_records_role_count(
+        conn,
+        "authenticated",
+        ISSUE_2773_USER_1,
+        "tax_records",
+    )
+    if owner_count != 1:
+        raise AssertionError(f"tax record tenant filtering failed: {owner_count}")
+
+    forged_owner_sqlstate = issue_2773_expect_denied(
+        conn,
+        role="authenticated",
+        user_id=ISSUE_2773_USER_1,
+        statement=(
+            "insert into public.tax_records "
+            "(user_id, year, type, amount, category) "
+            "values (%s::uuid, 2026, 'medical', 1000, 'forged owner')"
+        ),
+        params=(ISSUE_2773_USER_2,),
+    )
+
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("set local role authenticated")
+            cur.execute(
+                "select set_config('request.jwt.claim.sub', %s, true)",
+                (ISSUE_2773_USER_1,),
+            )
+            cur.execute(
+                "insert into public.tax_records "
+                "(user_id, year, type, amount, category) "
+                "values (%s::uuid, 2026, 'medical', 0, 'owner smoke') "
+                "returning id",
+                (ISSUE_2773_USER_1,),
+            )
+            temporary_record = cur.fetchone()[0]
+            cur.execute(
+                "update public.tax_records set category = 'owner updated' "
+                "where id = %s",
+                (temporary_record,),
+            )
+            cur.execute(
+                "delete from public.tax_records where id = %s",
+                (temporary_record,),
+            )
+
+    issue_2773_expect_denied(
+        conn,
+        role="anon",
+        user_id=None,
+        statement="select count(*) from public.tax_records",
+    )
+
+    return {
+        "enabled_tables": enabled_tables,
+        "policies": policy_names,
+        "missing_claim_count": missing_claim_count,
+        "owner_count": owner_count,
+        "forged_owner_sqlstate": forged_owner_sqlstate,
+        "owner_crud": "passed",
+        "anon_access": "denied",
+    }
+
+
 def check_actual_edge_function(args: argparse.Namespace, artifacts_dir: Path) -> None:
     import_result = run_command(
         [sys.executable, "scripts/check_edge_function_imports.py", "--root", "supabase/functions"],
@@ -824,6 +1125,9 @@ def run_smoke(args: argparse.Namespace) -> int:
             apply_sql_fixture(conn, ASSET_CHAT_MIGRATION, artifacts_dir)
             seed_asset_chat_fixture(conn)
             asset_chat_rls = check_asset_chat_rls(conn)
+            apply_sql_fixture(conn, TAX_RECORDS_MIGRATION, artifacts_dir)
+            seed_tax_records_fixture(conn)
+            tax_records_rls = check_tax_records_rls(conn)
             counts = {table: table_count(conn, table) for table in REQUIRED_TABLES}
 
         edge_result = run_edge_db_fixture(connection_url, args, artifacts_dir)
@@ -835,6 +1139,7 @@ def run_smoke(args: argparse.Namespace) -> int:
             "tables": counts,
             "tenant_rls": tenant_rls,
             "asset_chat_rls": asset_chat_rls,
+            "tax_records_rls": tax_records_rls,
         },
         "edge_fixture": {
             "path": args.edge_fixture.relative_to(ROOT).as_posix(),

--- a/supabase/migrations/20260820023000_create_tax_records.sql
+++ b/supabase/migrations/20260820023000_create_tax_records.sql
@@ -1,0 +1,102 @@
+-- Issue #2489: owner-scoped tax records for asset-management tax workflows.
+-- This migration adds persistence only. Calculators, tracking UI, exports,
+-- and invoice workflows remain in their separately scoped follow-up issues.
+
+begin;
+
+create table if not exists public.tax_records (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  year smallint not null,
+  type text not null,
+  amount numeric(20, 4) not null,
+  category text not null,
+  evidence_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint tax_records_year_valid
+    check (year between 1900 and 9999),
+  constraint tax_records_type_valid
+    check (type in ('furusato', 'medical', 'business', 'realestate', 'other')),
+  constraint tax_records_amount_non_negative
+    check (amount >= 0),
+  constraint tax_records_category_length
+    check (length(btrim(category)) between 1 and 200),
+  constraint tax_records_evidence_url_length
+    check (
+      evidence_url is null
+      or length(btrim(evidence_url)) between 1 and 2048
+    )
+);
+
+create index if not exists tax_records_user_year_type_idx
+  on public.tax_records (user_id, year desc, type, id);
+
+comment on table public.tax_records is
+  'Per-user tax records for furusato, medical, business, real-estate, and other tax workflows. Issue #2489.';
+comment on column public.tax_records.year is
+  'Japanese tax year used for deterministic filtering and later export.';
+comment on column public.tax_records.amount is
+  'Non-negative exact amount. Tax treatment and totals are calculated deterministically outside AI.';
+comment on column public.tax_records.category is
+  'User-facing category within the constrained tax record type.';
+comment on column public.tax_records.evidence_url is
+  'Optional evidence locator. It can contain sensitive data and is protected by owner-only RLS.';
+
+alter table public.tax_records enable row level security;
+
+-- RLS does not protect TRUNCATE, REFERENCES, or TRIGGER. Remove inherited
+-- privileges and expose only policy-backed CRUD to authenticated clients.
+revoke all privileges on table public.tax_records
+from public, anon, authenticated;
+
+grant all privileges on table public.tax_records to service_role;
+grant select, insert, update, delete on table public.tax_records
+to authenticated;
+
+drop policy if exists tax_records_select_own on public.tax_records;
+create policy tax_records_select_own
+  on public.tax_records
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists tax_records_insert_own on public.tax_records;
+create policy tax_records_insert_own
+  on public.tax_records
+  for insert
+  to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists tax_records_update_own on public.tax_records;
+create policy tax_records_update_own
+  on public.tax_records
+  for update
+  to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists tax_records_delete_own on public.tax_records;
+create policy tax_records_delete_own
+  on public.tax_records
+  for delete
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+create or replace function public.set_tax_records_updated_at()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists tax_records_updated_at on public.tax_records;
+create trigger tax_records_updated_at
+before update on public.tax_records
+for each row execute function public.set_tax_records_updated_at();
+
+commit;

--- a/test/scripts/test_testcontainers_supabase_smoke.py
+++ b/test/scripts/test_testcontainers_supabase_smoke.py
@@ -45,6 +45,22 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
             ["select 1", "select 2"],
         )
 
+    def test_sql_statements_preserve_quoted_semicolons(self) -> None:
+        sql = """
+        create function public.touch_row()
+        returns trigger language plpgsql as $body$
+        begin
+          new.updated_at = now();
+          return new;
+        end;
+        $body$;
+        select 'a;b';
+        """
+        statements = module.sql_statements(sql)
+        self.assertEqual(len(statements), 2)
+        self.assertIn("new.updated_at = now();", statements[0])
+        self.assertEqual(statements[1], "select 'a;b'")
+
     def test_plan_declares_no_production_credentials(self) -> None:
         plan = module.build_plan(
             ROOT / "test" / "fixtures" / "testcontainers" / "sql",
@@ -84,6 +100,21 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
             plan["asset_chat_checks"],
         )
 
+    def test_plan_includes_tax_records_rls_migration(self) -> None:
+        plan = module.build_plan(
+            ROOT / "test" / "fixtures" / "testcontainers" / "sql",
+            ROOT / "test" / "fixtures" / "testcontainers" / "edge-db-smoke.ts",
+            ROOT / "supabase" / "functions" / "health-check" / "index.ts",
+        )
+        self.assertEqual(
+            plan["tax_records_migration"],
+            "supabase/migrations/20260820023000_create_tax_records.sql",
+        )
+        self.assertIn(
+            "authenticated users cannot forge another owner",
+            plan["tax_records_checks"],
+        )
+
     def test_tenant_role_count_rejects_untrusted_identifiers(self) -> None:
         with self.assertRaisesRegex(ValueError, "unexpected role"):
             module.issue_2773_role_count(
@@ -105,6 +136,22 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
             )
         with self.assertRaisesRegex(ValueError, "unexpected table"):
             module.asset_chat_role_count(
+                None,
+                "authenticated",
+                None,
+                "pg_authid",
+            )
+
+    def test_tax_records_role_count_rejects_untrusted_identifiers(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unexpected role"):
+            module.tax_records_role_count(
+                None,
+                "postgres",
+                None,
+                "tax_records",
+            )
+        with self.assertRaisesRegex(ValueError, "unexpected table"):
+            module.tax_records_role_count(
                 None,
                 "authenticated",
                 None,

--- a/test/services/tax_records_schema_test.dart
+++ b/test/services/tax_records_schema_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260820023000_create_tax_records.sql';
+
+void main() {
+  group('tax records schema migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _migrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test('defines the owner-scoped tax record fields with exact money', () {
+      final block = _createTableBlock(sql, 'tax_records');
+
+      expect(block, contains('id uuid primary key default gen_random_uuid()'));
+      expect(
+        block,
+        contains(
+          'user_id uuid not null references auth.users(id) on delete cascade',
+        ),
+      );
+      expect(block, contains('year smallint not null'));
+      expect(block, contains('type text not null'));
+      expect(block, contains('amount numeric(20, 4) not null'));
+      expect(block, contains('category text not null'));
+      expect(block, contains('evidence_url text'));
+      expect(block, contains('created_at timestamptz not null default now()'));
+      expect(block, contains('updated_at timestamptz not null default now()'));
+      expect(block, isNot(contains('double precision')));
+      expect(block, isNot(contains('real not null')));
+    });
+
+    test('guards year, type, amount, category, and evidence URL', () {
+      final block = _createTableBlock(sql, 'tax_records');
+
+      expect(block, contains('check (year between 1900 and 9999)'));
+      expect(
+        block,
+        contains(
+          "check (type in ('furusato', 'medical', 'business', 'realestate', 'other'))",
+        ),
+      );
+      expect(block, contains('check (amount >= 0)'));
+      expect(
+        block,
+        contains('check (length(btrim(category)) between 1 and 200)'),
+      );
+      expect(block, contains('evidence_url is null'));
+      expect(block, contains('length(btrim(evidence_url)) between 1 and 2048'));
+    });
+
+    test('indexes owner, tax year, and type lookups', () {
+      expect(
+        sql,
+        contains('create index if not exists tax_records_user_year_type_idx'),
+      );
+      expect(
+        sql,
+        contains('on public.tax_records (user_id, year desc, type, id)'),
+      );
+    });
+
+    test('uses least-privilege grants and owner-only RLS', () {
+      expect(
+        sql,
+        contains('alter table public.tax_records enable row level security;'),
+      );
+      expect(
+        sql,
+        contains(
+          'revoke all privileges on table public.tax_records\n'
+          'from public, anon, authenticated;',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'grant all privileges on table public.tax_records to service_role;',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'grant select, insert, update, delete on table public.tax_records\n'
+          'to authenticated;',
+        ),
+      );
+      expect(sql, isNot(contains('to anon;')));
+
+      for (final operation in ['select', 'insert', 'update', 'delete']) {
+        expect(sql, contains('create policy tax_records_${operation}_own'));
+        expect(sql, contains('for $operation\n  to authenticated'));
+      }
+      expect(sql, contains('using ((select auth.uid()) = user_id)'));
+      expect(sql, contains('with check ((select auth.uid()) = user_id)'));
+    });
+
+    test('maintains updated_at with a table-specific trigger', () {
+      expect(
+        sql,
+        contains(
+          'create or replace function public.set_tax_records_updated_at()',
+        ),
+      );
+      expect(sql, contains("set search_path = ''"));
+      expect(sql, contains('create trigger tax_records_updated_at'));
+      expect(
+        sql,
+        contains(
+          'for each row execute function public.set_tax_records_updated_at();',
+        ),
+      );
+    });
+  });
+}
+
+String _createTableBlock(String sql, String table) {
+  final start = sql.indexOf('create table if not exists public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+
+  final end = sql.indexOf('\n);', start);
+  expect(
+    end,
+    isNonNegative,
+    reason: 'missing create table terminator for $table',
+  );
+
+  return sql.substring(start, end);
+}


### PR DESCRIPTION
## Summary

- add the `tax_records` table required by Issue #2489 with exact numeric amounts and the five requested tax types
- enforce owner-only CRUD through RLS, least-privilege grants, and a user/year/type composite index
- constrain tax year, non-negative amount, category length, and optional evidence URL length
- add deterministic schema tests plus disposable-Postgres coverage for migration syntax, grants, RLS isolation, owner CRUD, and forged-owner rejection
- make the Testcontainers SQL splitter preserve semicolons inside SQL strings and dollar-quoted trigger bodies so the real migration is applied end to end

## User impact

This is a storage-only foundation for the later furusato calculator, medical expense UI, tax export, and invoice work. No new UI or runtime query is enabled by this PR, so existing asset-management behavior is unchanged.

## Supabase egress review

- adds one empty table and one composite B-tree index; there is no data backfill
- adds no Flutter/Edge query, RPC, Storage operation, scheduled job, or network call
- therefore this PR adds zero steady-state requests, rows read, or response bytes
- `evidence_url` remains optional and owner-isolated; no evidence content is fetched or copied
- future consumers should query by `user_id`/`year` and remain separately scoped to #2490-#2493

## Minimal E2E Gate

- Implementation-detail independent: the disposable-Postgres test asserts database input/output and role-visible behavior, not source layout.
- Minimal scope: 3 I/O cases cover missing subject (zero rows), owner CRUD success, and forged owner rejection.
- E2E: `scripts/testcontainers_supabase_smoke.py` applies the real migration to PostgreSQL 16 and exercises it as `anon` and `authenticated` roles.
- E2E-Exception: No Flutter or browser route changes; the authoritative end-to-end boundary is the disposable PostgreSQL migration and RLS test.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 `/ultrareview` was not available inside this Codex-owned scoped execution; the real migration is instead proven by disposable-Postgres RLS tests and the PR AI Agent review remains a required gate.
- Security: public and anon retain no privileges; authenticated receives policy-backed CRUD only; missing or mismatched `auth.uid()` cannot read or write another user's rows.
- Rollback: no consumer is enabled, so the table is inert if rollout is paused. Before any writes, a forward migration may drop it; after writes exist, revoke consumers and preserve data while shipping a reviewed forward migration.
- Data migration: creates an empty table only, with no backfill or mutation of existing rows.
- Prod smoke: post-merge deployment must apply the migration successfully and confirm the production commit; the local PostgreSQL 16 smoke already validates schema and RLS behavior.
- Observability: deployment migration logs and the Testcontainers summary expose the applied boundary, enabled RLS table, policy set, owner count, and denied SQLSTATE.
- Unresolved ultrareview findings: none under this exception; any PR AI review finding will be resolved before merge.

## Validation

- `flutter analyze test/services/tax_records_schema_test.dart` — no issues
- `flutter test test/services/tax_records_schema_test.dart` — 5 passed
- `python test/scripts/test_testcontainers_supabase_smoke.py` — 12 passed
- `python scripts/testcontainers_supabase_smoke.py --artifacts-dir .testcontainers-logs` — passed on disposable PostgreSQL 16; forged owner rejected with `42501`
- `python scripts/check_migration_timestamps.py` — 1,947 unique timestamps, no collision
- `BASE_SHA=origin/main python scripts/check_migration_time_relative_check.py` — clean
- repository pre-commit quality gate — passed

Closes #2489
