### PR TITLE
fix: show video studio login requirement

### DIFF
--- a/lib/ui/features/video_studio/data/video_studio_gateway.dart
+++ b/lib/ui/features/video_studio/data/video_studio_gateway.dart
@@ -5,6 +5,16 @@ import '../domain/video_studio_models.dart';
 class VideoStudioException implements Exception {
   const VideoStudioException(this.code, [this.message]);
 
+  factory VideoStudioException.fromFunctionException(FunctionException error) {
+    final details = videoStudioMap(error.details);
+    final code = details['error']?.toString().trim();
+    final message = details['message']?.toString().trim();
+    return VideoStudioException(
+      code == null || code.isEmpty ? 'http_${error.status}' : code,
+      message == null || message.isEmpty ? error.reasonPhrase : message,
+    );
+  }
+
   final String code;
   final String? message;
 
@@ -99,14 +109,11 @@ class SupabaseVideoStudioGateway implements VideoStudioGateway {
     required String packKey,
     required String returnUrl,
   }) async {
-    final response = await _client.functions.invoke(
-      'schedule-hub',
-      body: {
-        'action': 'billing.create_video_credit_checkout_session',
-        'pack_key': packKey,
-        'return_url': returnUrl,
-      },
-    );
+    final response = await _invokeFunction('schedule-hub', {
+      'action': 'billing.create_video_credit_checkout_session',
+      'pack_key': packKey,
+      'return_url': returnUrl,
+    });
     final data = videoStudioMap(response.data);
     _throwForResponse(response.status, data);
     final uri = Uri.tryParse(data['checkout_url']?.toString() ?? '');
@@ -117,13 +124,21 @@ class SupabaseVideoStudioGateway implements VideoStudioGateway {
   }
 
   Future<Map<String, dynamic>> _invokeVideo(Map<String, dynamic> body) async {
-    final response = await _client.functions.invoke(
-      'video-generation-hub',
-      body: body,
-    );
+    final response = await _invokeFunction('video-generation-hub', body);
     final data = videoStudioMap(response.data);
     _throwForResponse(response.status, data);
     return data;
+  }
+
+  Future<FunctionResponse> _invokeFunction(
+    String functionName,
+    Map<String, dynamic> body,
+  ) async {
+    try {
+      return await _client.functions.invoke(functionName, body: body);
+    } on FunctionException catch (error) {
+      throw VideoStudioException.fromFunctionException(error);
+    }
   }
 
   void _throwForResponse(int status, Map<String, dynamic> data) {

--- a/lib/ui/features/video_studio/view_models/video_studio_view_model.dart
+++ b/lib/ui/features/video_studio/view_models/video_studio_view_model.dart
@@ -36,6 +36,7 @@ class VideoStudioViewModel extends ChangeNotifier {
   bool _isRefreshing = false;
   String? _openingOutputJobId;
   bool _isOpeningCheckout = false;
+  bool _authenticationRequired = false;
   String? _errorMessage;
   String? _noticeMessage;
   String? _idempotencyKey;
@@ -56,6 +57,7 @@ class VideoStudioViewModel extends ChangeNotifier {
   bool get isRefreshing => _isRefreshing;
   String? get openingOutputJobId => _openingOutputJobId;
   bool get isOpeningCheckout => _isOpeningCheckout;
+  bool get authenticationRequired => _authenticationRequired;
   String? get errorMessage => _errorMessage;
   String? get noticeMessage => _noticeMessage;
 
@@ -78,6 +80,7 @@ class VideoStudioViewModel extends ChangeNotifier {
 
   Future<void> load({Uri? currentUri}) async {
     _loadStatus = VideoStudioLoadStatus.loading;
+    _authenticationRequired = false;
     _errorMessage = null;
     _noticeMessage =
         currentUri?.queryParameters['billing'] == 'video_credits_success'
@@ -85,12 +88,14 @@ class VideoStudioViewModel extends ChangeNotifier {
             : null;
     notifyListeners();
     try {
-      final catalogFuture = _gateway.loadCatalog();
-      final balanceFuture = _gateway.loadBalance();
-      final jobsFuture = _gateway.listJobs();
-      _catalog = await catalogFuture;
-      _balance = await balanceFuture;
-      _jobs = await jobsFuture;
+      final results = await Future.wait<Object>([
+        _gateway.loadCatalog(),
+        _gateway.loadBalance(),
+        _gateway.listJobs(),
+      ]);
+      _catalog = results[0] as VideoStudioCatalog;
+      _balance = results[1] as VideoCreditBalance;
+      _jobs = results[2] as List<VideoGenerationJob>;
       if (_catalog?.models.isEmpty ?? true) {
         throw const VideoStudioException('catalog_empty');
       }
@@ -100,6 +105,9 @@ class VideoStudioViewModel extends ChangeNotifier {
       if (_activeJob != null) _startPolling();
     } catch (error) {
       _loadStatus = VideoStudioLoadStatus.failure;
+      _authenticationRequired =
+          error is VideoStudioException &&
+          error.code == 'authentication_required';
       _errorMessage = _friendlyError(error);
     }
     notifyListeners();

--- a/lib/ui/features/video_studio/view_models/video_studio_view_model.dart
+++ b/lib/ui/features/video_studio/view_models/video_studio_view_model.dart
@@ -105,8 +105,7 @@ class VideoStudioViewModel extends ChangeNotifier {
       if (_activeJob != null) _startPolling();
     } catch (error) {
       _loadStatus = VideoStudioLoadStatus.failure;
-      _authenticationRequired =
-          error is VideoStudioException &&
+      _authenticationRequired = error is VideoStudioException &&
           error.code == 'authentication_required';
       _errorMessage = _friendlyError(error);
     }

--- a/lib/ui/features/video_studio/views/video_studio_page.dart
+++ b/lib/ui/features/video_studio/views/video_studio_page.dart
@@ -683,10 +683,23 @@ class _LoadFailure extends StatelessWidget {
               style: const TextStyle(color: DesignTokens.textOnDark),
             ),
             const SizedBox(height: DesignTokens.space16),
-            FilledButton(
-              onPressed: () => viewModel.load(currentUri: Uri.base),
-              child: const Text('再試行'),
-            ),
+            if (viewModel.authenticationRequired) ...[
+              FilledButton.icon(
+                key: const Key('video-studio-login'),
+                onPressed: () => Navigator.of(context).pushNamed('/login'),
+                icon: const Icon(Icons.login),
+                label: const Text('ログインする'),
+              ),
+              const SizedBox(height: DesignTokens.space8),
+              TextButton(
+                onPressed: () => viewModel.load(currentUri: Uri.base),
+                child: const Text('ログイン済みなら再読み込み'),
+              ),
+            ] else
+              FilledButton(
+                onPressed: () => viewModel.load(currentUri: Uri.base),
+                child: const Text('再試行'),
+              ),
           ],
         ),
       ),

--- a/test/ui/features/video_studio/video_studio_gateway_test.dart
+++ b/test/ui/features/video_studio/video_studio_gateway_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/video_studio/data/video_studio_gateway.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+void main() {
+  group('VideoStudioException.fromFunctionException', () {
+    test('preserves the structured Edge Function error code and message', () {
+      final mapped = VideoStudioException.fromFunctionException(
+        const FunctionException(
+          status: 401,
+          details: {
+            'error': 'authentication_required',
+            'message': 'Sign in first',
+          },
+          reasonPhrase: 'Unauthorized',
+        ),
+      );
+
+      expect(mapped.code, 'authentication_required');
+      expect(mapped.message, 'Sign in first');
+    });
+
+    test('falls back to the HTTP status when details are not structured', () {
+      final mapped = VideoStudioException.fromFunctionException(
+        const FunctionException(
+          status: 503,
+          details: 'temporarily unavailable',
+          reasonPhrase: 'Service Unavailable',
+        ),
+      );
+
+      expect(mapped.code, 'http_503');
+      expect(mapped.message, 'Service Unavailable');
+    });
+  });
+}

--- a/test/ui/features/video_studio/video_studio_page_test.dart
+++ b/test/ui/features/video_studio/video_studio_page_test.dart
@@ -76,17 +76,42 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('authentication failure offers a direct login action', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        gateway: _AuthenticationRequiredGateway(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('この機能を使うにはログインしてください。'), findsOneWidget);
+    expect(find.byKey(const Key('video-studio-login')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('video-studio-login')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('video-studio-login-page')), findsOneWidget);
+  });
 }
 
-Widget _app({List<VideoGenerationJob> jobs = const []}) {
+Widget _app({
+  List<VideoGenerationJob> jobs = const [],
+  VideoStudioGateway? gateway,
+}) {
   return MaterialApp(
     routes: {
+      '/login': (_) => const Scaffold(
+        body: Text('Login page', key: Key('video-studio-login-page')),
+      ),
       '/terms': (_) => const SizedBox(),
       '/privacy': (_) => const SizedBox(),
       '/tokusho': (_) => const SizedBox(),
     },
     home: VideoStudioFeature(
-      gateway: _PageGateway(jobs: jobs),
+      gateway: gateway ?? _PageGateway(jobs: jobs),
       initialUri: Uri.parse('https://example.test/video-studio'),
     ),
   );
@@ -151,4 +176,11 @@ class _PageGateway implements VideoStudioGateway {
     required String returnUrl,
   }) async =>
       Uri.parse('https://checkout.stripe.test/session');
+}
+
+class _AuthenticationRequiredGateway extends _PageGateway {
+  @override
+  Future<VideoStudioCatalog> loadCatalog() => Future.error(
+        const VideoStudioException('authentication_required'),
+      );
 }

--- a/test/ui/features/video_studio/video_studio_page_test.dart
+++ b/test/ui/features/video_studio/video_studio_page_test.dart
@@ -104,8 +104,8 @@ Widget _app({
   return MaterialApp(
     routes: {
       '/login': (_) => const Scaffold(
-        body: Text('Login page', key: Key('video-studio-login-page')),
-      ),
+            body: Text('Login page', key: Key('video-studio-login-page')),
+          ),
       '/terms': (_) => const SizedBox(),
       '/privacy': (_) => const SizedBox(),
       '/tokusho': (_) => const SizedBox(),

--- a/test/ui/features/video_studio/video_studio_view_model_test.dart
+++ b/test/ui/features/video_studio/video_studio_view_model_test.dart
@@ -78,6 +78,21 @@ void main() {
     expect(gateway.createdIdempotencyKey, isNull);
   });
 
+  test('authentication failures expose a login-specific load state', () async {
+    final gateway = _FakeVideoStudioGateway(
+      balance: _balance(0),
+      loadError: const VideoStudioException('authentication_required'),
+    );
+    final viewModel = VideoStudioViewModel(gateway: gateway);
+    addTearDown(viewModel.dispose);
+
+    await viewModel.load();
+
+    expect(viewModel.loadStatus, VideoStudioLoadStatus.failure);
+    expect(viewModel.authenticationRequired, isTrue);
+    expect(viewModel.errorMessage, 'この機能を使うにはログインしてください。');
+  });
+
   test('completed history refreshes an expired or missing signed URL',
       () async {
     final completedWithoutUrl = _job(status: 'succeeded', includeOutput: false);
@@ -103,22 +118,31 @@ class _FakeVideoStudioGateway implements VideoStudioGateway {
     required this.balance,
     this.initialJobs = const [],
     this.refreshedJob,
+    this.loadError,
   });
 
   VideoCreditBalance balance;
   final List<VideoGenerationJob> initialJobs;
   final VideoGenerationJob? refreshedJob;
+  final Exception? loadError;
   String? createdIdempotencyKey;
   int refreshCount = 0;
 
   @override
-  Future<VideoStudioCatalog> loadCatalog() async => _catalog;
+  Future<VideoStudioCatalog> loadCatalog() async {
+    if (loadError case final error?) throw error;
+    return _catalog;
+  }
 
   @override
-  Future<VideoCreditBalance> loadBalance() async => balance;
+  Future<VideoCreditBalance> loadBalance() async {
+    return balance;
+  }
 
   @override
-  Future<List<VideoGenerationJob>> listJobs() async => initialJobs;
+  Future<List<VideoGenerationJob>> listJobs() async {
+    return initialJobs;
+  }
 
   @override
   Future<VideoCreateResult> createJob({


### PR DESCRIPTION
## User-visible outcome

- Supabase Edge Function が返す `authentication_required` を Flutter 側で保持します。
- 未ログインの `/video-studio` に正しい説明と「ログインする」CTAを表示します。
- 初期3リクエストを `Future.wait` で回収し、401時の未処理非同期エラーを防ぎます。

## Production evidence

- 2026-08-21 JST の本番smokeで、未ログイン時に汎用「動画サービスに接続できません」とJSエラー2件を確認しました。
- 本番Edge Function自体は `authentication_required` / 401を返しており、Dart `FunctionException` の変換漏れが原因です。

## Validation

- `dart analyze lib/ui/features/video_studio test/ui/features/video_studio`: no issues.
- `flutter test test/ui/features/video_studio`: 14 tests passed.
- `git diff --cached --check`: clean before commit.

## Minimal E2E Gate

- Implementation-detail independent: user-visible error copy and login navigation are asserted.
- Minimal scope: unauthenticated error, login CTA, existing authenticated layouts.
- E2E: production Browser smoke after deployment plus Flutter widget coverage.
- E2E-Exception: No new backend I/O or billing action; this fixes the already-observed unauthenticated production path.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Scoped client-side error translation and login CTA only; authentication policy, Stripe behavior, migrations, secrets, and GPU controls are unchanged.
- Security: preserves server-owned 401 and does not expose exception details.
- Rollback: revert this single commit.
- Data migration: none.
- Prod smoke: verify login-required copy and CTA on `/video-studio`.
- Observability: browser console should no longer receive unhandled load Future errors.
- Unresolved ultrareview findings: none.
