### PR TITLE
fix: preserve video attempts on worker control errors

### DIFF
--- a/services/video-inference-worker/test_worker.py
+++ b/services/video-inference-worker/test_worker.py
@@ -12,9 +12,13 @@ from worker import (
     InferenceTimeout,
     LeaseLost,
     Settings,
+    UploadFailed,
     WorkerApi,
+    WorkerError,
+    WorkerShutdown,
     build_wan_command,
     classify_inference_failure,
+    safe_worker_error_detail,
     validate_job,
     validate_output,
 )
@@ -47,6 +51,18 @@ class WorkerContractTest(unittest.TestCase):
             self.assertEqual(settings.worker_token, "z" * 48)
             self.assertEqual(settings.generation_timeout_seconds, 3600)
             self.assertFalse(InferenceTimeout.retryable)
+
+    def test_control_errors_do_not_consume_all_paid_job_attempts(self) -> None:
+        self.assertFalse(WorkerError.retryable)
+        self.assertTrue(UploadFailed.retryable)
+        self.assertTrue(WorkerShutdown.retryable)
+
+    def test_worker_error_detail_allows_codes_and_redacts_other_text(self) -> None:
+        coded = WorkerError("worker_hub_http_500")
+        unsafe = WorkerError("customer prompt or upstream response: private")
+
+        self.assertEqual(safe_worker_error_detail(coded), "worker_hub_http_500")
+        self.assertEqual(safe_worker_error_detail(unsafe), "inference_failed")
 
     def test_gcp_startup_mounts_secret_file_instead_of_token_environment(self) -> None:
         startup = (Path(__file__).parent / "gcp" / "startup.sh").read_text(

--- a/services/video-inference-worker/worker.py
+++ b/services/video-inference-worker/worker.py
@@ -29,11 +29,12 @@ JOB_ID_RE = re.compile(
 )
 WORKER_ID_RE = re.compile(r"^[A-Za-z0-9._-]{3,80}$")
 LEASE_TOKEN_RE = re.compile(r"^[a-f0-9]{64}$", re.IGNORECASE)
+SAFE_ERROR_DETAIL_RE = re.compile(r"^[a-z0-9_]{1,120}$")
 
 
 class WorkerError(RuntimeError):
     error_code = "inference_failed"
-    retryable = True
+    retryable = False
 
 
 class LeaseLost(WorkerError):
@@ -62,10 +63,12 @@ class OutputInvalid(WorkerError):
 
 class UploadFailed(WorkerError):
     error_code = "upload_failed"
+    retryable = True
 
 
 class WorkerShutdown(WorkerError):
     error_code = "worker_shutdown"
+    retryable = True
 
 
 @dataclass(frozen=True)
@@ -314,6 +317,12 @@ def classify_inference_failure(
     return InferenceProcessFailed("inference_process_failed")
 
 
+def safe_worker_error_detail(error: WorkerError) -> str:
+    """Return only an allowlisted diagnostic code, never raw exception text."""
+    detail = str(error).strip().lower()
+    return detail if SAFE_ERROR_DETAIL_RE.fullmatch(detail) else error.error_code
+
+
 def generate_video(
     settings: Settings,
     api: WorkerApi,
@@ -330,6 +339,7 @@ def generate_video(
     diagnostic_path: Path | None = None
     process: subprocess.Popen[bytes] | None = None
     try:
+        print(f"preparing video inference {job_id}", flush=True)
         with tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
@@ -359,6 +369,7 @@ def generate_video(
                 "TRANSFORMERS_OFFLINE": "1",
             }
         )
+        print(f"launching video inference {job_id}", flush=True)
         process = subprocess.Popen(
             build_wan_command(settings, job, output_path),
             cwd=settings.wan_source_dir,
@@ -534,7 +545,11 @@ def run() -> None:
         except LeaseLost:
             print(f"discarded expired video lease {job_id}", flush=True)
         except WorkerError as error:
-            print(f"video job failed: {error.error_code}", flush=True)
+            print(
+                "video job failed: "
+                f"{error.error_code} ({safe_worker_error_detail(error)})",
+                flush=True,
+            )
             if job_id and lease_token:
                 try:
                     api.fail(job_id, lease_token, error.error_code, error.retryable)


### PR DESCRIPTION
## Summary
- make generic worker/control errors terminal instead of immediately reclaiming the same paid job
- preserve explicit retryability for uploads and operator shutdowns
- log only allowlisted fixed diagnostic codes and prompt-free inference stages

## Production evidence
- the fixed digest and 64GB host were verified directly
- retry attempt 2 emitted generic inference_failed after 155 seconds and attempt 3 was reclaimed immediately
- attempt 3 then emitted the same generic code after 6 seconds, proving immediate retry consumed the final attempt before a stable inference could run

## Validation
- python -m unittest discover -s services/video-inference-worker -p 'test_*.py' (12 passed)
- python -m py_compile services/video-inference-worker/worker.py
- git diff --check

## Minimal E2E Gate
- E2E-Exception: This worker-only control-flow patch is covered by deterministic Python contract tests; another browser generation would consume GPU time before the production image is updated.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Deterministic worker tests plus direct production digest, host-memory, and journal evidence cover this incident follow-up.