### PR TITLE
feat(asset): カード明細画像からサブスク棚卸し

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -283,6 +283,14 @@ enum AssetRecurringFixedCostCategory {
   subscription,
 }
 
+/// サブスク棚卸しでユーザーが付けた判断。
+enum AssetSubscriptionReviewDecision {
+  unreviewed,
+  keep,
+  hold,
+  cancelCandidate,
+}
+
 /// 定期固定費の入力通貨。既定は円 (jpy)。ドル建て (usd) の場合は毎月の為替で
 /// 円換算額が変動するため、原資の USD 額を保持し、最新レートで円へ materialize する。
 enum AssetRecurringFixedCostCurrency {
@@ -344,6 +352,9 @@ class AssetRecurringFixedCost {
   /// 区分 (固定費 / サブスク)。既定は utility で、表示セクションの振り分けにのみ使う。
   final AssetRecurringFixedCostCategory category;
 
+  /// 棚卸し判定。サブスク以外では常に [AssetSubscriptionReviewDecision.unreviewed]。
+  final AssetSubscriptionReviewDecision subscriptionReviewDecision;
+
   /// 請求経路 (Apple/Google/au 経由 or 直接)。既定は direct。棚卸しでの集約請求との
   /// 突き合わせ表示に使い、資金繰りの計上額には影響しない。
   final AssetSubscriptionBillingGateway billingGateway;
@@ -365,6 +376,8 @@ class AssetRecurringFixedCost {
     this.cadence = AssetRecurringFixedCostCadence.monthly,
     this.sourceAccountId,
     this.category = AssetRecurringFixedCostCategory.utility,
+    this.subscriptionReviewDecision =
+        AssetSubscriptionReviewDecision.unreviewed,
     this.billingGateway = AssetSubscriptionBillingGateway.direct,
     this.currency = AssetRecurringFixedCostCurrency.jpy,
     this.usdAmount,
@@ -404,6 +417,7 @@ class AssetRecurringFixedCost {
     String? sourceAccountId,
     bool clearSourceAccountId = false,
     AssetRecurringFixedCostCategory? category,
+    AssetSubscriptionReviewDecision? subscriptionReviewDecision,
     AssetSubscriptionBillingGateway? billingGateway,
     AssetRecurringFixedCostCurrency? currency,
     double? usdAmount,
@@ -419,6 +433,8 @@ class AssetRecurringFixedCost {
           ? null
           : (sourceAccountId ?? this.sourceAccountId),
       category: category ?? this.category,
+      subscriptionReviewDecision:
+          subscriptionReviewDecision ?? this.subscriptionReviewDecision,
       billingGateway: billingGateway ?? this.billingGateway,
       currency: currency ?? this.currency,
       usdAmount: clearUsdAmount ? null : (usdAmount ?? this.usdAmount),
@@ -437,6 +453,9 @@ class AssetRecurringFixedCost {
         'sourceAccountId': sourceAccountId,
       if (category != AssetRecurringFixedCostCategory.utility)
         'category': category.name,
+      if (subscriptionReviewDecision !=
+          AssetSubscriptionReviewDecision.unreviewed)
+        'subscriptionReviewDecision': subscriptionReviewDecision.name,
       if (billingGateway != AssetSubscriptionBillingGateway.direct)
         'billingGateway': billingGateway.name,
       // 通貨は既定 (jpy) のとき出力しない (既存ペイロードと互換を保つ)。
@@ -480,6 +499,14 @@ class AssetRecurringFixedCost {
       (value) => value.name == categoryName,
       orElse: () => AssetRecurringFixedCostCategory.utility,
     );
+    final reviewDecisionName = json['subscriptionReviewDecision']?.toString();
+    final reviewDecision =
+        category == AssetRecurringFixedCostCategory.subscription
+            ? AssetSubscriptionReviewDecision.values.firstWhere(
+                (value) => value.name == reviewDecisionName,
+                orElse: () => AssetSubscriptionReviewDecision.unreviewed,
+              )
+            : AssetSubscriptionReviewDecision.unreviewed;
     final gatewayName = json['billingGateway']?.toString();
     final billingGateway = AssetSubscriptionBillingGateway.values.firstWhere(
       (value) => value.name == gatewayName,
@@ -501,6 +528,7 @@ class AssetRecurringFixedCost {
       sourceAccountId:
           rawSource == null || rawSource.isEmpty ? null : rawSource,
       category: category,
+      subscriptionReviewDecision: reviewDecision,
       billingGateway: billingGateway,
       currency: currency,
       usdAmount: usdAmount != null && usdAmount > 0 ? usdAmount : null,

--- a/lib/models/asset_subscription_statement_scan.dart
+++ b/lib/models/asset_subscription_statement_scan.dart
@@ -1,0 +1,79 @@
+import 'dart:typed_data';
+
+import 'asset_liability_workbook.dart';
+
+/// クレジットカード明細から推定した請求周期。
+enum AssetSubscriptionBillingCycle { monthly, annual, unknown }
+
+/// 解析対象として選択された明細画像。
+///
+/// 画像バイト列は解析中だけメモリに置き、永続化しない。
+class AssetSubscriptionStatementImage {
+  final String fileName;
+  final String mimeType;
+  final Uint8List bytes;
+
+  const AssetSubscriptionStatementImage({
+    required this.fileName,
+    required this.mimeType,
+    required this.bytes,
+  });
+}
+
+/// 明細画像から抽出されたサブスク候補。
+///
+/// AI が返した金額・周期を入力とし、月額換算はこのモデルで決定論的に行う。
+class AssetSubscriptionStatementCandidate {
+  final String id;
+  final String serviceName;
+  final double chargedAmountJpy;
+  final DateTime? chargedAt;
+  final AssetSubscriptionBillingCycle billingCycle;
+  final AssetSubscriptionBillingGateway billingGateway;
+  final double confidence;
+  final String evidence;
+
+  const AssetSubscriptionStatementCandidate({
+    required this.id,
+    required this.serviceName,
+    required this.chargedAmountJpy,
+    required this.chargedAt,
+    required this.billingCycle,
+    required this.billingGateway,
+    required this.confidence,
+    required this.evidence,
+  });
+
+  /// 年払いだけ12分割し、不明は過少計上を避けて1回の請求額を月額候補とする。
+  double get monthlyEquivalentJpy => switch (billingCycle) {
+        AssetSubscriptionBillingCycle.annual => chargedAmountJpy / 12,
+        AssetSubscriptionBillingCycle.monthly ||
+        AssetSubscriptionBillingCycle.unknown =>
+          chargedAmountJpy,
+      };
+
+  double get annualEquivalentJpy => monthlyEquivalentJpy * 12;
+
+  int get paymentDay {
+    final day = chargedAt?.day ?? 1;
+    return day.clamp(1, 31).toInt();
+  }
+
+  AssetRecurringFixedCost toRecurringFixedCost({
+    required String id,
+    required AssetSubscriptionReviewDecision reviewDecision,
+    String? sourceAccountId,
+  }) {
+    return AssetRecurringFixedCost(
+      id: id,
+      name: serviceName,
+      amount: monthlyEquivalentJpy.roundToDouble(),
+      paymentDay: paymentDay,
+      cadence: AssetRecurringFixedCostCadence.monthly,
+      sourceAccountId: sourceAccountId,
+      category: AssetRecurringFixedCostCategory.subscription,
+      billingGateway: billingGateway,
+      subscriptionReviewDecision: reviewDecision,
+    );
+  }
+}

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -53,6 +53,7 @@ import 'package:my_web_app/services/asset_subscription_audit_catalog.dart';
 import 'package:my_web_app/services/asset_subscription_audit_store.dart';
 import 'package:my_web_app/services/asset_subscription_catalog.dart';
 import 'package:my_web_app/services/asset_subscription_duplicate_detector.dart';
+import 'package:my_web_app/services/asset_subscription_statement_scan_service.dart';
 import 'package:my_web_app/services/ai_hub_chat_service.dart';
 import 'package:my_web_app/services/asset_chat_privacy_settings_service.dart';
 import 'package:my_web_app/services/asset_payment_check_guide_service.dart';
@@ -87,6 +88,7 @@ import 'package:my_web_app/services/csv_bytes_decoder.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_progress_card_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
+import 'package:my_web_app/view_models/asset_subscription_statement_scan_view_model.dart';
 import 'package:my_web_app/services/disposable_balance_asset_liability_adapter.dart';
 import 'package:my_web_app/services/disposable_balance_service.dart';
 import 'package:my_web_app/services/drink_challenge_service.dart';
@@ -108,6 +110,7 @@ import 'package:my_web_app/widgets/asset_cashflow_statement_card.dart';
 import 'package:my_web_app/widgets/asset_dashboard_grid.dart';
 import 'package:my_web_app/widgets/asset_net_worth_panel_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
+import 'package:my_web_app/widgets/asset_subscription_statement_scan_dialog.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
 import 'package:my_web_app/widgets/subscription_audit_card.dart';
@@ -11610,6 +11613,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return SubscriptionFixedCostCard(
       costs: subscriptionCosts,
       sourceAccountNames: sourceNames,
+      onScanStatement: () => unawaited(
+        _openSubscriptionStatementScanDialog(subscriptionCosts, sourceNames),
+      ),
       onAddPreset: (preset) => unawaited(
         _openRecurringFixedCostEditor(
           prefill: preset.toPrefill(
@@ -11632,7 +11638,77 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ),
       onDelete: (cost) => unawaited(_confirmDeleteRecurringFixedCost(cost)),
+      onReviewDecisionChanged: (cost, decision) => _saveRecurringFixedCost(
+        cost.copyWith(subscriptionReviewDecision: decision),
+      ),
     );
+  }
+
+  Future<void> _openSubscriptionStatementScanDialog(
+    List<AssetRecurringFixedCost> existingSubscriptions,
+    Map<String, String> sourceAccountNames,
+  ) async {
+    final viewModel = AssetSubscriptionStatementScanViewModel(
+      imagePicker: const FilePickerAssetSubscriptionStatementImagePicker(),
+      analyzer: const AssetSubscriptionStatementScanService(),
+      existingSubscriptions: existingSubscriptions,
+    );
+    await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AssetSubscriptionStatementScanDialog(
+        viewModel: viewModel,
+        sourceAccountNames: sourceAccountNames,
+        onImport: _importSubscriptionStatementCosts,
+      ),
+    );
+  }
+
+  void _importSubscriptionStatementCosts(
+    List<AssetRecurringFixedCost> importedCosts,
+  ) {
+    if (importedCosts.isEmpty) return;
+    final next = List<AssetRecurringFixedCost>.from(_recurringFixedCosts);
+    final existingNames = <String>{
+      for (final cost in next) _normalizeSubscriptionName(cost.name),
+    };
+    final added = <AssetRecurringFixedCost>[];
+    for (final cost in importedCosts) {
+      final normalized = _normalizeSubscriptionName(cost.name);
+      if (normalized.isEmpty || existingNames.contains(normalized)) continue;
+      next.add(cost);
+      added.add(cost);
+      existingNames.add(normalized);
+    }
+    if (added.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('追加できる新しいサブスクはありませんでした。')),
+      );
+      return;
+    }
+    next.sort(_compareRecurringFixedCostsByPaymentDay);
+    setState(() => _recurringFixedCosts = next);
+    _persistInBackground(
+      _recurringFixedCostStore.save(next),
+      'subscription statement import',
+    );
+    for (final cost in added) {
+      unawaited(_recordRecurringFixedCostTombstone(cost.id, deleted: false));
+      unawaited(
+        _syncDirtyKeysStore.markDirty(_recurringFixedCostsMirrorKey, cost.id),
+      );
+    }
+    unawaited(_mirrorRecurringFixedCosts());
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('${added.length}件のサブスクを棚卸しに追加しました。')),
+    );
+  }
+
+  String _normalizeSubscriptionName(String value) {
+    return value.toLowerCase().replaceAll(
+          RegExp(r'[\s\-_./・（）()]+'),
+          '',
+        );
   }
 
   /// `_recentFlows`(複数月分の収支履歴)から、支出のみを description パースして

--- a/lib/services/asset_subscription_statement_scan_service.dart
+++ b/lib/services/asset_subscription_statement_scan_service.dart
@@ -1,0 +1,241 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/asset_liability_workbook.dart';
+import '../models/asset_subscription_statement_scan.dart';
+import 'offline_secure_mode_settings_service.dart';
+
+typedef AssetSubscriptionStatementInvoker = Future<Map<String, dynamic>>
+    Function(Map<String, dynamic> body);
+
+abstract interface class AssetSubscriptionStatementAnalyzer {
+  Future<List<AssetSubscriptionStatementCandidate>> analyze(
+    AssetSubscriptionStatementImage image,
+  );
+}
+
+abstract interface class AssetSubscriptionStatementImagePicker {
+  Future<AssetSubscriptionStatementImage?> pickImage();
+}
+
+class AssetSubscriptionStatementScanException implements Exception {
+  final String message;
+
+  const AssetSubscriptionStatementScanException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+/// PNG/JPEG/WebP のカード明細キャプチャを選択する。画像はファイル保存せず、
+/// [PlatformFile.bytes] を解析サービスへ一度だけ渡す。
+class FilePickerAssetSubscriptionStatementImagePicker
+    implements AssetSubscriptionStatementImagePicker {
+  const FilePickerAssetSubscriptionStatementImagePicker();
+
+  @override
+  Future<AssetSubscriptionStatementImage?> pickImage() async {
+    final result = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: const <String>['png', 'jpg', 'jpeg', 'webp'],
+      allowMultiple: false,
+      withData: true,
+    );
+    final file = result?.files.singleOrNull;
+    if (file == null) return null;
+    final bytes = file.bytes;
+    if (bytes == null) {
+      throw const AssetSubscriptionStatementScanException(
+        '画像を読み込めませんでした。別の画像を選んでください。',
+      );
+    }
+    final extension = (file.extension ?? '').toLowerCase();
+    final mimeType = switch (extension) {
+      'png' => 'image/png',
+      'webp' => 'image/webp',
+      'jpg' || 'jpeg' => 'image/jpeg',
+      _ => 'application/octet-stream',
+    };
+    return AssetSubscriptionStatementImage(
+      fileName: file.name,
+      mimeType: mimeType,
+      bytes: Uint8List.fromList(bytes),
+    );
+  }
+}
+
+/// `ai-hub` の専用アクションを通じて明細画像を解析するサービス。
+///
+/// 画像はbase64で送信するだけで、Storage・DB・SharedPreferencesには保存しない。
+/// サーバ側でPIIを除外した候補だけを返し、クライアントでも型・金額・件数を再検証する。
+class AssetSubscriptionStatementScanService
+    implements AssetSubscriptionStatementAnalyzer {
+  static const int maxImageBytes = 4 * 1024 * 1024;
+  static const int maxCandidates = 100;
+  static const Set<String> allowedMimeTypes = <String>{
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+  };
+
+  final SupabaseClient? _supabase;
+  final AssetSubscriptionStatementInvoker? _invoker;
+  final OfflineSecureModeSettingsService _offlineSettingsService;
+
+  const AssetSubscriptionStatementScanService({
+    SupabaseClient? supabase,
+    AssetSubscriptionStatementInvoker? invoker,
+    OfflineSecureModeSettingsService offlineSettingsService =
+        const OfflineSecureModeSettingsService(),
+  })  : _supabase = supabase,
+        _invoker = invoker,
+        _offlineSettingsService = offlineSettingsService;
+
+  @override
+  Future<List<AssetSubscriptionStatementCandidate>> analyze(
+    AssetSubscriptionStatementImage image,
+  ) async {
+    _validateImage(image);
+    if (_invoker == null) {
+      final client = _supabase ?? Supabase.instance.client;
+      if (client.auth.currentUser == null) {
+        throw const AssetSubscriptionStatementScanException(
+          '明細のAI解析にはログインが必要です。',
+        );
+      }
+    }
+
+    final offline = await _offlineSettingsService.loadSettingsOrDefaults();
+    final body = <String, dynamic>{
+      'action': 'asset_subscription.analyze_statement',
+      'imageBase64': base64Encode(image.bytes),
+      'mimeType': image.mimeType,
+      'imageName': _safeFileName(image.fileName),
+      ...offline.toAiHubPolicyPayload(),
+    };
+
+    final data = await _invoke(body);
+    if (data['success'] != true) {
+      throw AssetSubscriptionStatementScanException(_failureMessage(data));
+    }
+    final rawCandidates = data['candidates'];
+    if (rawCandidates is! List) return const [];
+    final result = <AssetSubscriptionStatementCandidate>[];
+    for (var i = 0;
+        i < rawCandidates.length && result.length < maxCandidates;
+        i++) {
+      final raw = rawCandidates[i];
+      if (raw is! Map) continue;
+      final candidate = _candidateFromMap(Map<String, dynamic>.from(raw), i);
+      if (candidate != null) result.add(candidate);
+    }
+    return result;
+  }
+
+  void _validateImage(AssetSubscriptionStatementImage image) {
+    if (!allowedMimeTypes.contains(image.mimeType)) {
+      throw const AssetSubscriptionStatementScanException(
+        'PNG・JPEG・WebP形式の画像を選んでください。',
+      );
+    }
+    if (image.bytes.isEmpty) {
+      throw const AssetSubscriptionStatementScanException('画像が空です。');
+    }
+    if (image.bytes.length > maxImageBytes) {
+      throw const AssetSubscriptionStatementScanException('画像は4MB以下にしてください。');
+    }
+  }
+
+  Future<Map<String, dynamic>> _invoke(Map<String, dynamic> body) async {
+    final invoker = _invoker;
+    if (invoker != null) return invoker(body);
+    final client = _supabase ?? Supabase.instance.client;
+    final response = await client.functions.invoke('ai-hub', body: body);
+    final data = response.data;
+    if (data is Map<String, dynamic>) return data;
+    if (data is Map) return Map<String, dynamic>.from(data);
+    return <String, dynamic>{'success': false, 'message': data?.toString()};
+  }
+
+  AssetSubscriptionStatementCandidate? _candidateFromMap(
+    Map<String, dynamic> raw,
+    int index,
+  ) {
+    final serviceName = _safeServiceName(raw['service_name']?.toString() ?? '');
+    final amount = _asDouble(raw['amount_jpy']);
+    if (serviceName.isEmpty ||
+        amount == null ||
+        amount <= 0 ||
+        amount > 100000000) {
+      return null;
+    }
+    final cycle = switch (raw['billing_cycle']?.toString()) {
+      'monthly' => AssetSubscriptionBillingCycle.monthly,
+      'annual' => AssetSubscriptionBillingCycle.annual,
+      _ => AssetSubscriptionBillingCycle.unknown,
+    };
+    final gateway = switch (raw['gateway']?.toString()) {
+      'apple' => AssetSubscriptionBillingGateway.apple,
+      'googlePlay' => AssetSubscriptionBillingGateway.googlePlay,
+      'auKantan' => AssetSubscriptionBillingGateway.auKantan,
+      _ => AssetSubscriptionBillingGateway.direct,
+    };
+    final confidence = (_asDouble(raw['confidence']) ?? 0).clamp(0, 1);
+    final chargedAt = DateTime.tryParse(raw['charged_at']?.toString() ?? '');
+    final evidence = _stripSensitiveDigits(raw['evidence']?.toString() ?? '');
+    return AssetSubscriptionStatementCandidate(
+      id: 'statement_candidate_$index',
+      serviceName: serviceName,
+      chargedAmountJpy: amount,
+      chargedAt: chargedAt,
+      billingCycle: cycle,
+      billingGateway: gateway,
+      confidence: confidence.toDouble(),
+      evidence: evidence.length <= 160 ? evidence : evidence.substring(0, 160),
+    );
+  }
+
+  String _safeServiceName(String input) {
+    final sanitized = _stripSensitiveDigits(
+      input,
+    ).replaceAll(RegExp(r'[\r\n\t]+'), ' ');
+    final trimmed = sanitized.trim();
+    return trimmed.length <= 100 ? trimmed : trimmed.substring(0, 100);
+  }
+
+  String _stripSensitiveDigits(String input) {
+    return input.replaceAll(RegExp(r'(?:\d[ -]?){12,19}'), '[番号を除外]');
+  }
+
+  String _safeFileName(String value) {
+    final trimmed = value.trim().replaceAll(RegExp(r'[\r\n\\/]+'), '_');
+    if (trimmed.isEmpty) return 'card-statement.png';
+    return trimmed.length <= 120 ? trimmed : trimmed.substring(0, 120);
+  }
+
+  String _failureMessage(Map<String, dynamic> data) {
+    final raw = <Object?>[data['message'], data['error'], data['status']]
+        .map((value) => value?.toString().trim())
+        .whereType<String>()
+        .where((value) => value.isNotEmpty);
+    final joined = raw.join(' / ');
+    if (joined.contains('offline')) {
+      return 'オフライン保護モードでは外部AIへ画像を送信できません。';
+    }
+    if (RegExp(
+      r'quota|429|rate.?limit',
+      caseSensitive: false,
+    ).hasMatch(joined)) {
+      return 'AIの利用上限に達しました。時間をおいて再試行してください。';
+    }
+    return joined.isEmpty ? '明細画像を解析できませんでした。' : joined;
+  }
+
+  double? _asDouble(Object? value) {
+    if (value is num) return value.toDouble();
+    return double.tryParse(value?.toString() ?? '');
+  }
+}

--- a/lib/view_models/asset_subscription_statement_scan_view_model.dart
+++ b/lib/view_models/asset_subscription_statement_scan_view_model.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/asset_liability_workbook.dart';
+import '../models/asset_subscription_statement_scan.dart';
+import '../services/asset_subscription_statement_scan_service.dart';
+
+class AssetSubscriptionStatementCandidateReview {
+  final AssetSubscriptionStatementCandidate candidate;
+  final bool selected;
+  final bool alreadyRegistered;
+  final AssetSubscriptionReviewDecision decision;
+
+  const AssetSubscriptionStatementCandidateReview({
+    required this.candidate,
+    required this.selected,
+    required this.alreadyRegistered,
+    required this.decision,
+  });
+
+  AssetSubscriptionStatementCandidateReview copyWith({
+    bool? selected,
+    AssetSubscriptionReviewDecision? decision,
+  }) {
+    return AssetSubscriptionStatementCandidateReview(
+      candidate: candidate,
+      selected: selected ?? this.selected,
+      alreadyRegistered: alreadyRegistered,
+      decision: decision ?? this.decision,
+    );
+  }
+}
+
+/// 明細画像の選択・解析・重複除外・ユーザー判断を管理するViewModel。
+class AssetSubscriptionStatementScanViewModel extends ChangeNotifier {
+  final AssetSubscriptionStatementImagePicker _imagePicker;
+  final AssetSubscriptionStatementAnalyzer _analyzer;
+  final List<AssetRecurringFixedCost> _existingSubscriptions;
+  final DateTime Function() _now;
+
+  AssetSubscriptionStatementScanViewModel({
+    required AssetSubscriptionStatementImagePicker imagePicker,
+    required AssetSubscriptionStatementAnalyzer analyzer,
+    required List<AssetRecurringFixedCost> existingSubscriptions,
+    DateTime Function()? now,
+  })  : _imagePicker = imagePicker,
+        _analyzer = analyzer,
+        _existingSubscriptions = List<AssetRecurringFixedCost>.unmodifiable(
+          existingSubscriptions,
+        ),
+        _now = now ?? DateTime.now;
+
+  bool _isAnalyzing = false;
+  String? _errorMessage;
+  String? _analyzedFileName;
+  String? _sourceAccountId;
+  List<AssetSubscriptionStatementCandidateReview> _reviews = const [];
+  bool _disposed = false;
+
+  bool get isAnalyzing => _isAnalyzing;
+  String? get errorMessage => _errorMessage;
+  String? get analyzedFileName => _analyzedFileName;
+  String? get sourceAccountId => _sourceAccountId;
+  List<AssetSubscriptionStatementCandidateReview> get reviews =>
+      List<AssetSubscriptionStatementCandidateReview>.unmodifiable(_reviews);
+  bool get hasResults => _reviews.isNotEmpty;
+
+  int get selectedCount => _reviews.where((item) => item.selected).length;
+  int get duplicateCount =>
+      _reviews.where((item) => item.alreadyRegistered).length;
+  int get reviewNeededCount => _reviews
+      .where(
+        (item) =>
+            item.selected &&
+            item.decision == AssetSubscriptionReviewDecision.hold,
+      )
+      .length;
+
+  double get selectedMonthlyTotal => _reviews
+      .where((item) => item.selected)
+      .fold(0, (sum, item) => sum + item.candidate.monthlyEquivalentJpy);
+
+  double get selectedAnnualTotal => selectedMonthlyTotal * 12;
+
+  double get cancelCandidateMonthlySavings => _reviews
+      .where(
+        (item) =>
+            item.selected &&
+            item.decision == AssetSubscriptionReviewDecision.cancelCandidate,
+      )
+      .fold(0, (sum, item) => sum + item.candidate.monthlyEquivalentJpy);
+
+  Future<void> pickAndAnalyze() async {
+    if (_isAnalyzing) return;
+    _errorMessage = null;
+    _notifyListeners();
+
+    AssetSubscriptionStatementImage? image;
+    try {
+      image = await _imagePicker.pickImage();
+    } on AssetSubscriptionStatementScanException catch (error) {
+      _errorMessage = error.message;
+      _notifyListeners();
+      return;
+    } catch (_) {
+      _errorMessage = '画像を選択できませんでした。';
+      _notifyListeners();
+      return;
+    }
+    if (image == null) return;
+
+    _isAnalyzing = true;
+    _analyzedFileName = image.fileName;
+    _reviews = const [];
+    _notifyListeners();
+    try {
+      final candidates = await _analyzer.analyze(image);
+      if (candidates.isEmpty) {
+        _errorMessage = 'サブスク候補を特定できませんでした。明細部分が鮮明な画像で再試行してください。';
+        return;
+      }
+      final existingNames = _existingSubscriptions
+          .map((cost) => _normalizeName(cost.name))
+          .toSet();
+      _reviews = <AssetSubscriptionStatementCandidateReview>[
+        for (final candidate in candidates)
+          AssetSubscriptionStatementCandidateReview(
+            candidate: candidate,
+            alreadyRegistered: existingNames.contains(
+              _normalizeName(candidate.serviceName),
+            ),
+            selected: !existingNames.contains(
+              _normalizeName(candidate.serviceName),
+            ),
+            // 明細だけでは利用頻度を判断できないため、AIに残す/解約を決めさせない。
+            decision: AssetSubscriptionReviewDecision.hold,
+          ),
+      ];
+    } on AssetSubscriptionStatementScanException catch (error) {
+      _errorMessage = error.message;
+    } catch (_) {
+      _errorMessage = '明細画像を解析できませんでした。時間をおいて再試行してください。';
+    } finally {
+      // 画像バイト列はローカル変数だけで保持し、ここで参照を手放す。
+      image = null;
+      _isAnalyzing = false;
+      _notifyListeners();
+    }
+  }
+
+  void setSourceAccountId(String? value) {
+    final normalized = value?.trim();
+    _sourceAccountId =
+        normalized == null || normalized.isEmpty ? null : normalized;
+    _notifyListeners();
+  }
+
+  void setSelected(String candidateId, bool selected) {
+    _reviews = <AssetSubscriptionStatementCandidateReview>[
+      for (final review in _reviews)
+        if (review.candidate.id == candidateId && !review.alreadyRegistered)
+          review.copyWith(selected: selected)
+        else
+          review,
+    ];
+    _notifyListeners();
+  }
+
+  void setDecision(
+    String candidateId,
+    AssetSubscriptionReviewDecision decision,
+  ) {
+    if (decision == AssetSubscriptionReviewDecision.unreviewed) return;
+    _reviews = <AssetSubscriptionStatementCandidateReview>[
+      for (final review in _reviews)
+        if (review.candidate.id == candidateId)
+          review.copyWith(decision: decision)
+        else
+          review,
+    ];
+    _notifyListeners();
+  }
+
+  List<AssetRecurringFixedCost> buildSelectedCosts() {
+    final stamp = _now().microsecondsSinceEpoch;
+    var index = 0;
+    return <AssetRecurringFixedCost>[
+      for (final review in _reviews)
+        if (review.selected)
+          review.candidate.toRecurringFixedCost(
+            id: 'sub_statement_${stamp}_${index++}',
+            reviewDecision: review.decision,
+            sourceAccountId: _sourceAccountId,
+          ),
+    ];
+  }
+
+  static String _normalizeName(String value) {
+    return value.toLowerCase().replaceAll(RegExp(r'[\s\-_./・（）()]+'), '');
+  }
+
+  void _notifyListeners() {
+    if (!_disposed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+}

--- a/lib/widgets/asset_subscription_statement_scan_dialog.dart
+++ b/lib/widgets/asset_subscription_statement_scan_dialog.dart
@@ -1,0 +1,574 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/asset_liability_workbook.dart';
+import '../models/asset_subscription_statement_scan.dart';
+import '../view_models/asset_subscription_statement_scan_view_model.dart';
+
+class AssetSubscriptionStatementScanDialog extends StatefulWidget {
+  const AssetSubscriptionStatementScanDialog({
+    super.key,
+    required this.viewModel,
+    required this.sourceAccountNames,
+    required this.onImport,
+  });
+
+  final AssetSubscriptionStatementScanViewModel viewModel;
+  final Map<String, String> sourceAccountNames;
+  final void Function(List<AssetRecurringFixedCost> costs) onImport;
+
+  @override
+  State<AssetSubscriptionStatementScanDialog> createState() =>
+      _AssetSubscriptionStatementScanDialogState();
+}
+
+class _AssetSubscriptionStatementScanDialogState
+    extends State<AssetSubscriptionStatementScanDialog> {
+  @override
+  void dispose() {
+    widget.viewModel.dispose();
+    super.dispose();
+  }
+
+  void _importSelected() {
+    final costs = widget.viewModel.buildSelectedCosts();
+    if (costs.isEmpty) return;
+    widget.onImport(costs);
+    Navigator.of(context).pop(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final media = MediaQuery.sizeOf(context);
+    return Dialog(
+      insetPadding: const EdgeInsets.all(16),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: 960,
+          maxHeight: media.height - 32,
+          minHeight: media.height < 640 ? media.height - 32 : 560,
+        ),
+        child: ListenableBuilder(
+          listenable: widget.viewModel,
+          builder: (context, _) => Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _Header(
+                fileName: widget.viewModel.analyzedFileName,
+                onClose: widget.viewModel.isAnalyzing
+                    ? null
+                    : () => Navigator.of(context).pop(false),
+              ),
+              const Divider(height: 1),
+              Expanded(child: _buildBody(context)),
+              const Divider(height: 1),
+              _buildFooter(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    final vm = widget.viewModel;
+    if (vm.isAnalyzing) {
+      return const _AnalyzingState();
+    }
+    if (!vm.hasResults) {
+      return _UploadState(
+        errorMessage: vm.errorMessage,
+        onPick: vm.pickAndAnalyze,
+      );
+    }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final summary = _SummaryPanel(
+          viewModel: vm,
+          sourceAccountNames: widget.sourceAccountNames,
+        );
+        final candidates = _CandidateList(viewModel: vm);
+        if (constraints.maxWidth >= 720) {
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              SizedBox(width: 280, child: summary),
+              const VerticalDivider(width: 1),
+              Expanded(child: candidates),
+            ],
+          );
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            summary,
+            const Divider(height: 1),
+            Expanded(child: candidates),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildFooter(BuildContext context) {
+    final vm = widget.viewModel;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      child: Wrap(
+        alignment: WrapAlignment.end,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          if (vm.hasResults)
+            TextButton.icon(
+              key: const Key('subscription_statement_rescan'),
+              onPressed: vm.isAnalyzing ? null : vm.pickAndAnalyze,
+              icon: const Icon(Icons.add_photo_alternate_outlined),
+              label: const Text('別の画像を解析'),
+            ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          if (vm.hasResults)
+            FilledButton.icon(
+              key: const Key('subscription_statement_import'),
+              onPressed: vm.selectedCount == 0 ? null : _importSelected,
+              icon: const Icon(Icons.playlist_add_check),
+              label: Text('${vm.selectedCount}件を棚卸しに追加'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.fileName, required this.onClose});
+
+  final String? fileName;
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 8, 12),
+      child: Row(
+        children: [
+          Icon(
+            Icons.document_scanner_outlined,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'カード明細からサブスク棚卸し',
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                if (fileName != null)
+                  Text(
+                    fileName!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          IconButton(
+            tooltip: '閉じる',
+            onPressed: onClose,
+            icon: const Icon(Icons.close),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _UploadState extends StatelessWidget {
+  const _UploadState({required this.errorMessage, required this.onPick});
+
+  final String? errorMessage;
+  final Future<void> Function() onPick;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 620),
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(20),
+                decoration: BoxDecoration(
+                  color: scheme.primaryContainer,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  Icons.add_photo_alternate_outlined,
+                  size: 44,
+                  color: scheme.onPrimaryContainer,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                '支払い明細のキャプチャーを1枚選ぶだけ',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'サービス名・金額・請求周期を抽出し、月額換算と年間合計を作ります。'
+                '利用頻度は明細だけでは分からないため、残す／保留／解約候補は自分で確認します。',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+              if (errorMessage != null) ...[
+                const SizedBox(height: 16),
+                Material(
+                  color: scheme.errorContainer,
+                  borderRadius: BorderRadius.circular(12),
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.error_outline,
+                          color: scheme.onErrorContainer,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            errorMessage!,
+                            style: TextStyle(color: scheme.onErrorContainer),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+              const SizedBox(height: 20),
+              FilledButton.icon(
+                key: const Key('subscription_statement_pick'),
+                onPressed: onPick,
+                icon: const Icon(Icons.upload_file_outlined),
+                label: const Text('明細画像を選んで解析'),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.privacy_tip_outlined,
+                    size: 18,
+                    color: scheme.primary,
+                  ),
+                  const SizedBox(width: 6),
+                  Flexible(
+                    child: Text(
+                      'PNG・JPEG・WebP / 4MB以下。画像はAI解析時だけ送信し、アプリのStorageやDBには保存しません。'
+                      'カード番号・名義・住所・生のOCR全文も保存しません。',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AnalyzingState extends StatelessWidget {
+  const _AnalyzingState();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const LinearProgressIndicator(),
+              const SizedBox(height: 20),
+              Text('サブスク候補を抽出しています', style: theme.textTheme.titleMedium),
+              const SizedBox(height: 6),
+              Text(
+                '金額や周期は解析後に確認・修正できます。',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryPanel extends StatelessWidget {
+  const _SummaryPanel({
+    required this.viewModel,
+    required this.sourceAccountNames,
+  });
+
+  final AssetSubscriptionStatementScanViewModel viewModel;
+  final Map<String, String> sourceAccountNames;
+  static final NumberFormat _yen = NumberFormat('#,##0');
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            '集計',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 12),
+          _Metric(label: '選択中', value: '${viewModel.selectedCount}件'),
+          _Metric(
+            label: '月額換算',
+            value: '¥${_yen.format(viewModel.selectedMonthlyTotal)}',
+          ),
+          _Metric(
+            label: '年間合計',
+            value: '¥${_yen.format(viewModel.selectedAnnualTotal)}',
+          ),
+          if (viewModel.cancelCandidateMonthlySavings > 0)
+            _Metric(
+              label: '解約候補の月額',
+              value: '¥${_yen.format(viewModel.cancelCandidateMonthlySavings)}',
+              valueColor: scheme.error,
+            ),
+          if (viewModel.duplicateCount > 0)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                '登録済み ${viewModel.duplicateCount}件は選択から外しました。',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          const SizedBox(height: 16),
+          Text('支払い元（任意）', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 6),
+          DropdownButtonFormField<String?>(
+            key: ValueKey(viewModel.sourceAccountId),
+            initialValue: viewModel.sourceAccountId,
+            isExpanded: true,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+            items: <DropdownMenuItem<String?>>[
+              const DropdownMenuItem<String?>(
+                value: null,
+                child: Text('あとで設定'),
+              ),
+              for (final entry in sourceAccountNames.entries)
+                DropdownMenuItem<String?>(
+                  value: entry.key,
+                  child: Text(entry.value, overflow: TextOverflow.ellipsis),
+                ),
+            ],
+            onChanged: viewModel.setSourceAccountId,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            '年払いは請求額を12分割した月額換算で登録します。実際の更新日は登録後に編集できます。',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: scheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({required this.label, required this.value, this.valueColor});
+
+  final String label;
+  final String value;
+  final Color? valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Expanded(child: Text(label, style: theme.textTheme.bodyMedium)),
+          Text(
+            value,
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: valueColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CandidateList extends StatelessWidget {
+  const _CandidateList({required this.viewModel});
+
+  final AssetSubscriptionStatementScanViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      key: const Key('subscription_statement_candidates'),
+      padding: const EdgeInsets.all(12),
+      itemCount: viewModel.reviews.length,
+      itemBuilder: (context, index) => _CandidateCard(
+        review: viewModel.reviews[index],
+        onSelected: (value) =>
+            viewModel.setSelected(viewModel.reviews[index].candidate.id, value),
+        onDecision: (value) =>
+            viewModel.setDecision(viewModel.reviews[index].candidate.id, value),
+      ),
+    );
+  }
+}
+
+class _CandidateCard extends StatelessWidget {
+  const _CandidateCard({
+    required this.review,
+    required this.onSelected,
+    required this.onDecision,
+  });
+
+  final AssetSubscriptionStatementCandidateReview review;
+  final ValueChanged<bool> onSelected;
+  final ValueChanged<AssetSubscriptionReviewDecision> onDecision;
+  static final NumberFormat _yen = NumberFormat('#,##0');
+
+  String _cycleLabel(AssetSubscriptionBillingCycle cycle) => switch (cycle) {
+        AssetSubscriptionBillingCycle.monthly => '月払い',
+        AssetSubscriptionBillingCycle.annual => '年払い',
+        AssetSubscriptionBillingCycle.unknown => '周期要確認',
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final candidate = review.candidate;
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Card(
+      key: Key('subscription_statement_candidate_${candidate.id}'),
+      margin: const EdgeInsets.only(bottom: 10),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 6, 12, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            CheckboxListTile(
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+              value: review.selected,
+              onChanged: review.alreadyRegistered
+                  ? null
+                  : (value) => onSelected(value ?? false),
+              title: Text(
+                candidate.serviceName,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              subtitle: Text(
+                '${_cycleLabel(candidate.billingCycle)}・請求 ¥${_yen.format(candidate.chargedAmountJpy)}'
+                '・月額換算 ¥${_yen.format(candidate.monthlyEquivalentJpy)}',
+              ),
+              secondary: review.alreadyRegistered
+                  ? const Chip(label: Text('登録済み'))
+                  : null,
+            ),
+            if (candidate.evidence.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(left: 40, bottom: 8),
+                child: Text(
+                  candidate.evidence,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            Padding(
+              padding: const EdgeInsets.only(left: 40),
+              child: DropdownButtonFormField<AssetSubscriptionReviewDecision>(
+                key: ValueKey('${candidate.id}_${review.decision.name}'),
+                initialValue: review.decision,
+                decoration: const InputDecoration(
+                  labelText: '棚卸し判定',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                items: const [
+                  DropdownMenuItem(
+                    value: AssetSubscriptionReviewDecision.keep,
+                    child: Text('残す'),
+                  ),
+                  DropdownMenuItem(
+                    value: AssetSubscriptionReviewDecision.hold,
+                    child: Text('保留'),
+                  ),
+                  DropdownMenuItem(
+                    value: AssetSubscriptionReviewDecision.cancelCandidate,
+                    child: Text('解約候補'),
+                  ),
+                ],
+                onChanged: review.alreadyRegistered
+                    ? null
+                    : (value) {
+                        if (value != null) onDecision(value);
+                      },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/recurring_fixed_cost_editor_dialog.dart
+++ b/lib/widgets/recurring_fixed_cost_editor_dialog.dart
@@ -209,6 +209,12 @@ class _RecurringFixedCostEditorDialogState
       cadence: _cadence,
       sourceAccountId: _sourceAccountId,
       category: _category,
+      subscriptionReviewDecision:
+          _category == AssetRecurringFixedCostCategory.subscription
+              ? (widget.existing?.subscriptionReviewDecision ??
+                  widget.prefill?.subscriptionReviewDecision ??
+                  AssetSubscriptionReviewDecision.unreviewed)
+              : AssetSubscriptionReviewDecision.unreviewed,
       // 請求経路は区分=サブスクのときだけ意味を持つ。固定費では direct に固定する。
       billingGateway: _category == AssetRecurringFixedCostCategory.subscription
           ? _gateway

--- a/lib/widgets/subscription_fixed_cost_card.dart
+++ b/lib/widgets/subscription_fixed_cost_card.dart
@@ -46,8 +46,7 @@ class SubscriptionFixedCostCard extends StatelessWidget {
   final void Function(
     AssetRecurringFixedCost cost,
     AssetSubscriptionReviewDecision decision,
-  )
-  onReviewDecisionChanged;
+  ) onReviewDecisionChanged;
 
   static final NumberFormat _yen = NumberFormat('#,##0');
 

--- a/lib/widgets/subscription_fixed_cost_card.dart
+++ b/lib/widgets/subscription_fixed_cost_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import '../models/asset_liability_workbook.dart';
 import '../services/asset_subscription_catalog.dart';
@@ -18,8 +19,10 @@ class SubscriptionFixedCostCard extends StatelessWidget {
     required this.sourceAccountNames,
     required this.onAddPreset,
     required this.onAddCustom,
+    required this.onScanStatement,
     required this.onEdit,
     required this.onDelete,
+    required this.onReviewDecisionChanged,
     this.presets = AssetSubscriptionCatalog.presets,
   });
 
@@ -37,8 +40,16 @@ class SubscriptionFixedCostCard extends StatelessWidget {
 
   /// テンプレートに無いサブスクを手入力で追加。
   final VoidCallback onAddCustom;
+  final VoidCallback onScanStatement;
   final void Function(AssetRecurringFixedCost cost) onEdit;
   final void Function(AssetRecurringFixedCost cost) onDelete;
+  final void Function(
+    AssetRecurringFixedCost cost,
+    AssetSubscriptionReviewDecision decision,
+  )
+  onReviewDecisionChanged;
+
+  static final NumberFormat _yen = NumberFormat('#,##0');
 
   static String _normalize(String value) =>
       value.replaceAll(RegExp(r'\s+'), '').toLowerCase();
@@ -77,11 +88,38 @@ class SubscriptionFixedCostCard extends StatelessWidget {
     ];
   }
 
+  static String reviewDecisionLabel(AssetSubscriptionReviewDecision decision) {
+    return switch (decision) {
+      AssetSubscriptionReviewDecision.unreviewed => '未判定',
+      AssetSubscriptionReviewDecision.keep => '残す',
+      AssetSubscriptionReviewDecision.hold => '保留',
+      AssetSubscriptionReviewDecision.cancelCandidate => '解約候補',
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final availablePresets = _unregisteredPresets();
+    final monthlyTotal = costs.fold<double>(
+      0,
+      (sum, cost) => sum + cost.amount,
+    );
+    final cancelMonthly = costs
+        .where(
+          (cost) =>
+              cost.subscriptionReviewDecision ==
+              AssetSubscriptionReviewDecision.cancelCandidate,
+        )
+        .fold<double>(0, (sum, cost) => sum + cost.amount);
+    final unreviewedCount = costs
+        .where(
+          (cost) =>
+              cost.subscriptionReviewDecision ==
+              AssetSubscriptionReviewDecision.unreviewed,
+        )
+        .length;
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Card(
@@ -102,6 +140,19 @@ class SubscriptionFixedCostCard extends StatelessWidget {
                       ),
                     ),
                   ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  FilledButton.icon(
+                    key: const Key('subscription_statement_scan_open'),
+                    onPressed: onScanStatement,
+                    icon: const Icon(Icons.document_scanner_outlined),
+                    label: const Text('明細画像から棚卸し'),
+                  ),
                   TextButton.icon(
                     onPressed: onAddCustom,
                     icon: const Icon(Icons.add),
@@ -118,6 +169,37 @@ class SubscriptionFixedCostCard extends StatelessWidget {
                   color: scheme.onSurfaceVariant,
                 ),
               ),
+              if (costs.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    _SummaryChip(
+                      label: '月額合計',
+                      value: '¥${_yen.format(monthlyTotal)}',
+                    ),
+                    _SummaryChip(
+                      label: '年間合計',
+                      value: '¥${_yen.format(monthlyTotal * 12)}',
+                    ),
+                    if (cancelMonthly > 0)
+                      _SummaryChip(
+                        label: '解約候補',
+                        value: '月 ¥${_yen.format(cancelMonthly)}',
+                        color: scheme.errorContainer,
+                        foregroundColor: scheme.onErrorContainer,
+                      ),
+                    if (unreviewedCount > 0)
+                      _SummaryChip(
+                        label: '未判定',
+                        value: '$unreviewedCount件',
+                        color: scheme.secondaryContainer,
+                        foregroundColor: scheme.onSecondaryContainer,
+                      ),
+                  ],
+                ),
+              ],
               if (availablePresets.isNotEmpty) ...[
                 const SizedBox(height: 12),
                 Text(
@@ -187,6 +269,35 @@ class SubscriptionFixedCostCard extends StatelessWidget {
                             ),
                           ),
                         ),
+                        PopupMenuButton<AssetSubscriptionReviewDecision>(
+                          key: Key('subscription_review_${cost.id}'),
+                          tooltip: '${cost.name} の棚卸し判定',
+                          initialValue: cost.subscriptionReviewDecision,
+                          onSelected: (decision) =>
+                              onReviewDecisionChanged(cost, decision),
+                          itemBuilder: (context) => [
+                            for (final decision
+                                in AssetSubscriptionReviewDecision.values)
+                              PopupMenuItem(
+                                value: decision,
+                                child: Text(reviewDecisionLabel(decision)),
+                              ),
+                          ],
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 4,
+                            ),
+                            child: Chip(
+                              visualDensity: VisualDensity.compact,
+                              label: Text(
+                                reviewDecisionLabel(
+                                  cost.subscriptionReviewDecision,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
                         IconButton(
                           tooltip: '${cost.name} を編集',
                           icon: const Icon(Icons.edit_outlined),
@@ -203,6 +314,44 @@ class SubscriptionFixedCostCard extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _SummaryChip extends StatelessWidget {
+  const _SummaryChip({
+    required this.label,
+    required this.value,
+    this.color,
+    this.foregroundColor,
+  });
+
+  final String label;
+  final String value;
+  final Color? color;
+  final Color? foregroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color ?? theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text.rich(
+        TextSpan(
+          children: [
+            TextSpan(text: '$label '),
+            TextSpan(
+              text: value,
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+        style: theme.textTheme.labelMedium?.copyWith(color: foregroundColor),
       ),
     );
   }

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -123,6 +123,10 @@ import {
 } from "./company_a2a.ts";
 import { rankBm25 } from "../memory-search-hub/search/bm25.ts";
 import { embedTextWithGemini } from "../memory-search-hub/search/vector.ts";
+import {
+  buildSubscriptionStatementPrompt,
+  parseSubscriptionStatementResponse,
+} from "./subscription_statement_scan.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -4245,6 +4249,7 @@ serve(async (req: Request) => {
       "ai_hub.fetch_market_price",
       "asset.monthly_report.generate",
       "asset_liability.monthly_report.generate",
+      "asset_subscription.analyze_statement",
       "asset.chat",
       "ai_hub.asset_chat",
       "department_finance_summary",
@@ -6140,6 +6145,55 @@ serve(async (req: Request) => {
           detected_annual_rate_percent: detectedPercent,
           summary,
           confidence: asNumber(parsed.confidence, 0),
+        });
+      }
+
+      case "asset_subscription.analyze_statement": {
+        const parsedImage = parseInlineImage(body);
+        if (parsedImage.error) {
+          return json({ error: parsedImage.error }, parsedImage.status ?? 400);
+        }
+        const image = parsedImage.image;
+        if (!image) {
+          return json({ error: "imageBase64 required" }, 400);
+        }
+        if (
+          !["image/png", "image/jpeg", "image/webp"].includes(image.mimeType)
+        ) {
+          return json({ error: "PNG, JPEG, or WebP image required" }, 400);
+        }
+        const offlinePolicy = parseOfflineSecureModePolicy(body);
+        if (shouldBlockExternalProviderCall(offlinePolicy)) {
+          return json(
+            buildOfflineBlockedResponseBody(offlinePolicy, {
+              action: "asset_subscription.analyze_statement",
+              provider: "google",
+            }),
+            409,
+          );
+        }
+        const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
+        if (!geminiKey) {
+          return json({
+            success: false,
+            status: "apiKeyRequired",
+            secret_needed: "GEMINI_API_KEY",
+            message: "Supabase Secret GEMINI_API_KEY is required.",
+          });
+        }
+        const raw = await callGemini(
+          buildSubscriptionStatementPrompt(),
+          geminiKey,
+          image,
+        );
+        const candidates = parseSubscriptionStatementResponse(raw);
+        return json({
+          success: true,
+          provider: "google",
+          model: "gemini-2.5-flash",
+          candidates,
+          candidate_count: candidates.length,
+          image_persisted: false,
         });
       }
 

--- a/supabase/functions/ai-hub/subscription_statement_scan.ts
+++ b/supabase/functions/ai-hub/subscription_statement_scan.ts
@@ -1,0 +1,151 @@
+export type SubscriptionStatementCandidate = {
+  service_name: string;
+  amount_jpy: number;
+  charged_at: string | null;
+  billing_cycle: "monthly" | "annual" | "unknown";
+  gateway: "direct" | "apple" | "googlePlay" | "auKantan";
+  confidence: number;
+  evidence: string;
+};
+
+const MAX_CANDIDATES = 100;
+const LONG_NUMBER_PATTERN = /(?:^|\D)(?:\d[ -]?){12,19}(?=\D|$)/g;
+
+export function buildSubscriptionStatementPrompt(): string {
+  return [
+    "You extract recurring subscription charges from a Japanese credit-card statement screenshot.",
+    'Return JSON only: {"candidates":[...]}.',
+    "Each candidate must contain service_name, amount_jpy, charged_at, billing_cycle, gateway, confidence, evidence.",
+    "billing_cycle must be monthly, annual, or unknown. gateway must be direct, apple, googlePlay, or auKantan.",
+    "Include only likely recurring subscriptions (software, AI, cloud, video, music, news, learning, memberships).",
+    "Exclude groceries, transport, one-time shopping, cash advances, repayments, taxes, utilities unless clearly a subscription, refunds, and statement totals.",
+    "Do not guess unreadable amounts. If uncertain, omit the row or use billing_cycle=unknown with low confidence.",
+    "For repeated instances of the same service, return one representative candidate and infer the cycle only when supported by dates.",
+    "Never return card numbers, account numbers, customer names, addresses, phone numbers, email addresses, authentication data, or full OCR text.",
+    "evidence must be a short non-sensitive reason, at most 160 characters. charged_at must be YYYY-MM-DD or null.",
+  ].join("\n");
+}
+
+export function normalizeSubscriptionStatementCandidates(
+  value: unknown,
+): SubscriptionStatementCandidate[] {
+  const root = asRecord(value);
+  const rawCandidates = Array.isArray(root?.candidates)
+    ? root.candidates
+    : Array.isArray(value)
+    ? value
+    : [];
+  const deduped = new Map<string, SubscriptionStatementCandidate>();
+  for (const raw of rawCandidates.slice(0, MAX_CANDIDATES * 2)) {
+    const item = asRecord(raw);
+    if (!item) continue;
+    const serviceName = sanitizeText(item.service_name, 100);
+    const amount = finiteNumber(item.amount_jpy ?? item.amount);
+    if (
+      !serviceName || amount === null || amount <= 0 || amount > 100_000_000
+    ) {
+      continue;
+    }
+    const billingCycle = normalizeCycle(item.billing_cycle);
+    const gateway = normalizeGateway(item.gateway);
+    const chargedAt = normalizeDate(item.charged_at);
+    const confidence = clamp(finiteNumber(item.confidence) ?? 0, 0, 1);
+    const evidence = sanitizeText(item.evidence, 160);
+    const candidate: SubscriptionStatementCandidate = {
+      service_name: serviceName,
+      amount_jpy: Math.round(amount * 100) / 100,
+      charged_at: chargedAt,
+      billing_cycle: billingCycle,
+      gateway,
+      confidence,
+      evidence,
+    };
+    const key = `${normalizeServiceName(serviceName)}:${candidate.amount_jpy}`;
+    const current = deduped.get(key);
+    if (
+      !current ||
+      candidate.confidence > current.confidence ||
+      (candidate.confidence === current.confidence &&
+        (candidate.charged_at ?? "") > (current.charged_at ?? ""))
+    ) {
+      deduped.set(key, candidate);
+    }
+    if (deduped.size >= MAX_CANDIDATES) break;
+  }
+  return [...deduped.values()];
+}
+
+export function parseSubscriptionStatementResponse(
+  raw: string,
+): SubscriptionStatementCandidate[] {
+  const cleaned = raw
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+  try {
+    return normalizeSubscriptionStatementCandidates(JSON.parse(cleaned));
+  } catch {
+    return [];
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function sanitizeText(value: unknown, maxLength: number): string {
+  const text = String(value ?? "")
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(LONG_NUMBER_PATTERN, " [number removed] ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.slice(0, maxLength);
+}
+
+function normalizeServiceName(value: string): string {
+  return value.toLowerCase().replace(/[\s\p{P}\p{S}]/gu, "");
+}
+
+function normalizeCycle(
+  value: unknown,
+): SubscriptionStatementCandidate["billing_cycle"] {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (normalized === "monthly") return "monthly";
+  if (normalized === "annual" || normalized === "yearly") return "annual";
+  return "unknown";
+}
+
+function normalizeGateway(
+  value: unknown,
+): SubscriptionStatementCandidate["gateway"] {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (normalized === "apple") return "apple";
+  if (normalized === "googleplay" || normalized === "google_play") {
+    return "googlePlay";
+  }
+  if (normalized === "aukantan" || normalized === "au_kantan") {
+    return "auKantan";
+  }
+  return "direct";
+}
+
+function normalizeDate(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) return null;
+  const parsed = new Date(`${text}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime()) ||
+      parsed.toISOString().slice(0, 10) !== text
+    ? null
+    : text;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/supabase/functions/ai-hub/subscription_statement_scan_test.ts
+++ b/supabase/functions/ai-hub/subscription_statement_scan_test.ts
@@ -1,0 +1,68 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  buildSubscriptionStatementPrompt,
+  normalizeSubscriptionStatementCandidates,
+  parseSubscriptionStatementResponse,
+} from "./subscription_statement_scan.ts";
+
+Deno.test("subscription statement prompt prohibits returning sensitive data", () => {
+  const prompt = buildSubscriptionStatementPrompt();
+  assert(prompt.includes("Never return card numbers"));
+  assert(prompt.includes("Return JSON only"));
+});
+
+Deno.test("normalizes candidates, strips long numbers, and rejects bad amounts", () => {
+  const result = normalizeSubscriptionStatementCandidates({
+    candidates: [
+      {
+        service_name: "Netflix 4111 1111 1111 1111",
+        amount_jpy: 1980,
+        charged_at: "2026-08-10",
+        billing_cycle: "monthly",
+        gateway: "direct",
+        confidence: 1.4,
+        evidence: "monthly row for account 1234567890123456",
+      },
+      { service_name: "Broken", amount_jpy: -1 },
+    ],
+  });
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].service_name, "Netflix [number removed]");
+  assertEquals(result[0].confidence, 1);
+  assertEquals(result[0].evidence, "monthly row for account [number removed]");
+});
+
+Deno.test("deduplicates repeated statement rows and parses fenced JSON", () => {
+  const result = parseSubscriptionStatementResponse(`\`\`\`json
+  {"candidates":[
+    {"service_name":"Notion","amount_jpy":1650,"charged_at":"2026-07-01","billing_cycle":"monthly","confidence":0.7},
+    {"service_name":"Notion","amount_jpy":1650,"charged_at":"2026-08-01","billing_cycle":"monthly","confidence":0.9}
+  ]}
+  \`\`\``);
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].charged_at, "2026-08-01");
+  assertEquals(result[0].confidence, 0.9);
+});
+
+Deno.test("normalizes cycles, gateways, and impossible dates", () => {
+  const result = normalizeSubscriptionStatementCandidates([
+    {
+      service_name: "iCloud+",
+      amount_jpy: "15600",
+      charged_at: "2026-02-30",
+      billing_cycle: "yearly",
+      gateway: "google_play",
+      confidence: 0.8,
+    },
+  ]);
+
+  assertEquals(result[0].billing_cycle, "annual");
+  assertEquals(result[0].gateway, "googlePlay");
+  assertEquals(result[0].charged_at, null);
+});

--- a/test/services/asset_recurring_fixed_cost_store_test.dart
+++ b/test/services/asset_recurring_fixed_cost_store_test.dart
@@ -93,6 +93,36 @@ void main() {
       );
     });
 
+    test('subscription review decision round-trips through json', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'sub_claude',
+        name: 'Anthropic (Claude)',
+        amount: 3000,
+        paymentDay: 1,
+        category: AssetRecurringFixedCostCategory.subscription,
+        subscriptionReviewDecision:
+            AssetSubscriptionReviewDecision.cancelCandidate,
+      );
+      final json = cost.toJson();
+      expect(json['subscriptionReviewDecision'], 'cancelCandidate');
+      final restored = AssetRecurringFixedCost.fromJson('sub_claude', json);
+      expect(
+        restored!.subscriptionReviewDecision,
+        AssetSubscriptionReviewDecision.cancelCandidate,
+      );
+    });
+
+    test('legacy subscription defaults review decision to unreviewed', () {
+      final restored = AssetRecurringFixedCost.fromJson(
+        'sub_legacy',
+        {..._validJson(), 'category': 'subscription'},
+      );
+      expect(
+        restored!.subscriptionReviewDecision,
+        AssetSubscriptionReviewDecision.unreviewed,
+      );
+    });
+
     test('fromJson without category defaults to utility (back-compat)', () {
       // category キーが無い旧データ。
       final restored = AssetRecurringFixedCost.fromJson('x', _validJson());

--- a/test/services/asset_subscription_statement_scan_service_test.dart
+++ b/test/services/asset_subscription_statement_scan_service_test.dart
@@ -1,0 +1,122 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_subscription_statement_scan.dart';
+import 'package:my_web_app/services/asset_subscription_statement_scan_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  AssetSubscriptionStatementImage image({
+    String mimeType = 'image/png',
+    int byteCount = 4,
+  }) {
+    return AssetSubscriptionStatementImage(
+      fileName: 'statement.png',
+      mimeType: mimeType,
+      bytes: Uint8List(byteCount),
+    );
+  }
+
+  test('sends an ephemeral image and maps sanitized candidates', () async {
+    Map<String, dynamic>? request;
+    final service = AssetSubscriptionStatementScanService(
+      invoker: (body) async {
+        request = body;
+        return <String, dynamic>{
+          'success': true,
+          'candidates': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'service_name': 'Netflix',
+              'amount_jpy': 1980,
+              'charged_at': '2026-08-10',
+              'billing_cycle': 'monthly',
+              'gateway': 'direct',
+              'confidence': 0.92,
+              'evidence': '毎月同額の動画サービス請求',
+            },
+            <String, dynamic>{'service_name': '', 'amount_jpy': 0},
+          ],
+        };
+      },
+    );
+
+    final result = await service.analyze(image());
+
+    expect(request?['action'], 'asset_subscription.analyze_statement');
+    expect(request?['imageBase64'], isNotEmpty);
+    expect(request?.containsKey('persist'), isFalse);
+    expect(result, hasLength(1));
+    expect(result.single.serviceName, 'Netflix');
+    expect(result.single.monthlyEquivalentJpy, 1980);
+    expect(result.single.annualEquivalentJpy, 23760);
+  });
+
+  test('annual charge is converted deterministically on the client', () async {
+    final service = AssetSubscriptionStatementScanService(
+      invoker: (_) async => <String, dynamic>{
+        'success': true,
+        'candidates': <Map<String, dynamic>>[
+          <String, dynamic>{
+            'service_name': 'Cloud storage',
+            'amount_jpy': 12000,
+            'billing_cycle': 'annual',
+            'confidence': 0.8,
+          },
+        ],
+      },
+    );
+
+    final candidate = (await service.analyze(image())).single;
+    expect(candidate.monthlyEquivalentJpy, 1000);
+    expect(candidate.annualEquivalentJpy, 12000);
+  });
+
+  test('rejects unsupported and oversized images before invoking AI', () async {
+    var calls = 0;
+    final service = AssetSubscriptionStatementScanService(
+      invoker: (_) async {
+        calls++;
+        return <String, dynamic>{'success': true, 'candidates': <dynamic>[]};
+      },
+    );
+
+    await expectLater(
+      service.analyze(image(mimeType: 'application/pdf')),
+      throwsA(isA<AssetSubscriptionStatementScanException>()),
+    );
+    await expectLater(
+      service.analyze(
+        image(
+          byteCount: AssetSubscriptionStatementScanService.maxImageBytes + 1,
+        ),
+      ),
+      throwsA(isA<AssetSubscriptionStatementScanException>()),
+    );
+    expect(calls, 0);
+  });
+
+  test('removes long card-like numbers from returned text', () async {
+    final service = AssetSubscriptionStatementScanService(
+      invoker: (_) async => <String, dynamic>{
+        'success': true,
+        'candidates': <Map<String, dynamic>>[
+          <String, dynamic>{
+            'service_name': 'Notion 4111 1111 1111 1111',
+            'amount_jpy': 1650,
+            'billing_cycle': 'monthly',
+            'evidence': 'account 1234567890123456',
+          },
+        ],
+      },
+    );
+
+    final candidate = (await service.analyze(image())).single;
+    expect(candidate.serviceName, contains('[番号を除外]'));
+    expect(candidate.evidence, contains('[番号を除外]'));
+    expect(candidate.serviceName, isNot(contains('4111 1111')));
+  });
+}

--- a/test/view_models/asset_subscription_statement_scan_view_model_test.dart
+++ b/test/view_models/asset_subscription_statement_scan_view_model_test.dart
@@ -1,0 +1,137 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/models/asset_subscription_statement_scan.dart';
+import 'package:my_web_app/services/asset_subscription_statement_scan_service.dart';
+import 'package:my_web_app/view_models/asset_subscription_statement_scan_view_model.dart';
+
+void main() {
+  final image = AssetSubscriptionStatementImage(
+    fileName: 'statement.png',
+    mimeType: 'image/png',
+    bytes: Uint8List.fromList(<int>[1, 2, 3]),
+  );
+
+  test(
+    'analyzes, removes existing duplicates, and totals monthly amounts',
+    () async {
+      final viewModel = AssetSubscriptionStatementScanViewModel(
+        imagePicker: _FakePicker(image),
+        analyzer: _FakeAnalyzer(<AssetSubscriptionStatementCandidate>[
+          _candidate('netflix', 'Netflix', 1980),
+          _candidate(
+            'icloud',
+            'iCloud+',
+            12000,
+            cycle: AssetSubscriptionBillingCycle.annual,
+          ),
+        ]),
+        existingSubscriptions: const <AssetRecurringFixedCost>[
+          AssetRecurringFixedCost(
+            id: 'existing_netflix',
+            name: 'Netflix',
+            amount: 1980,
+            paymentDay: 10,
+            category: AssetRecurringFixedCostCategory.subscription,
+          ),
+        ],
+        now: () => DateTime(2026, 8, 22),
+      );
+
+      await viewModel.pickAndAnalyze();
+
+      expect(viewModel.reviews, hasLength(2));
+      expect(viewModel.duplicateCount, 1);
+      expect(viewModel.selectedCount, 1);
+      expect(viewModel.selectedMonthlyTotal, 1000);
+      expect(viewModel.selectedAnnualTotal, 12000);
+      expect(
+        viewModel.reviews.last.decision,
+        AssetSubscriptionReviewDecision.hold,
+      );
+    },
+  );
+
+  test(
+    'builds selected recurring costs with user decisions and source',
+    () async {
+      final viewModel = AssetSubscriptionStatementScanViewModel(
+        imagePicker: _FakePicker(image),
+        analyzer: _FakeAnalyzer(<AssetSubscriptionStatementCandidate>[
+          _candidate('netflix', 'Netflix', 1980),
+        ]),
+        existingSubscriptions: const <AssetRecurringFixedCost>[],
+        now: () => DateTime.fromMicrosecondsSinceEpoch(42),
+      );
+      await viewModel.pickAndAnalyze();
+      viewModel.setSourceAccountId('paypay_card');
+      viewModel.setDecision(
+        'netflix',
+        AssetSubscriptionReviewDecision.cancelCandidate,
+      );
+
+      final cost = viewModel.buildSelectedCosts().single;
+      expect(cost.id, 'sub_statement_42_0');
+      expect(cost.sourceAccountId, 'paypay_card');
+      expect(cost.amount, 1980);
+      expect(
+        cost.subscriptionReviewDecision,
+        AssetSubscriptionReviewDecision.cancelCandidate,
+      );
+      expect(viewModel.cancelCandidateMonthlySavings, 1980);
+    },
+  );
+
+  test('reports a clear empty-result error', () async {
+    final viewModel = AssetSubscriptionStatementScanViewModel(
+      imagePicker: _FakePicker(image),
+      analyzer: const _FakeAnalyzer(<AssetSubscriptionStatementCandidate>[]),
+      existingSubscriptions: const <AssetRecurringFixedCost>[],
+    );
+
+    await viewModel.pickAndAnalyze();
+
+    expect(viewModel.hasResults, isFalse);
+    expect(viewModel.errorMessage, contains('候補を特定できませんでした'));
+  });
+}
+
+AssetSubscriptionStatementCandidate _candidate(
+  String id,
+  String name,
+  double amount, {
+  AssetSubscriptionBillingCycle cycle = AssetSubscriptionBillingCycle.monthly,
+}) {
+  return AssetSubscriptionStatementCandidate(
+    id: id,
+    serviceName: name,
+    chargedAmountJpy: amount,
+    chargedAt: DateTime(2026, 8, 10),
+    billingCycle: cycle,
+    billingGateway: AssetSubscriptionBillingGateway.direct,
+    confidence: 0.9,
+    evidence: '定期請求の可能性',
+  );
+}
+
+class _FakePicker implements AssetSubscriptionStatementImagePicker {
+  final AssetSubscriptionStatementImage? image;
+
+  const _FakePicker(this.image);
+
+  @override
+  Future<AssetSubscriptionStatementImage?> pickImage() async => image;
+}
+
+class _FakeAnalyzer implements AssetSubscriptionStatementAnalyzer {
+  final List<AssetSubscriptionStatementCandidate> candidates;
+
+  const _FakeAnalyzer(this.candidates);
+
+  @override
+  Future<List<AssetSubscriptionStatementCandidate>> analyze(
+    AssetSubscriptionStatementImage image,
+  ) async =>
+      candidates;
+}

--- a/test/widgets/asset_subscription_statement_scan_dialog_test.dart
+++ b/test/widgets/asset_subscription_statement_scan_dialog_test.dart
@@ -1,0 +1,124 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/models/asset_subscription_statement_scan.dart';
+import 'package:my_web_app/services/asset_subscription_statement_scan_service.dart';
+import 'package:my_web_app/view_models/asset_subscription_statement_scan_view_model.dart';
+import 'package:my_web_app/widgets/asset_subscription_statement_scan_dialog.dart';
+
+void main() {
+  testWidgets('imports reviewed candidates and shows deterministic totals', (
+    tester,
+  ) async {
+    List<AssetRecurringFixedCost>? imported;
+    final viewModel = _viewModel();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetSubscriptionStatementScanDialog(
+            viewModel: viewModel,
+            sourceAccountNames: const <String, String>{
+              'paypay_card': 'PayPayカード',
+            },
+            onImport: (costs) => imported = costs,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('支払い明細のキャプチャーを1枚選ぶだけ'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('subscription_statement_pick')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Netflix'), findsOneWidget);
+    expect(find.textContaining('月額換算 ¥1,980'), findsOneWidget);
+    expect(find.text('月額換算'), findsOneWidget);
+    expect(find.text('¥1,980'), findsOneWidget);
+    expect(find.text('年間合計'), findsOneWidget);
+    expect(find.text('¥23,760'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('subscription_statement_import')));
+    await tester.pumpAndSettle();
+    expect(imported, hasLength(1));
+    expect(
+      imported!.single.subscriptionReviewDecision,
+      AssetSubscriptionReviewDecision.hold,
+    );
+  });
+
+  testWidgets('fits a narrow viewport without layout exceptions', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 780);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetSubscriptionStatementScanDialog(
+            viewModel: _viewModel(),
+            sourceAccountNames: const <String, String>{},
+            onImport: (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('subscription_statement_pick')));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Netflix'), findsOneWidget);
+    expect(
+      find.byKey(const Key('subscription_statement_import')),
+      findsOneWidget,
+    );
+  });
+}
+
+AssetSubscriptionStatementScanViewModel _viewModel() {
+  return AssetSubscriptionStatementScanViewModel(
+    imagePicker: const _FakePicker(),
+    analyzer: const _FakeAnalyzer(),
+    existingSubscriptions: const <AssetRecurringFixedCost>[],
+    now: () => DateTime.fromMicrosecondsSinceEpoch(42),
+  );
+}
+
+class _FakePicker implements AssetSubscriptionStatementImagePicker {
+  const _FakePicker();
+
+  @override
+  Future<AssetSubscriptionStatementImage?> pickImage() async {
+    return AssetSubscriptionStatementImage(
+      fileName: 'statement.png',
+      mimeType: 'image/png',
+      bytes: Uint8List.fromList(<int>[1, 2, 3]),
+    );
+  }
+}
+
+class _FakeAnalyzer implements AssetSubscriptionStatementAnalyzer {
+  const _FakeAnalyzer();
+
+  @override
+  Future<List<AssetSubscriptionStatementCandidate>> analyze(
+    AssetSubscriptionStatementImage image,
+  ) async {
+    return <AssetSubscriptionStatementCandidate>[
+      AssetSubscriptionStatementCandidate(
+        id: 'netflix',
+        serviceName: 'Netflix',
+        chargedAmountJpy: 1980,
+        chargedAt: DateTime(2026, 8, 10),
+        billingCycle: AssetSubscriptionBillingCycle.monthly,
+        billingGateway: AssetSubscriptionBillingGateway.direct,
+        confidence: 0.9,
+        evidence: '同額の定期請求',
+      ),
+    ];
+  }
+}

--- a/test/widgets/subscription_fixed_cost_card_test.dart
+++ b/test/widgets/subscription_fixed_cost_card_test.dart
@@ -216,7 +216,8 @@ void main() {
       expect(find.text('年間合計 ¥24,000'), findsOneWidget);
       expect(find.text('未判定 1件'), findsOneWidget);
 
-      await tester.tap(find.byKey(const Key('subscription_statement_scan_open')));
+      await tester
+          .tap(find.byKey(const Key('subscription_statement_scan_open')));
       expect(scanPressed, isTrue);
 
       await tester.tap(find.byKey(const Key('subscription_review_sub_notion')));

--- a/test/widgets/subscription_fixed_cost_card_test.dart
+++ b/test/widgets/subscription_fixed_cost_card_test.dart
@@ -31,8 +31,10 @@ void main() {
               presets: presets,
               onAddPreset: (preset) => addedPreset = preset,
               onAddCustom: () {},
+              onScanStatement: () {},
               onEdit: (_) {},
               onDelete: (_) {},
+              onReviewDecisionChanged: (_, __) {},
             ),
           ),
         ),
@@ -70,8 +72,10 @@ void main() {
               presets: presets,
               onAddPreset: (_) {},
               onAddCustom: () {},
+              onScanStatement: () {},
               onEdit: (_) {},
               onDelete: (_) {},
+              onReviewDecisionChanged: (_, __) {},
             ),
           ),
         ),
@@ -111,17 +115,20 @@ void main() {
               presets: presets,
               onAddPreset: (_) {},
               onAddCustom: () => customPressed = true,
+              onScanStatement: () {},
               onEdit: (cost) => edited = cost,
               onDelete: (cost) => deleted = cost,
+              onReviewDecisionChanged: (_, __) {},
             ),
           ),
         ),
       );
 
       expect(find.text('Anthropic (Claude)'), findsWidgets);
-      expect(find.textContaining('毎月1日'), findsOneWidget);
-      expect(find.textContaining('¥3,000'), findsOneWidget);
-      expect(find.textContaining('振替元: 三井住友銀行'), findsOneWidget);
+      expect(
+        find.text('毎月1日 / ¥3,000 / 振替元: 三井住友銀行'),
+        findsOneWidget,
+      );
 
       // 行ごとに 名称+内訳 を 1 つの semantics ラベルへまとめる。
       final rowSemantics = find.byWidgetPredicate(
@@ -161,14 +168,64 @@ void main() {
               presets: presets,
               onAddPreset: (_) {},
               onAddCustom: () {},
+              onScanStatement: () {},
               onEdit: (_) {},
               onDelete: (_) {},
+              onReviewDecisionChanged: (_, __) {},
             ),
           ),
         ),
       );
 
       expect(find.textContaining('Apple経由'), findsOneWidget);
+    });
+
+    testWidgets('opens statement scan and updates inventory decision',
+        (tester) async {
+      var scanPressed = false;
+      AssetSubscriptionReviewDecision? changedDecision;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SubscriptionFixedCostCard(
+              costs: const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'sub_notion',
+                  name: 'Notion',
+                  amount: 2000,
+                  paymentDay: 5,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                ),
+              ],
+              sourceAccountNames: const <String, String>{},
+              presets: presets,
+              onAddPreset: (_) {},
+              onAddCustom: () {},
+              onScanStatement: () => scanPressed = true,
+              onEdit: (_) {},
+              onDelete: (_) {},
+              onReviewDecisionChanged: (_, decision) {
+                changedDecision = decision;
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('月額合計 ¥2,000'), findsOneWidget);
+      expect(find.text('年間合計 ¥24,000'), findsOneWidget);
+      expect(find.text('未判定 1件'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('subscription_statement_scan_open')));
+      expect(scanPressed, isTrue);
+
+      await tester.tap(find.byKey(const Key('subscription_review_sub_notion')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('解約候補').last);
+      expect(
+        changedDecision,
+        AssetSubscriptionReviewDecision.cancelCandidate,
+      );
     });
   });
 }


### PR DESCRIPTION
## User-visible outcome

- 資産管理のサブスクカードから「明細画像から棚卸し」を開き、PNG/JPEG/WebP（4MB以下）1枚を解析できます。
- 抽出候補を重複除外し、月額・年間合計を確認して「残す / 保留 / 解約候補」をユーザーが決め、既存の固定費保存・端末間同期へ追加できます。
- 年払いの月額換算と合計はDartで決定論的に計算し、AIは候補抽出だけを担当します。

Closes #4659
Related #3559

## Architecture / persistence

- UI → ViewModel → 画像解析service → `ai-hub` の既存境界を維持。
- 画像バイト列は解析中のメモリと1回のEdge Functionリクエストだけで扱い、DB / Storage / SharedPreferencesへ保存しません。
- 保存するのはユーザー確認後の正規化済みサブスク候補だけです。既存`AssetRecurringFixedCostStore`とmirror同期を再利用します。
- `AssetSubscriptionReviewDecision` は後方互換で、旧データは`unreviewed`へフォールバックします。

## Egress / security

- 解析1回につき `ai-hub` 1リクエスト、Google Geminiへの外部画像送信1回。DB query、Storage upload/download、反復fetch、キャッシュは0です。
- クライアント/Edge Function双方で認証、PNG/JPEG/WebP、4MB上限を検証。候補は最大100件です。
- カード番号様の12〜19桁文字列、氏名、住所、連絡先、生OCR全文を返さないpromptとサーバー/クライアント再正規化を実装しました。
- provider keyはEdge Function内だけで利用し、Flutterへ公開しません。

## Validation

- `flutter analyze --no-pub`: no issues（71.3s）。
- focused Flutter tests: 33 passed（service / ViewModel / dialog / card / persistence）。
- `deno test supabase/functions/ai-hub/subscription_statement_scan_test.ts`: 4 passed。
- `deno check --node-modules-dir=auto --no-lock supabase/functions/ai-hub/index.ts`: passed。
- pre-commit: Deno lint、Edge Function import resilience check passed。
- Codex in-app browser: `/asset-management`で導線とダイアログを確認。390x844でもconsole error / overflowなし。

## Minimal E2E Gate

- Implementation-detail independent: 画像選択 → 候補確認 → 合計/判断 → 既存固定費への追加をユーザー可視結果として検証。
- Minimal cases: 正常候補、空/失敗、狭幅レイアウト。
- E2E-Exception: 実在する金融明細をPR検証で外部AIへ送ることは避け、fake analyzerを使うwidget testとローカル実画面の導線確認に分離しました。本番ではログイン済みテストアカウントと非機微な合成明細でsmokeします。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 別Claude Code #1レビューは未実施。金融画像egressのため認証、MIME/容量、PII除外、非永続化、決定論的金額、provider失敗を対象テストと手動レビューで確認しました。
- Rollback: merge commitをrevertし、`ai-hub`とWebを再デプロイ。migration / DB schema変更なし。
- Observability: `ai-hub` status、candidate_count、provider/model。画像・OCR全文はログ/レスポンスへ記録しません。
- Unresolved findings: 実画像のOCR精度は明細フォーマット依存。候補は自動確定せず、必ずユーザー確認を挟みます。

## Deployment

- main mergeで`Deploy to Production`がWebと変更された`ai-hub`を自動デプロイします。
- 既存のproduction `GEMINI_API_KEY`を使用。migrationと新規secretは不要です。
- デプロイ後にproduction `/asset-management`の導線、未ログイン拒否、合成明細1件の解析をsmokeし、workflowのmerge SHA一致を確認します。
