### PR TITLE
fix(home): improve feature tier text contrast

### DIFF
--- a/lib/widgets/home_tier/ai_recommended_features_list.dart
+++ b/lib/widgets/home_tier/ai_recommended_features_list.dart
@@ -125,8 +125,7 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
                 _stringValue(item['id']) ??
                 '',
           );
-          final label =
-              _stringValue(item['label']) ??
+          final label = _stringValue(item['label']) ??
               _stringValue(item['feature_label']) ??
               _fallbackLabel(route) ??
               _stringValue(item['title']) ??

--- a/lib/widgets/home_tier/ai_recommended_features_list.dart
+++ b/lib/widgets/home_tier/ai_recommended_features_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../utils/home_feature_actions.dart';
+import 'home_tier_styles.dart';
 
 class AiRecommendedFeaturesList extends StatefulWidget {
   const AiRecommendedFeaturesList({super.key});
@@ -75,21 +76,22 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
 
   @override
   Widget build(BuildContext context) {
+    final palette = HomeTierPalette.of(context);
     if (_loading) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
+      return Padding(
+        padding: const EdgeInsets.all(16),
         child: Row(
           children: [
-            SizedBox(
+            const SizedBox(
               width: 16,
               height: 16,
               child: CircularProgressIndicator(strokeWidth: 2),
             ),
-            SizedBox(width: 10),
+            const SizedBox(width: 10),
             Text(
               'AIがおすすめ機能を分析中...',
               style: TextStyle(
-                color: Color(0xFF94A3B8),
+                color: palette.secondaryText,
                 fontSize: 12,
                 height: 1.5,
               ),
@@ -102,14 +104,14 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
     return Column(
       children: [
         if (_error != null)
-          const Padding(
-            padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
             child: Align(
               alignment: Alignment.centerLeft,
               child: Text(
                 'おすすめの取得に失敗したため、固定候補を表示しています。',
                 style: TextStyle(
-                  color: Color(0xFF94A3B8),
+                  color: palette.secondaryText,
                   fontSize: 12,
                   height: 1.5,
                 ),
@@ -123,43 +125,18 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
                 _stringValue(item['id']) ??
                 '',
           );
-          final label = _stringValue(item['label']) ??
+          final label =
+              _stringValue(item['label']) ??
               _stringValue(item['feature_label']) ??
               _fallbackLabel(route) ??
               _stringValue(item['title']) ??
               'おすすめ機能';
           final reason = _stringValue(item['reason']) ?? _fallbackReason(route);
-          return ListTile(
-            dense: true,
-            leading: const Icon(
-              Icons.auto_awesome,
-              size: 18,
-              color: Color(0xFF6366F1),
-            ),
-            title: Text(
-              label,
-              style: const TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: Colors.white,
-                height: 1.5,
-              ),
-            ),
-            subtitle: reason.isNotEmpty
-                ? Text(
-                    reason,
-                    style: const TextStyle(
-                      fontSize: 11,
-                      color: Color(0xFF94A3B8),
-                      height: 1.5,
-                    ),
-                  )
-                : null,
-            trailing: const Icon(
-              Icons.chevron_right,
-              size: 16,
-              color: Color(0xFF64748B),
-            ),
+          return HomeTierFeatureListTile(
+            icon: Icons.auto_awesome,
+            iconColor: const Color(0xFF6366F1),
+            label: label,
+            description: reason,
             onTap: route.isEmpty
                 ? null
                 : () => openHomeFeature(context, route, label),

--- a/lib/widgets/home_tier/home_tier_styles.dart
+++ b/lib/widgets/home_tier/home_tier_styles.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+/// Theme-aware colors shared by the feature tiers on the home page.
+///
+/// The tier cards are transparent, so text and controls must follow the active
+/// color scheme instead of assuming a permanently dark background.
+class HomeTierPalette {
+  final Color primaryText;
+  final Color secondaryText;
+  final Color trailingIcon;
+  final Color chipBackground;
+  final Color chipBorder;
+  final bool isDark;
+
+  const HomeTierPalette({
+    required this.primaryText,
+    required this.secondaryText,
+    required this.trailingIcon,
+    required this.chipBackground,
+    required this.chipBorder,
+    required this.isDark,
+  });
+
+  factory HomeTierPalette.of(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return HomeTierPalette(
+      primaryText: scheme.onSurface,
+      secondaryText: scheme.onSurfaceVariant,
+      trailingIcon: scheme.onSurfaceVariant,
+      chipBackground: scheme.surfaceContainerHighest,
+      chipBorder: scheme.outlineVariant,
+      isDark: scheme.brightness == Brightness.dark,
+    );
+  }
+
+  Color tintedChipBackground(Color accent) {
+    return Color.alphaBlend(
+      accent.withValues(alpha: isDark ? 0.18 : 0.10),
+      chipBackground,
+    );
+  }
+}
+
+class HomeTierFeatureListTile extends StatelessWidget {
+  final IconData icon;
+  final Color iconColor;
+  final String label;
+  final String description;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+
+  const HomeTierFeatureListTile({
+    super.key,
+    required this.icon,
+    required this.iconColor,
+    required this.label,
+    this.description = '',
+    this.onTap,
+    this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = HomeTierPalette.of(context);
+    return ListTile(
+      dense: true,
+      leading: Icon(icon, size: 18, color: iconColor),
+      title: Text(
+        label,
+        style: TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+          color: palette.primaryText,
+          height: 1.5,
+        ),
+      ),
+      subtitle: description.isNotEmpty
+          ? Text(
+              description,
+              style: TextStyle(
+                fontSize: 11,
+                color: palette.secondaryText,
+                height: 1.5,
+              ),
+            )
+          : null,
+      trailing: Icon(
+        Icons.chevron_right,
+        size: 16,
+        color: palette.trailingIcon,
+      ),
+      onTap: onTap,
+      onLongPress: onLongPress,
+    );
+  }
+}

--- a/lib/widgets/home_tier/new_features_list.dart
+++ b/lib/widgets/home_tier/new_features_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../utils/home_feature_actions.dart';
+import 'home_tier_styles.dart';
 
 class NewFeaturesList extends StatefulWidget {
   const NewFeaturesList({super.key});
@@ -55,6 +56,7 @@ class _NewFeaturesListState extends State<NewFeaturesList> {
 
   @override
   Widget build(BuildContext context) {
+    final palette = HomeTierPalette.of(context);
     if (_loading) {
       return const Padding(
         padding: EdgeInsets.all(16),
@@ -62,25 +64,29 @@ class _NewFeaturesListState extends State<NewFeaturesList> {
       );
     }
     if (_items.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
+      return Padding(
+        padding: const EdgeInsets.all(16),
         child: Text(
           '直近14日間に追加された機能はありません。',
-          style: TextStyle(color: Color(0xFF94A3B8), fontSize: 13, height: 1.5),
+          style: TextStyle(
+            color: palette.secondaryText,
+            fontSize: 13,
+            height: 1.5,
+          ),
         ),
       );
     }
     return Column(
       children: [
         if (_showingLatestFallback)
-          const Padding(
-            padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
             child: Align(
               alignment: Alignment.centerLeft,
               child: Text(
                 '直近14日間の追加はありません。最新の追加機能を表示しています。',
                 style: TextStyle(
-                  color: Color(0xFF94A3B8),
+                  color: palette.secondaryText,
                   fontSize: 12,
                   height: 1.5,
                 ),
@@ -91,37 +97,11 @@ class _NewFeaturesListState extends State<NewFeaturesList> {
           final label = item['feature_label'] as String? ?? '新機能';
           final desc = item['description'] as String? ?? '';
           final route = _normalizeRoute(item['feature_route'] as String? ?? '');
-          return ListTile(
-            dense: true,
-            leading: const Icon(
-              Icons.new_releases_outlined,
-              size: 18,
-              color: Color(0xFFFF6B35),
-            ),
-            title: Text(
-              label,
-              style: const TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: Colors.white,
-                height: 1.5,
-              ),
-            ),
-            subtitle: desc.isNotEmpty
-                ? Text(
-                    desc,
-                    style: const TextStyle(
-                      fontSize: 11,
-                      color: Color(0xFF94A3B8),
-                      height: 1.5,
-                    ),
-                  )
-                : null,
-            trailing: const Icon(
-              Icons.chevron_right,
-              size: 16,
-              color: Color(0xFF64748B),
-            ),
+          return HomeTierFeatureListTile(
+            icon: Icons.new_releases_outlined,
+            iconColor: const Color(0xFFFF6B35),
+            label: label,
+            description: desc,
             onTap: route.isEmpty
                 ? null
                 : () => openHomeFeature(context, route, label),

--- a/lib/widgets/home_tier/popular_features_list.dart
+++ b/lib/widgets/home_tier/popular_features_list.dart
@@ -81,8 +81,7 @@ class _PopularFeaturesListState extends State<PopularFeaturesList> {
         runSpacing: 8,
         children: _items.map((item) {
           final route = _normalizeRoute(item['feature_route'] as String? ?? '');
-          final label =
-              (item['feature_label'] as String?) ??
+          final label = (item['feature_label'] as String?) ??
               (item['label'] as String?) ??
               _fallbackLabel(route);
           final countValue = item['use_count'];

--- a/lib/widgets/home_tier/popular_features_list.dart
+++ b/lib/widgets/home_tier/popular_features_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../utils/home_feature_actions.dart';
+import 'home_tier_styles.dart';
 
 class PopularFeaturesList extends StatefulWidget {
   const PopularFeaturesList({super.key});
@@ -66,6 +67,7 @@ class _PopularFeaturesListState extends State<PopularFeaturesList> {
 
   @override
   Widget build(BuildContext context) {
+    final palette = HomeTierPalette.of(context);
     if (_loading) {
       return const Padding(
         padding: EdgeInsets.all(16),
@@ -79,7 +81,8 @@ class _PopularFeaturesListState extends State<PopularFeaturesList> {
         runSpacing: 8,
         children: _items.map((item) {
           final route = _normalizeRoute(item['feature_route'] as String? ?? '');
-          final label = (item['feature_label'] as String?) ??
+          final label =
+              (item['feature_label'] as String?) ??
               (item['label'] as String?) ??
               _fallbackLabel(route);
           final countValue = item['use_count'];
@@ -96,13 +99,15 @@ class _PopularFeaturesListState extends State<PopularFeaturesList> {
               ),
               label: Text(
                 count > 0 ? '$label  $count' : label,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 12,
-                  color: Color(0xFFE2E8F0),
+                  color: palette.primaryText,
                   height: 1.5,
                 ),
               ),
-              backgroundColor: const Color(0xFF10201D),
+              backgroundColor: palette.tintedChipBackground(
+                const Color(0xFF0D9488),
+              ),
               side: const BorderSide(color: Color(0xFF0D9488), width: 0.8),
               onPressed: route.isEmpty
                   ? null

--- a/lib/widgets/home_tier/recent_features_list.dart
+++ b/lib/widgets/home_tier/recent_features_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../utils/home_feature_actions.dart';
+import 'home_tier_styles.dart';
 
 class RecentFeaturesList extends StatefulWidget {
   const RecentFeaturesList({super.key});
@@ -56,6 +57,7 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
 
   @override
   Widget build(BuildContext context) {
+    final palette = HomeTierPalette.of(context);
     if (_loading) {
       return const Padding(
         padding: EdgeInsets.all(16),
@@ -63,11 +65,15 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
       );
     }
     if (_items.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
+      return Padding(
+        padding: const EdgeInsets.all(16),
         child: Text(
           'まだ利用履歴がありません。',
-          style: TextStyle(color: Color(0xFF94A3B8), fontSize: 13, height: 1.5),
+          style: TextStyle(
+            color: palette.secondaryText,
+            fontSize: 13,
+            height: 1.5,
+          ),
         ),
       );
     }
@@ -78,7 +84,8 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
         runSpacing: 8,
         children: _items.map((item) {
           final route = _normalizeRoute(item['feature_route'] as String? ?? '');
-          final label = item['feature_label'] as String? ??
+          final label =
+              item['feature_label'] as String? ??
               route.substring(1).replaceAll('-', ' ');
           return GestureDetector(
             onLongPress: route.isEmpty
@@ -87,14 +94,14 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
             child: ActionChip(
               label: Text(
                 label,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 12,
-                  color: Color(0xFFE5E7EB),
+                  color: palette.primaryText,
                   height: 1.5,
                 ),
               ),
-              backgroundColor: const Color(0xFF1A1A1A),
-              side: const BorderSide(color: Color(0xFF2A2A2A)),
+              backgroundColor: palette.chipBackground,
+              side: BorderSide(color: palette.chipBorder),
               onPressed: route.isEmpty
                   ? null
                   : () => openHomeFeature(context, route, label),

--- a/lib/widgets/home_tier/recent_features_list.dart
+++ b/lib/widgets/home_tier/recent_features_list.dart
@@ -84,8 +84,7 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
         runSpacing: 8,
         children: _items.map((item) {
           final route = _normalizeRoute(item['feature_route'] as String? ?? '');
-          final label =
-              item['feature_label'] as String? ??
+          final label = item['feature_label'] as String? ??
               route.substring(1).replaceAll('-', ' ');
           return GestureDetector(
             onLongPress: route.isEmpty

--- a/lib/widgets/home_tier/system_fixed_features_list.dart
+++ b/lib/widgets/home_tier/system_fixed_features_list.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import '../../data/home_system_fixed.dart';
 import '../../utils/home_feature_actions.dart';
+import 'home_tier_styles.dart';
 
 class SystemFixedFeaturesList extends StatelessWidget {
   const SystemFixedFeaturesList({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final palette = HomeTierPalette.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
       child: Wrap(
@@ -19,13 +21,13 @@ class SystemFixedFeaturesList extends StatelessWidget {
               avatar: Icon(f.icon, size: 16, color: f.color),
               label: Text(
                 f.label,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 12,
-                  color: Color(0xFFE2E8F0),
+                  color: palette.primaryText,
                   height: 1.5,
                 ),
               ),
-              backgroundColor: const Color(0xFF1A1A1A),
+              backgroundColor: palette.chipBackground,
               side: BorderSide(color: f.color.withValues(alpha: 0.3)),
               onPressed: () => openHomeFeature(context, f.route, f.label),
             ),

--- a/lib/widgets/home_tier/user_pinned_features_list.dart
+++ b/lib/widgets/home_tier/user_pinned_features_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../utils/home_feature_actions.dart';
+import 'home_tier_styles.dart';
 
 class UserPinnedFeaturesList extends StatefulWidget {
   const UserPinnedFeaturesList({super.key});
@@ -62,6 +63,7 @@ class _UserPinnedFeaturesListState extends State<UserPinnedFeaturesList> {
 
   @override
   Widget build(BuildContext context) {
+    final palette = HomeTierPalette.of(context);
     if (_loading) {
       return const Padding(
         padding: EdgeInsets.all(16),
@@ -69,11 +71,15 @@ class _UserPinnedFeaturesListState extends State<UserPinnedFeaturesList> {
       );
     }
     if (_items.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
+      return Padding(
+        padding: const EdgeInsets.all(16),
         child: Text(
           '各セクションの機能チップを長押しすると、ここにお気に入りとして表示されます。',
-          style: TextStyle(color: Color(0xFF94A3B8), fontSize: 13, height: 1.5),
+          style: TextStyle(
+            color: palette.secondaryText,
+            fontSize: 13,
+            height: 1.5,
+          ),
         ),
       );
     }
@@ -89,9 +95,15 @@ class _UserPinnedFeaturesListState extends State<UserPinnedFeaturesList> {
           return InputChip(
             label: Text(
               label,
-              style: const TextStyle(fontSize: 12, height: 1.5),
+              style: TextStyle(
+                fontSize: 12,
+                color: palette.primaryText,
+                height: 1.5,
+              ),
             ),
-            backgroundColor: const Color(0xFF1E1E2E),
+            backgroundColor: palette.tintedChipBackground(
+              const Color(0xFF6366F1),
+            ),
             side: const BorderSide(color: Color(0xFF6366F1), width: 0.8),
             deleteIcon: const Icon(
               Icons.push_pin,

--- a/test/widgets/home_tier_styles_test.dart
+++ b/test/widgets/home_tier_styles_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/home_tier/home_tier_styles.dart';
+
+void main() {
+  group('HomeTierFeatureListTile', () {
+    for (final brightness in Brightness.values) {
+      testWidgets('uses readable $brightness theme colors', (tester) async {
+        final scheme = ColorScheme.fromSeed(
+          seedColor: const Color(0xFF6366F1),
+          brightness: brightness,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(colorScheme: scheme),
+            home: const Scaffold(
+              body: HomeTierFeatureListTile(
+                icon: Icons.auto_awesome,
+                iconColor: Color(0xFF6366F1),
+                label: 'AIおすすめ機能',
+                description: '目的に合う機能を案内します。',
+              ),
+            ),
+          ),
+        );
+
+        final title = tester.widget<Text>(find.text('AIおすすめ機能'));
+        final subtitle = tester.widget<Text>(find.text('目的に合う機能を案内します。'));
+        final trailing = tester.widget<Icon>(find.byIcon(Icons.chevron_right));
+
+        expect(title.style?.color, scheme.onSurface);
+        expect(subtitle.style?.color, scheme.onSurfaceVariant);
+        expect(trailing.color, scheme.onSurfaceVariant);
+        expect(
+          _contrastRatio(scheme.onSurface, scheme.surface),
+          greaterThanOrEqualTo(4.5),
+        );
+        expect(
+          _contrastRatio(scheme.onSurfaceVariant, scheme.surface),
+          greaterThanOrEqualTo(4.5),
+        );
+      });
+    }
+  });
+
+  group('HomeTierPalette', () {
+    for (final brightness in Brightness.values) {
+      testWidgets('keeps chip text distinct in $brightness mode', (
+        tester,
+      ) async {
+        late HomeTierPalette palette;
+        final scheme = ColorScheme.fromSeed(
+          seedColor: const Color(0xFF6366F1),
+          brightness: brightness,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(colorScheme: scheme),
+            home: Builder(
+              builder: (context) {
+                palette = HomeTierPalette.of(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        expect(palette.primaryText, scheme.onSurface);
+        expect(palette.chipBackground, scheme.surfaceContainerHighest);
+        expect(
+          _contrastRatio(palette.primaryText, palette.chipBackground),
+          greaterThanOrEqualTo(4.5),
+        );
+      });
+    }
+  });
+}
+
+double _contrastRatio(Color foreground, Color background) {
+  final foregroundLuminance = foreground.computeLuminance();
+  final backgroundLuminance = background.computeLuminance();
+  final lighter = foregroundLuminance > backgroundLuminance
+      ? foregroundLuminance
+      : backgroundLuminance;
+  final darker = foregroundLuminance > backgroundLuminance
+      ? backgroundLuminance
+      : foregroundLuminance;
+  return (lighter + 0.05) / (darker + 0.05);
+}


### PR DESCRIPTION
## 概要
- ホーム画面の「最近追加された機能」「AIおすすめ機能」の文字色をテーマ連動へ変更
- 最近使用・人気・固定・お気に入りの各チップをライト／ダーク両テーマで読みやすく調整
- 共通のテーマ配色コンポーネントとコントラスト回帰テストを追加

## 検証
- `flutter analyze --no-pub lib/widgets/home_tier test/widgets/home_tier_styles_test.dart`
- `flutter test --no-pub test/widgets/home_tier_styles_test.dart`（4件成功）
- `flutter build web --release --no-pub`
- `git diff origin/main...HEAD --check`

## ブラウザQA
- ローカルWebリリースビルドの起動を確認
- ローカルホストでは本番認証状態を引き継げないため、認証後コックピットの最終確認はデプロイ後に実施
- コンソールは既存のNotoフォント警告のみで、実行エラーなし

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: This theme-only change is covered by focused light and dark widget contrast tests; authenticated cockpit E2E requires a production Supabase session.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Theme-only color changes touch no security, payment, migration, deployment configuration, or persisted data paths.

## 影響範囲
- ホーム画面の階層型機能一覧の表示色のみ
- データ取得、ルーティング、永続化の変更なし