### PR TITLE
fix: make video generation progress observable

### DIFF
--- a/lib/ui/features/video_studio/domain/video_studio_models.dart
+++ b/lib/ui/features/video_studio/domain/video_studio_models.dart
@@ -116,6 +116,8 @@ class VideoGenerationJob {
     this.errorCode,
     this.outputUrl,
     this.outputExpiresAt,
+    this.startedAt,
+    this.updatedAt,
     this.completedAt,
   });
 
@@ -131,7 +133,9 @@ class VideoGenerationJob {
   final String? errorCode;
   final Uri? outputUrl;
   final DateTime? outputExpiresAt;
+  final DateTime? startedAt;
   final DateTime createdAt;
+  final DateTime? updatedAt;
   final DateTime? completedAt;
 
   bool get isTerminal =>
@@ -152,8 +156,10 @@ class VideoGenerationJob {
       errorCode: _nullableString(json['error_code']),
       outputUrl: _uri(json['output_url']),
       outputExpiresAt: _date(json['output_expires_at']),
+      startedAt: _date(json['started_at']),
       createdAt:
           _date(json['created_at']) ?? DateTime.fromMillisecondsSinceEpoch(0),
+      updatedAt: _date(json['updated_at']),
       completedAt: _date(json['completed_at']),
     );
   }

--- a/lib/ui/features/video_studio/views/video_studio_page.dart
+++ b/lib/ui/features/video_studio/views/video_studio_page.dart
@@ -434,6 +434,12 @@ class _JobCard extends StatelessWidget {
       'cancelled' => 'キャンセル',
       _ => job.status,
     };
+    final activity = switch (job.status) {
+      'queued' => '専用GPUを起動・準備しています。初回は3分前後かかります。',
+      'in_progress' =>
+        '専用GPUで推論中です。720p動画は十数分かかる場合があります。画面を閉じても処理は継続します。',
+      _ => null,
+    };
     return Container(
       margin: const EdgeInsets.only(bottom: DesignTokens.space8),
       padding: const EdgeInsets.all(DesignTokens.space12),
@@ -470,6 +476,25 @@ class _JobCard extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
             style: const TextStyle(color: DesignTokens.textOnDark),
           ),
+          if (activity != null) ...[
+            const SizedBox(height: DesignTokens.space12),
+            LinearProgressIndicator(
+              key: Key('video-progress-${job.id}'),
+              minHeight: 4,
+              color: DesignTokens.orange,
+              backgroundColor: DesignTokens.surface2,
+            ),
+            const SizedBox(height: DesignTokens.space8),
+            Text(activity, style: _secondaryStyle),
+            if (job.updatedAt != null) ...[
+              const SizedBox(height: DesignTokens.space4),
+              Text(
+                '最終処理確認 ${_clock(job.updatedAt!)}'
+                '${job.startedAt == null ? '' : '・生成開始 ${_clock(job.startedAt!)}'}',
+                style: _secondaryStyle,
+              ),
+            ],
+          ],
           if (job.isSuccessful) ...[
             const SizedBox(height: DesignTokens.space8),
             FilledButton.icon(
@@ -493,6 +518,12 @@ class _JobCard extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _clock(DateTime value) {
+    final local = value.toLocal();
+    String twoDigits(int number) => number.toString().padLeft(2, '0');
+    return '${twoDigits(local.hour)}:${twoDigits(local.minute)}';
   }
 
   Future<void> _openOutput(BuildContext context) async {

--- a/lib/ui/features/video_studio/views/video_studio_page.dart
+++ b/lib/ui/features/video_studio/views/video_studio_page.dart
@@ -436,8 +436,7 @@ class _JobCard extends StatelessWidget {
     };
     final activity = switch (job.status) {
       'queued' => '専用GPUを起動・準備しています。初回は3分前後かかります。',
-      'in_progress' =>
-        '専用GPUで推論中です。720p動画は十数分かかる場合があります。画面を閉じても処理は継続します。',
+      'in_progress' => '専用GPUで推論中です。720p動画は十数分かかる場合があります。画面を閉じても処理は継続します。',
       _ => null,
     };
     return Container(

--- a/services/video-inference-worker/README.md
+++ b/services/video-inference-worker/README.md
@@ -43,7 +43,9 @@ docker run --rm --gpus all \
 Required environment variables:
 
 - `VIDEO_WORKER_URL`: deployed `/functions/v1/video-worker-hub` HTTPS URL
-- `VIDEO_WORKER_TOKEN`: dedicated 32-256 character random secret
+- `VIDEO_WORKER_TOKEN_FILE`: preferred path to a mode-0400 file containing the
+  dedicated 32-256 character random secret
+- `VIDEO_WORKER_TOKEN`: local-development fallback when no token file is set
 - `VIDEO_WORKER_ID`: stable identifier such as `gpu-tokyo-01`
 - `VIDEO_IDLE_EXIT_SECONDS`: cleanly exit after an empty queue (300-1800;
   default 600), allowing the GCP host wrapper to power off the VM
@@ -51,9 +53,12 @@ Required environment variables:
 ## Security and operations
 
 - The worker never receives a Supabase service-role key.
+- Production mounts the worker token as a read-only file, so its value does not
+  appear in the systemd or Docker command line or the container environment.
 - Customer prompts are written to a mode-0600 temporary file and are not put in
   the OS process command line.
-- Each job has a 30-minute renewable lease and at most three attempts.
+- Each job has a 30-minute renewable lease. The worker renews it every minute,
+  allows up to 60 minutes for one L4 inference, and does not retry a timeout.
 - An empty queue shuts the worker down after 10 minutes; a clean worker exit
   powers off the GPU host, while the fixed startup auto-stop remains a backstop.
 - Output dimensions, duration, frame rate, codec, and size are checked with

--- a/services/video-inference-worker/gcp/startup.sh
+++ b/services/video-inference-worker/gcp/startup.sh
@@ -119,24 +119,40 @@ install -m 0755 /dev/stdin /usr/local/sbin/run-video-worker <<'WORKER_SCRIPT'
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-token="$(gcloud secrets versions access latest \
+readonly token_directory="/run/video-worker-secrets"
+readonly token_file="${token_directory}/video-worker-token"
+
+cleanup_worker_secret() {
+  rm -f "${token_file}"
+  rmdir "${token_directory}" 2>/dev/null || true
+}
+trap cleanup_worker_secret EXIT
+
+install -d -m 0700 "${token_directory}"
+gcloud secrets versions access latest \
   --secret=video-worker-token \
   --project=mighty-link-ai-connect \
-  --quiet)"
+  --quiet | tr -d '\r\n' > "${token_file}"
+if ! LC_ALL=C grep -Eq '^[A-Za-z0-9._~-]{32,256}$' "${token_file}"; then
+  echo "video-worker-token has an invalid format" >&2
+  exit 1
+fi
+chown 10001:10001 "${token_file}"
+chmod 0400 "${token_file}"
 
 set +e
 docker run --rm \
   --name video-worker \
   --gpus all \
   --env "VIDEO_WORKER_URL=${VIDEO_WORKER_URL}" \
-  --env "VIDEO_WORKER_TOKEN=${token}" \
+  --env VIDEO_WORKER_TOKEN_FILE=/run/secrets/video-worker-token \
   --env "VIDEO_WORKER_ID=${VIDEO_WORKER_ID}" \
   --env "VIDEO_IDLE_EXIT_SECONDS=${VIDEO_IDLE_EXIT_SECONDS}" \
+  --mount "type=bind,src=${token_file},dst=/run/secrets/video-worker-token,readonly" \
   --mount "type=bind,src=/srv/models/Wan2.2-TI2V-5B,dst=/models/Wan2.2-TI2V-5B,readonly" \
   "${VIDEO_CONTAINER_IMAGE}"
 exit_code=$?
 set -e
-unset token
 
 if [[ ${exit_code} -eq 0 ]]; then
   shutdown --poweroff now

--- a/services/video-inference-worker/test_worker.py
+++ b/services/video-inference-worker/test_worker.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 from worker import (
+    InferenceTimeout,
     LeaseLost,
     Settings,
     WorkerApi,
@@ -16,6 +18,41 @@ from worker import (
 
 
 class WorkerContractTest(unittest.TestCase):
+    def test_settings_prefers_mounted_worker_token_and_uses_l4_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as root_value:
+            root = Path(root_value)
+            source = root / "source"
+            model = root / "model"
+            output = root / "output"
+            source.mkdir()
+            model.mkdir()
+            (source / "generate.py").write_text("", encoding="utf-8")
+            token_file = root / "worker-token"
+            token_file.write_text("z" * 48, encoding="utf-8")
+            environment = {
+                "VIDEO_WORKER_URL": "https://example.test/functions/v1/video-worker-hub",
+                "VIDEO_WORKER_TOKEN": "must-not-win" * 4,
+                "VIDEO_WORKER_TOKEN_FILE": str(token_file),
+                "VIDEO_WORKER_ID": "gpu-worker-01",
+                "WAN_SOURCE_DIR": str(source),
+                "WAN_MODEL_DIR": str(model),
+                "VIDEO_OUTPUT_DIR": str(output),
+            }
+            with patch.dict(os.environ, environment, clear=True):
+                settings = Settings.from_env()
+
+            self.assertEqual(settings.worker_token, "z" * 48)
+            self.assertEqual(settings.generation_timeout_seconds, 3600)
+            self.assertFalse(InferenceTimeout.retryable)
+
+    def test_gcp_startup_mounts_secret_file_instead_of_token_environment(self) -> None:
+        startup = (Path(__file__).parent / "gcp" / "startup.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("VIDEO_WORKER_TOKEN_FILE=/run/secrets/video-worker-token", startup)
+        self.assertIn("dst=/run/secrets/video-worker-token,readonly", startup)
+        self.assertNotIn('--env "VIDEO_WORKER_TOKEN=${token}"', startup)
+
     def test_valid_job_contract_and_landscape_command(self) -> None:
         job = {
             "job_id": "11111111-1111-4111-8111-111111111111",

--- a/services/video-inference-worker/test_worker.py
+++ b/services/video-inference-worker/test_worker.py
@@ -7,11 +7,14 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from worker import (
+    InferenceMemoryExhausted,
+    InferenceProcessFailed,
     InferenceTimeout,
     LeaseLost,
     Settings,
     WorkerApi,
     build_wan_command,
+    classify_inference_failure,
     validate_job,
     validate_output,
 )
@@ -87,6 +90,30 @@ class WorkerContractTest(unittest.TestCase):
             )
         self.assertIn("704*1280", command)
         self.assertIn("ti2v-5B", command)
+
+    def test_inference_failure_is_classified_without_exposing_diagnostics(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            diagnostic = Path(root) / "diagnostic.log"
+            diagnostic.write_text(
+                "Namespace(prompt='private customer prompt') CUDA out of memory",
+                encoding="utf-8",
+            )
+            memory_error = classify_inference_failure(1, diagnostic)
+            process_error = classify_inference_failure(2, Path(root) / "missing.log")
+
+        self.assertIsInstance(memory_error, InferenceMemoryExhausted)
+        self.assertFalse(memory_error.retryable)
+        self.assertNotIn("private customer prompt", str(memory_error))
+        self.assertIsInstance(process_error, InferenceProcessFailed)
+        self.assertFalse(process_error.retryable)
+
+    def test_sigkill_is_treated_as_memory_pressure(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            diagnostic = Path(root) / "diagnostic.log"
+            diagnostic.write_bytes(b"")
+            error = classify_inference_failure(-9, diagnostic)
+
+        self.assertIsInstance(error, InferenceMemoryExhausted)
 
     def test_rejects_an_unsupported_runtime_contract(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "unsupported_model"):

--- a/services/video-inference-worker/worker.py
+++ b/services/video-inference-worker/worker.py
@@ -43,6 +43,7 @@ class LeaseLost(WorkerError):
 
 class InferenceTimeout(WorkerError):
     error_code = "inference_timeout"
+    retryable = False
 
 
 class OutputInvalid(WorkerError):
@@ -73,14 +74,21 @@ class Settings:
     @classmethod
     def from_env(cls) -> "Settings":
         worker_url = os.environ.get("VIDEO_WORKER_URL", "").strip()
-        worker_token = os.environ.get("VIDEO_WORKER_TOKEN", "").strip()
+        worker_token_file = os.environ.get("VIDEO_WORKER_TOKEN_FILE", "").strip()
+        if worker_token_file:
+            try:
+                worker_token = Path(worker_token_file).read_text(encoding="utf-8").strip()
+            except OSError as error:
+                raise ValueError("VIDEO_WORKER_TOKEN_FILE is unreadable") from error
+        else:
+            worker_token = os.environ.get("VIDEO_WORKER_TOKEN", "").strip()
         worker_id = os.environ.get("VIDEO_WORKER_ID", "gpu-worker-01").strip()
         source_dir = Path(os.environ.get("WAN_SOURCE_DIR", "/opt/Wan2.2"))
         model_dir = Path(os.environ.get("WAN_MODEL_DIR", "/models/Wan2.2-TI2V-5B"))
         output_dir = Path(os.environ.get("VIDEO_OUTPUT_DIR", "/work/output"))
         poll_seconds = float(os.environ.get("VIDEO_POLL_SECONDS", "5"))
         heartbeat_seconds = float(os.environ.get("VIDEO_HEARTBEAT_SECONDS", "60"))
-        timeout_seconds = int(os.environ.get("VIDEO_GENERATION_TIMEOUT_SECONDS", "1800"))
+        timeout_seconds = int(os.environ.get("VIDEO_GENERATION_TIMEOUT_SECONDS", "3600"))
         idle_exit_seconds = int(os.environ.get("VIDEO_IDLE_EXIT_SECONDS", "600"))
 
         parsed = urlparse(worker_url)
@@ -310,6 +318,7 @@ def generate_video(
             stderr=subprocess.DEVNULL,
             shell=False,
         )
+        print(f"started video inference {job_id}", flush=True)
         started = time.monotonic()
         next_heartbeat = started + settings.heartbeat_seconds
         while process.poll() is None:
@@ -324,6 +333,11 @@ def generate_video(
                 if not api.heartbeat(job_id, lease_token):
                     terminate(process)
                     raise LeaseLost("lease_lost")
+                elapsed_minutes = max(1, int((now - started) // 60))
+                print(
+                    f"video inference active {job_id}: {elapsed_minutes}m",
+                    flush=True,
+                )
                 next_heartbeat = now + settings.heartbeat_seconds
             time.sleep(2)
         if process.returncode != 0:

--- a/services/video-inference-worker/worker.py
+++ b/services/video-inference-worker/worker.py
@@ -46,6 +46,16 @@ class InferenceTimeout(WorkerError):
     retryable = False
 
 
+class InferenceMemoryExhausted(WorkerError):
+    error_code = "inference_memory_exhausted"
+    retryable = False
+
+
+class InferenceProcessFailed(WorkerError):
+    error_code = "inference_process_failed"
+    retryable = False
+
+
 class OutputInvalid(WorkerError):
     error_code = "output_invalid"
 
@@ -275,6 +285,35 @@ def build_wan_command(
     ]
 
 
+def classify_inference_failure(
+    return_code: int,
+    diagnostic_path: Path,
+) -> WorkerError:
+    """Classify a failed process without exposing its prompt-bearing output."""
+    diagnostic_tail = b""
+    try:
+        with diagnostic_path.open("rb") as diagnostic:
+            diagnostic.seek(0, os.SEEK_END)
+            diagnostic.seek(max(0, diagnostic.tell() - (2 * 1024 * 1024)))
+            diagnostic_tail = diagnostic.read().lower()
+    except OSError:
+        pass
+
+    memory_markers = (
+        b"cuda out of memory",
+        b"torch.outofmemoryerror",
+        b"out of memory",
+        b"cannot allocate memory",
+    )
+    sigkill = int(getattr(signal, "SIGKILL", 9))
+    killed_by_memory_pressure = return_code in {-sigkill, 128 + sigkill}
+    if killed_by_memory_pressure or any(
+        marker in diagnostic_tail for marker in memory_markers
+    ):
+        return InferenceMemoryExhausted("inference_memory_exhausted")
+    return InferenceProcessFailed("inference_process_failed")
+
+
 def generate_video(
     settings: Settings,
     api: WorkerApi,
@@ -287,6 +326,8 @@ def generate_video(
     output_path = settings.output_dir / f"{job_id}.mp4"
     output_path.unlink(missing_ok=True)
     prompt_file: Path | None = None
+    diagnostic_file: Any | None = None
+    diagnostic_path: Path | None = None
     process: subprocess.Popen[bytes] | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -300,6 +341,15 @@ def generate_video(
             temporary.write(prompt)
             prompt_file = Path(temporary.name)
         prompt_file.chmod(0o600)
+        diagnostic_file = tempfile.NamedTemporaryFile(
+            mode="w+b",
+            prefix="video-diagnostic-",
+            suffix=".log",
+            dir=settings.output_dir,
+            delete=False,
+        )
+        diagnostic_path = Path(diagnostic_file.name)
+        diagnostic_path.chmod(0o600)
         environment = os.environ.copy()
         environment.update(
             {
@@ -314,8 +364,8 @@ def generate_video(
             cwd=settings.wan_source_dir,
             env=environment,
             stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=diagnostic_file,
+            stderr=subprocess.STDOUT,
             shell=False,
         )
         print(f"started video inference {job_id}", flush=True)
@@ -341,7 +391,16 @@ def generate_video(
                 next_heartbeat = now + settings.heartbeat_seconds
             time.sleep(2)
         if process.returncode != 0:
-            raise WorkerError("inference_failed")
+            diagnostic_file.flush()
+            failure = classify_inference_failure(
+                process.returncode,
+                diagnostic_path,
+            )
+            print(
+                f"video inference exited {job_id}: {failure.error_code}",
+                flush=True,
+            )
+            raise failure
         validate_output(output_path, job)
         return output_path
     finally:
@@ -349,6 +408,10 @@ def generate_video(
             terminate(process)
         if prompt_file is not None:
             prompt_file.unlink(missing_ok=True)
+        if diagnostic_file is not None:
+            diagnostic_file.close()
+        if diagnostic_path is not None:
+            diagnostic_path.unlink(missing_ok=True)
 
 
 def validate_output(output_path: Path, job: dict[str, Any]) -> None:

--- a/supabase/functions/video-generation-hub/index.ts
+++ b/supabase/functions/video-generation-hub/index.ts
@@ -35,6 +35,7 @@ type JobRow = {
   charged_credits: number;
   output_storage_path: string | null;
   error_code: string | null;
+  started_at: string | null;
   created_at: string;
   updated_at: string;
   completed_at: string | null;
@@ -53,6 +54,7 @@ const JOB_SELECT = [
   "charged_credits",
   "output_storage_path",
   "error_code",
+  "started_at",
   "created_at",
   "updated_at",
   "completed_at",
@@ -327,6 +329,7 @@ async function publicJob(
     error_code: job.error_code,
     output_url: outputUrl,
     output_expires_at: outputExpiresAt,
+    started_at: job.started_at,
     created_at: job.created_at,
     updated_at: job.updated_at,
     completed_at: job.completed_at,

--- a/supabase/functions/video-worker-hub/worker_security.ts
+++ b/supabase/functions/video-worker-hub/worker_security.ts
@@ -37,6 +37,8 @@ export function isJobId(value: string): boolean {
 export function isWorkerErrorCode(value: string): boolean {
   return [
     "inference_failed",
+    "inference_memory_exhausted",
+    "inference_process_failed",
     "inference_timeout",
     "lease_lost",
     "output_invalid",

--- a/supabase/functions/video-worker-hub/worker_security_test.ts
+++ b/supabase/functions/video-worker-hub/worker_security_test.ts
@@ -33,6 +33,8 @@ Deno.test("worker identifiers and lease tokens are narrowly validated", () => {
   assertEquals(isLeaseToken("ab".repeat(32)), true);
   assertEquals(isLeaseToken("z".repeat(64)), false);
   assertEquals(isWorkerErrorCode("inference_failed"), true);
+  assertEquals(isWorkerErrorCode("inference_memory_exhausted"), true);
+  assertEquals(isWorkerErrorCode("inference_process_failed"), true);
   assertEquals(isWorkerErrorCode("raw exception text"), false);
 });
 

--- a/test/ui/features/video_studio/video_studio_models_test.dart
+++ b/test/ui/features/video_studio/video_studio_models_test.dart
@@ -45,11 +45,15 @@ void main() {
       'charged_credits': 300,
       'output_url': 'https://example.test/signed.mp4',
       'output_expires_at': '2026-08-20T12:00:00Z',
+      'started_at': '2026-08-20T10:03:00Z',
       'created_at': '2026-08-20T10:00:00Z',
+      'updated_at': '2026-08-20T10:08:00Z',
     });
 
     expect(job.isTerminal, isTrue);
     expect(job.isSuccessful, isTrue);
     expect(job.outputUrl?.host, 'example.test');
+    expect(job.startedAt, DateTime.utc(2026, 8, 20, 10, 3));
+    expect(job.updatedAt, DateTime.utc(2026, 8, 20, 10, 8));
   });
 }

--- a/test/ui/features/video_studio/video_studio_page_test.dart
+++ b/test/ui/features/video_studio/video_studio_page_test.dart
@@ -77,6 +77,39 @@ void main() {
     );
   });
 
+  testWidgets('active history explains GPU latency and shows worker activity', (
+    tester,
+  ) async {
+    final job = VideoGenerationJob(
+      id: '11111111-1111-4111-8111-111111111111',
+      modelKey: 'studio-video-v1',
+      prompt: 'A paper city wakes at sunrise',
+      durationSeconds: 5,
+      aspectRatio: '16:9',
+      resolution: '720p',
+      status: 'in_progress',
+      quotedCredits: 300,
+      chargedCredits: 0,
+      createdAt: DateTime.utc(2026, 8, 20, 10),
+      startedAt: DateTime.utc(2026, 8, 20, 10, 3),
+      updatedAt: DateTime.utc(2026, 8, 20, 10, 8),
+    );
+
+    await tester.pumpWidget(_app(jobs: [job]));
+    await tester.pump();
+
+    expect(
+      find.byKey(
+        const Key('video-progress-11111111-1111-4111-8111-111111111111'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('専用GPUで推論中です'), findsOneWidget);
+    expect(find.textContaining('最終処理確認'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
   testWidgets('authentication failure offers a direct login action', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- expose video worker start/heartbeat timestamps and show an indeterminate GPU progress state in Video Studio
- extend single-L4 inference timeout from 30 to 60 minutes and make timeout terminal so customers are not charged through repeated identical attempts
- capture a private, temporary inference diagnostic and report only bounded error codes; raw prompt-bearing output is never logged
- classify memory exhaustion and other process exits as terminal, preventing repeated 30-minute failures
- mount the dedicated worker token as a read-only file instead of placing it in the systemd/Docker command line
- add heartbeat progress logs that contain only the job ID and elapsed minutes

## Production evidence
- the reported job was claimed by `gpu-tokyo-01`; PostgreSQL heartbeats renewed its lease every minute
- NVIDIA L4 remained at 99-100% during Wan2.2 TI2V-5B inference
- after about 30 minutes the child process exited without an MP4, while GPU memory immediately returned to zero
- the 32GB host was already using about 21.5GiB before the final model-offload/VAE-decode stage, making host-memory pressure the leading cause
- attempt 1 was returned to `queued`; all 300 credits remain reserved and none have been charged

## Validation
- `flutter analyze lib/ui/features/video_studio test/ui/features/video_studio`
- `flutter test test/ui/features/video_studio/video_studio_models_test.dart test/ui/features/video_studio/video_studio_page_test.dart test/ui/features/video_studio/video_studio_view_model_test.dart test/ui/features/video_studio/video_studio_gateway_test.dart`
- `deno test supabase/functions/video-generation-hub/catalog_test.ts supabase/functions/video-generation-hub/worker_wake_test.ts supabase/functions/video-worker-hub/worker_security_test.ts`
- `deno check --no-lock --node-modules-dir=auto supabase/functions/video-generation-hub/index.ts`
- `python -m unittest discover -s services/video-inference-worker -p 'test_*.py'` (10 passed)
- Git Bash `bash -n services/video-inference-worker/gcp/startup.sh`

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Targeted widget tests and live GPU/DB monitoring cover this fix; a Playwright generation would create another paid GPU job.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code ultrareview was not run; deterministic Flutter, Deno, Python, shell, and live GPU/DB validation cover this incident fix.