### PR TITLE
fix(video): tile Wan2.2 VAE decode on L4

### DIFF
--- a/services/video-inference-worker/Dockerfile
+++ b/services/video-inference-worker/Dockerfile
@@ -44,6 +44,13 @@ RUN cd /opt/Wan2.2 \
     && git apply /tmp/wan22-release-dit-before-vae.patch \
     && rm -f /tmp/wan22-release-dit-before-vae.patch
 
+COPY patches/wan22-tiled-vae-decode.patch /tmp/wan22-tiled-vae-decode.patch
+RUN cd /opt/Wan2.2 \
+    && git apply --check /tmp/wan22-tiled-vae-decode.patch \
+    && git apply /tmp/wan22-tiled-vae-decode.patch \
+    && python3 -m py_compile wan/modules/vae2_2.py wan/textimage2video.py \
+    && rm -f /tmp/wan22-tiled-vae-decode.patch
+
 COPY wan_init.py /opt/Wan2.2/wan/__init__.py
 
 COPY requirements.txt /tmp/worker-requirements.txt

--- a/services/video-inference-worker/README.md
+++ b/services/video-inference-worker/README.md
@@ -59,6 +59,9 @@ Required environment variables:
   the OS process command line.
 - Each job has a 30-minute renewable lease. The worker renews it every minute,
   allows up to 60 minutes for one L4 inference, and does not retry a timeout.
+- Before VAE decode, the worker releases the DiT and decodes six overlapping
+  spatial tiles on the GPU. It blends those tiles in CPU memory so the fixed
+  720p contract remains within a single 24 GB L4's VRAM budget.
 - An empty queue shuts the worker down after 10 minutes; a clean worker exit
   powers off the GPU host, while the fixed startup auto-stop remains a backstop.
 - Output dimensions, duration, frame rate, codec, and size are checked with

--- a/services/video-inference-worker/patches/wan22-tiled-vae-decode.patch
+++ b/services/video-inference-worker/patches/wan22-tiled-vae-decode.patch
@@ -1,0 +1,161 @@
+diff --git a/wan/modules/vae2_2.py b/wan/modules/vae2_2.py
+--- a/wan/modules/vae2_2.py
++++ b/wan/modules/vae2_2.py
+@@ -1049,3 +1049,146 @@ class Wan2_2_VAE:
+         except TypeError as e:
+             logging.info(e)
+             return None
++
++    @staticmethod
++    def _tile_ranges(length, tile_size, tile_stride):
++        ranges = []
++        for start in range(0, length, tile_stride):
++            if (start - tile_stride >= 0 and
++                    start - tile_stride + tile_size >= length):
++                continue
++            ranges.append((start, min(start + tile_size, length)))
++        return ranges
++
++    @staticmethod
++    def _tiled_decode_mask(data, is_bound, border_height, border_width):
++        height, width = data.shape[-2:]
++        h = torch.ones(height, dtype=torch.float32, device="cpu")
++        w = torch.ones(width, dtype=torch.float32, device="cpu")
++
++        feather_height = min(border_height, height)
++        feather_width = min(border_width, width)
++        if not is_bound[0] and feather_height:
++            h[:feather_height] = (
++                torch.arange(feather_height, dtype=torch.float32) + 1
++            ) / feather_height
++        if not is_bound[1] and feather_height:
++            h[-feather_height:] = torch.flip(
++                (torch.arange(feather_height, dtype=torch.float32) + 1) /
++                feather_height,
++                dims=(0, ),
++            )
++        if not is_bound[2] and feather_width:
++            w[:feather_width] = (
++                torch.arange(feather_width, dtype=torch.float32) + 1
++            ) / feather_width
++        if not is_bound[3] and feather_width:
++            w[-feather_width:] = torch.flip(
++                (torch.arange(feather_width, dtype=torch.float32) + 1) /
++                feather_width,
++                dims=(0, ),
++            )
++
++        return torch.minimum(h[:, None], w[None, :]).view(
++            1, 1, 1, height, width)
++
++    def decode_tiled(self, zs, tile_size=32, tile_overlap=8):
++        """Decode spatial tiles on GPU and blend the results on CPU."""
++        try:
++            if not isinstance(zs, list):
++                raise TypeError("zs should be a list")
++            if tile_size <= 0 or tile_overlap < 0 or tile_overlap >= tile_size:
++                raise ValueError("invalid VAE tile geometry")
++
++            tile_stride = tile_size - tile_overlap
++            videos = []
++            with amp.autocast(dtype=self.dtype):
++                for latent in zs:
++                    z = latent.unsqueeze(0)
++                    height, width = z.shape[-2:]
++                    h_ranges = self._tile_ranges(height, tile_size,
++                                                 tile_stride)
++                    w_ranges = self._tile_ranges(width, tile_size,
++                                                 tile_stride)
++                    tile_count = len(h_ranges) * len(w_ranges)
++                    values = None
++                    weight = None
++                    scale_height = None
++                    scale_width = None
++                    tile_index = 0
++
++                    for h, h_end in h_ranges:
++                        for w, w_end in w_ranges:
++                            tile_index += 1
++                            latent_tile = z[:, :, :, h:h_end, w:w_end]
++                            decoded = self.model.decode(latent_tile, self.scale)
++                            decoded_cpu = decoded.to(
++                                device="cpu", dtype=torch.float32).clamp_(-1, 1)
++                            del decoded, latent_tile
++                            if torch.cuda.is_available():
++                                torch.cuda.empty_cache()
++
++                            current_scale_height = (
++                                decoded_cpu.shape[-2] // (h_end - h))
++                            current_scale_width = (
++                                decoded_cpu.shape[-1] // (w_end - w))
++                            if (current_scale_height <= 0 or
++                                    current_scale_width <= 0 or
++                                    decoded_cpu.shape[-2] !=
++                                    (h_end - h) * current_scale_height or
++                                    decoded_cpu.shape[-1] !=
++                                    (w_end - w) * current_scale_width):
++                                raise RuntimeError(
++                                    "unexpected tiled VAE spatial scale")
++
++                            if values is None:
++                                scale_height = current_scale_height
++                                scale_width = current_scale_width
++                                values = torch.zeros(
++                                    (1, decoded_cpu.shape[1],
++                                     decoded_cpu.shape[2],
++                                     height * scale_height,
++                                     width * scale_width),
++                                    dtype=torch.float32,
++                                    device="cpu",
++                                )
++                                weight = torch.zeros(
++                                    (1, 1, 1, height * scale_height,
++                                     width * scale_width),
++                                    dtype=torch.float32,
++                                    device="cpu",
++                                )
++                            elif (current_scale_height != scale_height or
++                                  current_scale_width != scale_width):
++                                raise RuntimeError(
++                                    "inconsistent tiled VAE spatial scale")
++
++                            mask = self._tiled_decode_mask(
++                                decoded_cpu,
++                                is_bound=(h == 0, h_end >= height, w == 0,
++                                          w_end >= width),
++                                border_height=tile_overlap * scale_height,
++                                border_width=tile_overlap * scale_width,
++                            )
++                            target_h = h * scale_height
++                            target_w = w * scale_width
++                            target_h_end = target_h + decoded_cpu.shape[-2]
++                            target_w_end = target_w + decoded_cpu.shape[-1]
++                            values[:, :, :, target_h:target_h_end,
++                                   target_w:target_w_end].add_(decoded_cpu * mask)
++                            weight[:, :, :, target_h:target_h_end,
++                                   target_w:target_w_end].add_(mask)
++                            del decoded_cpu, mask
++                            logging.info(
++                                "VAE tiled decode %s/%s complete", tile_index,
++                                tile_count)
++
++                    if values is None or weight is None or torch.any(weight == 0):
++                        raise RuntimeError("tiled VAE decode left output uncovered")
++                    values.div_(weight).clamp_(-1, 1)
++                    videos.append(values.squeeze(0))
++
++            return videos
++        except TypeError as e:
++            logging.info(e)
++            return None
+diff --git a/wan/textimage2video.py b/wan/textimage2video.py
+index dade34f..ac1832e 100644
+--- a/wan/textimage2video.py
++++ b/wan/textimage2video.py
+@@ -410,3 +410,4 @@ class WanTI2V:
+-                videos = self.vae.decode(x0)
+-
++                videos = self.vae.decode_tiled(
++                    x0, tile_size=32, tile_overlap=8)
++                # decode_tiled returns CPU-backed frames to bound VRAM.
+         if offload_model:

--- a/services/video-inference-worker/test_worker.py
+++ b/services/video-inference-worker/test_worker.py
@@ -73,6 +73,18 @@ class WorkerContractTest(unittest.TestCase):
         self.assertIn("dst=/run/secrets/video-worker-token,readonly", startup)
         self.assertNotIn('--env "VIDEO_WORKER_TOKEN=${token}"', startup)
 
+    def test_wan_patch_enables_cpu_blended_tiled_vae_decode(self) -> None:
+        root = Path(__file__).parent
+        dockerfile = (root / "Dockerfile").read_text(encoding="utf-8")
+        vae_patch = (root / "patches" / "wan22-tiled-vae-decode.patch").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("wan22-tiled-vae-decode.patch", dockerfile)
+        self.assertIn("def decode_tiled", vae_patch)
+        self.assertIn('device="cpu", dtype=torch.float32', vae_patch)
+        self.assertIn("tile_size=32, tile_overlap=8", vae_patch)
+
     def test_valid_job_contract_and_landscape_command(self) -> None:
         job = {
             "job_id": "11111111-1111-4111-8111-111111111111",


### PR DESCRIPTION
## Summary
- add a spatially tiled Wan2.2 TI2V-5B VAE decode path for the production L4 worker
- decode six overlapping 32x32 latent tiles on GPU and blend float32 output on CPU
- keep the existing 5-second 720p contract while bounding VAE VRAM after the DiT is released

## Production evidence
- job `e2b4afac-09fe-4d74-84ae-53865b0b5d13` reached VAE decode after 28 minutes of GPU inference
- the worker then reported `inference_gpu_memory_exhausted` on the single 24 GB L4
- host RAM remained about 18/67 GB, so spatial VAE tiling is the scoped fix

## Validation
- `python -m unittest test_worker.py` (14 passed)
- `deno test supabase/functions/video-worker-hub/worker_security_test.ts` (4 passed)
- both patches apply cleanly to pinned Wan2.2 `42bf4cf...`
- `python -m py_compile wan/modules/vae2_2.py wan/textimage2video.py`
- `git diff --check`
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Local `claude ultrareview 4673 --timeout 15` returned `Ultrareview is currently unavailable` on 2026-08-22. Deterministic tests and Cloud Build are required before merge; production verification will use one explicitly confirmed paid job, and rollback is the previously deployed immutable digest.
- Security: no worker token, Supabase credential, prompt, or output URL handling changes.
- Rollback: restore digest `sha256:6ae1e3d01706dcb7725a0be84a545cdf4c50e92ccffdc6fcd21c12e4845fa26f` and stop the VM.
- Data migration: none.
- Production smoke: after build and deploy, run one user-confirmed 5-second 720p job and monitor completion/refund.
- Observability: monitor worker heartbeat, GPU VRAM, host RAM, VAE tile progress, final job state, and automatic VM shutdown.
- Unresolved ultrareview findings: none produced because the service did not launch; any later Claude Code #1 finding remains merge-blocking until resolved.
