### PR TITLE
fix: make signup and login mode explicit on mobile

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -926,6 +926,15 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     _showAuthModeAndScroll(isSignUp: false);
   }
 
+  void _selectInlineAuthMode(bool isSignUp) {
+    if (_isLoading || _isSignUp == isSignUp) return;
+    setState(() {
+      _isSignUp = isSignUp;
+      _magicLinkErrorMessage = null;
+      _showInboxShortcut = false;
+    });
+  }
+
   void _scrollToTrialMagicLink({bool requestFocus = true}) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final captureContext = _trialEmailFocusNode.context;
@@ -5161,6 +5170,101 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     );
   }
 
+  Widget _buildAuthModeSelector() {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Semantics(
+      container: true,
+      label: 'アカウント操作の切り替え',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            '利用方法を選ぶ',
+            key: Key('landing_auth_mode_selector_heading'),
+            style: TextStyle(
+              color: Color(0xFF334155),
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          SegmentedButton<bool>(
+            key: const Key('landing_auth_mode_selector'),
+            expandedInsets: EdgeInsets.zero,
+            showSelectedIcon: true,
+            selectedIcon: const Icon(Icons.check_circle, size: 18),
+            segments: const [
+              ButtonSegment<bool>(
+                value: true,
+                icon: Icon(Icons.person_add_alt_1_outlined, size: 18),
+                label: Text(
+                  '新規登録',
+                  key: Key('landing_auth_mode_signup_option'),
+                ),
+                tooltip: '初めて利用する方',
+              ),
+              ButtonSegment<bool>(
+                value: false,
+                icon: Icon(Icons.login, size: 18),
+                label: Text(
+                  'ログイン',
+                  key: Key('landing_auth_mode_login_option'),
+                ),
+                tooltip: 'アカウントをお持ちの方',
+              ),
+            ],
+            selected: {_isSignUp},
+            onSelectionChanged: _isLoading
+                ? null
+                : (selection) => _selectInlineAuthMode(selection.first),
+            style: SegmentedButton.styleFrom(
+              minimumSize: const Size.fromHeight(54),
+              backgroundColor: colorScheme.surface,
+              foregroundColor: colorScheme.onSurfaceVariant,
+              selectedBackgroundColor: colorScheme.primary,
+              selectedForegroundColor: colorScheme.onPrimary,
+              side: BorderSide(color: colorScheme.outline),
+              textStyle: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 180),
+            child: Row(
+              key: ValueKey<bool>(_isSignUp),
+              children: [
+                Icon(
+                  _isSignUp
+                      ? Icons.person_add_alt_1_outlined
+                      : Icons.history_rounded,
+                  size: 17,
+                  color: colorScheme.primary,
+                ),
+                const SizedBox(width: 7),
+                Expanded(
+                  child: Text(
+                    _isSignUp ? '初めての方：無料アカウントを作成します' : '登録済みの方：続きから再開します',
+                    key: const Key('landing_auth_mode_status'),
+                    style: TextStyle(
+                      color: colorScheme.onSurfaceVariant,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildAuthSection() {
     final compactMagicLink = _hypothesisEnabled('h04');
     return KeyedSubtree(
@@ -5197,6 +5301,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                 ),
                 const SizedBox(height: 14),
               ],
+              _buildAuthModeSelector(),
+              const SizedBox(height: 18),
               Text(
                 _isSignUp ? '今すぐ無料ではじめる' : 'ログインして続きから再開',
                 key: const Key('landing_auth_mode_heading'),
@@ -5316,9 +5422,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       ),
               ),
               const SizedBox(height: 8),
-              const Text(
-                '新規登録もログインも、この1通で完了します。',
-                style: TextStyle(
+              Text(
+                _isSignUp ? 'メールを開くだけで新規登録が完了します。' : 'メールを開くだけでログインできます。',
+                key: const Key('landing_magic_link_mode_note'),
+                style: const TextStyle(
                   fontSize: 12,
                   color: Color(0xFF94A3B8),
                   height: 1.5,
@@ -5511,17 +5618,6 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   ),
                 ),
                 const SizedBox(height: 10),
-                TextButton(
-                  key: const Key('landing_auth_mode_toggle'),
-                  onPressed: _isLoading
-                      ? null
-                      : () {
-                          setState(() => _isSignUp = !_isSignUp);
-                        },
-                  child: Text(
-                    _isSignUp ? 'すでにアカウントがある場合はログイン' : 'アカウントがない場合は新規登録',
-                  ),
-                ),
               ] else ...[
                 TextButton.icon(
                   key: const Key('landing_h04_password_toggle'),

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -645,6 +645,62 @@ void main() {
   });
 
   testWidgets(
+    'mobile auth mode selector clearly switches signup and login copy',
+    (tester) async {
+      await pumpLanding(
+        tester,
+        assignment: _assignment('h04', LandingExperimentVariant.control),
+        size: const Size(390, 844),
+      );
+
+      final selectorFinder = find.byKey(
+        const Key('landing_auth_mode_selector'),
+      );
+      expect(selectorFinder, findsOneWidget);
+      expect(
+        tester.widget<SegmentedButton<bool>>(selectorFinder).selected,
+        <bool>{true},
+      );
+      expect(
+        find.text('初めての方：無料アカウントを作成します'),
+        findsOneWidget,
+      );
+      expect(find.text('メールを開くだけで新規登録が完了します。'), findsOneWidget);
+
+      await Scrollable.ensureVisible(
+        tester.element(selectorFinder),
+        alignment: 0.2,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('landing_auth_mode_login_option')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<SegmentedButton<bool>>(selectorFinder).selected,
+        <bool>{false},
+      );
+      expect(find.text('ログインして続きから再開'), findsOneWidget);
+      expect(find.text('Magic Linkでログイン'), findsOneWidget);
+      expect(find.text('登録済みの方：続きから再開します'), findsOneWidget);
+      expect(find.text('メールを開くだけでログインできます。'), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const Key('landing_auth_mode_signup_option')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<SegmentedButton<bool>>(selectorFinder).selected,
+        <bool>{true},
+      );
+      expect(find.text('今すぐ無料ではじめる'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
     'lp_intent trial brings the promised trial into view for every H03 arm and viewport',
     (tester) async {
       for (final size in <Size>[const Size(1200, 900), const Size(390, 844)]) {
@@ -1610,7 +1666,17 @@ void main() {
     await tester.pump(const Duration(milliseconds: 350));
     await tester.tap(passwordToggle);
     await tester.pump();
-    await tester.tap(find.byKey(const Key('landing_auth_mode_toggle')));
+    final authModeSelector = find.byKey(
+      const Key('landing_auth_mode_selector'),
+    );
+    await Scrollable.ensureVisible(
+      tester.element(authModeSelector),
+      alignment: 0.2,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('landing_auth_mode_login_option')),
+    );
     await tester.pump();
     expect(find.text('ログインして続きから再開'), findsOneWidget);
 


### PR DESCRIPTION
## User-visible outcome
- Replaces the hard-to-find auth mode text link with a full-width 新規登録 / ログイン segmented selector at the top of the landing auth form.
- Makes the active mode explicit with color, check icon, and a short status sentence.
- Keeps Google, Magic Link, and password CTA copy synchronized with the selected mode.

## Implementation notes
- Reuses the existing landing-page local auth state; no persistence, routing, or backend contract changes.
- Clears transient Magic Link error/inbox state when the user changes modes.
- Removes the old bottom-of-form mode toggle.

## Validation
- `dart format lib/pages/landing_page.dart test/pages/landing_page_conversion_test.dart` — clean
- `dart analyze lib/pages/landing_page.dart test/pages/landing_page_conversion_test.dart` — no issues
- `flutter test --no-pub test/pages/landing_page_conversion_test.dart` — 45 tests passed
- `git diff --check` — clean

## Responsive QA
- Added a 390x844 widget test covering signup → login → signup transitions and mode-specific copy.
- Existing mobile sticky CTA/auth flow tests continue to pass.

## Known limitation / recovery
- Local in-app-browser access to localhost was denied by the browser permission gate, so interactive localhost capture was not available. Production smoke verification will be performed after deployment; rollback remains a revert of this scoped commit.

## Minimal E2E Gate
- Implementation-detail independent: the test asserts the user-visible selected mode and CTA copy, not private internals.
- Minimal scope: 3 cases (initial signup state, switch to login, switch back to signup/recovery).
- E2E: Playwright production-route smoke is performed after deployment.
- E2E-Exception: This is a local presentation-state selector with no routing, backend, or authentication-submission contract change; the three user-visible cases are covered by the 390x844 widget test.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Production and rollback terms describe the release plan only; the diff is limited to landing-page presentation state and widget tests.
- Security: No credential, session, authorization, or authentication-submission logic changes.
- Data migration: None.
- Observability: Existing analytics calls and event contracts are unchanged.
- Unresolved ultrareview findings: none.
