### PR TITLE
fix: AI障害時も登録前トライアルを正直に継続

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -50,19 +50,18 @@ class LandingPage extends StatefulWidget {
     this.googleLoginEnabled,
     this.landingUri,
     this.showUnverifiedMarketingForQa = false,
-  }) : adapter = adapter ?? const SupabaseLandingPageAdapter(),
-       growthService = growthService ?? const GrowthMissionService(),
-       conversionAnalytics =
-           conversionAnalytics ?? const PostHogLandingConversionAnalytics(),
-       pendingTrialService =
-           pendingTrialService ?? const PendingLandingTrialService(),
-       signupCompletionService =
-           signupCompletionService ?? const LandingSignupCompletionService(),
-       acquisitionService =
-           acquisitionService ?? const GrowthAcquisitionService(),
-       conversionExperimentService =
-           conversionExperimentService ??
-           const LandingConversionExperimentService();
+  })  : adapter = adapter ?? const SupabaseLandingPageAdapter(),
+        growthService = growthService ?? const GrowthMissionService(),
+        conversionAnalytics =
+            conversionAnalytics ?? const PostHogLandingConversionAnalytics(),
+        pendingTrialService =
+            pendingTrialService ?? const PendingLandingTrialService(),
+        signupCompletionService =
+            signupCompletionService ?? const LandingSignupCompletionService(),
+        acquisitionService =
+            acquisitionService ?? const GrowthAcquisitionService(),
+        conversionExperimentService = conversionExperimentService ??
+            const LandingConversionExperimentService();
 
   @visibleForTesting
   static bool analyticsEnabledForUri(Uri? uri) {
@@ -221,8 +220,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   }
 
   Future<String> _resolveExperimentVisitorId() {
-    return _experimentVisitorIdFuture ??= widget.conversionExperimentService
-        .resolveVisitorId();
+    return _experimentVisitorIdFuture ??=
+        widget.conversionExperimentService.resolveVisitorId();
   }
 
   bool _hypothesisEnabled(String hypothesisId) {
@@ -286,8 +285,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         properties[key] = value;
       }
     }
-    properties['referral_present'] =
-        _pendingReferralCode != null ||
+    properties['referral_present'] = _pendingReferralCode != null ||
         const <String>{
           'ref',
           'referral',
@@ -391,8 +389,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
   Future<void> _bootstrapReferralInvite() async {
     await widget.growthService.capturePendingReferralFromUri();
-    final pendingReferralCode = await widget.growthService
-        .loadPendingReferralCode();
+    final pendingReferralCode =
+        await widget.growthService.loadPendingReferralCode();
     if (!mounted) {
       return;
     }
@@ -766,8 +764,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     } catch (e) {
       debugPrint('Trial preview failed: $e');
       unawaited(_recordConversionStage('trial_fallback'));
-      final canUseInstantPreview =
-          e is LandingPageAuthUnavailableException ||
+      final canUseInstantPreview = e is LandingPageAuthUnavailableException ||
           (e is LandingTrialPreviewException &&
               e.code == 'trial_ai_unavailable' &&
               e.canUseInstantPreview);
@@ -1098,9 +1095,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
     final compact = raw.replaceAll('\n', ' ').trim();
     if (compact.isNotEmpty) {
-      final safe = compact.length > 80
-          ? '${compact.substring(0, 80)}...'
-          : compact;
+      final safe =
+          compact.length > 80 ? '${compact.substring(0, 80)}...' : compact;
       return (safe, 'AIの返答をそのまま簡易表示しています。');
     }
 
@@ -2105,8 +2101,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   Future<void> _shareOnX() async {
     const siteUrl = 'https://my-web-app-b67f4.web.app/';
     final userCount = _totalUsers > 10 ? '登録者$_totalUsers人突破！' : '';
-    final text =
-        'スマホでギター録音＋21のSaaSを1アプリに統合。'
+    final text = 'スマホでギター録音＋21のSaaSを1アプリに統合。'
         '自分株式会社 $userCount\n'
         '無料コアから使えます。Proで支援できます👇\n'
         '$siteUrl\n'
@@ -4085,9 +4080,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         color: isDarkSteps ? const Color(0xFF1A1A1A) : Colors.white,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: isDarkSteps
-              ? const Color(0xFF2A2A2A)
-              : const Color(0xFFE2E8F0),
+          color:
+              isDarkSteps ? const Color(0xFF2A2A2A) : const Color(0xFFE2E8F0),
         ),
         boxShadow: [
           BoxShadow(
@@ -4247,8 +4241,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   firstUserGrowthMode
                       ? 'Xから来た方へ: まず1タップで結果を見る'
                       : heroMode
-                      ? '登録なしで試す: いま詰まっていることは？'
-                      : 'AIに「今日やる1件」を聞く',
+                          ? '登録なしで試す: いま詰まっていることは？'
+                          : 'AIに「今日やる1件」を聞く',
                   style: TextStyle(
                     fontSize: compactHero ? 16 : 18,
                     fontWeight: FontWeight.w800,
@@ -4260,10 +4254,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   firstUserGrowthMode
                       ? '入力・登録・カードは不要です。下のボタンだけで「今やる1件」を確認し、役立った時だけ保存できます。'
                       : compactHero
-                      ? '登録不要。例を押すか1行書くと「今やる1件」を返します。'
-                      : heroMode
-                      ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
-                      : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
+                          ? '登録不要。例を押すか1行書くと「今やる1件」を返します。'
+                          : heroMode
+                              ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
+                              : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
                   style: TextStyle(
                     color: heroMode
                         ? const Color(0xFFBCC6CE)
@@ -4294,15 +4288,14 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       avatar: Icon(Icons.flash_on, size: compactHero ? 16 : 18),
                       label: Text(compactHero ? '最優先' : '今日の最優先'),
                       visualDensity: compactHero ? VisualDensity.compact : null,
-                      materialTapTargetSize: compactHero
-                          ? MaterialTapTargetSize.shrinkWrap
-                          : null,
+                      materialTapTargetSize:
+                          compactHero ? MaterialTapTargetSize.shrinkWrap : null,
                       onPressed: _isTrialLoading
                           ? null
                           : () => _runQuickTrialSample(
-                              '今日の最優先タスクを1件に絞りたい',
-                              recordHeroCta: heroMode,
-                            ),
+                                '今日の最優先タスクを1件に絞りたい',
+                                recordHeroCta: heroMode,
+                              ),
                     ),
                     ActionChip(
                       key: const Key('landing_trial_sample_plan'),
@@ -4312,30 +4305,28 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       ),
                       label: Text(compactHero ? '計画' : '今日の計画を立てる'),
                       visualDensity: compactHero ? VisualDensity.compact : null,
-                      materialTapTargetSize: compactHero
-                          ? MaterialTapTargetSize.shrinkWrap
-                          : null,
+                      materialTapTargetSize:
+                          compactHero ? MaterialTapTargetSize.shrinkWrap : null,
                       onPressed: _isTrialLoading
                           ? null
                           : () => _runQuickTrialSample(
-                              '今日1日の計画を立てて、最も重要なことに集中したい',
-                              recordHeroCta: heroMode,
-                            ),
+                                '今日1日の計画を立てて、最も重要なことに集中したい',
+                                recordHeroCta: heroMode,
+                              ),
                     ),
                     ActionChip(
                       key: const Key('landing_trial_sample_procrastination'),
                       avatar: Icon(Icons.done_all, size: compactHero ? 16 : 18),
                       label: Text(compactHero ? '先送り' : '先送り解消'),
                       visualDensity: compactHero ? VisualDensity.compact : null,
-                      materialTapTargetSize: compactHero
-                          ? MaterialTapTargetSize.shrinkWrap
-                          : null,
+                      materialTapTargetSize:
+                          compactHero ? MaterialTapTargetSize.shrinkWrap : null,
                       onPressed: _isTrialLoading
                           ? null
                           : () => _runQuickTrialSample(
-                              '今いちばん先送りしていることを片付けたい',
-                              recordHeroCta: heroMode,
-                            ),
+                                '今いちばん先送りしていることを片付けたい',
+                                recordHeroCta: heroMode,
+                              ),
                     ),
                   ],
                 ),
@@ -4373,8 +4364,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                     onPressed: _isTrialLoading
                         ? null
                         : heroMode
-                        ? _runHeroTrialActionPreview
-                        : _runTrialActionPreview,
+                            ? _runHeroTrialActionPreview
+                            : _runTrialActionPreview,
                     icon: _isTrialLoading
                         ? const SizedBox(
                             width: 20,
@@ -4705,9 +4696,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
               onPressed: _isTrialLoading
                   ? null
                   : () => _runQuickTrialSample(
-                      samplePrompt,
-                      recordHeroCta: heroMode,
-                    ),
+                        samplePrompt,
+                        recordHeroCta: heroMode,
+                      ),
               icon: const Icon(Icons.bolt, size: 17),
               label: const Text('1タップで「今日やる1件」を出す'),
               style: FilledButton.styleFrom(
@@ -4725,9 +4716,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
               onPressed: _isTrialLoading
                   ? null
                   : () => _runQuickTrialSample(
-                      samplePrompt,
-                      recordHeroCta: heroMode,
-                    ),
+                        samplePrompt,
+                        recordHeroCta: heroMode,
+                      ),
               icon: const Icon(Icons.bolt, size: 17),
               label: const Text('この入力例でAIに提案させる'),
               style: OutlinedButton.styleFrom(
@@ -5114,9 +5105,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                 1: FlexColumnWidth(1),
               },
               border: TableBorder.all(
-                color: isDark
-                    ? const Color(0xFF374151)
-                    : const Color(0xFFE5E7EB),
+                color:
+                    isDark ? const Color(0xFF374151) : const Color(0xFFE5E7EB),
                 borderRadius: BorderRadius.circular(8),
               ),
               children: [
@@ -5125,13 +5115,13 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                     decoration: BoxDecoration(
                       color: i == 0
                           ? (isDark
-                                ? const Color(0xFF1E293B)
-                                : const Color(0xFFEEF2FF))
+                              ? const Color(0xFF1E293B)
+                              : const Color(0xFFEEF2FF))
                           : (i.isEven
-                                ? (isDark
-                                      ? const Color(0xFF111827)
-                                      : const Color(0xFFF9FAFB))
-                                : null),
+                              ? (isDark
+                                  ? const Color(0xFF111827)
+                                  : const Color(0xFFF9FAFB))
+                              : null),
                     ),
                     children: [
                       Padding(
@@ -5143,9 +5133,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                           rows[i].$1,
                           style: TextStyle(
                             fontSize: 13,
-                            fontWeight: i == 0
-                                ? FontWeight.w700
-                                : FontWeight.w500,
+                            fontWeight:
+                                i == 0 ? FontWeight.w700 : FontWeight.w500,
                             color: i == 0 ? const Color(0xFF3949AB) : null,
                             height: 1.5,
                           ),
@@ -5160,9 +5149,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                           rows[i].$2,
                           style: TextStyle(
                             fontSize: 13,
-                            fontWeight: i == 0
-                                ? FontWeight.w700
-                                : FontWeight.w400,
+                            fontWeight:
+                                i == 0 ? FontWeight.w700 : FontWeight.w400,
                             color: i == 0
                                 ? const Color(0xFF6B7280)
                                 : const Color(0xFF9CA3AF),
@@ -5413,11 +5401,11 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
               Text(
                 _isSignUp
                     ? (_googleLoginEnabled
-                          ? 'Google認証で無料登録できます。登録画面でカード情報は求めません。'
-                          : 'メールで届くログインリンクから無料登録できます。登録画面でカード情報は求めません。')
+                        ? 'Google認証で無料登録できます。登録画面でカード情報は求めません。'
+                        : 'メールで届くログインリンクから無料登録できます。登録画面でカード情報は求めません。')
                     : (_googleLoginEnabled
-                          ? 'Googleならパスワード入力なしで、そのまま続きから再開できます。'
-                          : '既存ユーザーもMagic Linkが最短です。パスワード入力なしで、そのまま再開できます。'),
+                        ? 'Googleならパスワード入力なしで、そのまま続きから再開できます。'
+                        : '既存ユーザーもMagic Linkが最短です。パスワード入力なしで、そのまま再開できます。'),
                 key: const Key('landing_auth_mode_description'),
                 style: const TextStyle(color: Color(0xFF64748B), height: 1.5),
               ),
@@ -5504,16 +5492,14 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                 height: 52,
                 child: _googleLoginEnabled
                     ? OutlinedButton(
-                        onPressed:
-                            (_isLoading ||
+                        onPressed: (_isLoading ||
                                 (_showInboxShortcut && _isMagicLinkCoolingDown))
                             ? null
                             : _sendMagicLink,
                         child: _buildMagicLinkButtonContent(),
                       )
                     : FilledButton(
-                        onPressed:
-                            (_isLoading ||
+                        onPressed: (_isLoading ||
                                 (_showInboxShortcut && _isMagicLinkCoolingDown))
                             ? null
                             : _sendMagicLink,
@@ -6566,11 +6552,11 @@ class _WorkflowLandingHero extends StatelessWidget {
         final compactTrial = compact && inlineTrial != null;
         final headingSize = compact
             ? compactTrial
-                  ? 26.0
-                  : 38.0
+                ? 26.0
+                : 38.0
             : constraints.maxWidth >= 1220
-            ? 68.0
-            : 56.0;
+                ? 68.0
+                : 56.0;
         final pagePadding = EdgeInsets.fromLTRB(
           compactTrial ? 12 : (compact ? 20 : 64),
           compactTrial ? 14 : (compact ? 24 : 36),
@@ -6601,15 +6587,15 @@ class _WorkflowLandingHero extends StatelessWidget {
                       filterQuality: FilterQuality.medium,
                       errorBuilder: (context, error, stackTrace) =>
                           const DecoratedBox(
-                            key: Key('landing_hero_media_fallback'),
-                            decoration: BoxDecoration(
-                              gradient: RadialGradient(
-                                center: Alignment(0.58, -0.3),
-                                radius: 1.22,
-                                colors: [Color(0xFF15334E), Color(0xFF07111E)],
-                              ),
-                            ),
+                        key: Key('landing_hero_media_fallback'),
+                        decoration: BoxDecoration(
+                          gradient: RadialGradient(
+                            center: Alignment(0.58, -0.3),
+                            radius: 1.22,
+                            colors: [Color(0xFF15334E), Color(0xFF07111E)],
                           ),
+                        ),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -13,6 +13,7 @@ import '../services/landing_conversion_experiment_service.dart';
 import '../services/landing_oauth_callback_failure.dart';
 import '../services/landing_page_adapter.dart';
 import '../services/landing_signup_completion_service.dart';
+import '../services/landing_trial_instant_preview.dart';
 import '../services/pending_landing_trial_service.dart';
 import '../services/route_visibility_observer.dart';
 import '../utils/route_document_title.dart';
@@ -49,18 +50,19 @@ class LandingPage extends StatefulWidget {
     this.googleLoginEnabled,
     this.landingUri,
     this.showUnverifiedMarketingForQa = false,
-  })  : adapter = adapter ?? const SupabaseLandingPageAdapter(),
-        growthService = growthService ?? const GrowthMissionService(),
-        conversionAnalytics =
-            conversionAnalytics ?? const PostHogLandingConversionAnalytics(),
-        pendingTrialService =
-            pendingTrialService ?? const PendingLandingTrialService(),
-        signupCompletionService =
-            signupCompletionService ?? const LandingSignupCompletionService(),
-        acquisitionService =
-            acquisitionService ?? const GrowthAcquisitionService(),
-        conversionExperimentService = conversionExperimentService ??
-            const LandingConversionExperimentService();
+  }) : adapter = adapter ?? const SupabaseLandingPageAdapter(),
+       growthService = growthService ?? const GrowthMissionService(),
+       conversionAnalytics =
+           conversionAnalytics ?? const PostHogLandingConversionAnalytics(),
+       pendingTrialService =
+           pendingTrialService ?? const PendingLandingTrialService(),
+       signupCompletionService =
+           signupCompletionService ?? const LandingSignupCompletionService(),
+       acquisitionService =
+           acquisitionService ?? const GrowthAcquisitionService(),
+       conversionExperimentService =
+           conversionExperimentService ??
+           const LandingConversionExperimentService();
 
   @visibleForTesting
   static bool analyticsEnabledForUri(Uri? uri) {
@@ -103,6 +105,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   bool _obscurePassword = true;
   bool _showPasswordAuth = false;
   bool _showSaveCtaPrompt = false;
+  bool _trialUsesInstantPreview = false;
   bool _showInboxShortcut = false;
   bool _showAllUniqueFeatures = false;
   bool _showTrialAnswerPreview = true;
@@ -218,8 +221,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   }
 
   Future<String> _resolveExperimentVisitorId() {
-    return _experimentVisitorIdFuture ??=
-        widget.conversionExperimentService.resolveVisitorId();
+    return _experimentVisitorIdFuture ??= widget.conversionExperimentService
+        .resolveVisitorId();
   }
 
   bool _hypothesisEnabled(String hypothesisId) {
@@ -283,7 +286,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         properties[key] = value;
       }
     }
-    properties['referral_present'] = _pendingReferralCode != null ||
+    properties['referral_present'] =
+        _pendingReferralCode != null ||
         const <String>{
           'ref',
           'referral',
@@ -387,8 +391,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
   Future<void> _bootstrapReferralInvite() async {
     await widget.growthService.capturePendingReferralFromUri();
-    final pendingReferralCode =
-        await widget.growthService.loadPendingReferralCode();
+    final pendingReferralCode = await widget.growthService
+        .loadPendingReferralCode();
     if (!mounted) {
       return;
     }
@@ -730,6 +734,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         _trialErrorTitle = '入力内容を確認してください';
         _trialErrorMessage = 'いま詰まっていることを1行入力してください。';
         _showSaveCtaPrompt = false;
+        _trialUsesInstantPreview = false;
       });
       return;
     }
@@ -743,6 +748,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       _trialErrorTitle = null;
       _trialErrorMessage = null;
       _showSaveCtaPrompt = false;
+      _trialUsesInstantPreview = false;
     });
     try {
       final result = await widget.adapter.improveTrialPrompt(prompt: input);
@@ -754,11 +760,31 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         _trialErrorTitle = null;
         _trialErrorMessage = null;
         _showSaveCtaPrompt = true;
+        _trialUsesInstantPreview = false;
       });
       _scrollToTrialMagicLink(requestFocus: false);
     } catch (e) {
       debugPrint('Trial preview failed: $e');
       unawaited(_recordConversionStage('trial_fallback'));
+      final canUseInstantPreview =
+          e is LandingPageAuthUnavailableException ||
+          (e is LandingTrialPreviewException &&
+              e.code == 'trial_ai_unavailable' &&
+              e.canUseInstantPreview);
+      if (canUseInstantPreview) {
+        final preview = buildLandingTrialInstantPreview(input);
+        if (!mounted) return;
+        setState(() {
+          _trialAction = preview.action;
+          _trialReason = preview.reason;
+          _trialErrorTitle = null;
+          _trialErrorMessage = null;
+          _showSaveCtaPrompt = false;
+          _trialUsesInstantPreview = true;
+        });
+        _scrollToTrialMagicLink(requestFocus: false);
+        return;
+      }
       final failure = _resolveTrialPreviewError(e);
       if (!mounted) return;
       setState(() {
@@ -767,6 +793,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         _trialErrorTitle = failure.$1;
         _trialErrorMessage = failure.$2;
         _showSaveCtaPrompt = false;
+        _trialUsesInstantPreview = false;
       });
     } finally {
       if (mounted) {
@@ -967,7 +994,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
   void _handleStickySignup() {
     unawaited(_recordConversionStage('sticky_cta'));
-    if (_trialAction != null && _hypothesisEnabled('h04')) {
+    if (_trialAction != null &&
+        !_trialUsesInstantPreview &&
+        _hypothesisEnabled('h04')) {
       unawaited(_recordSaveStages());
       setState(() {
         _showSaveCtaPrompt = true;
@@ -1069,8 +1098,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
     final compact = raw.replaceAll('\n', ' ').trim();
     if (compact.isNotEmpty) {
-      final safe =
-          compact.length > 80 ? '${compact.substring(0, 80)}...' : compact;
+      final safe = compact.length > 80
+          ? '${compact.substring(0, 80)}...'
+          : compact;
       return (safe, 'AIの返答をそのまま簡易表示しています。');
     }
 
@@ -1114,7 +1144,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         _trialReason == null &&
         _trialErrorTitle == null &&
         _trialErrorMessage == null &&
-        !_showSaveCtaPrompt) {
+        !_showSaveCtaPrompt &&
+        !_trialUsesInstantPreview) {
       return;
     }
     setState(() {
@@ -1123,6 +1154,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       _trialErrorTitle = null;
       _trialErrorMessage = null;
       _showSaveCtaPrompt = false;
+      _trialUsesInstantPreview = false;
       if (shouldRestorePreview) {
         _showTrialAnswerPreview = true;
       }
@@ -2073,7 +2105,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   Future<void> _shareOnX() async {
     const siteUrl = 'https://my-web-app-b67f4.web.app/';
     final userCount = _totalUsers > 10 ? '登録者$_totalUsers人突破！' : '';
-    final text = 'スマホでギター録音＋21のSaaSを1アプリに統合。'
+    final text =
+        'スマホでギター録音＋21のSaaSを1アプリに統合。'
         '自分株式会社 $userCount\n'
         '無料コアから使えます。Proで支援できます👇\n'
         '$siteUrl\n'
@@ -4052,8 +4085,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         color: isDarkSteps ? const Color(0xFF1A1A1A) : Colors.white,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color:
-              isDarkSteps ? const Color(0xFF2A2A2A) : const Color(0xFFE2E8F0),
+          color: isDarkSteps
+              ? const Color(0xFF2A2A2A)
+              : const Color(0xFFE2E8F0),
         ),
         boxShadow: [
           BoxShadow(
@@ -4213,8 +4247,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   firstUserGrowthMode
                       ? 'Xから来た方へ: まず1タップで結果を見る'
                       : heroMode
-                          ? '登録なしで試す: いま詰まっていることは？'
-                          : 'AIに「今日やる1件」を聞く',
+                      ? '登録なしで試す: いま詰まっていることは？'
+                      : 'AIに「今日やる1件」を聞く',
                   style: TextStyle(
                     fontSize: compactHero ? 16 : 18,
                     fontWeight: FontWeight.w800,
@@ -4226,10 +4260,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   firstUserGrowthMode
                       ? '入力・登録・カードは不要です。下のボタンだけで「今やる1件」を確認し、役立った時だけ保存できます。'
                       : compactHero
-                          ? '登録不要。例を押すか1行書くと「今やる1件」を返します。'
-                          : heroMode
-                              ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
-                              : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
+                      ? '登録不要。例を押すか1行書くと「今やる1件」を返します。'
+                      : heroMode
+                      ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
+                      : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
                   style: TextStyle(
                     color: heroMode
                         ? const Color(0xFFBCC6CE)
@@ -4260,14 +4294,15 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       avatar: Icon(Icons.flash_on, size: compactHero ? 16 : 18),
                       label: Text(compactHero ? '最優先' : '今日の最優先'),
                       visualDensity: compactHero ? VisualDensity.compact : null,
-                      materialTapTargetSize:
-                          compactHero ? MaterialTapTargetSize.shrinkWrap : null,
+                      materialTapTargetSize: compactHero
+                          ? MaterialTapTargetSize.shrinkWrap
+                          : null,
                       onPressed: _isTrialLoading
                           ? null
                           : () => _runQuickTrialSample(
-                                '今日の最優先タスクを1件に絞りたい',
-                                recordHeroCta: heroMode,
-                              ),
+                              '今日の最優先タスクを1件に絞りたい',
+                              recordHeroCta: heroMode,
+                            ),
                     ),
                     ActionChip(
                       key: const Key('landing_trial_sample_plan'),
@@ -4277,28 +4312,30 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       ),
                       label: Text(compactHero ? '計画' : '今日の計画を立てる'),
                       visualDensity: compactHero ? VisualDensity.compact : null,
-                      materialTapTargetSize:
-                          compactHero ? MaterialTapTargetSize.shrinkWrap : null,
+                      materialTapTargetSize: compactHero
+                          ? MaterialTapTargetSize.shrinkWrap
+                          : null,
                       onPressed: _isTrialLoading
                           ? null
                           : () => _runQuickTrialSample(
-                                '今日1日の計画を立てて、最も重要なことに集中したい',
-                                recordHeroCta: heroMode,
-                              ),
+                              '今日1日の計画を立てて、最も重要なことに集中したい',
+                              recordHeroCta: heroMode,
+                            ),
                     ),
                     ActionChip(
                       key: const Key('landing_trial_sample_procrastination'),
                       avatar: Icon(Icons.done_all, size: compactHero ? 16 : 18),
                       label: Text(compactHero ? '先送り' : '先送り解消'),
                       visualDensity: compactHero ? VisualDensity.compact : null,
-                      materialTapTargetSize:
-                          compactHero ? MaterialTapTargetSize.shrinkWrap : null,
+                      materialTapTargetSize: compactHero
+                          ? MaterialTapTargetSize.shrinkWrap
+                          : null,
                       onPressed: _isTrialLoading
                           ? null
                           : () => _runQuickTrialSample(
-                                '今いちばん先送りしていることを片付けたい',
-                                recordHeroCta: heroMode,
-                              ),
+                              '今いちばん先送りしていることを片付けたい',
+                              recordHeroCta: heroMode,
+                            ),
                     ),
                   ],
                 ),
@@ -4336,8 +4373,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                     onPressed: _isTrialLoading
                         ? null
                         : heroMode
-                            ? _runHeroTrialActionPreview
-                            : _runTrialActionPreview,
+                        ? _runHeroTrialActionPreview
+                        : _runTrialActionPreview,
                     icon: _isTrialLoading
                         ? const SizedBox(
                             width: 20,
@@ -4471,7 +4508,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          'AIからの提案',
+                          _trialUsesInstantPreview
+                              ? '簡易プレビュー（AI未使用）'
+                              : 'AIからの提案',
+                          key: const Key('landing_trial_result_source'),
                           style: TextStyle(
                             fontSize: 12,
                             fontWeight: FontWeight.w700,
@@ -4504,7 +4544,39 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                             ),
                           ),
                         ],
-                        if (_hypothesisEnabled('h10')) ...[
+                        if (_trialUsesInstantPreview) ...[
+                          const SizedBox(height: 10),
+                          Container(
+                            key: const Key(
+                              'landing_trial_instant_preview_notice',
+                            ),
+                            width: double.infinity,
+                            padding: const EdgeInsets.all(10),
+                            decoration: BoxDecoration(
+                              color: heroMode
+                                  ? const Color(0xFF142431)
+                                  : const Color(0xFFF8FAFC),
+                              borderRadius: BorderRadius.circular(6),
+                              border: Border.all(
+                                color: heroMode
+                                    ? const Color(0x665B7181)
+                                    : const Color(0xFFCBD5E1),
+                              ),
+                            ),
+                            child: Text(
+                              'AIに接続できなかったため、入力内容を端末内のルールで整理した簡易案です。登録や保存は行いません。',
+                              style: TextStyle(
+                                color: heroMode
+                                    ? const Color(0xFFBCC6CE)
+                                    : const Color(0xFF475569),
+                                fontSize: 12,
+                                height: 1.5,
+                              ),
+                            ),
+                          ),
+                        ],
+                        if (!_trialUsesInstantPreview &&
+                            _hypothesisEnabled('h10')) ...[
                           const SizedBox(height: 10),
                           Text(
                             '登録すると、今回の入力・提案・理由を同じブラウザから引き継げます。',
@@ -4520,7 +4592,17 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                           ),
                         ],
                         const SizedBox(height: 12),
-                        if (_hypothesisEnabled('h04'))
+                        if (_trialUsesInstantPreview)
+                          SizedBox(
+                            width: double.infinity,
+                            child: OutlinedButton.icon(
+                              key: const Key('landing_trial_ai_retry'),
+                              onPressed: _runTrialActionPreview,
+                              icon: const Icon(Icons.refresh),
+                              label: const Text('AIの提案をもう一度試す'),
+                            ),
+                          )
+                        else if (_hypothesisEnabled('h04'))
                           _buildInlineTrialMagicLink()
                         else
                           SizedBox(
@@ -4623,9 +4705,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
               onPressed: _isTrialLoading
                   ? null
                   : () => _runQuickTrialSample(
-                        samplePrompt,
-                        recordHeroCta: heroMode,
-                      ),
+                      samplePrompt,
+                      recordHeroCta: heroMode,
+                    ),
               icon: const Icon(Icons.bolt, size: 17),
               label: const Text('1タップで「今日やる1件」を出す'),
               style: FilledButton.styleFrom(
@@ -4643,9 +4725,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
               onPressed: _isTrialLoading
                   ? null
                   : () => _runQuickTrialSample(
-                        samplePrompt,
-                        recordHeroCta: heroMode,
-                      ),
+                      samplePrompt,
+                      recordHeroCta: heroMode,
+                    ),
               icon: const Icon(Icons.bolt, size: 17),
               label: const Text('この入力例でAIに提案させる'),
               style: OutlinedButton.styleFrom(
@@ -5032,8 +5114,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                 1: FlexColumnWidth(1),
               },
               border: TableBorder.all(
-                color:
-                    isDark ? const Color(0xFF374151) : const Color(0xFFE5E7EB),
+                color: isDark
+                    ? const Color(0xFF374151)
+                    : const Color(0xFFE5E7EB),
                 borderRadius: BorderRadius.circular(8),
               ),
               children: [
@@ -5042,13 +5125,13 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                     decoration: BoxDecoration(
                       color: i == 0
                           ? (isDark
-                              ? const Color(0xFF1E293B)
-                              : const Color(0xFFEEF2FF))
+                                ? const Color(0xFF1E293B)
+                                : const Color(0xFFEEF2FF))
                           : (i.isEven
-                              ? (isDark
-                                  ? const Color(0xFF111827)
-                                  : const Color(0xFFF9FAFB))
-                              : null),
+                                ? (isDark
+                                      ? const Color(0xFF111827)
+                                      : const Color(0xFFF9FAFB))
+                                : null),
                     ),
                     children: [
                       Padding(
@@ -5060,8 +5143,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                           rows[i].$1,
                           style: TextStyle(
                             fontSize: 13,
-                            fontWeight:
-                                i == 0 ? FontWeight.w700 : FontWeight.w500,
+                            fontWeight: i == 0
+                                ? FontWeight.w700
+                                : FontWeight.w500,
                             color: i == 0 ? const Color(0xFF3949AB) : null,
                             height: 1.5,
                           ),
@@ -5076,8 +5160,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                           rows[i].$2,
                           style: TextStyle(
                             fontSize: 13,
-                            fontWeight:
-                                i == 0 ? FontWeight.w700 : FontWeight.w400,
+                            fontWeight: i == 0
+                                ? FontWeight.w700
+                                : FontWeight.w400,
                             color: i == 0
                                 ? const Color(0xFF6B7280)
                                 : const Color(0xFF9CA3AF),
@@ -5328,11 +5413,11 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
               Text(
                 _isSignUp
                     ? (_googleLoginEnabled
-                        ? 'Google認証で無料登録できます。登録画面でカード情報は求めません。'
-                        : 'メールで届くログインリンクから無料登録できます。登録画面でカード情報は求めません。')
+                          ? 'Google認証で無料登録できます。登録画面でカード情報は求めません。'
+                          : 'メールで届くログインリンクから無料登録できます。登録画面でカード情報は求めません。')
                     : (_googleLoginEnabled
-                        ? 'Googleならパスワード入力なしで、そのまま続きから再開できます。'
-                        : '既存ユーザーもMagic Linkが最短です。パスワード入力なしで、そのまま再開できます。'),
+                          ? 'Googleならパスワード入力なしで、そのまま続きから再開できます。'
+                          : '既存ユーザーもMagic Linkが最短です。パスワード入力なしで、そのまま再開できます。'),
                 key: const Key('landing_auth_mode_description'),
                 style: const TextStyle(color: Color(0xFF64748B), height: 1.5),
               ),
@@ -5419,14 +5504,16 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                 height: 52,
                 child: _googleLoginEnabled
                     ? OutlinedButton(
-                        onPressed: (_isLoading ||
+                        onPressed:
+                            (_isLoading ||
                                 (_showInboxShortcut && _isMagicLinkCoolingDown))
                             ? null
                             : _sendMagicLink,
                         child: _buildMagicLinkButtonContent(),
                       )
                     : FilledButton(
-                        onPressed: (_isLoading ||
+                        onPressed:
+                            (_isLoading ||
                                 (_showInboxShortcut && _isMagicLinkCoolingDown))
                             ? null
                             : _sendMagicLink,
@@ -6479,11 +6566,11 @@ class _WorkflowLandingHero extends StatelessWidget {
         final compactTrial = compact && inlineTrial != null;
         final headingSize = compact
             ? compactTrial
-                ? 26.0
-                : 38.0
+                  ? 26.0
+                  : 38.0
             : constraints.maxWidth >= 1220
-                ? 68.0
-                : 56.0;
+            ? 68.0
+            : 56.0;
         final pagePadding = EdgeInsets.fromLTRB(
           compactTrial ? 12 : (compact ? 20 : 64),
           compactTrial ? 14 : (compact ? 24 : 36),
@@ -6514,15 +6601,15 @@ class _WorkflowLandingHero extends StatelessWidget {
                       filterQuality: FilterQuality.medium,
                       errorBuilder: (context, error, stackTrace) =>
                           const DecoratedBox(
-                        key: Key('landing_hero_media_fallback'),
-                        decoration: BoxDecoration(
-                          gradient: RadialGradient(
-                            center: Alignment(0.58, -0.3),
-                            radius: 1.22,
-                            colors: [Color(0xFF15334E), Color(0xFF07111E)],
+                            key: Key('landing_hero_media_fallback'),
+                            decoration: BoxDecoration(
+                              gradient: RadialGradient(
+                                center: Alignment(0.58, -0.3),
+                                radius: 1.22,
+                                colors: [Color(0xFF15334E), Color(0xFF07111E)],
+                              ),
+                            ),
                           ),
-                        ),
-                      ),
                     ),
                   ),
                 ),

--- a/lib/services/landing_page_adapter.dart
+++ b/lib/services/landing_page_adapter.dart
@@ -134,10 +134,10 @@ class LandingPageViewStats {
   });
 
   const LandingPageViewStats.empty()
-    : todayViews = 0,
-      monthViews = 0,
-      totalViews = 0,
-      series = const <LandingPageViewPoint>[];
+      : todayViews = 0,
+        monthViews = 0,
+        totalViews = 0,
+        series = const <LandingPageViewPoint>[];
 }
 
 class LandingSocialProofStats {
@@ -149,7 +149,9 @@ class LandingSocialProofStats {
     required this.publicMemoCount,
   });
 
-  const LandingSocialProofStats.empty() : totalUsers = 0, publicMemoCount = 0;
+  const LandingSocialProofStats.empty()
+      : totalUsers = 0,
+        publicMemoCount = 0;
 }
 
 abstract interface class LandingPageAdapter {
@@ -274,12 +276,10 @@ class SupabaseLandingPageAdapter implements LandingPageAdapter {
 
     try {
       final dynamic raw = await client.rpc('get_lp_view_stats');
-      final data = raw is Map
-          ? Map<String, dynamic>.from(raw)
-          : <String, dynamic>{};
-      final seriesRaw = data['series'] is List
-          ? data['series'] as List
-          : const <dynamic>[];
+      final data =
+          raw is Map ? Map<String, dynamic>.from(raw) : <String, dynamic>{};
+      final seriesRaw =
+          data['series'] is List ? data['series'] as List : const <dynamic>[];
 
       final series = <LandingPageViewPoint>[];
       for (final rowRaw in seriesRaw) {
@@ -372,9 +372,8 @@ class SupabaseLandingPageAdapter implements LandingPageAdapter {
       );
     } on FunctionException catch (error) {
       final details = error.details;
-      final errorCode = details is Map
-          ? details['error']?.toString().trim()
-          : null;
+      final errorCode =
+          details is Map ? details['error']?.toString().trim() : null;
       final canUseInstantPreview =
           details is Map && details['canUseInstantPreview'] == true;
       throw LandingTrialPreviewException(

--- a/lib/services/landing_page_adapter.dart
+++ b/lib/services/landing_page_adapter.dart
@@ -100,11 +100,17 @@ String landingGoogleOAuthFailureEventKey(
 class LandingTrialPreviewException implements Exception {
   final String code;
   final int? statusCode;
+  final bool canUseInstantPreview;
 
-  const LandingTrialPreviewException(this.code, {this.statusCode});
+  const LandingTrialPreviewException(
+    this.code, {
+    this.statusCode,
+    this.canUseInstantPreview = false,
+  });
 
   @override
-  String toString() => 'LandingTrialPreviewException($code, $statusCode)';
+  String toString() =>
+      'LandingTrialPreviewException($code, $statusCode, $canUseInstantPreview)';
 }
 
 class LandingPageViewPoint {
@@ -128,10 +134,10 @@ class LandingPageViewStats {
   });
 
   const LandingPageViewStats.empty()
-      : todayViews = 0,
-        monthViews = 0,
-        totalViews = 0,
-        series = const <LandingPageViewPoint>[];
+    : todayViews = 0,
+      monthViews = 0,
+      totalViews = 0,
+      series = const <LandingPageViewPoint>[];
 }
 
 class LandingSocialProofStats {
@@ -143,9 +149,7 @@ class LandingSocialProofStats {
     required this.publicMemoCount,
   });
 
-  const LandingSocialProofStats.empty()
-      : totalUsers = 0,
-        publicMemoCount = 0;
+  const LandingSocialProofStats.empty() : totalUsers = 0, publicMemoCount = 0;
 }
 
 abstract interface class LandingPageAdapter {
@@ -270,10 +274,12 @@ class SupabaseLandingPageAdapter implements LandingPageAdapter {
 
     try {
       final dynamic raw = await client.rpc('get_lp_view_stats');
-      final data =
-          raw is Map ? Map<String, dynamic>.from(raw) : <String, dynamic>{};
-      final seriesRaw =
-          data['series'] is List ? data['series'] as List : const <dynamic>[];
+      final data = raw is Map
+          ? Map<String, dynamic>.from(raw)
+          : <String, dynamic>{};
+      final seriesRaw = data['series'] is List
+          ? data['series'] as List
+          : const <dynamic>[];
 
       final series = <LandingPageViewPoint>[];
       for (final rowRaw in seriesRaw) {
@@ -366,13 +372,17 @@ class SupabaseLandingPageAdapter implements LandingPageAdapter {
       );
     } on FunctionException catch (error) {
       final details = error.details;
-      final errorCode =
-          details is Map ? details['error']?.toString().trim() : null;
+      final errorCode = details is Map
+          ? details['error']?.toString().trim()
+          : null;
+      final canUseInstantPreview =
+          details is Map && details['canUseInstantPreview'] == true;
       throw LandingTrialPreviewException(
         (errorCode == null || errorCode.isEmpty)
             ? 'trial_ai_unavailable'
             : errorCode,
         statusCode: error.status,
+        canUseInstantPreview: canUseInstantPreview,
       );
     }
     final data = response.data is Map<String, dynamic>
@@ -389,6 +399,7 @@ class SupabaseLandingPageAdapter implements LandingPageAdapter {
           ? data['error'].toString().trim()
           : 'trial_ai_unavailable',
       statusCode: response.status,
+      canUseInstantPreview: data['canUseInstantPreview'] == true,
     );
   }
 

--- a/lib/services/landing_trial_instant_preview.dart
+++ b/lib/services/landing_trial_instant_preview.dart
@@ -1,0 +1,50 @@
+class LandingTrialInstantPreview {
+  final String action;
+  final String reason;
+
+  const LandingTrialInstantPreview({
+    required this.action,
+    required this.reason,
+  });
+}
+
+LandingTrialInstantPreview buildLandingTrialInstantPreview(String prompt) {
+  final normalized = prompt.trim().toLowerCase();
+
+  bool containsAny(Iterable<String> terms) {
+    return terms.any(normalized.contains);
+  }
+
+  if (containsAny(const <String>['お金', '家計', '支出', '固定費', '貯金', '請求', '予算'])) {
+    return const LandingTrialInstantPreview(
+      action: '直近30日の明細を開き、金額が最も大きい固定費を1件書き出す',
+      reason: '契約変更はせず、まず10分で見直し候補を事実から1件に絞れるためです。',
+    );
+  }
+
+  if (containsAny(const <String>['学習', '勉強', '資格', '試験', '読書', '講座'])) {
+    return const LandingTrialInstantPreview(
+      action: '学ぶテーマを1つだけ選び、最初に確認する教材を開く',
+      reason: '計画を増やす前に、10分で着手できる入口を1つ作れるためです。',
+    );
+  }
+
+  if (containsAny(const <String>['健康', '体調', '睡眠', '運動', '疲れ', '休む'])) {
+    return const LandingTrialInstantPreview(
+      action: '今日いちばん気になる体調を1つメモし、無理なくできる10分の行動を決める',
+      reason: '大きな目標ではなく、今の状態を確認して安全に始められるためです。',
+    );
+  }
+
+  if (containsAny(const <String>['仕事', '案件', 'タスク', '締切', '連絡', '先送り'])) {
+    return const LandingTrialInstantPreview(
+      action: '止まっている作業を1件開き、次に確認する相手か資料を1つ決める',
+      reason: '優先順位を考え続ける前に、10分で進捗を作れるためです。',
+    );
+  }
+
+  return const LandingTrialInstantPreview(
+    action: 'いま困っていることを1文にし、最初に確認する相手か資料を1つ決める',
+    reason: '結論を急がず、10分で次の判断に必要な情報を1つ増やせるためです。',
+  );
+}

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -378,9 +378,7 @@ void main() {
       ),
     );
 
-    final notice = find.byKey(
-      const Key('landing_google_oauth_callback_error'),
-    );
+    final notice = find.byKey(const Key('landing_google_oauth_callback_error'));
     expect(notice, findsOneWidget);
     expect(find.byKey(const Key('landing_google_oauth_retry')), findsOneWidget);
     expect(
@@ -1021,10 +1019,7 @@ void main() {
       find.byKey(const Key('landing_h10_continuity_value')),
       findsOneWidget,
     );
-    expect(
-      find.textContaining('今回の入力・提案・理由を同じブラウザから引き継げます'),
-      findsOneWidget,
-    );
+    expect(find.textContaining('今回の入力・提案・理由を同じブラウザから引き継げます'), findsOneWidget);
     expect(find.textContaining('実行履歴'), findsNothing);
     expect(
       find.byKey(const Key('landing_h04_inline_magic_capture')),
@@ -1065,34 +1060,25 @@ void main() {
     expect(find.textContaining('21サービス分'), findsNothing);
   });
 
-  testWidgets(
-    'pricing disclosure keeps verified trust essentials visible',
-    (tester) async {
-      await pumpLanding(
-        tester,
-        assignment: _assignment('h01', LandingExperimentVariant.treatment),
-      );
+  testWidgets('pricing disclosure keeps verified trust essentials visible', (
+    tester,
+  ) async {
+    await pumpLanding(
+      tester,
+      assignment: _assignment('h01', LandingExperimentVariant.treatment),
+    );
 
-      expect(
-        find.byKey(const Key('landing_pricing_trust_summary')),
-        findsOneWidget,
-      );
-      expect(
-        find.text(
-          '無料登録: カード不要 / 有料プラン: 内容・料金を事前確認',
-        ),
-        findsOneWidget,
-      );
-      expect(
-        find.byKey(const Key('landing_pricing_disclosure_link')),
-        findsOneWidget,
-      );
-      expect(
-        find.text('競合サービスとの料金比較を見る'),
-        findsNothing,
-      );
-    },
-  );
+    expect(
+      find.byKey(const Key('landing_pricing_trust_summary')),
+      findsOneWidget,
+    );
+    expect(find.text('無料登録: カード不要 / 有料プラン: 内容・料金を事前確認'), findsOneWidget);
+    expect(
+      find.byKey(const Key('landing_pricing_disclosure_link')),
+      findsOneWidget,
+    );
+    expect(find.text('競合サービスとの料金比較を見る'), findsNothing);
+  });
 
   testWidgets('hero media keeps a readable fallback contract', (tester) async {
     await pumpLanding(
@@ -1253,9 +1239,7 @@ void main() {
       );
       expect(find.textContaining('134機能'), findsNothing);
       expect(
-        find.text(
-          '悩みを1文入力すると、AIが最初の一手を提案します。実行するかはあなたが決め、役立つ提案だけ登録後に引き継げます。',
-        ),
+        find.text('悩みを1文入力すると、AIが最初の一手を提案します。実行するかはあなたが決め、役立つ提案だけ登録後に引き継げます。'),
         findsOneWidget,
       );
     },
@@ -1469,6 +1453,101 @@ void main() {
     );
   });
 
+  testWidgets('trial provider fallback shows an honest instant preview', (
+    tester,
+  ) async {
+    final adapter = await pumpLanding(
+      tester,
+      assignment: _assignment('h01', LandingExperimentVariant.treatment),
+    );
+    adapter.trialError = const LandingTrialPreviewException(
+      'trial_ai_unavailable',
+      statusCode: 503,
+      canUseInstantPreview: true,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('landing_h11_answer_preview_action')),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('landing_trial_error')), findsNothing);
+    expect(find.text('簡易プレビュー（AI未使用）'), findsOneWidget);
+    expect(find.textContaining('止まっている作業を1件開き'), findsOneWidget);
+    expect(
+      find.byKey(const Key('landing_trial_instant_preview_notice')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('landing_trial_ai_retry')), findsOneWidget);
+    expect(
+      find.byKey(const Key('landing_h04_inline_magic_capture')),
+      findsNothing,
+    );
+    expect(
+      adapter.conversionEvents,
+      contains('lp_exp_h01_treatment_trial_fallback'),
+    );
+
+    adapter.trialError = null;
+    final retry = find.byKey(const Key('landing_trial_ai_retry'));
+    await tester.ensureVisible(retry);
+    await tester.tap(retry);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('簡易プレビュー（AI未使用）'), findsNothing);
+    expect(find.text('AIからの提案'), findsOneWidget);
+    expect(find.text('重要な案件を1件選ぶ'), findsOneWidget);
+    expect(
+      find.byKey(const Key('landing_h04_inline_magic_capture')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      'instant preview stays usable without becoming a mobile save path', (
+    tester,
+  ) async {
+    final adapter = await pumpLanding(
+      tester,
+      assignment: _assignment('h01', LandingExperimentVariant.treatment),
+      size: const Size(390, 844),
+    );
+    adapter.trialError = const LandingTrialPreviewException(
+      'trial_ai_unavailable',
+      statusCode: 503,
+      canUseInstantPreview: true,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('landing_h11_answer_preview_action')),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final notice = find.byKey(
+      const Key('landing_trial_instant_preview_notice'),
+    );
+    await tester.ensureVisible(notice);
+    await tester.pumpAndSettle();
+
+    expect(notice, findsOneWidget);
+    expect(find.byKey(const Key('landing_trial_ai_retry')), findsOneWidget);
+    expect(
+      find.byKey(const Key('landing_h04_inline_magic_capture')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(
+      find.byKey(const Key('landing_h09_mobile_sticky_cta')),
+    );
+    await tester.pump();
+
+    expect(adapter.saveCtas, 0);
+  });
+
   testWidgets('trial quota exhaustion explains the daily limit', (
     tester,
   ) async {
@@ -1479,6 +1558,7 @@ void main() {
     adapter.trialError = const LandingTrialPreviewException(
       'trial_quota_exhausted',
       statusCode: 429,
+      canUseInstantPreview: true,
     );
 
     await tester.tap(

--- a/test/services/landing_trial_instant_preview_test.dart
+++ b/test/services/landing_trial_instant_preview_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/landing_trial_instant_preview.dart';
+
+void main() {
+  test('builds a finance preview from finance wording', () {
+    final preview = buildLandingTrialInstantPreview(
+      '家計の固定費が高く、今月どの支出から見直すべきか決められません',
+    );
+
+    expect(preview.action, contains('固定費'));
+    expect(preview.reason, contains('契約変更はせず'));
+  });
+
+  test('builds a learning preview from learning wording', () {
+    final preview = buildLandingTrialInstantPreview(
+      '資格の勉強が進まず、どの教材から再開すべきか迷っています',
+    );
+
+    expect(preview.action, contains('教材'));
+    expect(preview.reason, contains('10分'));
+  });
+
+  test('builds a work preview for the public sample prompt', () {
+    final preview = buildLandingTrialInstantPreview('仕事が多すぎて、何から始めるか決められない');
+
+    expect(preview.action, contains('止まっている作業'));
+    expect(preview.reason, contains('10分'));
+  });
+
+  test('uses a bounded generic preview for unmatched wording', () {
+    final preview = buildLandingTrialInstantPreview('何から考えればいいか分かりません');
+
+    expect(preview.action, contains('確認する相手か資料'));
+    expect(preview.action, isNot(contains('AI')));
+  });
+}


### PR DESCRIPTION
## Outcome
- Keep the registration-free landing-page trial useful when the AI provider is unavailable.
- Show a deterministic on-device preview with an explicit `AI未使用` label instead of a dead-end error.
- Do not expose save or registration continuation for fallback content; offer an AI retry only.

## Architecture and behavior
- Propagate the Edge Function `canUseInstantPreview` signal through `LandingTrialPreviewException`.
- Generate bounded category-specific fallback copy in a pure Dart service without echoing raw prompts.
- Preserve normal AI success, input validation, quota messaging, authentication, analytics, and H03/H04/H10 behavior.
- No persistence or database changes.

## Validation
- `flutter test test/services/landing_trial_instant_preview_test.dart test/pages/landing_page_conversion_test.dart test/widgets/landing_story_journey_test.dart` — 56 passed.
- `flutter analyze lib/pages/landing_page.dart lib/services/landing_page_adapter.dart lib/services/landing_trial_instant_preview.dart test/pages/landing_page_conversion_test.dart test/services/landing_trial_instant_preview_test.dart` — no issues.
- `flutter build web --release` — succeeded.
- Local release browser QA: 1280x720 and 390x844, no horizontal overflow, no console warnings/errors, normal AI result path succeeded.
- Provider recovery prevented forcing a real-browser outage during the final QA; desktop/mobile fallback states and retry/save suppression are covered deterministically by widget tests.

## Coordination
- Subagents: none.
- Recovery: revert this PR to restore the previous error-only provider failure behavior.

## Minimal E2E Gate

- Implementation-detail independent: the tests assert user-visible input/output, labels, retry behavior, and save-path suppression rather than private internals.
- Minimal scope: about 3 cases cover the happy path, provider error fallback, and recovery retry across desktop/mobile behavior.
- E2E: Playwright browser smoke covers the live happy path and responsive route.
- E2E-Exception: The provider-outage state is dependency-injected and covered by focused Flutter widget tests because a stable external outage cannot be forced in test/e2e.
