### PR TITLE
[資産管理] 明細棚卸し画面から直接ログイン

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -111,6 +111,7 @@ import 'package:my_web_app/widgets/asset_dashboard_grid.dart';
 import 'package:my_web_app/widgets/asset_net_worth_panel_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/asset_subscription_statement_scan_dialog.dart';
+import 'package:my_web_app/widgets/asset_subscription_login_dialog.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
 import 'package:my_web_app/widgets/subscription_audit_card.dart';
@@ -11660,8 +11661,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         viewModel: viewModel,
         sourceAccountNames: sourceAccountNames,
         onImport: _importSubscriptionStatementCosts,
+        onLogin: _openAssetSubscriptionLoginDialog,
       ),
     );
+  }
+
+  Future<bool> _openAssetSubscriptionLoginDialog() async {
+    return await showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) => const AssetSubscriptionLoginDialog(),
+        ) ??
+        false;
   }
 
   void _importSubscriptionStatementCosts(

--- a/lib/services/asset_subscription_login_service.dart
+++ b/lib/services/asset_subscription_login_service.dart
@@ -1,0 +1,78 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+abstract interface class AssetSubscriptionLoginService {
+  Future<void> signInWithPassword({
+    required String email,
+    required String password,
+  });
+}
+
+class AssetSubscriptionLoginException implements Exception {
+  const AssetSubscriptionLoginException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// サブスク明細画面内の再認証だけを担う小さなサービス。
+///
+/// 入力されたパスワードは Supabase Auth へ渡すだけで、
+/// アプリ独自のローカルストレージやDBには保存しない。
+/// 認証後のセッション管理は Supabase SDK に委ねる。
+class SupabaseAssetSubscriptionLoginService
+    implements AssetSubscriptionLoginService {
+  const SupabaseAssetSubscriptionLoginService({SupabaseClient? supabase})
+      : _supabase = supabase;
+
+  final SupabaseClient? _supabase;
+
+  SupabaseClient get _client => _supabase ?? Supabase.instance.client;
+
+  @override
+  Future<void> signInWithPassword({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final response = await _client.auth.signInWithPassword(
+        email: email,
+        password: password,
+      );
+      if (response.session == null) {
+        throw const AssetSubscriptionLoginException(
+          'ログイン状態を確認できませんでした。もう一度お試しください。',
+        );
+      }
+    } on AssetSubscriptionLoginException {
+      rethrow;
+    } on AuthException catch (error) {
+      throw AssetSubscriptionLoginException(_messageForAuthError(error));
+    } catch (_) {
+      throw const AssetSubscriptionLoginException(
+        'ログインできませんでした。通信状況を確認してください。',
+      );
+    }
+  }
+
+  String _messageForAuthError(AuthException error) {
+    final code = (error.code ?? '').toLowerCase();
+    final message = error.message.toLowerCase();
+    final status = error.statusCode?.toString() ?? '';
+    if (code == 'invalid_credentials' ||
+        code == 'invalid_grant' ||
+        message.contains('invalid login credentials')) {
+      return 'メールアドレスかパスワードが一致していません。';
+    }
+    if (code == 'email_not_confirmed') {
+      return 'メールアドレスの確認が完了していません。';
+    }
+    if (code == 'over_request_rate_limit' ||
+        status == '429' ||
+        message.contains('rate limit')) {
+      return 'ログインの試行回数が多すぎます。少し待ってからお試しください。';
+    }
+    return 'ログインできませんでした。入力内容を確認してください。';
+  }
+}

--- a/lib/services/asset_subscription_statement_scan_service.dart
+++ b/lib/services/asset_subscription_statement_scan_service.dart
@@ -21,10 +21,19 @@ abstract interface class AssetSubscriptionStatementImagePicker {
   Future<AssetSubscriptionStatementImage?> pickImage();
 }
 
+enum AssetSubscriptionStatementScanFailure { general, authenticationRequired }
+
 class AssetSubscriptionStatementScanException implements Exception {
   final String message;
+  final AssetSubscriptionStatementScanFailure failure;
 
-  const AssetSubscriptionStatementScanException(this.message);
+  const AssetSubscriptionStatementScanException(
+    this.message, {
+    this.failure = AssetSubscriptionStatementScanFailure.general,
+  });
+
+  bool get requiresLogin =>
+      failure == AssetSubscriptionStatementScanFailure.authenticationRequired;
 
   @override
   String toString() => message;
@@ -104,6 +113,7 @@ class AssetSubscriptionStatementScanService
       if (client.auth.currentUser == null) {
         throw const AssetSubscriptionStatementScanException(
           '明細のAI解析にはログインが必要です。',
+          failure: AssetSubscriptionStatementScanFailure.authenticationRequired,
         );
       }
     }

--- a/lib/view_models/asset_subscription_statement_scan_view_model.dart
+++ b/lib/view_models/asset_subscription_statement_scan_view_model.dart
@@ -51,6 +51,8 @@ class AssetSubscriptionStatementScanViewModel extends ChangeNotifier {
 
   bool _isAnalyzing = false;
   String? _errorMessage;
+  String? _infoMessage;
+  bool _loginRequired = false;
   String? _analyzedFileName;
   String? _sourceAccountId;
   List<AssetSubscriptionStatementCandidateReview> _reviews = const [];
@@ -58,6 +60,8 @@ class AssetSubscriptionStatementScanViewModel extends ChangeNotifier {
 
   bool get isAnalyzing => _isAnalyzing;
   String? get errorMessage => _errorMessage;
+  String? get infoMessage => _infoMessage;
+  bool get loginRequired => _loginRequired;
   String? get analyzedFileName => _analyzedFileName;
   String? get sourceAccountId => _sourceAccountId;
   List<AssetSubscriptionStatementCandidateReview> get reviews =>
@@ -92,6 +96,8 @@ class AssetSubscriptionStatementScanViewModel extends ChangeNotifier {
   Future<void> pickAndAnalyze() async {
     if (_isAnalyzing) return;
     _errorMessage = null;
+    _infoMessage = null;
+    _loginRequired = false;
     _notifyListeners();
 
     AssetSubscriptionStatementImage? image;
@@ -137,6 +143,7 @@ class AssetSubscriptionStatementScanViewModel extends ChangeNotifier {
       ];
     } on AssetSubscriptionStatementScanException catch (error) {
       _errorMessage = error.message;
+      _loginRequired = error.requiresLogin;
     } catch (_) {
       _errorMessage = '明細画像を解析できませんでした。時間をおいて再試行してください。';
     } finally {
@@ -145,6 +152,14 @@ class AssetSubscriptionStatementScanViewModel extends ChangeNotifier {
       _isAnalyzing = false;
       _notifyListeners();
     }
+  }
+
+  void markSignedIn() {
+    _errorMessage = null;
+    _loginRequired = false;
+    _analyzedFileName = null;
+    _infoMessage = 'ログインしました。安全のため、明細画像をもう一度選んでください。';
+    _notifyListeners();
   }
 
   void setSourceAccountId(String? value) {

--- a/lib/widgets/asset_subscription_login_dialog.dart
+++ b/lib/widgets/asset_subscription_login_dialog.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+
+import '../services/asset_subscription_login_service.dart';
+
+class AssetSubscriptionLoginDialog extends StatefulWidget {
+  const AssetSubscriptionLoginDialog({
+    super.key,
+    AssetSubscriptionLoginService? loginService,
+  }) : loginService =
+            loginService ?? const SupabaseAssetSubscriptionLoginService();
+
+  final AssetSubscriptionLoginService loginService;
+
+  @override
+  State<AssetSubscriptionLoginDialog> createState() =>
+      _AssetSubscriptionLoginDialogState();
+}
+
+class _AssetSubscriptionLoginDialogState
+    extends State<AssetSubscriptionLoginDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _isSubmitting = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _signIn() async {
+    if (_isSubmitting || !(_formKey.currentState?.validate() ?? false)) return;
+    setState(() {
+      _isSubmitting = true;
+      _errorMessage = null;
+    });
+    try {
+      await widget.loginService.signInWithPassword(
+        email: _emailController.text.trim(),
+        password: _passwordController.text,
+      );
+      if (!mounted) return;
+      Navigator.of(context).pop(true);
+    } on AssetSubscriptionLoginException catch (error) {
+      if (mounted) setState(() => _errorMessage = error.message);
+    } catch (_) {
+      if (mounted) {
+        setState(() => _errorMessage = 'ログインできませんでした。もう一度お試しください。');
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return AlertDialog(
+      title: const Row(
+        children: [
+          Icon(Icons.login),
+          SizedBox(width: 10),
+          Expanded(child: Text('ログインして解析を続ける')),
+        ],
+      ),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: SingleChildScrollView(
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'アプリに登録済みのメールアドレスとパスワードを入力してください。',
+                  style: TextStyle(color: scheme.onSurfaceVariant),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  key: const Key('subscription_login_email'),
+                  controller: _emailController,
+                  enabled: !_isSubmitting,
+                  autofocus: true,
+                  keyboardType: TextInputType.emailAddress,
+                  textInputAction: TextInputAction.next,
+                  autofillHints: const [AutofillHints.username],
+                  decoration: const InputDecoration(
+                    labelText: 'メールアドレス',
+                    prefixIcon: Icon(Icons.email_outlined),
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    final email = value?.trim() ?? '';
+                    if (!RegExp(
+                      r'^[^\s@]+@[^\s@]+\.[^\s@]+$',
+                    ).hasMatch(email)) {
+                      return '正しいメールアドレスを入力してください。';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  key: const Key('subscription_login_password'),
+                  controller: _passwordController,
+                  enabled: !_isSubmitting,
+                  obscureText: _obscurePassword,
+                  enableSuggestions: false,
+                  autocorrect: false,
+                  autofillHints: const [AutofillHints.password],
+                  textInputAction: TextInputAction.done,
+                  onFieldSubmitted: (_) => _signIn(),
+                  decoration: InputDecoration(
+                    labelText: 'パスワード',
+                    prefixIcon: const Icon(Icons.lock_outline),
+                    border: const OutlineInputBorder(),
+                    suffixIcon: IconButton(
+                      tooltip: _obscurePassword ? '表示' : '非表示',
+                      onPressed: _isSubmitting
+                          ? null
+                          : () => setState(
+                                () => _obscurePassword = !_obscurePassword,
+                              ),
+                      icon: Icon(
+                        _obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility,
+                      ),
+                    ),
+                  ),
+                  validator: (value) =>
+                      (value ?? '').isEmpty ? 'パスワードを入力してください。' : null,
+                ),
+                if (_errorMessage != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    _errorMessage!,
+                    key: const Key('subscription_login_error'),
+                    style: TextStyle(color: scheme.error),
+                  ),
+                ],
+                const SizedBox(height: 12),
+                Text(
+                  '入力したパスワードは保存しません。ログイン状態は安全に維持されます。',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed:
+              _isSubmitting ? null : () => Navigator.of(context).pop(false),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton.icon(
+          key: const Key('subscription_login_submit'),
+          onPressed: _isSubmitting ? null : _signIn,
+          icon: _isSubmitting
+              ? const SizedBox.square(
+                  dimension: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.login),
+          label: const Text('ログイン'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/asset_subscription_statement_scan_dialog.dart
+++ b/lib/widgets/asset_subscription_statement_scan_dialog.dart
@@ -11,11 +11,13 @@ class AssetSubscriptionStatementScanDialog extends StatefulWidget {
     required this.viewModel,
     required this.sourceAccountNames,
     required this.onImport,
+    this.onLogin,
   });
 
   final AssetSubscriptionStatementScanViewModel viewModel;
   final Map<String, String> sourceAccountNames;
   final void Function(List<AssetRecurringFixedCost> costs) onImport;
+  final Future<bool> Function()? onLogin;
 
   @override
   State<AssetSubscriptionStatementScanDialog> createState() =>
@@ -78,6 +80,9 @@ class _AssetSubscriptionStatementScanDialogState
     if (!vm.hasResults) {
       return _UploadState(
         errorMessage: vm.errorMessage,
+        infoMessage: vm.infoMessage,
+        loginRequired: vm.loginRequired,
+        onLogin: widget.onLogin == null ? null : _openLogin,
         onPick: vm.pickAndAnalyze,
       );
     }
@@ -108,6 +113,14 @@ class _AssetSubscriptionStatementScanDialogState
         );
       },
     );
+  }
+
+  Future<void> _openLogin() async {
+    final onLogin = widget.onLogin;
+    if (onLogin == null) return;
+    final signedIn = await onLogin();
+    if (!mounted || !signedIn) return;
+    widget.viewModel.markSignedIn();
   }
 
   Widget _buildFooter(BuildContext context) {
@@ -196,9 +209,18 @@ class _Header extends StatelessWidget {
 }
 
 class _UploadState extends StatelessWidget {
-  const _UploadState({required this.errorMessage, required this.onPick});
+  const _UploadState({
+    required this.errorMessage,
+    required this.infoMessage,
+    required this.loginRequired,
+    required this.onLogin,
+    required this.onPick,
+  });
 
   final String? errorMessage;
+  final String? infoMessage;
+  final bool loginRequired;
+  final Future<void> Function()? onLogin;
   final Future<void> Function() onPick;
 
   @override
@@ -248,17 +270,63 @@ class _UploadState extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                   child: Padding(
                     padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.error_outline,
+                              color: scheme.onErrorContainer,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                errorMessage!,
+                                style: TextStyle(
+                                  color: scheme.onErrorContainer,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        if (loginRequired && onLogin != null) ...[
+                          const SizedBox(height: 10),
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: FilledButton.icon(
+                              key: const Key('subscription_statement_login'),
+                              onPressed: onLogin,
+                              icon: const Icon(Icons.login),
+                              label: const Text('この画面でログイン'),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+              if (infoMessage != null) ...[
+                const SizedBox(height: 16),
+                Material(
+                  color: scheme.secondaryContainer,
+                  borderRadius: BorderRadius.circular(12),
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
                     child: Row(
                       children: [
                         Icon(
-                          Icons.error_outline,
-                          color: scheme.onErrorContainer,
+                          Icons.check_circle_outline,
+                          color: scheme.onSecondaryContainer,
                         ),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
-                            errorMessage!,
-                            style: TextStyle(color: scheme.onErrorContainer),
+                            infoMessage!,
+                            style: TextStyle(
+                              color: scheme.onSecondaryContainer,
+                            ),
                           ),
                         ),
                       ],

--- a/test/widgets/asset_subscription_login_dialog_test.dart
+++ b/test/widgets/asset_subscription_login_dialog_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_subscription_login_service.dart';
+import 'package:my_web_app/widgets/asset_subscription_login_dialog.dart';
+
+void main() {
+  testWidgets('signs in inside the dialog and returns success', (tester) async {
+    final service = _FakeLoginService();
+    bool? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => FilledButton(
+            onPressed: () async {
+              result = await showDialog<bool>(
+                context: context,
+                builder: (_) =>
+                    AssetSubscriptionLoginDialog(loginService: service),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('subscription_login_email')),
+      'owner@example.com',
+    );
+    await tester.enterText(
+      find.byKey(const Key('subscription_login_password')),
+      'secret-password',
+    );
+    await tester.tap(find.byKey(const Key('subscription_login_submit')));
+    await tester.pumpAndSettle();
+
+    expect(service.email, 'owner@example.com');
+    expect(service.password, 'secret-password');
+    expect(result, isTrue);
+    expect(find.text('ログインして解析を続ける'), findsNothing);
+  });
+
+  testWidgets('keeps the dialog open and shows a login error', (tester) async {
+    final service = _FakeLoginService(
+      error: const AssetSubscriptionLoginException('認証情報が一致しません。'),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetSubscriptionLoginDialog(loginService: service),
+        ),
+      ),
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('subscription_login_email')),
+      'owner@example.com',
+    );
+    await tester.enterText(
+      find.byKey(const Key('subscription_login_password')),
+      'wrong-password',
+    );
+    await tester.tap(find.byKey(const Key('subscription_login_submit')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('subscription_login_error')), findsOneWidget);
+    expect(find.text('認証情報が一致しません。'), findsOneWidget);
+  });
+}
+
+class _FakeLoginService implements AssetSubscriptionLoginService {
+  _FakeLoginService({this.error});
+
+  final AssetSubscriptionLoginException? error;
+  String? email;
+  String? password;
+
+  @override
+  Future<void> signInWithPassword({
+    required String email,
+    required String password,
+  }) async {
+    this.email = email;
+    this.password = password;
+    if (error != null) throw error!;
+  }
+}

--- a/test/widgets/asset_subscription_statement_scan_dialog_test.dart
+++ b/test/widgets/asset_subscription_statement_scan_dialog_test.dart
@@ -77,6 +77,46 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('opens inline login after an authentication failure', (
+    tester,
+  ) async {
+    var loginCalls = 0;
+    final viewModel = AssetSubscriptionStatementScanViewModel(
+      imagePicker: const _FakePicker(),
+      analyzer: const _AuthenticationRequiredAnalyzer(),
+      existingSubscriptions: const <AssetRecurringFixedCost>[],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetSubscriptionStatementScanDialog(
+            viewModel: viewModel,
+            sourceAccountNames: const <String, String>{},
+            onImport: (_) {},
+            onLogin: () async {
+              loginCalls++;
+              return true;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('subscription_statement_pick')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('subscription_statement_login')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('subscription_statement_login')));
+    await tester.pumpAndSettle();
+
+    expect(loginCalls, 1);
+    expect(find.textContaining('ログインしました'), findsOneWidget);
+    expect(viewModel.loginRequired, isFalse);
+  });
 }
 
 AssetSubscriptionStatementScanViewModel _viewModel() {
@@ -120,5 +160,20 @@ class _FakeAnalyzer implements AssetSubscriptionStatementAnalyzer {
         evidence: '同額の定期請求',
       ),
     ];
+  }
+}
+
+class _AuthenticationRequiredAnalyzer
+    implements AssetSubscriptionStatementAnalyzer {
+  const _AuthenticationRequiredAnalyzer();
+
+  @override
+  Future<List<AssetSubscriptionStatementCandidate>> analyze(
+    AssetSubscriptionStatementImage image,
+  ) {
+    throw const AssetSubscriptionStatementScanException(
+      '明細のAI解析にはログインが必要です。',
+      failure: AssetSubscriptionStatementScanFailure.authenticationRequired,
+    );
   }
 }


### PR DESCRIPTION
## 概要

カード明細からサブスクを棚卸しするダイアログで認証が必要になった際、画面を離れずに直接ログインできるようにします。

Closes #4676
Related: #4659

## 変更内容

- 明細解析の失敗理由に `authenticationRequired` を追加
- 認証時だけ「この画面でログイン」ボタンを表示
- メールアドレス/パスワードのインラインログインダイアログを追加
- Supabase Auth呼び出しを専用サービスへ分離し、認証エラーを日本語表示
- 成功後は画像を保持せず、明細画像の再選択を案内
- 入力パスワードをアプリ独自のStorage/DBへ保存しない旨を明示

## セキュリティ / プライバシー

- 公式Supabase Flutter SDKの `signInWithPassword` を利用
- service_roleキーや秘密情報は追加していない
- ログイン中に明細画像のバイト列を保持・送信しない
- 画像非保存、PII除外、認証境界は既存仕様を維持
- DBスキーマ、RLS、Storage、Edge Functionの変更なし

## 検証

- `dart format --output=none --set-exit-if-changed`（対象8ファイル）
- `flutter test test/widgets/asset_subscription_login_dialog_test.dart test/widgets/asset_subscription_statement_scan_dialog_test.dart test/view_models/asset_subscription_statement_scan_view_model_test.dart test/services/asset_subscription_statement_scan_service_test.dart`
  - 12 tests passed
- 対象8ファイルの `flutter analyze`
  - No issues found（構造実装後。最終文言変更は文字列/コメントのみ）
- `git diff --check`

## Minimal E2E Declaration

- 対象: `/asset-management` → サブスク → 明細画像から棚卸し
- 未ログイン時: 認証エラー → 「この画面でログイン」→ ログインダイアログ表示
- 成功後: 元ダイアログへ復帰し、画像再選択メッセージ表示
- 実アカウントのパスワード入力は自動化しない
- CI後に本番の広幅/狭幅レイアウトとコンソールエラーを確認する
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: A real authenticated account and credential would be required; widget tests cover the visible states and production smoke will verify layout without entering or storing credentials.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: No ultrareview was run because this uses the existing Supabase client Auth API and adds no schema, RLS, service key, data migration, destructive operation, or app-owned credential persistence.
