### PR TITLE
fix: repair video credit checkout customer

### DIFF
--- a/lib/ui/features/video_studio/view_models/video_studio_view_model.dart
+++ b/lib/ui/features/video_studio/view_models/video_studio_view_model.dart
@@ -277,6 +277,7 @@ class VideoStudioViewModel extends ChangeNotifier {
       'worker_temporarily_unavailable' => '生成状況を確認できませんでした。少し待って再試行します。',
       'prompt_not_allowed' => 'この内容は生成できません。プロンプトを変更してください。',
       'output_not_ready' => '完成動画を取得できませんでした。少し待って再度お試しください。',
+      'video_credit_checkout_unavailable' => '購入画面を開けませんでした。時間をおいて再度お試しください。',
       _ => '動画サービスに接続できませんでした。時間をおいて再度お試しください。',
     };
   }

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -46,6 +46,11 @@ import {
   videoCreditPack,
   videoCreditPackMetadata,
 } from "../_shared/video_credit_packs.ts";
+import {
+  isMissingStripeCustomer,
+  stripeApiErrorDetails,
+  stripeApiErrorFromResponse,
+} from "./stripe_api_error.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -359,10 +364,7 @@ async function stripePostForm(
   });
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
-    const err = asRecord(data.error) ?? {};
-    throw new Error(
-      asString(err.message) || `Stripe API failed: ${response.status}`,
-    );
+    throw stripeApiErrorFromResponse(response.status, data);
   }
   return asRecord(data) ?? {};
 }
@@ -383,10 +385,7 @@ async function stripeGet(
   });
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
-    const err = asRecord(data.error) ?? {};
-    throw new Error(
-      asString(err.message) || `Stripe API failed: ${response.status}`,
-    );
+    throw stripeApiErrorFromResponse(response.status, data);
   }
   return asRecord(data) ?? {};
 }
@@ -407,10 +406,11 @@ async function getBillingSubscription(
 async function getOrCreateStripeCustomer(
   admin: SupabaseClient,
   userId: string,
+  replaceExisting = false,
 ): Promise<string> {
   const current = await getBillingSubscription(admin, userId);
   const existingCustomer = asString(current?.stripe_customer_id);
-  if (existingCustomer) return existingCustomer;
+  if (existingCustomer && !replaceExisting) return existingCustomer;
 
   const { data: userData, error: userError } = await admin.auth.admin
     .getUserById(userId);
@@ -428,7 +428,10 @@ async function getOrCreateStripeCustomer(
     stripe_customer_id: customerId,
     tier: asString(current?.tier, "free"),
     status: asString(current?.status, "active"),
-    metadata: { ...(asRecord(current?.metadata) ?? {}), source: "checkout" },
+    metadata: {
+      ...(asRecord(current?.metadata) ?? {}),
+      source: replaceExisting ? "checkout_customer_repair" : "checkout",
+    },
   }, { onConflict: "user_id" });
   if (error) throw new Error(error.message);
   return customerId;
@@ -1854,45 +1857,71 @@ serve(async (req: Request) => {
         if (!pack) {
           return json({ error: "invalid_video_credit_pack" }, 400);
         }
-        const customerId = await getOrCreateStripeCustomer(admin, userId!);
-        const returnUrl = billingReturnUrl(body.return_url, "/video-studio");
-        const metadata = videoCreditPackMetadata(userId!, pack);
-        const session = await stripePostForm("/checkout/sessions", {
-          mode: "payment",
-          locale: "ja",
-          customer: customerId,
-          success_url: withBillingParam(returnUrl, "video_credits_success"),
-          cancel_url: withBillingParam(returnUrl, "video_credits_cancel"),
-          "line_items[0][price_data][currency]": "jpy",
-          "line_items[0][price_data][product_data][name]":
-            `AI動画クレジット ${pack.name}`,
-          "line_items[0][price_data][product_data][description]":
-            pack.description,
-          "line_items[0][price_data][unit_amount]": String(pack.amountJpy),
-          "line_items[0][quantity]": "1",
-          "metadata[offer]": metadata.offer,
-          "metadata[user_id]": metadata.user_id,
-          "metadata[video_credit_pack_key]": metadata.video_credit_pack_key,
-          "metadata[video_credits]": metadata.video_credits,
-          "metadata[amount_jpy]": metadata.amount_jpy,
-          "payment_intent_data[metadata][offer]": metadata.offer,
-          "payment_intent_data[metadata][user_id]": metadata.user_id,
-          "payment_intent_data[metadata][video_credit_pack_key]":
-            metadata.video_credit_pack_key,
-          "payment_intent_data[metadata][video_credits]":
-            metadata.video_credits,
-          "payment_intent_data[metadata][amount_jpy]": metadata.amount_jpy,
-        });
-        return json({
-          success: true,
-          id: session.id,
-          checkout_url: session.url,
-          pack: {
-            key: pack.key,
-            credits: pack.credits,
-            amount_jpy: pack.amountJpy,
-          },
-        });
+        try {
+          let customerId = await getOrCreateStripeCustomer(admin, userId!);
+          const returnUrl = billingReturnUrl(body.return_url, "/video-studio");
+          const metadata = videoCreditPackMetadata(userId!, pack);
+          const createSession = (stripeCustomerId: string) =>
+            stripePostForm("/checkout/sessions", {
+              mode: "payment",
+              locale: "ja",
+              customer: stripeCustomerId,
+              success_url: withBillingParam(
+                returnUrl,
+                "video_credits_success",
+              ),
+              cancel_url: withBillingParam(returnUrl, "video_credits_cancel"),
+              "line_items[0][price_data][currency]": "jpy",
+              "line_items[0][price_data][product_data][name]":
+                `AI動画クレジット ${pack.name}`,
+              "line_items[0][price_data][product_data][description]":
+                pack.description,
+              "line_items[0][price_data][unit_amount]": String(pack.amountJpy),
+              "line_items[0][quantity]": "1",
+              "metadata[offer]": metadata.offer,
+              "metadata[user_id]": metadata.user_id,
+              "metadata[video_credit_pack_key]": metadata.video_credit_pack_key,
+              "metadata[video_credits]": metadata.video_credits,
+              "metadata[amount_jpy]": metadata.amount_jpy,
+              "payment_intent_data[metadata][offer]": metadata.offer,
+              "payment_intent_data[metadata][user_id]": metadata.user_id,
+              "payment_intent_data[metadata][video_credit_pack_key]":
+                metadata.video_credit_pack_key,
+              "payment_intent_data[metadata][video_credits]":
+                metadata.video_credits,
+              "payment_intent_data[metadata][amount_jpy]": metadata.amount_jpy,
+            });
+
+          let session: Record<string, unknown>;
+          try {
+            session = await createSession(customerId);
+          } catch (error) {
+            if (!isMissingStripeCustomer(error)) throw error;
+            console.warn(
+              "[schedule-hub] repairing stale Stripe customer",
+              stripeApiErrorDetails(error),
+            );
+            customerId = await getOrCreateStripeCustomer(admin, userId!, true);
+            session = await createSession(customerId);
+          }
+
+          return json({
+            success: true,
+            id: session.id,
+            checkout_url: session.url,
+            pack: {
+              key: pack.key,
+              credits: pack.credits,
+              amount_jpy: pack.amountJpy,
+            },
+          });
+        } catch (error) {
+          console.error(
+            "[schedule-hub] video credit checkout failed",
+            stripeApiErrorDetails(error) ?? { code: "internal_error" },
+          );
+          return json({ error: "video_credit_checkout_unavailable" }, 502);
+        }
       }
 
       case "billing.create_portal_session": {

--- a/supabase/functions/schedule-hub/stripe_api_error.ts
+++ b/supabase/functions/schedule-hub/stripe_api_error.ts
@@ -1,0 +1,56 @@
+export type StripeApiErrorDetails = {
+  status: number;
+  code: string;
+  param: string;
+};
+
+export class StripeApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    readonly param: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "StripeApiError";
+  }
+}
+
+export function stripeApiErrorFromResponse(
+  status: number,
+  data: unknown,
+): StripeApiError {
+  const root = asRecord(data);
+  const error = asRecord(root?.error);
+  const code = asString(error?.code);
+  const param = asString(error?.param);
+  const message = asString(error?.message) || `Stripe API failed: ${status}`;
+  return new StripeApiError(status, code, param, message);
+}
+
+export function isMissingStripeCustomer(error: unknown): boolean {
+  return error instanceof StripeApiError &&
+    error.code === "resource_missing" &&
+    error.param === "customer";
+}
+
+export function stripeApiErrorDetails(
+  error: unknown,
+): StripeApiErrorDetails | null {
+  if (!(error instanceof StripeApiError)) return null;
+  return {
+    status: error.status,
+    code: error.code || "stripe_api_error",
+    param: error.param,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/supabase/functions/schedule-hub/stripe_api_error_test.ts
+++ b/supabase/functions/schedule-hub/stripe_api_error_test.ts
@@ -1,0 +1,61 @@
+import {
+  assertEquals,
+  assertFalse,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  isMissingStripeCustomer,
+  StripeApiError,
+  stripeApiErrorDetails,
+  stripeApiErrorFromResponse,
+} from "./stripe_api_error.ts";
+
+Deno.test("Stripe resource_missing for customer is repairable", () => {
+  const error = stripeApiErrorFromResponse(400, {
+    error: {
+      code: "resource_missing",
+      param: "customer",
+      message: "No such customer: cus_stale",
+    },
+  });
+
+  assertEquals(isMissingStripeCustomer(error), true);
+  assertEquals(stripeApiErrorDetails(error), {
+    status: 400,
+    code: "resource_missing",
+    param: "customer",
+  });
+});
+
+Deno.test("other Stripe resource failures are not customer repairs", () => {
+  const error = stripeApiErrorFromResponse(400, {
+    error: {
+      code: "resource_missing",
+      param: "line_items[0][price]",
+      message: "No such price",
+    },
+  });
+
+  assertFalse(isMissingStripeCustomer(error));
+});
+
+Deno.test("Stripe error details never include the upstream message", () => {
+  const error = new StripeApiError(
+    400,
+    "resource_missing",
+    "customer",
+    "No such customer: cus_sensitive",
+  );
+
+  const details = stripeApiErrorDetails(error);
+  assertEquals(details, {
+    status: 400,
+    code: "resource_missing",
+    param: "customer",
+  });
+  assertFalse(JSON.stringify(details).includes("cus_sensitive"));
+});
+
+Deno.test("non-Stripe errors do not expose structured details", () => {
+  assertEquals(stripeApiErrorDetails(new Error("database detail")), null);
+  assertFalse(isMissingStripeCustomer(new Error("resource_missing")));
+});

--- a/test/ui/features/video_studio/video_studio_view_model_test.dart
+++ b/test/ui/features/video_studio/video_studio_view_model_test.dart
@@ -111,6 +111,26 @@ void main() {
     expect(gateway.refreshCount, 1);
     expect(viewModel.jobs.single.outputUrl, output);
   });
+
+  test('checkout failures use a purchase-specific error message', () async {
+    final gateway = _FakeVideoStudioGateway(
+      balance: _balance(0),
+      checkoutError: const VideoStudioException(
+        'video_credit_checkout_unavailable',
+      ),
+    );
+    final viewModel = VideoStudioViewModel(gateway: gateway);
+    addTearDown(viewModel.dispose);
+    await viewModel.load();
+
+    final checkout = await viewModel.createCheckout(
+      'starter',
+      'https://example.test/video-studio',
+    );
+
+    expect(checkout, isNull);
+    expect(viewModel.errorMessage, '購入画面を開けませんでした。時間をおいて再度お試しください。');
+  });
 }
 
 class _FakeVideoStudioGateway implements VideoStudioGateway {
@@ -119,12 +139,14 @@ class _FakeVideoStudioGateway implements VideoStudioGateway {
     this.initialJobs = const [],
     this.refreshedJob,
     this.loadError,
+    this.checkoutError,
   });
 
   VideoCreditBalance balance;
   final List<VideoGenerationJob> initialJobs;
   final VideoGenerationJob? refreshedJob;
   final Exception? loadError;
+  final Exception? checkoutError;
   String? createdIdempotencyKey;
   int refreshCount = 0;
 
@@ -171,8 +193,10 @@ class _FakeVideoStudioGateway implements VideoStudioGateway {
   Future<Uri> createCreditCheckout({
     required String packKey,
     required String returnUrl,
-  }) async =>
-      Uri.parse('https://checkout.stripe.test/session');
+  }) async {
+    if (checkoutError case final error?) throw error;
+    return Uri.parse('https://checkout.stripe.test/session');
+  }
 }
 
 const _catalog = VideoStudioCatalog(


### PR DESCRIPTION
## User-visible outcome

- 動画クレジット購入時、保存済みStripe顧客IDが現在のStripeアカウントに存在しない場合は新しい顧客を作成し、Checkout Session作成を1回だけ自動再試行します。
- 購入処理が最終的に失敗した場合は、Stripeの内部メッセージや顧客IDを返さず、購入専用の案内を表示します。
- 課金額・クレジット数・決済完了条件は変更しません。

## Production evidence

- 2026-08-22 03:19:54 JST と 03:20:02 JST に、`schedule-hub` の同一Checkout actionが500を返したことを本番Edge Functionログで確認しました。
- 保存済みStripe顧客レコードは現在のStripe secret更新より前に作成され、既存実装は存在確認なしで再利用していました。Stripeの`resource_missing` / `customer`応答と一致する経路を自己修復対象に限定しています。
- FlutterのRenderBox known-race警告とpreload警告は非致命で、今回のCheckout 500とは別経路です。

## Validation

- `deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/schedule-hub`: 52 passed.
- `deno check --config supabase/functions/deno.json supabase/functions/schedule-hub/index.ts`: passed.
- `deno lint --config supabase/functions/deno.json` (changed schedule-hub files): passed.
- `flutter test --no-pub test/ui/features/video_studio/video_studio_view_model_test.dart`: 7 passed.
- `dart analyze lib/ui/features/video_studio test/ui/features/video_studio`: no issues.
- `flutter build web --release --no-pub`: passed.
- pre-commit quality gate and import resilience check: passed.

## Minimal E2E Gate

- Implementation-detail independent: Checkout URL creation and user-visible purchase error are the observable outcomes.
- Minimal scope: stale customer repair, non-customer Stripe error rejection, redacted error detail, Flutter purchase-specific message.
- E2E: after production deployment, the logged-in user explicitly confirms creating a ¥500 Checkout Session; navigation to Stripe Checkout is verified before any payment confirmation.
- E2E-Exception: pre-merge cannot safely reproduce the production Stripe customer mismatch or create a live Checkout Session without an external side effect.

## High-risk Ultrareview Gate

- Reviewer: Codex #1
- High-Risk-Ultrareview-Exception: A separate Claude Code #1 ultrareview is unavailable; targeted Deno/Flutter tests, production evidence, type checks, lint, and release build cover the scoped repair.
- Security: only Stripe `resource_missing` with `param=customer` triggers repair; upstream message and customer ID are excluded from API responses and structured logs.
- Rollback: revert this single commit; no migration is involved.
- Data migration: none.
- Prod smoke: create Checkout Session after explicit user confirmation, verify Stripe-hosted page, and confirm no new 500 in `schedule-hub` logs.
- Observability: structured status/code/param only; no customer ID or Stripe upstream message.
- Unresolved ultrareview findings: none.