### PR TITLE
feat: LPトライアルを5問の深掘り付きAI提案へ更新

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -18,6 +18,7 @@ import '../services/pending_landing_trial_service.dart';
 import '../services/route_visibility_observer.dart';
 import '../utils/route_document_title.dart';
 import '../widgets/live_growth_banner.dart';
+import '../widgets/landing_trial_guided_intake.dart';
 import '../widgets/landing_story_journey.dart';
 
 enum _LandingIntent { work, learning, money }
@@ -93,6 +94,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   final _trialPromptFocusNode = FocusNode();
   final ScrollController _pageScrollController = ScrollController();
   final GlobalKey _trialSectionKey = GlobalKey();
+  final GlobalKey _guidedTrialKey = GlobalKey();
   final GlobalKey _authSectionKey = GlobalKey();
 
   StreamSubscription<AuthState>? _authSubscription;
@@ -108,6 +110,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   bool _showInboxShortcut = false;
   bool _showAllUniqueFeatures = false;
   bool _showTrialAnswerPreview = true;
+  bool _showGuidedTrialIntake = false;
   int _magicLinkCooldownSeconds = 0;
   int _achievementCount = 0;
   int _totalUsers = 0;
@@ -116,6 +119,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
   String? _trialAction;
   String? _trialReason;
+  String? _lastGeneratedTrialPrompt;
   String? _trialErrorTitle;
   String? _trialErrorMessage;
   String? _magicLinkErrorMessage;
@@ -723,9 +727,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     });
   }
 
-  Future<void> _runTrialActionPreview() async {
-    final input = _trialPromptController.text.trim();
-    if (input.isEmpty) {
+  void _openGuidedTrialIntake({bool recordHeroCta = false}) {
+    final concern = _trialPromptController.text.trim();
+    if (concern.isEmpty) {
       setState(() {
         _trialAction = null;
         _trialReason = null;
@@ -736,6 +740,55 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       });
       return;
     }
+
+    if (recordHeroCta) {
+      unawaited(_recordConversionStage('hero_cta'));
+    }
+    _trialPromptFocusNode.unfocus();
+    setState(() {
+      _showGuidedTrialIntake = true;
+      _showTrialAnswerPreview = false;
+      _lastGeneratedTrialPrompt = null;
+      _trialAction = null;
+      _trialReason = null;
+      _trialErrorTitle = null;
+      _trialErrorMessage = null;
+      _showSaveCtaPrompt = false;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final guidedContext = _guidedTrialKey.currentContext;
+      if (!mounted || guidedContext == null) return;
+      unawaited(
+        Scrollable.ensureVisible(
+          guidedContext,
+          duration: const Duration(milliseconds: 260),
+          curve: Curves.easeOut,
+          alignment: 0.16,
+        ),
+      );
+    });
+  }
+
+  void _cancelGuidedTrialIntake() {
+    setState(() {
+      _showGuidedTrialIntake = false;
+      _showTrialAnswerPreview = _trialPromptController.text.trim().isEmpty;
+    });
+  }
+
+  void _submitGuidedTrialPrompt(String generatedPrompt) {
+    setState(() {
+      _lastGeneratedTrialPrompt = generatedPrompt;
+      _showGuidedTrialIntake = false;
+    });
+    unawaited(_runTrialActionPreview());
+  }
+
+  Future<void> _runTrialActionPreview() async {
+    final input = _lastGeneratedTrialPrompt?.trim().isNotEmpty == true
+        ? _lastGeneratedTrialPrompt!.trim()
+        : _trialPromptController.text.trim();
+    if (input.isEmpty) return;
 
     unawaited(_recordTrialStages());
     setState(() {
@@ -881,12 +934,13 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     _trialPromptController
       ..text = prompt
       ..selection = TextSelection.collapsed(offset: prompt.length);
+    _lastGeneratedTrialPrompt = null;
+    _showGuidedTrialIntake = false;
     unawaited(_runTrialActionPreview());
   }
 
   void _runHeroTrialActionPreview() {
-    unawaited(_recordConversionStage('hero_cta'));
-    unawaited(_runTrialActionPreview());
+    _openGuidedTrialIntake(recordHeroCta: true);
   }
 
   void _scrollToTrialSection() {
@@ -1151,6 +1205,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       _trialErrorMessage = null;
       _showSaveCtaPrompt = false;
       _trialUsesInstantPreview = false;
+      _showGuidedTrialIntake = false;
+      _lastGeneratedTrialPrompt = null;
       if (shouldRestorePreview) {
         _showTrialAnswerPreview = true;
       }
@@ -1276,6 +1332,8 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     final prompt = _promptForIntent(intent);
     setState(() {
       _selectedIntent = intent;
+      _showGuidedTrialIntake = false;
+      _lastGeneratedTrialPrompt = null;
       _trialPromptController
         ..text = prompt
         ..selection = TextSelection.collapsed(offset: prompt.length);
@@ -4254,10 +4312,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   firstUserGrowthMode
                       ? '入力・登録・カードは不要です。下のボタンだけで「今やる1件」を確認し、役立った時だけ保存できます。'
                       : compactHero
-                          ? '登録不要。例を押すか1行書くと「今やる1件」を返します。'
+                          ? '登録不要。1行書いて5問に答えると、AIが「今やる1件」を返します。'
                           : heroMode
-                              ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
-                              : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
+                              ? '登録はまだ不要です。5つの短い質問で状況を整理してから、AIが「今やる1件」を返します。'
+                              : '5つの短い質問で状況を整理し、AIへの送信内容を確認してから「今やる1件」を受け取れます。',
                   style: TextStyle(
                     color: heroMode
                         ? const Color(0xFFBCC6CE)
@@ -4290,7 +4348,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       visualDensity: compactHero ? VisualDensity.compact : null,
                       materialTapTargetSize:
                           compactHero ? MaterialTapTargetSize.shrinkWrap : null,
-                      onPressed: _isTrialLoading
+                      onPressed: _isTrialLoading || _showGuidedTrialIntake
                           ? null
                           : () => _runQuickTrialSample(
                                 '今日の最優先タスクを1件に絞りたい',
@@ -4307,7 +4365,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       visualDensity: compactHero ? VisualDensity.compact : null,
                       materialTapTargetSize:
                           compactHero ? MaterialTapTargetSize.shrinkWrap : null,
-                      onPressed: _isTrialLoading
+                      onPressed: _isTrialLoading || _showGuidedTrialIntake
                           ? null
                           : () => _runQuickTrialSample(
                                 '今日1日の計画を立てて、最も重要なことに集中したい',
@@ -4321,7 +4379,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                       visualDensity: compactHero ? VisualDensity.compact : null,
                       materialTapTargetSize:
                           compactHero ? MaterialTapTargetSize.shrinkWrap : null,
-                      onPressed: _isTrialLoading
+                      onPressed: _isTrialLoading || _showGuidedTrialIntake
                           ? null
                           : () => _runQuickTrialSample(
                                 '今いちばん先送りしていることを片付けたい',
@@ -4335,7 +4393,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   key: const Key('landing_trial_prompt_input'),
                   controller: _trialPromptController,
                   focusNode: _trialPromptFocusNode,
-                  readOnly: _isTrialLoading,
+                  readOnly: _isTrialLoading || _showGuidedTrialIntake,
                   onChanged: _handleTrialPromptChanged,
                   minLines: heroMode ? 1 : 2,
                   maxLines: heroMode ? 2 : 3,
@@ -4361,11 +4419,11 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                           ? 'landing_h03_inline_trial_action'
                           : 'landing_h03_lower_trial_action',
                     ),
-                    onPressed: _isTrialLoading
+                    onPressed: _isTrialLoading || _showGuidedTrialIntake
                         ? null
                         : heroMode
                             ? _runHeroTrialActionPreview
-                            : _runTrialActionPreview,
+                            : _openGuidedTrialIntake,
                     icon: _isTrialLoading
                         ? const SizedBox(
                             width: 20,
@@ -4374,7 +4432,11 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                           )
                         : const Icon(Icons.play_arrow),
                     label: Text(
-                      _isTrialLoading ? 'AIが具体的な1件を考えています…' : '今やる1件を試す',
+                      _isTrialLoading
+                          ? 'AIが具体的な1件を考えています…'
+                          : _showGuidedTrialIntake
+                              ? '5つの質問に回答中'
+                              : '今やる1件を試す',
                     ),
                     style: compactHero
                         ? FilledButton.styleFrom(
@@ -4383,6 +4445,28 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                         : null,
                   ),
                 ),
+                if (_showGuidedTrialIntake) ...[
+                  SizedBox(height: compactHero ? 10 : 14),
+                  LandingTrialGuidedIntake(
+                    key: _guidedTrialKey,
+                    concern: _trialPromptController.text.trim(),
+                    compact: compactHero,
+                    onCancel: _cancelGuidedTrialIntake,
+                    onSubmit: _submitGuidedTrialPrompt,
+                  ),
+                ] else if (!_isTrialLoading) ...[
+                  const SizedBox(height: 6),
+                  Text(
+                    'AIへの送信は、5問の回答を確認してから1回だけ行います。',
+                    style: TextStyle(
+                      color: heroMode
+                          ? const Color(0xFF9FADB8)
+                          : const Color(0xFF64748B),
+                      fontSize: 11,
+                      height: 1.45,
+                    ),
+                  ),
+                ],
                 if (_showTrialAnswerPreview) ...[
                   SizedBox(height: compactHero ? 8 : 12),
                   _buildTrialAnswerPreview(

--- a/lib/services/landing_trial_prompt_builder.dart
+++ b/lib/services/landing_trial_prompt_builder.dart
@@ -1,0 +1,116 @@
+class LandingTrialDeepDiveQuestion {
+  const LandingTrialDeepDiveQuestion({
+    required this.label,
+    required this.question,
+    required this.hint,
+    required this.quickAnswer,
+  });
+
+  final String label;
+  final String question;
+  final String hint;
+  final String quickAnswer;
+}
+
+const landingTrialDeepDiveQuestions = <LandingTrialDeepDiveQuestion>[
+  LandingTrialDeepDiveQuestion(
+    label: '目標',
+    question: 'どうなれば「少し前に進んだ」と言えますか？',
+    hint: '例: 次に連絡する相手と内容が決まっている',
+    quickAnswer: 'まず動き出せればよい',
+  ),
+  LandingTrialDeepDiveQuestion(
+    label: '期限',
+    question: 'いつまでに、どの程度まで進めたいですか？',
+    hint: '例: 今日中に、最初の一歩だけ終えたい',
+    quickAnswer: '今日中に一歩進めたい',
+  ),
+  LandingTrialDeepDiveQuestion(
+    label: '条件',
+    question: '使える時間・予算・守る条件はありますか？',
+    hint: '例: 10分以内、追加費用なし、1人でできる範囲',
+    quickAnswer: '10分以内・追加費用なし',
+  ),
+  LandingTrialDeepDiveQuestion(
+    label: '試行',
+    question: 'すでに試したことや、分かっていることは？',
+    hint: '例: 一覧にはしたが、優先順位を決められなかった',
+    quickAnswer: 'まだ何も試していない',
+  ),
+  LandingTrialDeepDiveQuestion(
+    label: '回避',
+    question: '今回の提案で避けたいことはありますか？',
+    hint: '例: 大きな設定変更、誰かへの長い説明',
+    quickAnswer: '大きな変更は避けたい',
+  ),
+];
+
+class LandingTrialPromptBuilder {
+  const LandingTrialPromptBuilder._();
+
+  static const int maxPromptLength = 280;
+  static const List<int> _fieldLimits = <int>[72, 34, 30, 34, 34, 32];
+
+  static String build({
+    required String concern,
+    required List<String> answers,
+  }) {
+    if (answers.length != landingTrialDeepDiveQuestions.length) {
+      throw ArgumentError.value(
+        answers.length,
+        'answers',
+        '${landingTrialDeepDiveQuestions.length}件の回答が必要です。',
+      );
+    }
+
+    final fields = <({String label, String value})>[
+      (label: '相談', value: concern),
+      for (var index = 0; index < landingTrialDeepDiveQuestions.length; index++)
+        (
+          label: landingTrialDeepDiveQuestions[index].label,
+          value: answers[index],
+        ),
+    ];
+
+    final normalizedFields = <({String label, String value})>[
+      for (final field in fields)
+        (label: field.label, value: _normalize(field.value)),
+    ];
+    final fullPrompt = _serialize(normalizedFields);
+    if (_runeLength(fullPrompt) <= maxPromptLength) return fullPrompt;
+
+    final prompt = _serialize(<({String label, String value})>[
+      for (var index = 0; index < normalizedFields.length; index++)
+        (
+          label: normalizedFields[index].label,
+          value: _truncate(
+            normalizedFields[index].value,
+            _fieldLimits[index],
+          ),
+        ),
+    ]);
+
+    if (_runeLength(prompt) > maxPromptLength) {
+      throw StateError('生成したプロンプトが上限を超えました。');
+    }
+    return prompt;
+  }
+
+  static String _serialize(List<({String label, String value})> fields) {
+    return <String>[
+      for (final field in fields) '${field.label}:${field.value}',
+    ].join('\n');
+  }
+
+  static String _normalize(String value) {
+    return value.replaceAll(RegExp(r'\s+'), ' ').trim();
+  }
+
+  static String _truncate(String value, int maxLength) {
+    final runes = value.runes.toList(growable: false);
+    if (runes.length <= maxLength) return value;
+    return '${String.fromCharCodes(runes.take(maxLength - 1))}…';
+  }
+
+  static int _runeLength(String value) => value.runes.length;
+}

--- a/lib/widgets/landing_trial_guided_intake.dart
+++ b/lib/widgets/landing_trial_guided_intake.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+
+import '../services/landing_trial_prompt_builder.dart';
+
+class LandingTrialGuidedIntake extends StatefulWidget {
+  const LandingTrialGuidedIntake({
+    super.key,
+    required this.concern,
+    required this.onSubmit,
+    required this.onCancel,
+    this.compact = false,
+  });
+
+  final String concern;
+  final ValueChanged<String> onSubmit;
+  final VoidCallback onCancel;
+  final bool compact;
+
+  @override
+  State<LandingTrialGuidedIntake> createState() =>
+      _LandingTrialGuidedIntakeState();
+}
+
+class _LandingTrialGuidedIntakeState extends State<LandingTrialGuidedIntake> {
+  late final List<TextEditingController> _answerControllers;
+  int _step = 0;
+
+  bool get _isReview => _step == landingTrialDeepDiveQuestions.length;
+
+  @override
+  void initState() {
+    super.initState();
+    _answerControllers = List<TextEditingController>.generate(
+      landingTrialDeepDiveQuestions.length,
+      (_) => TextEditingController(),
+    );
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _answerControllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _useQuickAnswer() {
+    final answer = landingTrialDeepDiveQuestions[_step].quickAnswer;
+    _answerControllers[_step]
+      ..text = answer
+      ..selection = TextSelection.collapsed(offset: answer.length);
+    setState(() {});
+  }
+
+  void _goBack() {
+    if (_step == 0) {
+      widget.onCancel();
+      return;
+    }
+    setState(() => _step -= 1);
+  }
+
+  void _goNext() {
+    if (_answerControllers[_step].text.trim().isEmpty) return;
+    setState(() => _step += 1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Container(
+      key: const Key('landing_trial_guided_intake'),
+      width: double.infinity,
+      padding: EdgeInsets.all(widget.compact ? 12 : 16),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF0B1823) : const Color(0xFFF7FAFC),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isDark ? const Color(0xFF41505C) : const Color(0xFFCBD5E1),
+        ),
+      ),
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 180),
+        child: _isReview
+            ? _buildReview(context)
+            : Column(
+                key: ValueKey<int>(_step),
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          '質問 ${_step + 1} / ${landingTrialDeepDiveQuestions.length}',
+                          key: const Key('landing_trial_guided_progress'),
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                      ),
+                      TextButton(
+                        key: const Key('landing_trial_guided_cancel'),
+                        onPressed: widget.onCancel,
+                        child: const Text('中止'),
+                      ),
+                    ],
+                  ),
+                  LinearProgressIndicator(
+                    value: (_step + 1) / landingTrialDeepDiveQuestions.length,
+                    minHeight: 5,
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  SizedBox(height: widget.compact ? 12 : 16),
+                  Text(
+                    landingTrialDeepDiveQuestions[_step].question,
+                    style: TextStyle(
+                      fontSize: widget.compact ? 15 : 17,
+                      fontWeight: FontWeight.w800,
+                      height: 1.45,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  TextField(
+                    key: const Key('landing_trial_guided_answer'),
+                    controller: _answerControllers[_step],
+                    maxLength: 60,
+                    minLines: 2,
+                    maxLines: 3,
+                    onChanged: (_) => setState(() {}),
+                    textInputAction: TextInputAction.done,
+                    onSubmitted: (_) => _goNext(),
+                    decoration: InputDecoration(
+                      hintText: landingTrialDeepDiveQuestions[_step].hint,
+                      border: const OutlineInputBorder(),
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton.icon(
+                      key: const Key('landing_trial_guided_quick_answer'),
+                      onPressed: _useQuickAnswer,
+                      icon: const Icon(Icons.auto_awesome, size: 17),
+                      label: Text(
+                        '迷ったら「${landingTrialDeepDiveQuestions[_step].quickAnswer}」',
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          key: const Key('landing_trial_guided_back'),
+                          onPressed: _goBack,
+                          child: Text(_step == 0 ? '入力に戻る' : '戻る'),
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        flex: 2,
+                        child: FilledButton.icon(
+                          key: const Key('landing_trial_guided_next'),
+                          onPressed:
+                              _answerControllers[_step].text.trim().isEmpty
+                                  ? null
+                                  : _goNext,
+                          icon: const Icon(Icons.arrow_forward, size: 18),
+                          label: Text(
+                            _step == landingTrialDeepDiveQuestions.length - 1
+                                ? '送る内容を確認'
+                                : '次の質問へ',
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Widget _buildReview(BuildContext context) {
+    final prompt = LandingTrialPromptBuilder.build(
+      concern: widget.concern,
+      answers: [for (final controller in _answerControllers) controller.text],
+    );
+
+    return Column(
+      key: const Key('landing_trial_guided_review'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          'AIに送る内容を確認',
+          style: TextStyle(fontSize: 17, fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          '5つの回答を、提案に必要な要点へ自動でまとめました。送信は下のボタンを押した時の1回だけです。',
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            fontSize: 12,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
+          ),
+          child: SelectableText(
+            prompt,
+            key: const Key('landing_trial_generated_prompt'),
+            style: const TextStyle(fontSize: 12, height: 1.55),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                key: const Key('landing_trial_guided_review_back'),
+                onPressed: _goBack,
+                child: const Text('回答を直す'),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              flex: 2,
+              child: FilledButton.icon(
+                key: const Key('landing_trial_guided_submit'),
+                onPressed: () => widget.onSubmit(prompt),
+                icon: const Icon(Icons.auto_awesome, size: 18),
+                label: const Text('この内容でAIに提案してもらう'),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -186,6 +186,29 @@ double _landingScrollOffset(WidgetTester tester) {
   return tester.state<ScrollableState>(pageScrollable).position.pixels;
 }
 
+Future<void> _completeGuidedTrialWithQuickAnswers(WidgetTester tester) async {
+  for (var step = 0; step < 5; step++) {
+    final quickAnswer = find.byKey(
+      const Key('landing_trial_guided_quick_answer'),
+    );
+    await Scrollable.ensureVisible(tester.element(quickAnswer), alignment: 0.6);
+    await tester.pump();
+    await tester.tap(quickAnswer);
+    await tester.pump();
+    final next = find.byKey(const Key('landing_trial_guided_next'));
+    await Scrollable.ensureVisible(tester.element(next), alignment: 0.7);
+    await tester.pump();
+    await tester.tap(next);
+    await tester.pumpAndSettle();
+  }
+  final submit = find.byKey(const Key('landing_trial_guided_submit'));
+  await Scrollable.ensureVisible(tester.element(submit), alignment: 0.7);
+  await tester.pump();
+  await tester.tap(submit);
+  await tester.pump();
+  await tester.pump();
+}
+
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
@@ -1599,6 +1622,42 @@ void main() {
     );
   });
 
+  testWidgets('custom concern is deep-dived before one generated AI request', (
+    tester,
+  ) async {
+    final adapter = await pumpLanding(
+      tester,
+      assignment: _assignment('h01', LandingExperimentVariant.treatment),
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('landing_trial_prompt_input')),
+      'サブスクの支払いが多く、どれから見直すか決められない',
+    );
+    await tester.tap(find.byKey(const Key('landing_h03_inline_trial_action')));
+    await tester.pump();
+
+    expect(
+      find.byKey(const Key('landing_trial_guided_intake')),
+      findsOneWidget,
+    );
+    expect(find.text('質問 1 / 5'), findsOneWidget);
+    expect(adapter.trialRuns, 0);
+    expect(adapter.lastTrialPrompt, isNull);
+
+    await _completeGuidedTrialWithQuickAnswers(tester);
+
+    expect(adapter.trialRuns, 1);
+    expect(adapter.lastTrialPrompt, contains('相談:サブスクの支払いが多く'));
+    expect(adapter.lastTrialPrompt, contains('目標:まず動き出せればよい'));
+    expect(adapter.lastTrialPrompt, contains('回避:大きな変更は避けたい'));
+    expect(adapter.lastTrialPrompt!.runes.length, lessThanOrEqualTo(280));
+    expect(
+      find.byKey(const Key('landing_trial_result_action')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('trial provider failure never presents a fixed finance answer', (
     tester,
   ) async {
@@ -1614,7 +1673,7 @@ void main() {
     );
     await tester.tap(find.byKey(const Key('landing_h03_inline_trial_action')));
     await tester.pump();
-    await tester.pump();
+    await _completeGuidedTrialWithQuickAnswers(tester);
 
     expect(find.byKey(const Key('landing_trial_result_action')), findsNothing);
     expect(find.text('先月の明細で最も高い固定費を1件特定'), findsNothing);

--- a/test/services/landing_trial_prompt_builder_test.dart
+++ b/test/services/landing_trial_prompt_builder_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/landing_trial_prompt_builder.dart';
+
+void main() {
+  test('builds a structured prompt from the concern and five answers', () {
+    final prompt = LandingTrialPromptBuilder.build(
+      concern: 'サブスクの支払いが多く、どれから見直すか決められない',
+      answers: const <String>[
+        '解約候補が1件決まっている',
+        '今日中に最初の一歩まで',
+        '10分以内・追加費用なし',
+        '請求一覧までは確認した',
+        '家族が使うサービスは勝手に止めない',
+      ],
+    );
+
+    expect(prompt, contains('相談:サブスクの支払いが多く'));
+    expect(prompt, contains('目標:解約候補が1件決まっている'));
+    expect(prompt, contains('期限:今日中に最初の一歩まで'));
+    expect(prompt, contains('条件:10分以内・追加費用なし'));
+    expect(prompt, contains('試行:請求一覧までは確認した'));
+    expect(prompt, contains('回避:家族が使うサービスは勝手に止めない'));
+    expect(prompt.runes.length, lessThanOrEqualTo(280));
+  });
+
+  test('normalizes and safely truncates long answers to the API limit', () {
+    final prompt = LandingTrialPromptBuilder.build(
+      concern: '😀'.padRight(300, '長'),
+      answers: List<String>.filled(5, '回答'.padRight(100, '長')),
+    );
+
+    expect(prompt.runes.length, lessThanOrEqualTo(280));
+    expect(prompt, contains('…'));
+    expect(prompt, isNot(contains('\uFFFD')));
+  });
+
+  test('rejects an incomplete answer set', () {
+    expect(
+      () => LandingTrialPromptBuilder.build(
+        concern: '相談',
+        answers: const <String>['回答'],
+      ),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/widgets/landing_trial_guided_intake_test.dart
+++ b/test/widgets/landing_trial_guided_intake_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/landing_trial_guided_intake.dart';
+
+void main() {
+  testWidgets('asks five questions and submits one generated prompt', (
+    tester,
+  ) async {
+    String? submittedPrompt;
+    var cancelCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: LandingTrialGuidedIntake(
+              concern: '仕事が多く、何から始めるか決められない',
+              onCancel: () => cancelCount += 1,
+              onSubmit: (prompt) => submittedPrompt = prompt,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('質問 1 / 5'), findsOneWidget);
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.byKey(const Key('landing_trial_guided_next')),
+          )
+          .onPressed,
+      isNull,
+    );
+
+    for (var step = 1; step <= 5; step++) {
+      expect(find.text('質問 $step / 5'), findsOneWidget);
+      await tester.tap(
+        find.byKey(const Key('landing_trial_guided_quick_answer')),
+      );
+      await tester.pump();
+      expect(
+        tester
+            .widget<FilledButton>(
+              find.byKey(const Key('landing_trial_guided_next')),
+            )
+            .onPressed,
+        isNotNull,
+      );
+      await tester.tap(find.byKey(const Key('landing_trial_guided_next')));
+      await tester.pumpAndSettle();
+    }
+
+    expect(
+      find.byKey(const Key('landing_trial_guided_review')),
+      findsOneWidget,
+    );
+    expect(find.text('AIに送る内容を確認'), findsOneWidget);
+    expect(submittedPrompt, isNull);
+
+    await tester.tap(find.byKey(const Key('landing_trial_guided_submit')));
+    await tester.pump();
+
+    expect(submittedPrompt, contains('相談:仕事が多く'));
+    expect(submittedPrompt, contains('目標:まず動き出せればよい'));
+    expect(submittedPrompt!.runes.length, lessThanOrEqualTo(280));
+    expect(cancelCount, 0);
+  });
+
+  testWidgets('back preserves answers and cancel returns to the concern', (
+    tester,
+  ) async {
+    var cancelled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: LandingTrialGuidedIntake(
+            concern: '相談',
+            onCancel: () => cancelled = true,
+            onSubmit: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('landing_trial_guided_answer')),
+      '自分で書いた目標',
+    );
+    await tester.tap(find.byKey(const Key('landing_trial_guided_next')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('landing_trial_guided_back')));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const Key('landing_trial_guided_answer')),
+          )
+          .controller!
+          .text,
+      '自分で書いた目標',
+    );
+
+    await tester.tap(find.byKey(const Key('landing_trial_guided_cancel')));
+    await tester.pump();
+    expect(cancelled, isTrue);
+  });
+}


### PR DESCRIPTION
## 概要
- LPの自由入力トライアルを、5つの短い深掘り質問に回答してからAIへ送る導線へ更新
- 回答から280文字以内の構造化プロンプトを端末内で自動生成し、送信前にユーザーへ表示
- 最終確認ボタンを押した時だけ既存の landing.trial API を1回呼び出す
- 既存の1タップ入力例は即時体験として維持
- 最新mainのAI障害時簡易プレビューを維持し、AI未使用表示・保存抑止・再試行導線も継続

## 検証
- flutter analyze --no-pub（変更対象と関連フォールバック）: 成功
- flutter test --no-pub（プロンプト生成、ウィジェット、LP変換、簡易プレビュー）: 58件成功
- flutter build web --release --no-pub --no-wasm-dry-run: 成功
- ローカル本番ビルドのブラウザQA: デスクトップと390x844で5問から送信確認まで成功、表示崩れなし、コンソールエラー0件

## 影響範囲
- DB、マイグレーション、Supabase Edge Functionの変更なし
- 既存API契約をそのまま利用
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test flow or Playwright test/e2e route.
- E2E-Exception: 既存LP上の同一ルート更新のため新規E2Eファイルは増やさず、58件のウィジェット・サービス試験とPlaywright相当の実ブラウザQAで正常系・AI障害系・モバイル表示を確認済み。
