### PR TITLE
fix: release video model before VAE decode

### DIFF
--- a/services/video-inference-worker/Dockerfile
+++ b/services/video-inference-worker/Dockerfile
@@ -38,6 +38,12 @@ RUN git clone https://github.com/Wan-Video/Wan2.2.git /opt/Wan2.2 \
         "flash_attn==${FLASH_ATTN_VERSION}" \
     && rm -f /tmp/wan-requirements.txt
 
+COPY patches/wan22-release-dit-before-vae.patch /tmp/wan22-release-dit-before-vae.patch
+RUN cd /opt/Wan2.2 \
+    && git apply --check /tmp/wan22-release-dit-before-vae.patch \
+    && git apply /tmp/wan22-release-dit-before-vae.patch \
+    && rm -f /tmp/wan22-release-dit-before-vae.patch
+
 COPY wan_init.py /opt/Wan2.2/wan/__init__.py
 
 COPY requirements.txt /tmp/worker-requirements.txt

--- a/services/video-inference-worker/patches/wan22-release-dit-before-vae.patch
+++ b/services/video-inference-worker/patches/wan22-release-dit-before-vae.patch
@@ -1,0 +1,34 @@
+diff --git a/wan/textimage2video.py b/wan/textimage2video.py
+--- a/wan/textimage2video.py
++++ b/wan/textimage2video.py
+@@ -392,19 +392,27 @@ class WanTI2V:
+                     return_dict=False,
+                     generator=seed_g)[0]
+                 latents = [temp_x0.squeeze(0)]
+             x0 = latents
++
++            # The first-party worker runs one generation per subprocess. Release
++            # diffusion-only tensors before VAE decode, and drop the DiT instead
++            # of copying its full parameter set from GPU back to host memory.
++            del context, context_null, mask1, mask2, arg_c, arg_null
++            del latent_model_input, timestep, temp_ts
++            del noise_pred_cond, noise_pred_uncond, noise_pred, temp_x0
++            del noise, latents, timesteps, sample_scheduler
+             if offload_model:
+-                self.model.cpu()
+                 torch.cuda.synchronize()
++                del self.model
++                gc.collect()
+                 torch.cuda.empty_cache()
+             if self.rank == 0:
+                 videos = self.vae.decode(x0)
+ 
+-        del noise, latents
+-        del sample_scheduler
+         if offload_model:
+             gc.collect()
+             torch.cuda.synchronize()
++            torch.cuda.empty_cache()
+         if dist.is_initialized():
+             dist.barrier()
+ 

--- a/services/video-inference-worker/test_worker.py
+++ b/services/video-inference-worker/test_worker.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from worker import (
-    InferenceMemoryExhausted,
+    InferenceGpuMemoryExhausted,
+    InferenceHostMemoryExhausted,
     InferenceProcessFailed,
     InferenceTimeout,
     LeaseLost,
@@ -117,7 +118,7 @@ class WorkerContractTest(unittest.TestCase):
             memory_error = classify_inference_failure(1, diagnostic)
             process_error = classify_inference_failure(2, Path(root) / "missing.log")
 
-        self.assertIsInstance(memory_error, InferenceMemoryExhausted)
+        self.assertIsInstance(memory_error, InferenceGpuMemoryExhausted)
         self.assertFalse(memory_error.retryable)
         self.assertNotIn("private customer prompt", str(memory_error))
         self.assertIsInstance(process_error, InferenceProcessFailed)
@@ -129,7 +130,15 @@ class WorkerContractTest(unittest.TestCase):
             diagnostic.write_bytes(b"")
             error = classify_inference_failure(-9, diagnostic)
 
-        self.assertIsInstance(error, InferenceMemoryExhausted)
+        self.assertIsInstance(error, InferenceHostMemoryExhausted)
+
+    def test_host_allocation_failure_is_classified_separately(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            diagnostic = Path(root) / "diagnostic.log"
+            diagnostic.write_bytes(b"std::bad_alloc")
+            error = classify_inference_failure(1, diagnostic)
+
+        self.assertIsInstance(error, InferenceHostMemoryExhausted)
 
     def test_rejects_an_unsupported_runtime_contract(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "unsupported_model"):

--- a/services/video-inference-worker/worker.py
+++ b/services/video-inference-worker/worker.py
@@ -47,8 +47,13 @@ class InferenceTimeout(WorkerError):
     retryable = False
 
 
-class InferenceMemoryExhausted(WorkerError):
-    error_code = "inference_memory_exhausted"
+class InferenceGpuMemoryExhausted(WorkerError):
+    error_code = "inference_gpu_memory_exhausted"
+    retryable = False
+
+
+class InferenceHostMemoryExhausted(WorkerError):
+    error_code = "inference_host_memory_exhausted"
     retryable = False
 
 
@@ -302,18 +307,23 @@ def classify_inference_failure(
     except OSError:
         pass
 
-    memory_markers = (
+    gpu_memory_markers = (
         b"cuda out of memory",
         b"torch.outofmemoryerror",
-        b"out of memory",
+        b"cublas_status_alloc_failed",
+    )
+    host_memory_markers = (
+        b"memoryerror",
+        b"std::bad_alloc",
         b"cannot allocate memory",
     )
     sigkill = int(getattr(signal, "SIGKILL", 9))
-    killed_by_memory_pressure = return_code in {-sigkill, 128 + sigkill}
-    if killed_by_memory_pressure or any(
-        marker in diagnostic_tail for marker in memory_markers
+    if any(marker in diagnostic_tail for marker in gpu_memory_markers):
+        return InferenceGpuMemoryExhausted("inference_gpu_memory_exhausted")
+    if return_code in {-sigkill, 128 + sigkill} or any(
+        marker in diagnostic_tail for marker in host_memory_markers
     ):
-        return InferenceMemoryExhausted("inference_memory_exhausted")
+        return InferenceHostMemoryExhausted("inference_host_memory_exhausted")
     return InferenceProcessFailed("inference_process_failed")
 
 

--- a/supabase/functions/video-worker-hub/worker_security.ts
+++ b/supabase/functions/video-worker-hub/worker_security.ts
@@ -37,6 +37,8 @@ export function isJobId(value: string): boolean {
 export function isWorkerErrorCode(value: string): boolean {
   return [
     "inference_failed",
+    "inference_gpu_memory_exhausted",
+    "inference_host_memory_exhausted",
     "inference_memory_exhausted",
     "inference_process_failed",
     "inference_timeout",

--- a/supabase/functions/video-worker-hub/worker_security_test.ts
+++ b/supabase/functions/video-worker-hub/worker_security_test.ts
@@ -33,6 +33,8 @@ Deno.test("worker identifiers and lease tokens are narrowly validated", () => {
   assertEquals(isLeaseToken("ab".repeat(32)), true);
   assertEquals(isLeaseToken("z".repeat(64)), false);
   assertEquals(isWorkerErrorCode("inference_failed"), true);
+  assertEquals(isWorkerErrorCode("inference_gpu_memory_exhausted"), true);
+  assertEquals(isWorkerErrorCode("inference_host_memory_exhausted"), true);
   assertEquals(isWorkerErrorCode("inference_memory_exhausted"), true);
   assertEquals(isWorkerErrorCode("inference_process_failed"), true);
   assertEquals(isWorkerErrorCode("raw exception text"), false);


### PR DESCRIPTION
## Summary - patch the pinned Wan2.2 TI2V pipeline to release diffusion tensors before VAE decode - delete the per-process DiT model instead of copying it from GPU back to host memory - classify host SIGKILL and CUDA OOM separately while retaining the legacy accepted error code  ## Validation - Python worker tests: 13 passed - Deno format and lint: passed - Edge security tests: 4 passed - Patch applies to Wan2.2 commit 42bf4cfaa384bc21833865abc2f9e6c0e67233dc - Patched upstream module compiles successfully  ## Production recovery - Previous paid job d613b655-a479-4158-9f29-9ae988baab9c failed during the transition into final VAE decode and was fully refunded. - GPU VM remains terminated; deploy and another explicitly confirmed paid retry are still required. 

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 is unavailable in this recovery session; the scoped worker change has deterministic tests and an immutable-image rollback.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test flow or Playwright test/e2e route.
- E2E-Exception: GPU inference requires the dedicated L4 VM and a paid job, so CI uses deterministic contract tests and production smoke remains gated on explicit confirmation.
