### PR TITLE
feat(shop): AI成果物の販売公開ループを追加

### DIFF
--- a/.agents/skills/digital-product-publishing-loop/SKILL.md
+++ b/.agents/skills/digital-product-publishing-loop/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: digital-product-publishing-loop
+description: Prepare explicitly exported or local AI-assisted artifacts for human-reviewed staging in this repository's digital product store. Use for artifact intake, provenance, risk gates, readiness review, rejection/retry, or publication rollback; it does not authorize live publication or financial actions.
+---
+
+# Digital Product Publishing Loop
+
+Turn intermediate artifacts into reviewable product candidates while keeping publication authority with a human.
+
+## Boundaries
+
+- Accept only paths the user explicitly provides. For ChatGPT, accept explicit exports only. For Codex, Claude Code, and Antigravity, accept explicit local workspace/artifact paths or exports.
+- Never scrape consumer UIs, inspect unrelated task history or auth caches, or use third-party OAuth to control Antigravity.
+- Never transmit artifact content or secrets. The local intake helper records hashes, MIME, size, provenance, and finding counts without matched values.
+- Preparation and dry-run staging do not authorize Stripe Product/Price creation, charges, live Storage uploads, live database writes, `is_active = true`, deployment, deletion, refunds, or external messages.
+- Ask for explicit authorization immediately before each external/live mutation, name the exact target and environment, and preserve proof of outcome. Stop if authorization or proof is missing.
+- Do not describe idea briefs as exclusive property or guaranteed copyright. Describe them as non-exclusive reference or planning material.
+
+## Workflow
+
+1. Read `docs/ARTIFACT_PUBLISHING_LOOP.md` and `docs/DIGITAL_PRODUCT_STORE.md`. Preserve existing `/shop` checkout, purchase, and download semantics.
+2. Confirm the explicit input paths, source tool, and intake method. Do not broaden the scan root.
+3. Run `python scripts/artifact_intake.py ... --output <local-manifest> --fail-on-risk`. Add `--artifact-kind design|prompt|idea|game|...` for ambiguous file types and run different product kinds separately. A risk exit code is a review result, not permission to bypass a gate.
+4. Review the manifest locally. Stop and require redaction or replacement for secrets/PII; require human decisions for rights, face/voice consent, ChatGPT Voice Output, and concrete human contribution.
+5. Prepare candidate/provenance/check data idempotently by SHA-256. Keep files and matched sensitive values out of the database. Initial products remain inactive.
+6. Use `/admin/artifact-publishing` to inspect readiness and record decisions only in their evidence stage: automated scans in `automated_checks`, rights/contribution in `human_review`, and price/object/integrity in `staged`. Use reject/retry or rollback instead of skipping stages.
+7. Record concrete human contribution when approving. When moving an approved candidate to staged, link an existing inactive product and enter the reviewed JPY price and private `product-downloads` path. Do not create the Stripe Price, Storage object, or active listing automatically. Verify display price, private bucket/path, object size, and SHA-256.
+8. Treat `ready` as a decision packet, not approval to publish. A human must separately authorize the live action with target/environment/rollback proof before `is_active = true` or deployment.
+9. If a live product has a problem, stop new sales by explicitly setting it inactive before moving `published` back to `ready`. Never delete purchases, entitlements, or the private artifact as rollback.
+
+Read [references/safety-gates.md](references/safety-gates.md) when evaluating readiness, deciding whether a check may be not-applicable, or preparing a live handoff.

--- a/.agents/skills/digital-product-publishing-loop/agents/openai.yaml
+++ b/.agents/skills/digital-product-publishing-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Digital Product Publishing Loop"
+  short_description: "Review AI artifacts before safe product release"
+  default_prompt: "Use $digital-product-publishing-loop to prepare an explicit local artifact for reviewed staging."

--- a/.agents/skills/digital-product-publishing-loop/references/safety-gates.md
+++ b/.agents/skills/digital-product-publishing-loop/references/safety-gates.md
@@ -1,0 +1,33 @@
+# Safety gates and handoff evidence
+
+## Required hard gates
+
+The candidate has nine hard checks. `secret_scan`, `pii_scan`, `human_contribution`, `price_match`, `private_object`, and `content_integrity` must be `pass`. Only `third_party_license`, `face_voice_consent`, and `chatgpt_voice_output` may be `not_applicable`, with a human-written reason.
+
+Block readiness when any of these are true:
+
+- a secret or PII finding has not been removed and rescanned;
+- third-party license terms are missing or incompatible;
+- a depicted face or recorded/synthetic voice lacks the required consent;
+- ChatGPT Voice Output is proposed as standalone audio;
+- the record does not identify concrete human selection, editing, assembly, or verification;
+- the shop display price does not match the reviewed Stripe Price;
+- the product is not in the private `product-downloads` bucket;
+- object path, measured byte size, or SHA-256 is missing or mismatched.
+
+Automated findings cannot mark human or external-evidence gates as passed. Do not use a waiver, retry, or stage rollback to erase prior audit evidence.
+Review each gate only in its assigned stage. Return the candidate to that stage before replacing evidence; do not edit a passed gate in place after approval.
+
+## Live handoff packet
+
+Before requesting live authorization, provide:
+
+- candidate ID, product ID, SHA-256, byte size, and version;
+- source/provenance summary without local secret-bearing paths when unnecessary;
+- nine gate statuses and concise evidence;
+- reviewed Stripe Price ID, JPY amount, mode, private bucket/path, and object verification;
+- exact proposed live command/action and environment;
+- rollback action (`is_active = false`) and validation plan;
+- the authorization reference to record in the publication run.
+
+After an authorized action, record observable proof. A command returning success without catalog, checkout/download, and audit verification is not publication proof.

--- a/docs/ARTIFACT_PUBLISHING_LOOP.md
+++ b/docs/ARTIFACT_PUBLISHING_LOOP.md
@@ -1,0 +1,139 @@
+# AI支援成果物のデジタル商品公開ループ
+
+ChatGPTの明示的なエクスポート、またはCodex・Claude Code・Antigravityの
+ローカルworkspace/artifactファイルを、レビュー済みデジタル商品へ変えるための
+閉ループです。ツールの画面をスクレイピングせず、候補の準備と公開権限を分離します。
+
+```mermaid
+flowchart LR
+    A[明示したローカル入力] --> B[SHA-256 / MIME / size]
+    B --> C{秘密情報・PII}
+    C -->|検出| R[却下・修正]
+    R --> A
+    C -->|合格| H{人手レビュー}
+    H -->|権利・同意・寄与不足| R
+    H -->|人手承認| S[非公開商品へステージ]
+    S --> G{価格・private object・hash}
+    G -->|不一致| R
+    G -->|全hard gate合格| E[公開準備完了]
+    E -->|別手順で明示承認| P[is_active = true]
+    P --> O[既存 /shop checkout・download]
+    O --> V[監査・購入後検証]
+    V -->|改善版| A
+    V -->|問題| X[is_active = false]
+    X --> E
+```
+
+## 自動ゲートと人間のゲート
+
+| ゲート | 自動化できること | 人間が必ず判断すること |
+|---|---|---|
+| 取込 | 明示パスの走査、SHA-256、MIME、size、manifest内dedup | 入力範囲と出所が正しいか |
+| リスク | 明白な秘密情報・メール・電話等のパターン検出 | 誤検知、文脈、完全な削除を確認 |
+| 権利 | 音声・動画を同意確認対象として提示 | 第三者ライセンス、顔・声の同意、利用規約 |
+| 創作寄与 | 記録欄と必須checkを用意 | 人間が構成・編集・検証した具体的内容 |
+| 商品ステージ | DB価格、非公開bucket/path、hash、sizeの一致を検査 | Stripe Priceと実物、商品説明、法務表示 |
+| 公開 | readinessを表示し監査eventを残す | live DB、Stripe、Storage、deployの実行承認 |
+
+次はhard blockです。自動処理は合格に書き換えたり、迂回したりできません。
+
+- 秘密情報または未解消のPIIリスク
+- 未確認の第三者素材ライセンス
+- 必要な顔・声の同意がないこと
+- ChatGPT Voice Outputをstandalone音声として販売すること
+- 人間の具体的な寄与記録がないこと
+- 表示価格とStripe Priceの不一致
+- private Storage object、実測size、SHA-256の不足・不一致
+
+`idea` 商品は「企画brief」「非独占的な参考素材」と説明します。独占性や著作権の
+成立を保証する商品説明にしません。
+
+## ローカル取込
+
+ヘルパーは標準ライブラリだけを使い、ネットワーク送信を行いません。入力はコマンドで
+明示したファイルまたはdirectoryだけです。symlinkは走査せず、検出した値そのものを
+manifestへ書きません。同じSHA-256は1候補にまとめ、複数の出所をprovenanceとして残します。
+
+```powershell
+python scripts/artifact_intake.py `
+  'C:\explicit\exports\product-draft' `
+  --source-tool codex `
+  --intake-method local_workspace `
+  --artifact-kind template `
+  --output 'C:\review\artifact-manifest.json' `
+  --fail-on-risk
+```
+
+ChatGPTは`--intake-method explicit_export`だけを受け付けます。標準出力で確認する場合は
+`--output -`を使います。`--fail-on-risk`はfindingがあれば終了code 2を返しますが、
+manifest自体はローカルへ作るため、レビューと修正に使えます。
+
+manifestの主要fieldは`artifact_sha256`、`mime_type`、`file_size_bytes`、
+保守的に推定した`artifact_kind`、
+`provenance[]`、値を含まない`risk_scan.findings[]`です。importは自動送信ではありません。
+画像・音声・動画・文章・template以外の曖昧な拡張子では、`--artifact-kind`に
+`design`、`prompt`、`idea`、`game`、`bundle`などを明示します（defaultは`auto`）。
+1回の実行では入力全体に同じ種別を適用するため、種別が異なる成果物は実行を分けます。
+レビュー済みの管理者sessionから`intake_artifact_candidate` RPCへ各entryとprovenanceを
+渡すと、SHA-256をkeyに候補と出所を同一transactionでatomic upsertできます。RPCは
+候補を`intake`より先へ進めず、ファイル本文、findingのmatched value、秘密値は受け取りません。
+
+## tool別の境界
+
+- ChatGPT: ユーザーが明示的に保存・エクスポートしたファイルだけ。consumer UIや会話画面を
+  スクレイピングしません。Voice Outputのstandalone販売はblockします。
+- Codex / Claude Code: ユーザーが指定したworkspaceまたはartifact exportだけ。task履歴、
+  認証cache、設定directory、環境変数を自動探索しません。
+- Antigravity: 明示したlocal workspace/artifact exportだけ。consumer UIの操作や
+  third-party OAuthでの制御を行いません。
+
+## DB state machineと権限
+
+管理画面は`/admin/artifact-publishing`です。`user_profiles.is_admin`の既存管理者だけが
+候補、provenance、check、run、eventを読めます。anonにはtable privilegeがなく、
+authenticated roleのData API accessもadmin限定RLSにより通常buyerへrowを返しません。
+管理者にもeventのinsert/update/delete権限は
+なく、triggerだけが監査eventを追記します。
+
+各checkは証拠を作るstageでだけ更新できます。`secret_scan` / `pii_scan`は
+`automated_checks`、権利・同意・人間の寄与は`human_review`、価格・private object・
+content integrityは`staged`です。証拠を修正するときは先に該当stageへ戻すため、
+承認後のcheckだけを書き換えてreadiness表示と監査状態をずらすことはできません。
+
+通常経路は次の通りです。
+
+```text
+intake → automated_checks → human_review → approved → staged → ready
+                                                             ↓ explicit live action
+                                                          published
+```
+
+任意の公開前stageから理由つき`rejected`へ移動でき、`rejected → intake`で再試行します。
+後退経路は自動検査・人手レビュー・stagedへ限定されています。`approved_by`と
+`approved_at`は人手承認transition時の`auth.uid()`からDB triggerが設定し、clientは
+指定できません。
+
+`human_review → approved`では、人間が行った構成・選択・編集・検証を20文字以上で
+記録します。`approved → staged`では、既に用意したinactive商品ID、確認済みJPY価格、
+private `product-downloads` object pathを同じ更新で保存します。いずれも管理画面から入力でき、
+商品をactiveにする操作は含みません。
+
+新しいloop候補へlinkした`shop_products`だけは、`ready`、全hard gate、人手承認、
+価格、private bucket/path、SHA-256、sizeが一致しない限り`is_active = true`を拒否します。
+候補にlinkしていない既存商品、`/shop` checkout、購入権利、downloadの意味は変更しません。
+
+## 公開とrollback
+
+この機能はStripe Product/Price、charge、Storage object、商品削除、live publish、deployを
+作成・実行しません。`ready`は「実行してよい」ではなく「人間が最終判断できる材料が
+揃った」です。live actionには、その時点での明示承認、対象product ID、環境、実測値、
+rollback手順を残します。
+
+- 公開前の問題: 理由つきrejectまたは前stageへ戻し、同じhashのまま内容を差し替えない。
+  修正ファイルは新しいSHA-256として再取込します。
+- 公開後の問題: 最初に`is_active = false`として新規購入を停止し、次に
+  `published → ready`へ戻します。
+- 購入済み権利、`shop_purchases`、private file、Stripe Priceを削除しません。
+  既存購入者の再downloadと返金監査を維持します。
+
+販売・配信の既存運用は[デジタル商品ストア運用手順](DIGITAL_PRODUCT_STORE.md)を併用してください。

--- a/docs/DIGITAL_PRODUCT_STORE.md
+++ b/docs/DIGITAL_PRODUCT_STORE.md
@@ -2,6 +2,11 @@
 
 Issue: [#4627](https://github.com/kanta13jp1/my_web_app/issues/4627)
 
+AI支援の中間成果物を商品候補へ変える場合は、先に
+[AI支援成果物のデジタル商品公開ループ](ARTIFACT_PUBLISHING_LOOP.md)で出所、秘密情報、
+PII、権利、人間の寄与、価格、private object、SHA-256をレビューしてください。
+`/admin/artifact-publishing`の`ready`はlive公開の許可ではなく、最終判断の準備完了です。
+
 画像、音声、動画、デザイン、文章、プロンプト、アイデア、ゲーム、テンプレートを、
 運営者本人が買い切り商品として販売するための手順です。第三者出品や売上分配は扱いません。
 
@@ -144,6 +149,10 @@ values (
 ## 7. 販売を開始・停止する
 
 法務表示と検証が完了した後だけ公開します。
+
+`artifact_candidates.product_id`にlinkした商品は、候補が`ready`で全hard gateと人手承認を
+満たすまで、DB triggerが`is_active = true`を拒否します。次のSQLは対象、環境、価格、
+Storage実測値、rollback手順を人が再確認し、live DB変更を明示承認した後だけ実行します。
 
 ```sql
 update public.shop_products

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -33489,3 +33489,11 @@ watcher が名指しできるのはスナップショット時点で**生存し�
 - 前回の「再クロール待ち」から発見シグナル生成まで掘り下げ、全47 URLの`lastmod`をページ更新と無関係なデプロイ日に揃える実装を確認した。
 - Googleが検証可能な重要更新日のみを利用できるよう、`date_modified`を明示した`/philosophy`だけに`lastmod=2026-08-19`を出し、未確認46 URLでは省略するよう修正した。URL一覧・本文・導線は変更していない。
 - 検証: SEO生成テスト17件、Python構文確認、`flutter analyze --no-pub`、Web release build、47 URL/1 lastmodの生成物監査、ローカルブラウザ描画が成功。順位への寄与は未断定で、次回は無関係デプロイ後の日付維持と週次のクロール／インデックス変化を確認する。
+
+### 販売基盤セッション記録: AI成果物の公開ループ (2026-08-22 JST)
+
+- ChatGPTの明示exportとCodex・Claude Code・Antigravityの指定workspace成果物を、画像・音声・動画・デザイン・文章・プロンプト・アイデア・ゲーム・テンプレート・bundleの商品候補として扱う管理ループを追加した。
+- 取込は指定pathだけをlocal scanし、SHA-256でdedupする。秘密情報・PIIのmatched valueやファイル本文はDBへ送らず、出所、権利・同意、人間の寄与、価格、private object、size、hashの9 hard gateをstage別に記録する。
+- `ready`とlive公開を分離し、linked商品は全gateと人手承認が揃うまで`is_active=true`をDB triggerで拒否する。問題時は販売停止、stage rollback、修正版の再取込で閉ループに戻す。
+- 管理画面、migration contract、local intake test、responsive widget test、運用docs、repository skillを同じ設計へ同期した。既存購入・download・Stripe Priceをrollbackで削除しない。
+- 検証はFlutter 12件、local intake 5件、変更対象の静的解析、linked Supabaseのmigration dry-run、1440px/390pxブラウザ表示で実施し、live商品自体はactive化していない。

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,6 +72,7 @@ import 'package:my_web_app/pages/tech_blog_tracker_page.dart';
 import 'package:my_web_app/pages/thought_anchor_page.dart';
 import 'package:my_web_app/pages/rewards_page.dart';
 import 'package:my_web_app/pages/admin_analytics_page.dart';
+import 'package:my_web_app/pages/admin_artifact_publishing_page.dart';
 import 'package:my_web_app/pages/admin/feedback_list_page.dart';
 import 'package:my_web_app/pages/admin/quota_dashboard_page.dart';
 import 'package:my_web_app/pages/admin/blog_management_page.dart';
@@ -901,6 +902,11 @@ Route<dynamic> generateAppRoute(
     case '/admin':
       return MaterialPageRoute(
         builder: (_) => const AdminAnalyticsPage(),
+      );
+    case '/admin/artifact-publishing':
+      return MaterialPageRoute(
+        builder: (_) => const AdminArtifactPublishingPage(),
+        settings: settings,
       );
     case '/templates':
       return MaterialPageRoute(

--- a/lib/models/artifact_publishing.dart
+++ b/lib/models/artifact_publishing.dart
@@ -1,0 +1,204 @@
+enum ArtifactStage {
+  intake('intake', '取込'),
+  automatedChecks('automated_checks', '自動検査'),
+  humanReview('human_review', '人手レビュー'),
+  approved('approved', '人手承認済み'),
+  staged('staged', '商品ステージ'),
+  ready('ready', '公開準備完了'),
+  published('published', '公開済み'),
+  rejected('rejected', '却下');
+
+  const ArtifactStage(this.databaseValue, this.labelJa);
+
+  factory ArtifactStage.fromDatabase(String? value) => values.firstWhere(
+        (stage) => stage.databaseValue == value,
+        orElse: () => ArtifactStage.intake,
+      );
+
+  final String databaseValue;
+  final String labelJa;
+
+  bool get canReject => this != published && this != rejected;
+
+  List<ArtifactStage> get transitionTargets => switch (this) {
+        intake => const [automatedChecks],
+        automatedChecks => const [humanReview, intake],
+        humanReview => const [approved, automatedChecks],
+        approved => const [staged, humanReview],
+        staged => const [ready, humanReview],
+        ready => const [published, staged],
+        published => const [ready],
+        rejected => const [intake],
+      };
+}
+
+enum ArtifactCheckStatus {
+  pending('pending', '未確認'),
+  passed('pass', '合格'),
+  failed('fail', 'ブロック'),
+  notApplicable('not_applicable', '対象外');
+
+  const ArtifactCheckStatus(this.databaseValue, this.labelJa);
+
+  factory ArtifactCheckStatus.fromDatabase(String? value) => values.firstWhere(
+        (status) => status.databaseValue == value,
+        orElse: () => ArtifactCheckStatus.pending,
+      );
+
+  final String databaseValue;
+  final String labelJa;
+}
+
+class ArtifactCheck {
+  const ArtifactCheck({
+    required this.key,
+    required this.kind,
+    required this.status,
+    required this.isHardGate,
+    required this.evidenceSummary,
+  });
+
+  factory ArtifactCheck.fromRow(Map<String, dynamic> row) => ArtifactCheck(
+        key: row['check_key'] as String? ?? '',
+        kind: row['check_kind'] as String? ?? '',
+        status: ArtifactCheckStatus.fromDatabase(row['status'] as String?),
+        isHardGate: row['is_hard_gate'] as bool? ?? true,
+        evidenceSummary: row['evidence_summary'] as String? ?? '',
+      );
+
+  final String key;
+  final String kind;
+  final ArtifactCheckStatus status;
+  final bool isHardGate;
+  final String evidenceSummary;
+
+  bool get allowsNotApplicable => const {
+        'third_party_license',
+        'face_voice_consent',
+        'chatgpt_voice_output',
+      }.contains(key);
+
+  bool get isSatisfied =>
+      status == ArtifactCheckStatus.passed ||
+      (allowsNotApplicable && status == ArtifactCheckStatus.notApplicable);
+
+  bool canEditAt(ArtifactStage stage) => switch (key) {
+        'secret_scan' || 'pii_scan' => stage == ArtifactStage.automatedChecks,
+        'third_party_license' ||
+        'face_voice_consent' ||
+        'chatgpt_voice_output' ||
+        'human_contribution' =>
+          stage == ArtifactStage.humanReview,
+        'price_match' ||
+        'private_object' ||
+        'content_integrity' =>
+          stage == ArtifactStage.staged,
+        _ => false,
+      };
+
+  String get labelJa => switch (key) {
+        'secret_scan' => '秘密情報',
+        'pii_scan' => '個人情報',
+        'third_party_license' => '第三者ライセンス',
+        'face_voice_consent' => '顔・声の同意',
+        'chatgpt_voice_output' => 'Voice Output 制限',
+        'human_contribution' => '人間の寄与',
+        'price_match' => '価格一致',
+        'private_object' => '非公開ファイル',
+        'content_integrity' => 'ハッシュ整合',
+        _ => key,
+      };
+}
+
+class ArtifactCandidate {
+  const ArtifactCandidate({
+    required this.id,
+    required this.title,
+    required this.sha256,
+    required this.mimeType,
+    required this.fileSizeBytes,
+    required this.kind,
+    required this.stage,
+    required this.checks,
+    required this.sourceTools,
+    required this.productId,
+    required this.productName,
+    required this.productActive,
+    required this.intendedPriceJpy,
+    required this.proposedStorageBucket,
+    required this.proposedStoragePath,
+    required this.humanContributionSummary,
+    required this.rejectionReason,
+    required this.updatedAt,
+  });
+
+  factory ArtifactCandidate.fromRow(Map<String, dynamic> row) {
+    final checkRows = row['artifact_checks'] as List<dynamic>? ?? const [];
+    final provenanceRows =
+        row['artifact_provenance'] as List<dynamic>? ?? const [];
+    final rawProduct = row['shop_products'];
+    final product = rawProduct is Map
+        ? Map<String, dynamic>.from(rawProduct)
+        : const <String, dynamic>{};
+    final checks = checkRows
+        .map(
+          (raw) => ArtifactCheck.fromRow(Map<String, dynamic>.from(raw as Map)),
+        )
+        .toList(growable: false)
+      ..sort((left, right) => left.key.compareTo(right.key));
+    final tools = provenanceRows
+        .map((raw) => (raw as Map)['source_tool']?.toString() ?? '')
+        .where((tool) => tool.isNotEmpty)
+        .toSet()
+        .toList(growable: false)
+      ..sort();
+    return ArtifactCandidate(
+      id: row['id'] as String? ?? '',
+      title: row['title'] as String? ?? '',
+      sha256: row['artifact_sha256'] as String? ?? '',
+      mimeType: row['mime_type'] as String? ?? '',
+      fileSizeBytes: (row['file_size_bytes'] as num?)?.toInt() ?? 0,
+      kind: row['artifact_kind'] as String? ?? '',
+      stage: ArtifactStage.fromDatabase(row['stage'] as String?),
+      checks: checks,
+      sourceTools: tools,
+      productId: row['product_id'] as String?,
+      productName: product['name_ja'] as String?,
+      productActive: product['is_active'] as bool? ?? false,
+      intendedPriceJpy: (row['intended_price_jpy'] as num?)?.toInt(),
+      proposedStorageBucket: row['proposed_storage_bucket'] as String?,
+      proposedStoragePath: row['proposed_storage_path'] as String?,
+      humanContributionSummary:
+          row['human_contribution_summary'] as String? ?? '',
+      rejectionReason: row['rejection_reason'] as String? ?? '',
+      updatedAt: DateTime.tryParse(row['updated_at'] as String? ?? ''),
+    );
+  }
+
+  final String id;
+  final String title;
+  final String sha256;
+  final String mimeType;
+  final int fileSizeBytes;
+  final String kind;
+  final ArtifactStage stage;
+  final List<ArtifactCheck> checks;
+  final List<String> sourceTools;
+  final String? productId;
+  final String? productName;
+  final bool productActive;
+  final int? intendedPriceJpy;
+  final String? proposedStorageBucket;
+  final String? proposedStoragePath;
+  final String humanContributionSummary;
+  final String rejectionReason;
+  final DateTime? updatedAt;
+
+  int get satisfiedHardGateCount =>
+      checks.where((check) => check.isHardGate && check.isSatisfied).length;
+
+  int get hardGateCount => checks.where((check) => check.isHardGate).length;
+
+  bool get allHardGatesSatisfied =>
+      hardGateCount == 9 && satisfiedHardGateCount == hardGateCount;
+}

--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -2195,6 +2195,39 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                       color: const Color(0xFF1A1A2E),
                       child: ListTile(
                         leading: const Icon(
+                          Icons.published_with_changes_outlined,
+                          color: Color(0xFFFF6B35),
+                        ),
+                        title: const Text(
+                          'AI成果物 公開ループ',
+                          style: TextStyle(
+                            color: Color(0xFFE5E7EB),
+                            fontWeight: FontWeight.bold,
+                            height: 1.5,
+                          ),
+                        ),
+                        subtitle: const Text(
+                          '候補、権利、検査、商品ステージを人手承認つきで管理',
+                          style: TextStyle(
+                            color: Color(0xB3E5E7EB),
+                            height: 1.5,
+                          ),
+                        ),
+                        trailing: const Icon(
+                          Icons.chevron_right,
+                          color: Color(0x8AE5E7EB),
+                        ),
+                        onTap: () => Navigator.pushNamed(
+                          context,
+                          '/admin/artifact-publishing',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Card(
+                      color: const Color(0xFF1A1A2E),
+                      child: ListTile(
+                        leading: const Icon(
                           Icons.edit_note,
                           color: Color(0xFFFF6B35),
                         ),

--- a/lib/pages/admin_artifact_publishing_page.dart
+++ b/lib/pages/admin_artifact_publishing_page.dart
@@ -1,0 +1,825 @@
+import 'package:flutter/material.dart';
+
+import '../models/artifact_publishing.dart';
+import '../services/artifact_publishing_service.dart';
+import '../view_models/artifact_publishing_view_model.dart';
+
+class AdminArtifactPublishingPage extends StatefulWidget {
+  const AdminArtifactPublishingPage({super.key, this.gateway});
+
+  final ArtifactPublishingGateway? gateway;
+
+  @override
+  State<AdminArtifactPublishingPage> createState() =>
+      _AdminArtifactPublishingPageState();
+}
+
+class _AdminArtifactPublishingPageState
+    extends State<AdminArtifactPublishingPage> {
+  late final ArtifactPublishingViewModel _viewModel;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = ArtifactPublishingViewModel(
+      gateway: widget.gateway ?? ArtifactPublishingService(),
+    )..addListener(_onChanged);
+    _viewModel.load();
+  }
+
+  @override
+  void dispose() {
+    _viewModel
+      ..removeListener(_onChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onChanged() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AI成果物 公開ループ'),
+        actions: [
+          IconButton(
+            tooltip: '再読み込み',
+            onPressed: _viewModel.loading ? null : _viewModel.load,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: _body(context),
+    );
+  }
+
+  Widget _body(BuildContext context) {
+    if (_viewModel.loading && !_viewModel.accessChecked) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (!_viewModel.authorized) {
+      return _AccessDenied(error: _viewModel.error);
+    }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final horizontal = constraints.maxWidth >= 720 ? 32.0 : 16.0;
+        return RefreshIndicator(
+          onRefresh: _viewModel.load,
+          child: ListView(
+            padding: EdgeInsets.fromLTRB(horizontal, 20, horizontal, 48),
+            children: [
+              const _SafetyBanner(),
+              const SizedBox(height: 20),
+              const _PublishingLoopDiagram(),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Text(
+                    '候補成果物',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  const Spacer(),
+                  Text('${_viewModel.candidates.length}件'),
+                ],
+              ),
+              if (_viewModel.error != null) ...[
+                const SizedBox(height: 12),
+                _InlineError(message: _viewModel.error!),
+              ],
+              const SizedBox(height: 12),
+              if (_viewModel.candidates.isEmpty)
+                const _EmptyCandidates()
+              else
+                ..._viewModel.candidates.map(
+                  (candidate) => Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: _CandidateCard(
+                      candidate: candidate,
+                      working: _viewModel.workingCandidateId == candidate.id,
+                      onTransition: (target) => _transition(candidate, target),
+                      onReviewCheck: (check, status) =>
+                          _reviewCheck(candidate, check, status),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _transition(
+    ArtifactCandidate candidate,
+    ArtifactStage target,
+  ) async {
+    String? rejectionReason;
+    String? humanContributionSummary;
+    _StageProductInput? stageProduct;
+    if (target == ArtifactStage.rejected) {
+      rejectionReason = await _textDecisionDialog(
+        title: '候補を却下',
+        message: '監査記録に残す却下理由を10文字以上で入力してください。',
+        confirmLabel: '却下を記録',
+        destructive: true,
+        minimumLength: 10,
+      );
+      if (rejectionReason == null) return;
+    } else if (target == ArtifactStage.approved) {
+      humanContributionSummary = await _textDecisionDialog(
+        title: '人手承認を記録',
+        message: '構成・選択・編集・検証など、人間が加えた創作的な寄与を20文字以上で記録してください。'
+            'この操作だけでは商品を公開しません。',
+        confirmLabel: '寄与を記録して承認',
+        minimumLength: 20,
+        initialValue: candidate.humanContributionSummary,
+      );
+      if (humanContributionSummary == null) return;
+    } else if (target == ArtifactStage.staged &&
+        candidate.stage == ArtifactStage.approved) {
+      stageProduct = await _stageProductDialog(candidate);
+      if (stageProduct == null) return;
+    } else if (target == ArtifactStage.published && !candidate.productActive) {
+      _showMessage('商品を外部の承認済み手順で有効化した後に公開済みへ進めます。');
+      return;
+    }
+
+    final succeeded = await _viewModel.transition(
+      candidate,
+      target,
+      rejectionReason: rejectionReason,
+      humanContributionSummary: humanContributionSummary,
+      productId: stageProduct?.productId,
+      intendedPriceJpy: stageProduct?.intendedPriceJpy,
+      proposedStoragePath: stageProduct?.storagePath,
+    );
+    if (!mounted) return;
+    _showMessage(succeeded ? 'ステージを更新しました。' : 'ステージ更新に失敗しました。');
+  }
+
+  Future<void> _reviewCheck(
+    ArtifactCandidate candidate,
+    ArtifactCheck check,
+    ArtifactCheckStatus status,
+  ) async {
+    String? evidence;
+    if (status != ArtifactCheckStatus.pending) {
+      evidence = await _textDecisionDialog(
+        title: '${check.labelJa}: ${status.labelJa}',
+        message: '秘密値や個人情報そのものは貼らず、確認方法と根拠だけを記録してください。',
+        confirmLabel: '検査結果を記録',
+        minimumLength: 3,
+      );
+      if (evidence == null) return;
+    }
+    final succeeded = await _viewModel.reviewCheck(
+      candidate,
+      check,
+      status,
+      evidenceSummary: evidence,
+    );
+    if (!mounted) return;
+    _showMessage(succeeded ? '検査結果を更新しました。' : '検査結果の更新に失敗しました。');
+  }
+
+  Future<String?> _textDecisionDialog({
+    required String title,
+    required String message,
+    required String confirmLabel,
+    required int minimumLength,
+    bool destructive = false,
+    String initialValue = '',
+  }) =>
+      showDialog<String>(
+        context: context,
+        builder: (_) => _TextDecisionDialog(
+          title: title,
+          message: message,
+          confirmLabel: confirmLabel,
+          minimumLength: minimumLength,
+          destructive: destructive,
+          initialValue: initialValue,
+        ),
+      );
+
+  Future<_StageProductInput?> _stageProductDialog(
+    ArtifactCandidate candidate,
+  ) =>
+      showDialog<_StageProductInput>(
+        context: context,
+        builder: (_) => _StageProductDialog(candidate: candidate),
+      );
+
+  void _showMessage(String message) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+}
+
+class _PublishingLoopDiagram extends StatelessWidget {
+  const _PublishingLoopDiagram();
+
+  static const _steps = [
+    (Icons.file_open_outlined, '明示取込', 'ローカルでhash・リスク検査'),
+    (Icons.rule_folder_outlined, '自動ゲート', '秘密情報・PIIをブロック'),
+    (Icons.fact_check_outlined, '人手レビュー', '権利・同意・寄与を確認'),
+    (Icons.inventory_2_outlined, '安全なステージ', '非公開Storage・価格を照合'),
+    (Icons.publish_outlined, '明示公開', '別手順の承認後のみ有効化'),
+    (Icons.history_outlined, '監査・改善', 'イベントを残し再取込へ'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Semantics(
+      label: '明示取込、自動ゲート、人手レビュー、安全なステージ、明示公開、監査改善の循環',
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colors.surfaceContainerLow,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: colors.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('公開ループ', style: Theme.of(context).textTheme.titleLarge),
+              const SizedBox(height: 4),
+              Text(
+                '自動化は準備まで。公開権限と販売権限は人間が保持します。',
+                style: TextStyle(color: colors.onSurfaceVariant),
+              ),
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 8,
+                runSpacing: 10,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  for (var index = 0; index < _steps.length; index++) ...[
+                    _LoopStep(step: _steps[index]),
+                    if (index < _steps.length - 1)
+                      Icon(Icons.arrow_forward, color: colors.primary),
+                  ],
+                  Icon(Icons.replay, color: colors.tertiary),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LoopStep extends StatelessWidget {
+  const _LoopStep({required this.step});
+
+  final (IconData, String, String) step;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Container(
+      width: 152,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(step.$1, color: colors.primary),
+          const SizedBox(height: 8),
+          Text(step.$2, style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: 3),
+          Text(
+            step.$3,
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CandidateCard extends StatelessWidget {
+  const _CandidateCard({
+    required this.candidate,
+    required this.working,
+    required this.onTransition,
+    required this.onReviewCheck,
+  });
+
+  final ArtifactCandidate candidate;
+  final bool working;
+  final ValueChanged<ArtifactStage> onTransition;
+  final void Function(ArtifactCheck, ArtifactCheckStatus) onReviewCheck;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.all(18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Wrap(
+              spacing: 10,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                Text(
+                  candidate.title,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                Chip(label: Text(candidate.stage.labelJa)),
+                Chip(
+                  avatar: Icon(
+                    candidate.allHardGatesSatisfied
+                        ? Icons.verified_outlined
+                        : Icons.pending_actions_outlined,
+                    size: 18,
+                  ),
+                  label: Text(
+                    '必須 ${candidate.satisfiedHardGateCount}/${candidate.hardGateCount}',
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              '${candidate.kind} • ${candidate.mimeType} • '
+              '${_formatBytes(candidate.fileSizeBytes)}',
+              style: TextStyle(color: colors.onSurfaceVariant),
+            ),
+            const SizedBox(height: 2),
+            SelectableText(
+              'SHA-256 ${candidate.sha256}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 2),
+            Text(
+              '出所: ${candidate.sourceTools.isEmpty ? '未登録' : candidate.sourceTools.join(', ')}'
+              ' / 商品: ${candidate.productName ?? candidate.productId ?? '未連携'}'
+              '${candidate.productActive ? '（有効）' : ''}',
+            ),
+            if (candidate.humanContributionSummary.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text('人間の寄与: ${candidate.humanContributionSummary}'),
+            ],
+            if (candidate.proposedStoragePath != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                'ステージ: ¥${candidate.intendedPriceJpy ?? '-'} / '
+                '${candidate.proposedStorageBucket}/${candidate.proposedStoragePath}',
+              ),
+            ],
+            const SizedBox(height: 14),
+            Text('必須チェック', style: Theme.of(context).textTheme.titleSmall),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: candidate.checks
+                  .map(
+                    (check) => _CheckMenu(
+                      check: check,
+                      enabled: !working && check.canEditAt(candidate.stage),
+                      onSelected: (status) => onReviewCheck(check, status),
+                    ),
+                  )
+                  .toList(growable: false),
+            ),
+            if (candidate.rejectionReason.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Text(
+                '却下理由: ${candidate.rejectionReason}',
+                style: TextStyle(color: colors.error),
+              ),
+            ],
+            const SizedBox(height: 16),
+            if (working)
+              const LinearProgressIndicator()
+            else
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final target in candidate.stage.transitionTargets)
+                    target.index > candidate.stage.index ||
+                            candidate.stage == ArtifactStage.rejected
+                        ? FilledButton.tonalIcon(
+                            onPressed: () => onTransition(target),
+                            icon: Icon(
+                              target == ArtifactStage.intake
+                                  ? Icons.replay
+                                  : Icons.arrow_forward,
+                            ),
+                            label: Text(
+                              _transitionLabel(candidate.stage, target),
+                            ),
+                          )
+                        : OutlinedButton.icon(
+                            onPressed: () => onTransition(target),
+                            icon: const Icon(Icons.undo),
+                            label: Text('${target.labelJa}へ戻す'),
+                          ),
+                  if (candidate.stage.canReject)
+                    TextButton.icon(
+                      onPressed: () => onTransition(ArtifactStage.rejected),
+                      icon: const Icon(Icons.block),
+                      label: const Text('却下'),
+                    ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _transitionLabel(ArtifactStage from, ArtifactStage target) {
+    if (from == ArtifactStage.humanReview && target == ArtifactStage.approved) {
+      return '人手承認を記録';
+    }
+    if (from == ArtifactStage.rejected && target == ArtifactStage.intake) {
+      return '再取込して再試行';
+    }
+    return '${target.labelJa}へ進む';
+  }
+
+  static String _formatBytes(int bytes) {
+    if (bytes >= 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    if (bytes >= 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    return '$bytes B';
+  }
+}
+
+class _CheckMenu extends StatelessWidget {
+  const _CheckMenu({
+    required this.check,
+    required this.enabled,
+    required this.onSelected,
+  });
+
+  final ArtifactCheck check;
+  final bool enabled;
+  final ValueChanged<ArtifactCheckStatus> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final color = switch (check.status) {
+      ArtifactCheckStatus.pending => colors.outline,
+      ArtifactCheckStatus.passed => colors.primary,
+      ArtifactCheckStatus.failed => colors.error,
+      ArtifactCheckStatus.notApplicable => colors.tertiary,
+    };
+    return PopupMenuButton<ArtifactCheckStatus>(
+      enabled: enabled,
+      tooltip: '${check.labelJa}の結果を記録',
+      onSelected: onSelected,
+      itemBuilder: (_) => [
+        for (final status in ArtifactCheckStatus.values)
+          if (status != ArtifactCheckStatus.notApplicable ||
+              check.allowsNotApplicable)
+            PopupMenuItem(value: status, child: Text(status.labelJa)),
+      ],
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+        decoration: BoxDecoration(
+          border: Border.all(color: color),
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Text('${check.labelJa}: ${check.status.labelJa}'),
+      ),
+    );
+  }
+}
+
+class _SafetyBanner extends StatelessWidget {
+  const _SafetyBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colors.primaryContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: const Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.lock_person_outlined),
+          SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              '管理者専用。ここでは候補・検査・ステージだけを更新します。'
+              '料金作成、課金、Storageアップロード、商品削除、is_active=true、'
+              'デプロイは実行しません。',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AccessDenied extends StatelessWidget {
+  const _AccessDenied({this.error});
+
+  final String? error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 440),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.admin_panel_settings_outlined, size: 48),
+              const SizedBox(height: 12),
+              Text(
+                '管理者のみ利用できます',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              if (error != null) ...[
+                const SizedBox(height: 8),
+                Text(error!, textAlign: TextAlign.center),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineError extends StatelessWidget {
+  const _InlineError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.all(12),
+        color: Theme.of(context).colorScheme.errorContainer,
+        child: Text(message),
+      );
+}
+
+class _EmptyCandidates extends StatelessWidget {
+  const _EmptyCandidates();
+
+  @override
+  Widget build(BuildContext context) => const Card(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            '候補はありません。ローカル取込ヘルパーでmanifestを作成し、'
+            '承認済みの管理手順で取り込んでください。',
+          ),
+        ),
+      );
+}
+
+class _TextDecisionDialog extends StatefulWidget {
+  const _TextDecisionDialog({
+    required this.title,
+    required this.message,
+    required this.confirmLabel,
+    required this.minimumLength,
+    required this.destructive,
+    required this.initialValue,
+  });
+
+  final String title;
+  final String message;
+  final String confirmLabel;
+  final int minimumLength;
+  final bool destructive;
+  final String initialValue;
+
+  @override
+  State<_TextDecisionDialog> createState() => _TextDecisionDialogState();
+}
+
+class _TextDecisionDialogState extends State<_TextDecisionDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final value = _controller.text.trim();
+    return AlertDialog(
+      title: Text(widget.title),
+      content: SingleChildScrollView(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 460),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(widget.message),
+              const SizedBox(height: 16),
+              TextField(
+                key: const ValueKey('decision-evidence'),
+                controller: _controller,
+                autofocus: true,
+                minLines: 3,
+                maxLines: 6,
+                maxLength: 1000,
+                onChanged: (_) => setState(() {}),
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  labelText: '根拠・説明',
+                  helperText: '${widget.minimumLength}文字以上',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          style: widget.destructive
+              ? FilledButton.styleFrom(
+                  backgroundColor: Theme.of(context).colorScheme.error,
+                )
+              : null,
+          onPressed: value.length >= widget.minimumLength
+              ? () => Navigator.pop(context, value)
+              : null,
+          child: Text(widget.confirmLabel),
+        ),
+      ],
+    );
+  }
+}
+
+class _StageProductDialog extends StatefulWidget {
+  const _StageProductDialog({required this.candidate});
+
+  final ArtifactCandidate candidate;
+
+  @override
+  State<_StageProductDialog> createState() => _StageProductDialogState();
+}
+
+class _StageProductDialogState extends State<_StageProductDialog> {
+  late final TextEditingController _productIdController;
+  late final TextEditingController _priceController;
+  late final TextEditingController _pathController;
+
+  @override
+  void initState() {
+    super.initState();
+    _productIdController = TextEditingController(
+      text: widget.candidate.productId ?? '',
+    );
+    _priceController = TextEditingController(
+      text: widget.candidate.intendedPriceJpy?.toString() ?? '',
+    );
+    _pathController = TextEditingController(
+      text: widget.candidate.proposedStoragePath ?? '',
+    );
+  }
+
+  @override
+  void dispose() {
+    _productIdController.dispose();
+    _priceController.dispose();
+    _pathController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final productId = _productIdController.text.trim();
+    final price = int.tryParse(_priceController.text.trim());
+    final storagePath = _pathController.text.trim();
+    final pathSegments = storagePath.split('/');
+    final validPath = storagePath.isNotEmpty &&
+        !storagePath.startsWith('/') &&
+        !storagePath.endsWith('/') &&
+        !pathSegments.contains('..');
+    final valid =
+        productId.isNotEmpty && price != null && price >= 50 && validPath;
+
+    return AlertDialog(
+      title: const Text('非公開の商品をステージ'),
+      content: SingleChildScrollView(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 480),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '既に作成済みで is_active=false の商品IDと、価格・非公開Storageの'
+                '照合値を入力します。この画面から商品作成や公開は行いません。',
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                key: const ValueKey('stage-product-id'),
+                controller: _productIdController,
+                autofocus: true,
+                onChanged: (_) => setState(() {}),
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: '商品ID',
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const ValueKey('stage-price-jpy'),
+                controller: _priceController,
+                keyboardType: TextInputType.number,
+                onChanged: (_) => setState(() {}),
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: '販売価格（円）',
+                  helperText: '50円以上',
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const ValueKey('stage-storage-path'),
+                controller: _pathController,
+                onChanged: (_) => setState(() {}),
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: '非公開Storageパス',
+                  prefixText: 'product-downloads/',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: valid
+              ? () => Navigator.pop(
+                    context,
+                    _StageProductInput(
+                      productId: productId,
+                      intendedPriceJpy: price,
+                      storagePath: storagePath,
+                    ),
+                  )
+              : null,
+          child: const Text('照合情報を保存してステージ'),
+        ),
+      ],
+    );
+  }
+}
+
+class _StageProductInput {
+  const _StageProductInput({
+    required this.productId,
+    required this.intendedPriceJpy,
+    required this.storagePath,
+  });
+
+  final String productId;
+  final int intendedPriceJpy;
+  final String storagePath;
+}

--- a/lib/services/artifact_publishing_service.dart
+++ b/lib/services/artifact_publishing_service.dart
@@ -1,0 +1,138 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/artifact_publishing.dart';
+import 'supabase_client_provider.dart';
+
+abstract interface class ArtifactPublishingGateway {
+  Future<bool> isCurrentUserAdmin();
+
+  Future<List<ArtifactCandidate>> fetchCandidates();
+
+  Future<void> transitionStage({
+    required String candidateId,
+    required ArtifactStage expectedStage,
+    required ArtifactStage targetStage,
+    String? rejectionReason,
+    String? humanContributionSummary,
+    String? productId,
+    int? intendedPriceJpy,
+    String? proposedStoragePath,
+  });
+
+  Future<void> reviewCheck({
+    required String candidateId,
+    required String checkKey,
+    required ArtifactCheckStatus status,
+    String? evidenceSummary,
+  });
+}
+
+class ArtifactPublishingService implements ArtifactPublishingGateway {
+  ArtifactPublishingService({SupabaseClient? client})
+      : _client = client ?? supabase;
+
+  final SupabaseClient _client;
+
+  static const _candidateColumns =
+      'id, title, artifact_sha256, mime_type, file_size_bytes, artifact_kind, '
+      'stage, product_id, intended_price_jpy, proposed_storage_bucket, '
+      'proposed_storage_path, human_contribution_summary, rejection_reason, '
+      'updated_at, artifact_checks(check_key, check_kind, is_hard_gate, status, '
+      'evidence_summary), artifact_provenance(source_tool), '
+      'shop_products(id, name_ja, is_active)';
+
+  @override
+  Future<bool> isCurrentUserAdmin() async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) return false;
+    final profile = await _client
+        .from('user_profiles')
+        .select('is_admin')
+        .eq('user_id', userId)
+        .maybeSingle();
+    return profile?['is_admin'] == true;
+  }
+
+  @override
+  Future<List<ArtifactCandidate>> fetchCandidates() async {
+    final rows = await _client
+        .from('artifact_candidates')
+        .select(_candidateColumns)
+        .order('updated_at', ascending: false)
+        .limit(100);
+    return (rows as List<dynamic>)
+        .map(
+          (raw) =>
+              ArtifactCandidate.fromRow(Map<String, dynamic>.from(raw as Map)),
+        )
+        .toList(growable: false);
+  }
+
+  @override
+  Future<void> transitionStage({
+    required String candidateId,
+    required ArtifactStage expectedStage,
+    required ArtifactStage targetStage,
+    String? rejectionReason,
+    String? humanContributionSummary,
+    String? productId,
+    int? intendedPriceJpy,
+    String? proposedStoragePath,
+  }) async {
+    final result = await _client
+        .from('artifact_candidates')
+        .update({
+          'stage': targetStage.databaseValue,
+          if (targetStage == ArtifactStage.rejected)
+            'rejection_reason': rejectionReason,
+          if (targetStage == ArtifactStage.approved)
+            'human_contribution_summary': humanContributionSummary?.trim(),
+          if (targetStage == ArtifactStage.staged) ...{
+            'product_id': productId?.trim(),
+            'intended_price_jpy': intendedPriceJpy,
+            'proposed_storage_bucket': 'product-downloads',
+            'proposed_storage_path': proposedStoragePath?.trim(),
+          },
+        })
+        .eq('id', candidateId)
+        .eq('stage', expectedStage.databaseValue)
+        .select('id')
+        .maybeSingle();
+    if (result == null) {
+      throw const ArtifactPublishingException('候補が別の操作で更新されました。再読み込みしてください。');
+    }
+  }
+
+  @override
+  Future<void> reviewCheck({
+    required String candidateId,
+    required String checkKey,
+    required ArtifactCheckStatus status,
+    String? evidenceSummary,
+  }) async {
+    final result = await _client
+        .from('artifact_checks')
+        .update({
+          'status': status.databaseValue,
+          'evidence_summary': status == ArtifactCheckStatus.pending
+              ? null
+              : evidenceSummary?.trim(),
+        })
+        .eq('candidate_id', candidateId)
+        .eq('check_key', checkKey)
+        .select('id')
+        .maybeSingle();
+    if (result == null) {
+      throw const ArtifactPublishingException('検査結果が別の操作で更新されました。再読み込みしてください。');
+    }
+  }
+}
+
+class ArtifactPublishingException implements Exception {
+  const ArtifactPublishingException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/view_models/artifact_publishing_view_model.dart
+++ b/lib/view_models/artifact_publishing_view_model.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/artifact_publishing.dart';
+import '../services/artifact_publishing_service.dart';
+
+class ArtifactPublishingViewModel extends ChangeNotifier {
+  ArtifactPublishingViewModel({required ArtifactPublishingGateway gateway})
+      : _gateway = gateway;
+
+  final ArtifactPublishingGateway _gateway;
+
+  bool _loading = false;
+  bool _authorized = false;
+  bool _accessChecked = false;
+  String? _error;
+  String? _workingCandidateId;
+  List<ArtifactCandidate> _candidates = const [];
+
+  bool get loading => _loading;
+  bool get authorized => _authorized;
+  bool get accessChecked => _accessChecked;
+  String? get error => _error;
+  String? get workingCandidateId => _workingCandidateId;
+  List<ArtifactCandidate> get candidates => _candidates;
+
+  Future<void> load() async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _authorized = await _gateway.isCurrentUserAdmin();
+      _accessChecked = true;
+      _candidates = _authorized ? await _gateway.fetchCandidates() : const [];
+    } catch (error) {
+      _accessChecked = true;
+      _authorized = false;
+      _error = error.toString();
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> transition(
+    ArtifactCandidate candidate,
+    ArtifactStage target, {
+    String? rejectionReason,
+    String? humanContributionSummary,
+    String? productId,
+    int? intendedPriceJpy,
+    String? proposedStoragePath,
+  }) async {
+    return _runCandidateAction(candidate.id, () async {
+      await _gateway.transitionStage(
+        candidateId: candidate.id,
+        expectedStage: candidate.stage,
+        targetStage: target,
+        rejectionReason: rejectionReason,
+        humanContributionSummary: humanContributionSummary,
+        productId: productId,
+        intendedPriceJpy: intendedPriceJpy,
+        proposedStoragePath: proposedStoragePath,
+      );
+      _candidates = await _gateway.fetchCandidates();
+    });
+  }
+
+  Future<bool> reviewCheck(
+    ArtifactCandidate candidate,
+    ArtifactCheck check,
+    ArtifactCheckStatus status, {
+    String? evidenceSummary,
+  }) async {
+    return _runCandidateAction(candidate.id, () async {
+      await _gateway.reviewCheck(
+        candidateId: candidate.id,
+        checkKey: check.key,
+        status: status,
+        evidenceSummary: evidenceSummary,
+      );
+      _candidates = await _gateway.fetchCandidates();
+    });
+  }
+
+  Future<bool> _runCandidateAction(
+    String candidateId,
+    Future<void> Function() action,
+  ) async {
+    _workingCandidateId = candidateId;
+    _error = null;
+    notifyListeners();
+    try {
+      await action();
+      return true;
+    } catch (error) {
+      _error = error.toString();
+      return false;
+    } finally {
+      _workingCandidateId = null;
+      notifyListeners();
+    }
+  }
+}

--- a/scripts/artifact_intake.py
+++ b/scripts/artifact_intake.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Build a local-only, deduplicated manifest for explicit artifact inputs.
+
+The helper reads only paths supplied on the command line, never opens tool UIs,
+and never performs network requests. Findings contain rule IDs and counts, not
+the matched secret or personal data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+READ_CHUNK_BYTES = 1024 * 1024
+DEFAULT_RISK_SCAN_BYTES = 10 * 1024 * 1024
+
+SOURCE_TOOLS = (
+    "chatgpt",
+    "codex",
+    "claude_code",
+    "antigravity",
+    "other_explicit_export",
+)
+INTAKE_METHODS = ("explicit_export", "local_workspace")
+ARTIFACT_KINDS = (
+    "image",
+    "audio",
+    "video",
+    "design",
+    "writing",
+    "prompt",
+    "idea",
+    "game",
+    "template",
+    "bundle",
+)
+
+TEXT_SUFFIXES = {
+    ".csv",
+    ".dart",
+    ".env",
+    ".html",
+    ".json",
+    ".md",
+    ".py",
+    ".sql",
+    ".svg",
+    ".toml",
+    ".tsv",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+
+SECRET_RULES = {
+    "private_key": re.compile(r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----"),
+    "openai_api_key": re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b"),
+    "stripe_live_secret": re.compile(r"\bsk_live_[A-Za-z0-9]{16,}\b"),
+    "github_token": re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),
+    "aws_access_key": re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"),
+    "credential_assignment": re.compile(
+        r"(?im)^\s*(?:api[_-]?key|secret|password|passwd|token)\s*[:=]\s*"
+        r"['\"]?[^\s'\"]{12,}"
+    ),
+}
+
+PII_RULES = {
+    "email_address": re.compile(
+        r"\b[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+        r"[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+\b"
+    ),
+    "japanese_phone": re.compile(
+        r"(?<!\d)(?:0\d{1,4}[- ]?\d{1,4}[- ]?\d{3,4}|"
+        r"\+81[- ]?\d{1,4}[- ]?\d{1,4}[- ]?\d{3,4})(?!\d)"
+    ),
+    "japanese_postal_code": re.compile(r"(?<!\d)\d{3}-\d{4}(?!\d)"),
+    "japanese_my_number_candidate": re.compile(r"(?<!\d)\d{12}(?!\d)"),
+}
+
+
+def _arguments(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan explicitly supplied local files/directories and write a "
+            "deduplicated, importable JSON manifest. No data is transmitted."
+        )
+    )
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument("--source-tool", required=True, choices=SOURCE_TOOLS)
+    parser.add_argument(
+        "--intake-method", required=True, choices=INTAKE_METHODS
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Manifest path, or '-' for stdout. Existing manifests are merged.",
+    )
+    parser.add_argument(
+        "--max-risk-scan-bytes",
+        type=int,
+        default=DEFAULT_RISK_SCAN_BYTES,
+        help="Maximum decoded bytes inspected per text-like file (default 10 MiB).",
+    )
+    parser.add_argument(
+        "--artifact-kind",
+        default="auto",
+        choices=("auto", *ARTIFACT_KINDS),
+        help=(
+            "Product kind for all supplied paths. Use an explicit kind for "
+            "designs, prompts, ideas, games, or other ambiguous file types."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-risk",
+        action="store_true",
+        help="Return exit code 2 when any block/review finding is present.",
+    )
+    args = parser.parse_args(argv)
+    if args.source_tool == "chatgpt" and args.intake_method != "explicit_export":
+        parser.error("ChatGPT intake is limited to explicit exports")
+    if args.max_risk_scan_bytes < 0:
+        parser.error("--max-risk-scan-bytes must be non-negative")
+    return args
+
+
+def _explicit_files(
+    inputs: Iterable[Path], *, excluded_paths: set[Path] | None = None
+) -> list[tuple[Path, str]]:
+    excluded_paths = excluded_paths or set()
+    files: list[tuple[Path, str]] = []
+    for supplied in inputs:
+        expanded = supplied.expanduser()
+        if expanded.is_symlink():
+            raise ValueError(f"symlink inputs are not scanned: {supplied}")
+        path = expanded.resolve(strict=True)
+        if path.is_file():
+            if path not in excluded_paths:
+                files.append((path, path.name))
+            continue
+        if not path.is_dir():
+            raise ValueError(f"not a regular file or directory: {supplied}")
+        for child in sorted(path.rglob("*"), key=lambda item: item.as_posix()):
+            if (
+                child.is_symlink()
+                or not child.is_file()
+                or child.resolve() in excluded_paths
+            ):
+                continue
+            locator = (Path(path.name) / child.relative_to(path)).as_posix()
+            files.append((child, locator))
+    return sorted(files, key=lambda item: (item[1], item[0].as_posix()))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(READ_CHUNK_BYTES):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _mime_type(path: Path) -> str:
+    guessed, encoding = mimetypes.guess_type(path.name, strict=False)
+    if guessed:
+        return f"{guessed}; encoding={encoding}" if encoding else guessed
+    return "application/octet-stream"
+
+
+def _artifact_kind(path: Path, mime_type: str) -> str:
+    base_mime = mime_type.split(";", 1)[0]
+    if base_mime.startswith("image/"):
+        return "image"
+    if base_mime.startswith("audio/"):
+        return "audio"
+    if base_mime.startswith("video/"):
+        return "video"
+    if path.suffix.lower() in {".md", ".pdf", ".txt"}:
+        return "writing"
+    if path.suffix.lower() in {".json", ".toml", ".yaml", ".yml"}:
+        return "template"
+    return "bundle"
+
+
+def _is_text_like(path: Path, mime_type: str) -> bool:
+    return (
+        mime_type.startswith("text/")
+        or mime_type.split(";", 1)[0]
+        in {
+            "application/json",
+            "application/javascript",
+            "application/sql",
+            "application/xml",
+        }
+        or path.suffix.lower() in TEXT_SUFFIXES
+        or path.name.lower().startswith(".env")
+    )
+
+
+def _read_risk_text(path: Path, limit: int) -> tuple[str, bool]:
+    if limit == 0:
+        return "", path.stat().st_size > 0
+    with path.open("rb") as handle:
+        data = handle.read(limit + 1)
+    truncated = len(data) > limit
+    return data[:limit].decode("utf-8", errors="ignore"), truncated
+
+
+def _count_matches(pattern: re.Pattern[str], text: str) -> int:
+    return sum(1 for _ in pattern.finditer(text))
+
+
+def _risk_findings(
+    path: Path,
+    mime_type: str,
+    source_tool: str,
+    max_scan_bytes: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    findings: list[dict[str, Any]] = []
+    truncated = False
+    if _is_text_like(path, mime_type):
+        text, truncated = _read_risk_text(path, max_scan_bytes)
+        for rule_id, pattern in SECRET_RULES.items():
+            count = _count_matches(pattern, text)
+            if count:
+                findings.append(
+                    {
+                        "category": "secret",
+                        "rule_id": rule_id,
+                        "severity": "block",
+                        "count": count,
+                    }
+                )
+        for rule_id, pattern in PII_RULES.items():
+            count = _count_matches(pattern, text)
+            if count:
+                findings.append(
+                    {
+                        "category": "pii",
+                        "rule_id": rule_id,
+                        "severity": "block",
+                        "count": count,
+                    }
+                )
+
+    base_mime = mime_type.split(";", 1)[0]
+    if base_mime.startswith(("audio/", "video/")):
+        findings.append(
+            {
+                "category": "rights",
+                "rule_id": "face_voice_consent_review",
+                "severity": "review",
+                "count": 1,
+            }
+        )
+    if source_tool == "chatgpt" and base_mime.startswith("audio/"):
+        findings.append(
+            {
+                "category": "rights",
+                "rule_id": "chatgpt_voice_output_standalone_audio",
+                "severity": "block",
+                "count": 1,
+            }
+        )
+    if path.stat().st_size == 0:
+        findings.append(
+            {
+                "category": "integrity",
+                "rule_id": "empty_file",
+                "severity": "block",
+                "count": 1,
+            }
+        )
+    return sorted(findings, key=lambda item: (item["category"], item["rule_id"])), truncated
+
+
+def _entry(
+    path: Path,
+    locator: str,
+    source_tool: str,
+    intake_method: str,
+    max_scan_bytes: int,
+    artifact_kind: str,
+) -> dict[str, Any]:
+    mime_type = _mime_type(path)
+    findings, truncated = _risk_findings(
+        path, mime_type, source_tool, max_scan_bytes
+    )
+    return {
+        "title": path.name,
+        "artifact_sha256": _sha256(path),
+        "mime_type": mime_type,
+        "file_size_bytes": path.stat().st_size,
+        "artifact_kind": (
+            _artifact_kind(path, mime_type)
+            if artifact_kind == "auto"
+            else artifact_kind
+        ),
+        "provenance": [
+            {
+                "source_tool": source_tool,
+                "intake_method": intake_method,
+                "source_locator": locator,
+            }
+        ],
+        "risk_scan": {
+            "findings": findings,
+            "scan_truncated": truncated,
+            "matched_values_included": False,
+        },
+    }
+
+
+def _load_existing(output: str) -> dict[str, Any]:
+    if output == "-":
+        return {"schema_version": SCHEMA_VERSION, "entries": []}
+    path = Path(output)
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "entries": []}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != SCHEMA_VERSION or not isinstance(
+        data.get("entries"), list
+    ):
+        raise ValueError("existing output is not an artifact intake v1 manifest")
+    return data
+
+
+def _merge_entry(existing: dict[str, Any], incoming: dict[str, Any]) -> None:
+    provenance = {
+        (
+            item["source_tool"],
+            item["intake_method"],
+            item["source_locator"],
+        ): item
+        for item in existing.get("provenance", [])
+    }
+    for item in incoming["provenance"]:
+        provenance[
+            (item["source_tool"], item["intake_method"], item["source_locator"])
+        ] = item
+    existing["provenance"] = sorted(
+        provenance.values(),
+        key=lambda item: (
+            item["source_tool"], item["intake_method"], item["source_locator"]
+        ),
+    )
+
+    finding_map = {
+        (item["category"], item["rule_id"], item["severity"]): item
+        for item in existing.get("risk_scan", {}).get("findings", [])
+    }
+    for item in incoming["risk_scan"]["findings"]:
+        key = (item["category"], item["rule_id"], item["severity"])
+        prior = finding_map.get(key)
+        if prior is None or item["count"] > prior["count"]:
+            finding_map[key] = item
+    existing["risk_scan"] = {
+        "findings": sorted(
+            finding_map.values(),
+            key=lambda item: (item["category"], item["rule_id"]),
+        ),
+        "scan_truncated": bool(
+            existing.get("risk_scan", {}).get("scan_truncated")
+            or incoming["risk_scan"]["scan_truncated"]
+        ),
+        "matched_values_included": False,
+    }
+
+
+def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
+    manifest = _load_existing(args.output)
+    by_hash = {
+        entry["artifact_sha256"]: entry for entry in manifest.get("entries", [])
+    }
+    excluded_paths = (
+        set()
+        if args.output == "-"
+        else {Path(args.output).expanduser().resolve()}
+    )
+    for path, locator in _explicit_files(
+        args.paths, excluded_paths=excluded_paths
+    ):
+        incoming = _entry(
+            path,
+            locator,
+            args.source_tool,
+            args.intake_method,
+            args.max_risk_scan_bytes,
+            args.artifact_kind,
+        )
+        sha256 = incoming["artifact_sha256"]
+        if sha256 in by_hash:
+            if args.artifact_kind != "auto":
+                by_hash[sha256]["artifact_kind"] = args.artifact_kind
+            _merge_entry(by_hash[sha256], incoming)
+        else:
+            by_hash[sha256] = incoming
+
+    entries = sorted(by_hash.values(), key=lambda item: item["artifact_sha256"])
+    findings = [
+        finding
+        for entry in entries
+        for finding in entry.get("risk_scan", {}).get("findings", [])
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "local_only": True,
+        "entries": entries,
+        "summary": {
+            "unique_artifacts": len(entries),
+            "blocked_artifacts": sum(
+                any(finding["severity"] == "block" for finding in entry["risk_scan"]["findings"])
+                for entry in entries
+            ),
+            "review_artifacts": sum(
+                any(finding["severity"] == "review" for finding in entry["risk_scan"]["findings"])
+                for entry in entries
+            ),
+            "finding_count": len(findings),
+        },
+    }
+
+
+def _write_manifest(manifest: dict[str, Any], output: str) -> None:
+    rendered = json.dumps(manifest, ensure_ascii=False, indent=2) + "\n"
+    if output == "-":
+        sys.stdout.write(rendered)
+        return
+    target = Path(output).expanduser().resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
+    )
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, target)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = _arguments(argv)
+        manifest = build_manifest(args)
+        _write_manifest(manifest, args.output)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"artifact intake failed: {error}", file=sys.stderr)
+        return 1
+    has_risk = manifest["summary"]["finding_count"] > 0
+    return 2 if args.fail_on_risk and has_risk else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_artifact_intake.py
+++ b/scripts/tests/test_artifact_intake.py
@@ -1,0 +1,145 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts import artifact_intake
+
+
+class ArtifactIntakeTest(unittest.TestCase):
+    def test_hashes_sorts_and_deduplicates_without_copying_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            first = root / "first"
+            second = root / "second"
+            first.mkdir()
+            second.mkdir()
+            sensitive = "api_key=sk-proj-abcdefghijklmnopqrstuvwxyz\nuser@example.com\n"
+            (first / "artifact.txt").write_text(sensitive, encoding="utf-8")
+            (second / "copy.txt").write_text(sensitive, encoding="utf-8")
+            output = root / "manifest.json"
+
+            exit_code = artifact_intake.main(
+                [
+                    str(second),
+                    str(first),
+                    "--source-tool",
+                    "codex",
+                    "--intake-method",
+                    "local_workspace",
+                    "--output",
+                    str(output),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            manifest = json.loads(output.read_text(encoding="utf-8"))
+            self.assertTrue(manifest["local_only"])
+            self.assertEqual(manifest["summary"]["unique_artifacts"], 1)
+            entry = manifest["entries"][0]
+            self.assertEqual(len(entry["provenance"]), 2)
+            self.assertFalse(entry["risk_scan"]["matched_values_included"])
+            rendered = output.read_text(encoding="utf-8")
+            self.assertNotIn("sk-proj-abcdefghijklmnopqrstuvwxyz", rendered)
+            self.assertNotIn("user@example.com", rendered)
+            self.assertEqual(
+                {finding["category"] for finding in entry["risk_scan"]["findings"]},
+                {"secret", "pii"},
+            )
+
+    def test_existing_manifest_merge_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            artifact = root / "draft.md"
+            artifact.write_text("A human-edited draft.\n", encoding="utf-8")
+            output = root / "manifest.json"
+            command = [
+                str(artifact),
+                "--source-tool",
+                "claude_code",
+                "--intake-method",
+                "local_workspace",
+                "--output",
+                str(output),
+            ]
+
+            self.assertEqual(artifact_intake.main(command), 0)
+            first_render = output.read_bytes()
+            self.assertEqual(artifact_intake.main(command), 0)
+
+            self.assertEqual(output.read_bytes(), first_render)
+
+    def test_explicit_kind_supports_ambiguous_sellable_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            artifact = root / "concept.md"
+            artifact.write_text("Human-curated product concept.\n", encoding="utf-8")
+            output = root / "manifest.json"
+
+            exit_code = artifact_intake.main(
+                [
+                    str(artifact),
+                    "--source-tool",
+                    "antigravity",
+                    "--intake-method",
+                    "local_workspace",
+                    "--artifact-kind",
+                    "idea",
+                    "--output",
+                    str(output),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            entry = json.loads(output.read_text(encoding="utf-8"))["entries"][0]
+            self.assertEqual(entry["artifact_kind"], "idea")
+
+    def test_chatgpt_local_workspace_intake_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            artifact = Path(temporary_directory) / "export.txt"
+            artifact.write_text("export", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                artifact_intake._arguments(
+                    [
+                        str(artifact),
+                        "--source-tool",
+                        "chatgpt",
+                        "--intake-method",
+                        "local_workspace",
+                        "--output",
+                        "-",
+                    ]
+                )
+
+    def test_chatgpt_audio_is_a_blocking_rights_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            audio = root / "voice.mp3"
+            audio.write_bytes(b"ID3test")
+            output = root / "manifest.json"
+
+            exit_code = artifact_intake.main(
+                [
+                    str(audio),
+                    "--source-tool",
+                    "chatgpt",
+                    "--intake-method",
+                    "explicit_export",
+                    "--output",
+                    str(output),
+                    "--fail-on-risk",
+                ]
+            )
+
+            self.assertEqual(exit_code, 2)
+            findings = json.loads(output.read_text(encoding="utf-8"))["entries"][0][
+                "risk_scan"
+            ]["findings"]
+            self.assertIn(
+                "chatgpt_voice_output_standalone_audio",
+                {finding["rule_id"] for finding in findings},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/supabase/migrations/20260822074004_create_artifact_publishing_loop.sql
+++ b/supabase/migrations/20260822074004_create_artifact_publishing_loop.sql
@@ -1,0 +1,1046 @@
+-- Closed-loop review pipeline for explicitly exported/local AI-assisted artifacts.
+--
+-- This migration deliberately does not create products, Stripe Prices, Storage
+-- objects, or active listings. It records preparation and review evidence. The
+-- existing shop checkout/download paths remain the only buyer-facing paths.
+
+create schema if not exists private;
+
+create table public.artifact_candidates (
+  id uuid primary key default gen_random_uuid(),
+  title text not null check (char_length(btrim(title)) between 1 and 200),
+  artifact_sha256 text not null unique
+    check (artifact_sha256 ~ '^[0-9a-f]{64}$'),
+  mime_type text not null
+    check (char_length(btrim(mime_type)) between 1 and 255),
+  file_size_bytes bigint not null check (file_size_bytes > 0),
+  artifact_kind text not null check (artifact_kind in (
+    'image', 'audio', 'video', 'design', 'writing',
+    'prompt', 'idea', 'game', 'template', 'bundle'
+  )),
+  stage text not null default 'intake' check (stage in (
+    'intake', 'automated_checks', 'human_review', 'approved',
+    'staged', 'ready', 'published', 'rejected'
+  )),
+  intended_price_jpy integer check (intended_price_jpy >= 50),
+  product_id text references public.shop_products(id) on delete restrict,
+  proposed_storage_bucket text,
+  proposed_storage_path text,
+  human_contribution_summary text,
+  rejection_reason text,
+  created_by uuid not null references auth.users(id) on delete restrict
+    default auth.uid(),
+  approved_by uuid references auth.users(id) on delete restrict,
+  approved_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint artifact_candidates_product_stage_check check (
+    stage in ('intake', 'automated_checks', 'human_review', 'approved', 'rejected')
+    or product_id is not null
+  ),
+  constraint artifact_candidates_storage_pair_check check (
+    (proposed_storage_bucket is null) = (proposed_storage_path is null)
+  ),
+  constraint artifact_candidates_private_bucket_check check (
+    proposed_storage_bucket is null
+    or proposed_storage_bucket = 'product-downloads'
+  ),
+  constraint artifact_candidates_storage_path_check check (
+    proposed_storage_path is null
+    or (
+      char_length(btrim(proposed_storage_path)) between 1 and 1024
+      and proposed_storage_path = btrim(proposed_storage_path)
+      and proposed_storage_path !~ '(^|/)\.\.(/|$)'
+      and proposed_storage_path !~ '[[:cntrl:]]'
+    )
+  ),
+  constraint artifact_candidates_human_contribution_check check (
+    human_contribution_summary is null
+    or char_length(btrim(human_contribution_summary)) between 20 and 4000
+  ),
+  constraint artifact_candidates_rejection_reason_check check (
+    rejection_reason is null
+    or char_length(btrim(rejection_reason)) between 10 and 2000
+  ),
+  constraint artifact_candidates_approval_pair_check check (
+    (approved_by is null) = (approved_at is null)
+  )
+);
+
+create table public.artifact_provenance (
+  id uuid primary key default gen_random_uuid(),
+  candidate_id uuid not null references public.artifact_candidates(id)
+    on delete cascade,
+  source_tool text not null check (source_tool in (
+    'chatgpt', 'codex', 'claude_code', 'antigravity', 'other_explicit_export'
+  )),
+  intake_method text not null check (intake_method in (
+    'explicit_export', 'local_workspace'
+  )),
+  source_locator text not null
+    check (char_length(btrim(source_locator)) between 1 and 1024),
+  tool_version text,
+  exported_at timestamptz,
+  contribution_role text not null default 'intermediate_artifact'
+    check (contribution_role in (
+      'intermediate_artifact', 'reference', 'human_revision', 'final_assembly'
+    )),
+  recorded_by uuid not null references auth.users(id) on delete restrict
+    default auth.uid(),
+  created_at timestamptz not null default now(),
+  unique (candidate_id, source_tool, source_locator),
+  constraint artifact_provenance_intake_boundary_check check (
+    source_tool <> 'chatgpt' or intake_method = 'explicit_export'
+  )
+);
+
+create table public.artifact_checks (
+  id uuid primary key default gen_random_uuid(),
+  candidate_id uuid not null references public.artifact_candidates(id)
+    on delete cascade,
+  check_key text not null check (check_key in (
+    'secret_scan', 'pii_scan', 'third_party_license',
+    'face_voice_consent', 'chatgpt_voice_output', 'human_contribution',
+    'price_match', 'private_object', 'content_integrity'
+  )),
+  check_kind text not null check (check_kind in (
+    'automated', 'human', 'external_evidence'
+  )),
+  is_hard_gate boolean not null default true check (is_hard_gate),
+  status text not null default 'pending' check (status in (
+    'pending', 'pass', 'fail', 'not_applicable'
+  )),
+  evidence_summary text,
+  reviewed_by uuid references auth.users(id) on delete restrict,
+  reviewed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (candidate_id, check_key),
+  constraint artifact_checks_evidence_length_check check (
+    evidence_summary is null
+    or char_length(btrim(evidence_summary)) between 3 and 4000
+  ),
+  constraint artifact_checks_review_pair_check check (
+    (reviewed_by is null) = (reviewed_at is null)
+  ),
+  constraint artifact_checks_decision_evidence_check check (
+    status = 'pending'
+    or (
+      evidence_summary is not null
+      and reviewed_by is not null
+      and reviewed_at is not null
+    )
+  ),
+  constraint artifact_checks_contextual_na_check check (
+    status <> 'not_applicable'
+    or check_key in (
+      'third_party_license', 'face_voice_consent', 'chatgpt_voice_output'
+    )
+  )
+);
+
+create table public.artifact_publication_runs (
+  id uuid primary key default gen_random_uuid(),
+  candidate_id uuid not null references public.artifact_candidates(id)
+    on delete restrict,
+  product_id text references public.shop_products(id) on delete restrict,
+  target text not null default 'staging' check (target in ('staging', 'production')),
+  dry_run boolean not null default true,
+  status text not null default 'planned' check (status in (
+    'planned', 'running', 'succeeded', 'failed', 'canceled', 'rolled_back'
+  )),
+  authorization_reference text,
+  validation_summary text,
+  error_summary text,
+  initiated_by uuid not null references auth.users(id) on delete restrict
+    default auth.uid(),
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint artifact_publication_runs_live_auth_check check (
+    dry_run
+    or (
+      authorization_reference is not null
+      and char_length(btrim(authorization_reference)) between 8 and 500
+    )
+  ),
+  constraint artifact_publication_runs_time_check check (
+    finished_at is null or started_at is not null
+  )
+);
+
+create table public.artifact_publication_events (
+  id bigint generated always as identity primary key,
+  candidate_id uuid not null references public.artifact_candidates(id)
+    on delete restrict,
+  run_id uuid references public.artifact_publication_runs(id) on delete restrict,
+  product_id text references public.shop_products(id) on delete restrict,
+  event_type text not null check (event_type in (
+    'candidate_created', 'stage_transition', 'check_updated',
+    'product_activated', 'product_deactivated', 'run_status_changed'
+  )),
+  from_value text,
+  to_value text,
+  details jsonb not null default '{}'::jsonb
+    check (jsonb_typeof(details) = 'object'),
+  actor_id uuid references auth.users(id) on delete set null,
+  occurred_at timestamptz not null default now()
+);
+
+comment on table public.artifact_candidates is
+  'Admin-only intermediate artifacts moving through human-gated product review.';
+comment on column public.artifact_candidates.artifact_sha256 is
+  'Content-derived deduplication key produced by the local intake helper.';
+comment on table public.artifact_provenance is
+  'Admin-only source boundary records. ChatGPT accepts explicit exports only.';
+comment on table public.artifact_checks is
+  'Hard publication gates. not_applicable is limited to contextual checks.';
+comment on table public.artifact_publication_runs is
+  'Dry-run/staging/authorized publication attempt records; never a billing command.';
+comment on table public.artifact_publication_events is
+  'Append-only audit events emitted by database triggers.';
+
+create index artifact_candidates_product_id_idx
+  on public.artifact_candidates (product_id)
+  where product_id is not null;
+create index artifact_candidates_created_by_idx
+  on public.artifact_candidates (created_by);
+create index artifact_candidates_approved_by_idx
+  on public.artifact_candidates (approved_by)
+  where approved_by is not null;
+create index artifact_candidates_review_queue_idx
+  on public.artifact_candidates (stage, updated_at, id)
+  where stage not in ('published', 'rejected');
+create index artifact_provenance_candidate_id_idx
+  on public.artifact_provenance (candidate_id);
+create index artifact_provenance_recorded_by_idx
+  on public.artifact_provenance (recorded_by);
+create index artifact_checks_candidate_status_idx
+  on public.artifact_checks (candidate_id, status, check_key);
+create index artifact_checks_reviewed_by_idx
+  on public.artifact_checks (reviewed_by)
+  where reviewed_by is not null;
+create index artifact_publication_runs_candidate_id_idx
+  on public.artifact_publication_runs (candidate_id, created_at desc);
+create index artifact_publication_runs_product_id_idx
+  on public.artifact_publication_runs (product_id)
+  where product_id is not null;
+create index artifact_publication_runs_initiated_by_idx
+  on public.artifact_publication_runs (initiated_by);
+create index artifact_publication_runs_active_idx
+  on public.artifact_publication_runs (created_at, id)
+  where status in ('planned', 'running');
+create index artifact_publication_events_candidate_id_idx
+  on public.artifact_publication_events (candidate_id, occurred_at desc, id desc);
+create index artifact_publication_events_run_id_idx
+  on public.artifact_publication_events (run_id)
+  where run_id is not null;
+create index artifact_publication_events_product_id_idx
+  on public.artifact_publication_events (product_id)
+  where product_id is not null;
+create index artifact_publication_events_actor_id_idx
+  on public.artifact_publication_events (actor_id)
+  where actor_id is not null;
+
+-- Atomic metadata-only intake. It stores no file body or matched secret/PII
+-- value and cannot move the candidate beyond intake. SECURITY INVOKER keeps
+-- the admin RLS checks in force.
+create or replace function public.intake_artifact_candidate(
+  intake_title text,
+  intake_sha256 text,
+  intake_mime_type text,
+  intake_file_size_bytes bigint,
+  intake_artifact_kind text,
+  intake_source_tool text,
+  intake_source_method text,
+  intake_source_locator text,
+  intake_human_contribution_summary text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  actor uuid := auth.uid();
+  candidate_id uuid;
+begin
+  if actor is null or not public.is_user_admin(actor) then
+    raise exception 'artifact_intake_admin_required' using errcode = '42501';
+  end if;
+
+  insert into public.artifact_candidates (
+    title, artifact_sha256, mime_type, file_size_bytes, artifact_kind,
+    human_contribution_summary, created_by
+  ) values (
+    intake_title, intake_sha256, intake_mime_type, intake_file_size_bytes,
+    intake_artifact_kind, intake_human_contribution_summary, actor
+  )
+  on conflict (artifact_sha256) do update
+    set updated_at = public.artifact_candidates.updated_at
+  returning id into candidate_id;
+
+  insert into public.artifact_provenance (
+    candidate_id, source_tool, intake_method, source_locator, recorded_by
+  ) values (
+    candidate_id, intake_source_tool, intake_source_method,
+    intake_source_locator, actor
+  )
+  on conflict (candidate_id, source_tool, source_locator) do nothing;
+
+  return candidate_id;
+end;
+$$;
+
+create or replace function private.artifact_trigger_actor_authorized()
+returns boolean
+language sql
+stable
+security invoker
+set search_path = ''
+as $$
+  select
+    (
+      auth.uid() is not null
+      and public.is_user_admin(auth.uid())
+    )
+    or coalesce(auth.jwt() ->> 'role', '') = 'service_role'
+    or session_user in ('postgres', 'supabase_admin', 'supabase_auth_admin')
+$$;
+
+-- Storage metadata is private by design, so this trigger-only helper is the
+-- narrow privileged lookup used to prove that the referenced object exists.
+create or replace function private.artifact_private_object_exists(
+  check_bucket text,
+  check_path text,
+  check_size_bytes bigint
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    private.artifact_trigger_actor_authorized()
+    and exists (
+      select 1
+      from storage.objects as object
+      where object.bucket_id = check_bucket
+        and object.name = check_path
+        and object.metadata ->> 'size' ~ '^[0-9]+$'
+        and (object.metadata ->> 'size')::bigint = check_size_bytes
+    )
+$$;
+
+-- This helper is not exposed through the Data API. It is used by trigger code
+-- to evaluate the full set of hard gates under the caller's privileges.
+create or replace function private.artifact_candidate_hard_gates_pass(
+  check_candidate_id uuid
+)
+returns boolean
+language sql
+stable
+security invoker
+set search_path = ''
+as $$
+  select
+    count(*) = 9
+    and bool_and(
+      case
+        when checks.check_key in (
+          'third_party_license', 'face_voice_consent', 'chatgpt_voice_output'
+        ) then checks.status in ('pass', 'not_applicable')
+        else checks.status = 'pass'
+      end
+    )
+  from public.artifact_checks as checks
+  where checks.candidate_id = check_candidate_id
+    and checks.is_hard_gate
+$$;
+
+create or replace function private.artifact_candidate_matches_product(
+  check_candidate_id uuid,
+  check_product_id text,
+  allowed_stages text[]
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select private.artifact_trigger_actor_authorized() and exists (
+    select 1
+    from public.artifact_candidates as candidate
+    join public.shop_products as product on product.id = candidate.product_id
+    join storage.buckets as bucket on bucket.id = product.storage_bucket
+    where candidate.id = check_candidate_id
+      and candidate.product_id = check_product_id
+      and candidate.stage = any (allowed_stages)
+      and candidate.approved_by is not null
+      and candidate.approved_at is not null
+      and candidate.intended_price_jpy = product.price_jpy
+      and product.stripe_price_id is not null
+      and btrim(product.stripe_price_id) <> ''
+      and candidate.proposed_storage_bucket = product.storage_bucket
+      and candidate.proposed_storage_path = product.storage_path
+      and product.storage_bucket = 'product-downloads'
+      and not bucket.public
+      and private.artifact_private_object_exists(
+        product.storage_bucket, product.storage_path, candidate.file_size_bytes
+      )
+      and product.sha256 = candidate.artifact_sha256
+      and product.file_size_bytes = candidate.file_size_bytes
+      and private.artifact_candidate_hard_gates_pass(candidate.id)
+  )
+$$;
+
+-- Direct table updates remain RLS-controlled. This trigger is the state
+-- machine: it prevents skipped stages and derives approval identity from the
+-- authenticated caller rather than accepting a client-supplied reviewer.
+create or replace function private.guard_artifact_candidate_transition()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor uuid := auth.uid();
+  allowed boolean := false;
+begin
+  if not private.artifact_trigger_actor_authorized() then
+    raise exception 'artifact_transition_actor_not_authorized'
+      using errcode = '42501';
+  end if;
+  new.updated_at := now();
+
+  if tg_op = 'INSERT' then
+    if new.stage <> 'intake' then
+      raise exception 'artifact_candidate_must_start_at_intake'
+        using errcode = '23514';
+    end if;
+    return new;
+  end if;
+
+  if new.artifact_sha256 is distinct from old.artifact_sha256
+    or new.mime_type is distinct from old.mime_type
+    or new.file_size_bytes is distinct from old.file_size_bytes
+    or new.artifact_kind is distinct from old.artifact_kind
+    or new.created_by is distinct from old.created_by
+  then
+    raise exception 'artifact_identity_is_immutable'
+      using errcode = '23514';
+  end if;
+
+  if new.approved_by is distinct from old.approved_by
+     or new.approved_at is distinct from old.approved_at then
+    raise exception 'artifact_approval_is_derived_from_stage_transition'
+      using errcode = '23514';
+  end if;
+
+  if old.stage in ('staged', 'ready', 'published') and (
+    new.intended_price_jpy is distinct from old.intended_price_jpy
+    or new.proposed_storage_bucket is distinct from old.proposed_storage_bucket
+    or new.proposed_storage_path is distinct from old.proposed_storage_path
+    or new.human_contribution_summary is distinct from old.human_contribution_summary
+  ) then
+    raise exception 'approved_publication_evidence_is_immutable'
+      using errcode = '23514';
+  end if;
+
+  if old.stage in ('staged', 'ready', 'published')
+     and new.product_id is distinct from old.product_id then
+    raise exception 'artifact_product_link_locked_after_staging'
+      using errcode = '23514';
+  end if;
+
+  if new.stage = old.stage then
+    return new;
+  end if;
+
+  allowed :=
+    (old.stage = 'intake' and new.stage = 'automated_checks')
+    or (old.stage = 'automated_checks' and new.stage in ('human_review', 'intake'))
+    or (old.stage = 'human_review' and new.stage in ('approved', 'automated_checks'))
+    or (old.stage = 'approved' and new.stage in ('staged', 'human_review'))
+    or (old.stage = 'staged' and new.stage in ('ready', 'human_review'))
+    or (old.stage = 'ready' and new.stage = 'staged')
+    or (old.stage = 'ready' and new.stage = 'published')
+    or (old.stage = 'published' and new.stage = 'ready')
+    or (old.stage = 'rejected' and new.stage = 'intake')
+    or (old.stage not in ('published', 'rejected') and new.stage = 'rejected');
+
+  if not allowed then
+    raise exception 'invalid_artifact_stage_transition:%->%', old.stage, new.stage
+      using errcode = '23514';
+  end if;
+
+  if new.stage = 'human_review' and old.stage = 'automated_checks' then
+    if exists (
+      select 1
+      from public.artifact_checks as checks
+      where checks.candidate_id = old.id
+        and checks.check_key in ('secret_scan', 'pii_scan')
+        and checks.status <> 'pass'
+    ) then
+      raise exception 'automated_risk_checks_not_passed'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.stage = 'approved' then
+    if actor is null or not public.is_user_admin(actor) then
+      raise exception 'human_admin_approval_required' using errcode = '42501';
+    end if;
+    if new.human_contribution_summary is null then
+      raise exception 'human_contribution_summary_required'
+        using errcode = '23514';
+    end if;
+    if exists (
+      select 1
+      from public.artifact_checks as checks
+      where checks.candidate_id = old.id
+        and checks.check_key in (
+          'third_party_license', 'face_voice_consent',
+          'chatgpt_voice_output', 'human_contribution'
+        )
+        and (
+          (checks.check_key = 'human_contribution' and checks.status <> 'pass')
+          or (
+            checks.check_key <> 'human_contribution'
+            and checks.status not in ('pass', 'not_applicable')
+          )
+        )
+    ) then
+      raise exception 'human_rights_checks_not_passed'
+        using errcode = '23514';
+    end if;
+    new.approved_by := actor;
+    new.approved_at := now();
+  elsif new.stage in ('intake', 'automated_checks', 'human_review') then
+    new.approved_by := null;
+    new.approved_at := null;
+  end if;
+
+  if new.stage = 'staged' and old.stage = 'approved' then
+    if new.product_id is null then
+      raise exception 'inactive_product_link_required' using errcode = '23514';
+    end if;
+    if not exists (
+      select 1 from public.shop_products as product
+      where product.id = new.product_id and not product.is_active
+    ) then
+      raise exception 'linked_product_must_be_inactive' using errcode = '23514';
+    end if;
+  end if;
+
+  if new.stage = 'ready' and old.stage = 'staged' then
+    if not private.artifact_candidate_matches_product(
+      old.id, new.product_id, array['staged']::text[]
+    ) then
+      raise exception 'publication_hard_gates_not_satisfied'
+        using errcode = '23514';
+    end if;
+    if exists (
+      select 1 from public.shop_products as product
+      where product.id = new.product_id and product.is_active
+    ) then
+      raise exception 'ready_product_must_remain_inactive'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.stage = 'published' then
+    if not exists (
+      select 1 from public.shop_products as product
+      where product.id = new.product_id and product.is_active
+    ) then
+      raise exception 'explicit_product_activation_required'
+        using errcode = '23514';
+    end if;
+    if not private.artifact_candidate_matches_product(
+      old.id, new.product_id, array['ready']::text[]
+    ) then
+      raise exception 'published_product_no_longer_matches_evidence'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if old.stage = 'published' and new.stage = 'ready' and exists (
+    select 1 from public.shop_products as product
+    where product.id = old.product_id and product.is_active
+  ) then
+    raise exception 'deactivate_product_before_rollback'
+      using errcode = '23514';
+  end if;
+
+  if new.stage = 'rejected' then
+    if new.rejection_reason is null then
+      raise exception 'rejection_reason_required' using errcode = '23514';
+    end if;
+  elsif old.stage = 'rejected' then
+    new.rejection_reason := null;
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function private.prepare_artifact_check_decision()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  actor uuid := auth.uid();
+begin
+  if new.candidate_id is distinct from old.candidate_id
+     or new.check_key is distinct from old.check_key
+     or new.check_kind is distinct from old.check_kind
+     or new.is_hard_gate is distinct from old.is_hard_gate
+     or new.reviewed_by is distinct from old.reviewed_by
+     or new.reviewed_at is distinct from old.reviewed_at then
+    raise exception 'artifact_check_identity_is_immutable' using errcode = '23514';
+  end if;
+
+  new.updated_at := now();
+  if not (
+    (new.check_key in ('secret_scan', 'pii_scan')
+      and exists (
+        select 1 from public.artifact_candidates as candidate
+        where candidate.id = new.candidate_id
+          and candidate.stage = 'automated_checks'
+      ))
+    or (new.check_key in (
+          'third_party_license', 'face_voice_consent',
+          'chatgpt_voice_output', 'human_contribution'
+        )
+      and exists (
+        select 1 from public.artifact_candidates as candidate
+        where candidate.id = new.candidate_id
+          and candidate.stage = 'human_review'
+      ))
+    or (new.check_key in ('price_match', 'private_object', 'content_integrity')
+      and exists (
+        select 1 from public.artifact_candidates as candidate
+        where candidate.id = new.candidate_id
+          and candidate.stage = 'staged'
+      ))
+  ) then
+    raise exception 'artifact_check_wrong_stage' using errcode = '23514';
+  end if;
+  if new.check_key = 'chatgpt_voice_output'
+     and new.status in ('pass', 'not_applicable')
+     and exists (
+       select 1
+       from public.artifact_candidates as candidate
+       join public.artifact_provenance as provenance
+         on provenance.candidate_id = candidate.id
+       where candidate.id = new.candidate_id
+         and candidate.mime_type like 'audio/%'
+         and provenance.source_tool = 'chatgpt'
+     ) then
+    raise exception 'chatgpt_voice_output_standalone_audio_blocked'
+      using errcode = '23514';
+  end if;
+  if new.status is distinct from old.status
+     or new.evidence_summary is distinct from old.evidence_summary then
+    if actor is null or not public.is_user_admin(actor) then
+      raise exception 'admin_check_review_required' using errcode = '42501';
+    end if;
+    if new.status = 'pending' then
+      new.reviewed_by := null;
+      new.reviewed_at := null;
+      new.evidence_summary := null;
+    else
+      new.reviewed_by := actor;
+      new.reviewed_at := now();
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function private.guard_artifact_publication_run()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  allowed boolean := false;
+begin
+  if not private.artifact_trigger_actor_authorized() then
+    raise exception 'publication_run_actor_not_authorized'
+      using errcode = '42501';
+  end if;
+  new.updated_at := now();
+  if tg_op = 'INSERT' then
+    if new.status <> 'planned' then
+      raise exception 'publication_run_must_start_planned' using errcode = '23514';
+    end if;
+    if not new.dry_run and (
+      new.product_id is null
+      or not private.artifact_candidate_matches_product(
+        new.candidate_id, new.product_id, array['ready']::text[]
+      )
+    ) then
+      raise exception 'live_run_requires_ready_candidate' using errcode = '23514';
+    end if;
+    return new;
+  end if;
+
+  if new.candidate_id is distinct from old.candidate_id
+     or new.product_id is distinct from old.product_id
+     or new.target is distinct from old.target
+     or new.dry_run is distinct from old.dry_run
+     or new.authorization_reference is distinct from old.authorization_reference
+     or new.initiated_by is distinct from old.initiated_by
+     or new.created_at is distinct from old.created_at then
+    raise exception 'publication_run_identity_is_immutable' using errcode = '23514';
+  end if;
+
+  if new.status = old.status then
+    return new;
+  end if;
+  allowed :=
+    (old.status = 'planned' and new.status in ('running', 'canceled'))
+    or (old.status = 'running' and new.status in ('succeeded', 'failed', 'canceled'))
+    or (old.status = 'succeeded' and new.status = 'rolled_back');
+  if not allowed then
+    raise exception 'invalid_publication_run_transition:%->%', old.status, new.status
+      using errcode = '23514';
+  end if;
+
+  if new.status = 'running' then
+    new.started_at := coalesce(old.started_at, now());
+  elsif new.status in ('succeeded', 'failed', 'canceled', 'rolled_back') then
+    new.started_at := coalesce(old.started_at, now());
+    new.finished_at := now();
+  end if;
+  if new.status = 'succeeded' and (
+    new.validation_summary is null
+    or char_length(btrim(new.validation_summary)) < 8
+  ) then
+    raise exception 'successful_run_requires_validation_summary'
+      using errcode = '23514';
+  end if;
+  if new.status = 'failed' and (
+    new.error_summary is null or char_length(btrim(new.error_summary)) < 3
+  ) then
+    raise exception 'failed_run_requires_error_summary'
+      using errcode = '23514';
+  end if;
+  return new;
+end;
+$$;
+
+-- The trigger-only audit writers need to insert into append-only tables even
+-- though authenticated admins intentionally have no INSERT grant on events.
+create or replace function private.seed_and_audit_artifact_candidate()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not private.artifact_trigger_actor_authorized() then
+    raise exception 'artifact_audit_actor_not_authorized' using errcode = '42501';
+  end if;
+  insert into public.artifact_checks (candidate_id, check_key, check_kind)
+  values
+    (new.id, 'secret_scan', 'automated'),
+    (new.id, 'pii_scan', 'automated'),
+    (new.id, 'third_party_license', 'human'),
+    (new.id, 'face_voice_consent', 'human'),
+    (new.id, 'chatgpt_voice_output', 'human'),
+    (new.id, 'human_contribution', 'human'),
+    (new.id, 'price_match', 'external_evidence'),
+    (new.id, 'private_object', 'external_evidence'),
+    (new.id, 'content_integrity', 'external_evidence')
+  on conflict (candidate_id, check_key) do nothing;
+
+  insert into public.artifact_publication_events (
+    candidate_id, product_id, event_type, to_value, actor_id
+  ) values (
+    new.id, new.product_id, 'candidate_created', new.stage, auth.uid()
+  );
+  return new;
+end;
+$$;
+
+create or replace function private.audit_artifact_candidate_transition()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not private.artifact_trigger_actor_authorized() then
+    raise exception 'artifact_audit_actor_not_authorized' using errcode = '42501';
+  end if;
+  if new.stage is distinct from old.stage then
+    insert into public.artifact_publication_events (
+      candidate_id, product_id, event_type, from_value, to_value, actor_id
+    ) values (
+      new.id, new.product_id, 'stage_transition', old.stage, new.stage, auth.uid()
+    );
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function private.audit_artifact_check_update()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not private.artifact_trigger_actor_authorized() then
+    raise exception 'artifact_audit_actor_not_authorized' using errcode = '42501';
+  end if;
+  if new.status is distinct from old.status
+     or new.evidence_summary is distinct from old.evidence_summary then
+    insert into public.artifact_publication_events (
+      candidate_id, event_type, from_value, to_value, details, actor_id
+    ) values (
+      new.candidate_id,
+      'check_updated',
+      old.status,
+      new.status,
+      jsonb_build_object(
+        'check_key', new.check_key,
+        'evidence_changed', new.evidence_summary is distinct from old.evidence_summary
+      ),
+      auth.uid()
+    );
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function private.audit_artifact_publication_run()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not private.artifact_trigger_actor_authorized() then
+    raise exception 'artifact_audit_actor_not_authorized' using errcode = '42501';
+  end if;
+  if new.status is distinct from old.status then
+    insert into public.artifact_publication_events (
+      candidate_id, run_id, product_id, event_type,
+      from_value, to_value, actor_id
+    ) values (
+      new.candidate_id, new.id, new.product_id, 'run_status_changed',
+      old.status, new.status, auth.uid()
+    );
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function private.guard_linked_shop_product_activation()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not private.artifact_trigger_actor_authorized() then
+    raise exception 'product_activation_actor_not_authorized'
+      using errcode = '42501';
+  end if;
+  if new.is_active and exists (
+    select 1 from public.artifact_candidates as candidate
+    where candidate.product_id = new.id
+  ) and not exists (
+    select 1
+    from public.artifact_candidates as candidate
+    where candidate.product_id = new.id
+      and private.artifact_candidate_matches_product(
+        candidate.id, new.id, array['ready', 'published']::text[]
+      )
+  ) then
+    raise exception 'linked_artifact_product_not_publication_ready'
+      using errcode = '23514';
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function private.audit_linked_shop_product_state()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not private.artifact_trigger_actor_authorized() then
+    raise exception 'artifact_audit_actor_not_authorized' using errcode = '42501';
+  end if;
+  if new.is_active is distinct from old.is_active then
+    insert into public.artifact_publication_events (
+      candidate_id, product_id, event_type, from_value, to_value, actor_id
+    )
+    select
+      candidate.id,
+      new.id,
+      case when new.is_active then 'product_activated' else 'product_deactivated' end,
+      old.is_active::text,
+      new.is_active::text,
+      auth.uid()
+    from public.artifact_candidates as candidate
+    where candidate.product_id = new.id;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger artifact_candidates_guard
+  before insert or update on public.artifact_candidates
+  for each row execute function private.guard_artifact_candidate_transition();
+create trigger artifact_candidates_seed_audit
+  after insert on public.artifact_candidates
+  for each row execute function private.seed_and_audit_artifact_candidate();
+create trigger artifact_candidates_transition_audit
+  after update on public.artifact_candidates
+  for each row execute function private.audit_artifact_candidate_transition();
+create trigger artifact_checks_prepare_decision
+  before update on public.artifact_checks
+  for each row execute function private.prepare_artifact_check_decision();
+create trigger artifact_checks_update_audit
+  after update on public.artifact_checks
+  for each row execute function private.audit_artifact_check_update();
+create trigger artifact_publication_runs_guard
+  before insert or update on public.artifact_publication_runs
+  for each row execute function private.guard_artifact_publication_run();
+create trigger artifact_publication_runs_audit
+  after update on public.artifact_publication_runs
+  for each row execute function private.audit_artifact_publication_run();
+create trigger shop_products_artifact_activation_guard
+  before update on public.shop_products
+  for each row execute function private.guard_linked_shop_product_activation();
+create trigger shop_products_artifact_state_audit
+  after update on public.shop_products
+  for each row execute function private.audit_linked_shop_product_state();
+
+alter table public.artifact_candidates enable row level security;
+alter table public.artifact_provenance enable row level security;
+alter table public.artifact_checks enable row level security;
+alter table public.artifact_publication_runs enable row level security;
+alter table public.artifact_publication_events enable row level security;
+
+create policy artifact_candidates_admin_select on public.artifact_candidates
+  for select to authenticated
+  using ((select public.is_user_admin((select auth.uid()))));
+create policy artifact_candidates_admin_insert on public.artifact_candidates
+  for insert to authenticated
+  with check (
+    (select public.is_user_admin((select auth.uid())))
+    and created_by = (select auth.uid())
+  );
+create policy artifact_candidates_admin_update on public.artifact_candidates
+  for update to authenticated
+  using ((select public.is_user_admin((select auth.uid()))))
+  with check ((select public.is_user_admin((select auth.uid()))));
+
+create policy artifact_provenance_admin_select on public.artifact_provenance
+  for select to authenticated
+  using ((select public.is_user_admin((select auth.uid()))));
+create policy artifact_provenance_admin_insert on public.artifact_provenance
+  for insert to authenticated
+  with check (
+    (select public.is_user_admin((select auth.uid())))
+    and recorded_by = (select auth.uid())
+  );
+create policy artifact_checks_admin_select on public.artifact_checks
+  for select to authenticated
+  using ((select public.is_user_admin((select auth.uid()))));
+create policy artifact_checks_admin_update on public.artifact_checks
+  for update to authenticated
+  using ((select public.is_user_admin((select auth.uid()))))
+  with check ((select public.is_user_admin((select auth.uid()))));
+
+create policy artifact_publication_runs_admin_select
+  on public.artifact_publication_runs
+  for select to authenticated
+  using ((select public.is_user_admin((select auth.uid()))));
+create policy artifact_publication_runs_admin_insert
+  on public.artifact_publication_runs
+  for insert to authenticated
+  with check (
+    (select public.is_user_admin((select auth.uid())))
+    and initiated_by = (select auth.uid())
+  );
+create policy artifact_publication_runs_admin_update
+  on public.artifact_publication_runs
+  for update to authenticated
+  using ((select public.is_user_admin((select auth.uid()))))
+  with check ((select public.is_user_admin((select auth.uid()))));
+
+create policy artifact_publication_events_admin_select
+  on public.artifact_publication_events
+  for select to authenticated
+  using ((select public.is_user_admin((select auth.uid()))));
+
+-- Inactive linked products must be visible to admins for readiness review, but
+-- no authenticated shop-product write policy is added here.
+create policy shop_products_admin_read on public.shop_products
+  for select to authenticated
+  using ((select public.is_user_admin((select auth.uid()))));
+
+revoke all on table public.artifact_candidates from anon, authenticated;
+revoke all on table public.artifact_provenance from anon, authenticated;
+revoke all on table public.artifact_checks from anon, authenticated;
+revoke all on table public.artifact_publication_runs from anon, authenticated;
+revoke all on table public.artifact_publication_events from anon, authenticated;
+revoke all on sequence public.artifact_publication_events_id_seq
+  from anon, authenticated;
+
+grant select, insert, update on table public.artifact_candidates to authenticated;
+grant select, insert on table public.artifact_provenance to authenticated;
+grant select, update on table public.artifact_checks to authenticated;
+grant select, insert, update on table public.artifact_publication_runs
+  to authenticated;
+grant select on table public.artifact_publication_events to authenticated;
+
+revoke execute on function public.intake_artifact_candidate(
+  text, text, text, bigint, text, text, text, text, text
+) from public, anon, service_role;
+grant execute on function public.intake_artifact_candidate(
+  text, text, text, bigint, text, text, text, text, text
+) to authenticated;
+
+revoke execute on function private.artifact_candidate_hard_gates_pass(uuid)
+  from public, anon, authenticated, service_role;
+revoke execute on function private.artifact_private_object_exists(text, text, bigint)
+  from public, anon, authenticated, service_role;
+revoke execute on function private.artifact_candidate_matches_product(uuid, text, text[])
+  from public, anon, authenticated, service_role;
+revoke execute on function private.guard_artifact_candidate_transition()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.prepare_artifact_check_decision()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.seed_and_audit_artifact_candidate()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.audit_artifact_candidate_transition()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.audit_artifact_check_update()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.guard_artifact_publication_run()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.artifact_trigger_actor_authorized()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.audit_artifact_publication_run()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.guard_linked_shop_product_activation()
+  from public, anon, authenticated, service_role;
+revoke execute on function private.audit_linked_shop_product_state()
+  from public, anon, authenticated, service_role;

--- a/supabase/tests/artifact_publishing_loop_contract.sql
+++ b/supabase/tests/artifact_publishing_loop_contract.sql
@@ -1,0 +1,223 @@
+begin;
+
+create or replace function pg_temp.assert_true(
+  condition boolean,
+  failure_message text
+)
+returns void
+language plpgsql
+as $$
+begin
+  if not coalesce(condition, false) then
+    raise exception 'artifact publishing contract failed: %', failure_message;
+  end if;
+end;
+$$;
+
+insert into auth.users (id)
+values
+  ('a1111111-1111-4111-8111-111111111111'),
+  ('a2222222-2222-4222-8222-222222222222');
+
+insert into public.user_profiles (user_id, is_admin, is_public)
+values
+  ('a1111111-1111-4111-8111-111111111111', true, false),
+  ('a2222222-2222-4222-8222-222222222222', false, false);
+
+insert into public.shop_products (
+  id, name_ja, summary_ja, price_jpy, stripe_price_id,
+  storage_bucket, storage_path, version, file_size_bytes, sha256, is_active
+)
+values (
+  'artifact-contract-product', '契約テスト商品', 'ローカルrollback対象',
+  1200, 'price_contract_only', 'product-downloads',
+  'contract/artifact.zip', '1.0', 1024,
+  repeat('a', 64), false
+);
+
+insert into storage.objects (bucket_id, name, metadata)
+values (
+  'product-downloads', 'contract/artifact.zip', '{"size": 1024}'::jsonb
+);
+
+select pg_temp.assert_true(
+  not has_table_privilege('anon', 'public.artifact_candidates', 'SELECT')
+  and not has_table_privilege('anon', 'public.artifact_checks', 'SELECT')
+  and not has_table_privilege(
+    'authenticated', 'public.artifact_publication_events', 'INSERT'
+  ),
+  'buyers and anonymous callers must not read candidates or forge events'
+);
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub', 'a1111111-1111-4111-8111-111111111111', true
+);
+
+insert into public.artifact_candidates (
+  id, title, artifact_sha256, mime_type, file_size_bytes, artifact_kind,
+  intended_price_jpy, product_id, proposed_storage_bucket,
+  proposed_storage_path, human_contribution_summary
+)
+values (
+  'a3333333-3333-4333-8333-333333333333',
+  '契約テスト成果物', repeat('a', 64), 'application/zip', 1024, 'bundle',
+  1200, 'artifact-contract-product', 'product-downloads',
+  'contract/artifact.zip', '人間が構成、校正、権利確認、商品説明の最終編集を担当した記録です。'
+);
+
+insert into public.artifact_provenance (
+  candidate_id, source_tool, intake_method, source_locator
+)
+values (
+  'a3333333-3333-4333-8333-333333333333',
+  'codex', 'local_workspace', 'contract/artifact.zip'
+);
+
+select pg_temp.assert_true(
+  (
+    select count(*) = 9
+    from public.artifact_checks
+    where candidate_id = 'a3333333-3333-4333-8333-333333333333'
+  ),
+  'candidate intake must seed all nine hard gates atomically'
+);
+
+update public.artifact_candidates
+set stage = 'automated_checks'
+where id = 'a3333333-3333-4333-8333-333333333333';
+
+do $$
+declare
+  blocked boolean := false;
+begin
+  begin
+    update public.artifact_checks
+    set status = 'pass', evidence_summary = 'premature human review'
+    where candidate_id = 'a3333333-3333-4333-8333-333333333333'
+      and check_key = 'third_party_license';
+  exception when check_violation then
+    blocked := sqlerrm = 'artifact_check_wrong_stage';
+  end;
+  perform pg_temp.assert_true(blocked, 'checks must be reviewed in their stage');
+end;
+$$;
+
+do $$
+declare
+  blocked boolean := false;
+begin
+  begin
+    update public.artifact_candidates
+    set stage = 'human_review'
+    where id = 'a3333333-3333-4333-8333-333333333333';
+  exception when check_violation then
+    blocked := sqlerrm = 'automated_risk_checks_not_passed';
+  end;
+  perform pg_temp.assert_true(blocked, 'PII/secrets must block human review');
+end;
+$$;
+
+update public.artifact_checks
+set status = 'pass', evidence_summary = 'local scanner found no matched values'
+where candidate_id = 'a3333333-3333-4333-8333-333333333333'
+  and check_key in ('secret_scan', 'pii_scan');
+
+update public.artifact_candidates
+set stage = 'human_review'
+where id = 'a3333333-3333-4333-8333-333333333333';
+
+update public.artifact_checks
+set
+  status = case
+    when check_key in (
+      'third_party_license', 'face_voice_consent', 'chatgpt_voice_output'
+    ) then 'not_applicable'
+    else 'pass'
+  end,
+  evidence_summary = 'reviewed locally without including sensitive values'
+where candidate_id = 'a3333333-3333-4333-8333-333333333333'
+  and check_key in (
+    'third_party_license', 'face_voice_consent',
+    'chatgpt_voice_output', 'human_contribution'
+  );
+
+update public.artifact_candidates
+set stage = 'approved'
+where id = 'a3333333-3333-4333-8333-333333333333';
+update public.artifact_candidates
+set stage = 'staged'
+where id = 'a3333333-3333-4333-8333-333333333333';
+
+reset role;
+do $$
+declare
+  blocked boolean := false;
+begin
+  begin
+    update public.shop_products
+    set is_active = true
+    where id = 'artifact-contract-product';
+  exception when check_violation then
+    blocked := sqlerrm = 'linked_artifact_product_not_publication_ready';
+  end;
+  perform pg_temp.assert_true(blocked, 'an incomplete candidate must not activate');
+end;
+$$;
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub', 'a1111111-1111-4111-8111-111111111111', true
+);
+update public.artifact_checks
+set status = 'pass', evidence_summary = 'staged product evidence matched locally'
+where candidate_id = 'a3333333-3333-4333-8333-333333333333'
+  and check_key in ('price_match', 'private_object', 'content_integrity');
+update public.artifact_candidates
+set stage = 'ready'
+where id = 'a3333333-3333-4333-8333-333333333333';
+
+select pg_temp.assert_true(
+  (
+    select approved_by = 'a1111111-1111-4111-8111-111111111111'
+      and approved_at is not null
+    from public.artifact_candidates
+    where id = 'a3333333-3333-4333-8333-333333333333'
+  ),
+  'human approval identity must be derived from auth.uid()'
+);
+
+select set_config(
+  'request.jwt.claim.sub', 'a2222222-2222-4222-8222-222222222222', true
+);
+select pg_temp.assert_true(
+  not exists (
+    select 1 from public.artifact_candidates
+    where id = 'a3333333-3333-4333-8333-333333333333'
+  ),
+  'an authenticated non-admin must not read candidate rows'
+);
+
+reset role;
+update public.shop_products
+set is_active = true
+where id = 'artifact-contract-product';
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub', 'a1111111-1111-4111-8111-111111111111', true
+);
+update public.artifact_candidates
+set stage = 'published'
+where id = 'a3333333-3333-4333-8333-333333333333';
+
+select pg_temp.assert_true(
+  (
+    select count(*) >= 8
+    from public.artifact_publication_events
+    where candidate_id = 'a3333333-3333-4333-8333-333333333333'
+  ),
+  'stage, check, and activation changes must emit append-only audit events'
+);
+
+rollback;

--- a/test/models/artifact_publishing_test.dart
+++ b/test/models/artifact_publishing_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/artifact_publishing.dart';
+
+void main() {
+  test('candidate parses nested provenance, product, and hard-gate readiness',
+      () {
+    final candidate = ArtifactCandidate.fromRow({
+      'id': 'candidate-1',
+      'title': 'Human-edited template',
+      'artifact_sha256':
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'mime_type': 'application/zip',
+      'file_size_bytes': 1024,
+      'artifact_kind': 'template',
+      'stage': 'staged',
+      'updated_at': '2026-08-22T08:00:00Z',
+      'product_id': 'product-1',
+      'shop_products': {
+        'id': 'product-1',
+        'name_ja': 'テンプレート商品',
+        'is_active': false,
+      },
+      'artifact_provenance': [
+        {'source_tool': 'codex'},
+        {'source_tool': 'chatgpt'},
+      ],
+      'artifact_checks': [
+        for (final key in const [
+          'secret_scan',
+          'pii_scan',
+          'third_party_license',
+          'face_voice_consent',
+          'chatgpt_voice_output',
+          'human_contribution',
+          'price_match',
+          'private_object',
+          'content_integrity',
+        ])
+          {
+            'check_key': key,
+            'check_kind': 'human',
+            'is_hard_gate': true,
+            'status': key == 'face_voice_consent' ? 'not_applicable' : 'pass',
+            'evidence_summary': 'reviewed',
+          },
+      ],
+    });
+
+    expect(candidate.sourceTools, ['chatgpt', 'codex']);
+    expect(candidate.productName, 'テンプレート商品');
+    expect(candidate.productActive, isFalse);
+    expect(candidate.hardGateCount, 9);
+    expect(candidate.satisfiedHardGateCount, 9);
+    expect(candidate.allHardGatesSatisfied, isTrue);
+  });
+
+  test('transition targets include explicit reject retry and rollback paths',
+      () {
+    expect(
+      ArtifactStage.rejected.transitionTargets,
+      [ArtifactStage.intake],
+    );
+    expect(
+      ArtifactStage.ready.transitionTargets,
+      [ArtifactStage.published, ArtifactStage.staged],
+    );
+    expect(ArtifactStage.published.canReject, isFalse);
+  });
+
+  test('checks are editable only at their evidence stage', () {
+    const automated = ArtifactCheck(
+      key: 'secret_scan',
+      kind: 'automated',
+      status: ArtifactCheckStatus.pending,
+      isHardGate: true,
+      evidenceSummary: '',
+    );
+    const human = ArtifactCheck(
+      key: 'human_contribution',
+      kind: 'human',
+      status: ArtifactCheckStatus.pending,
+      isHardGate: true,
+      evidenceSummary: '',
+    );
+    const staged = ArtifactCheck(
+      key: 'private_object',
+      kind: 'external_evidence',
+      status: ArtifactCheckStatus.pending,
+      isHardGate: true,
+      evidenceSummary: '',
+    );
+
+    expect(automated.canEditAt(ArtifactStage.automatedChecks), isTrue);
+    expect(automated.canEditAt(ArtifactStage.humanReview), isFalse);
+    expect(human.canEditAt(ArtifactStage.humanReview), isTrue);
+    expect(human.canEditAt(ArtifactStage.approved), isFalse);
+    expect(staged.canEditAt(ArtifactStage.staged), isTrue);
+    expect(staged.canEditAt(ArtifactStage.ready), isFalse);
+  });
+}

--- a/test/pages/admin_artifact_publishing_page_test.dart
+++ b/test/pages/admin_artifact_publishing_page_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/artifact_publishing.dart';
+import 'package:my_web_app/pages/admin_artifact_publishing_page.dart';
+import 'package:my_web_app/services/artifact_publishing_service.dart';
+
+void main() {
+  testWidgets('non-admin sees no publishing candidate data', (tester) async {
+    final gateway = _FakeGateway(authorized: false, candidates: [_candidate()]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: AdminArtifactPublishingPage(gateway: gateway)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('管理者のみ利用できます'), findsOneWidget);
+    expect(find.text('draft-template.zip'), findsNothing);
+    expect(gateway.fetchCount, 0);
+  });
+
+  testWidgets('admin sees visual loop, hard gates, and safe stage action', (
+    tester,
+  ) async {
+    final gateway = _FakeGateway(authorized: true, candidates: [_candidate()]);
+    tester.view.physicalSize = const Size(1280, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(home: AdminArtifactPublishingPage(gateway: gateway)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('公開ループ'), findsOneWidget);
+    expect(find.text('明示取込'), findsOneWidget);
+    expect(find.text('人手レビュー'), findsOneWidget);
+    expect(find.text('明示公開'), findsOneWidget);
+    expect(find.text('draft-template.zip'), findsOneWidget);
+    expect(find.text('必須 2/9'), findsOneWidget);
+    expect(find.text('秘密情報: 合格'), findsOneWidget);
+
+    final action = find.text('自動検査へ進む');
+    await tester.ensureVisible(action);
+    await tester.tap(action);
+    await tester.pumpAndSettle();
+
+    expect(gateway.lastTarget, ArtifactStage.automatedChecks);
+    expect(find.text('ステージを更新しました。'), findsOneWidget);
+  });
+
+  testWidgets('approval records human contribution before moving forward', (
+    tester,
+  ) async {
+    final candidate = _candidate(stage: ArtifactStage.humanReview);
+    final gateway = _FakeGateway(authorized: true, candidates: [candidate]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: AdminArtifactPublishingPage(gateway: gateway)),
+    );
+    await tester.pumpAndSettle();
+
+    final approveAction = find.text('人手承認を記録');
+    await tester.drag(find.byType(ListView), const Offset(0, -600));
+    await tester.pumpAndSettle();
+    await tester.tap(approveAction);
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byType(TextField),
+      '構成、編集、校正、権利確認と最終検証を人間が担当しました。',
+    );
+    await tester.pump();
+    await tester.tap(find.text('寄与を記録して承認'));
+    await tester.pumpAndSettle();
+
+    expect(gateway.lastTarget, ArtifactStage.approved);
+    expect(gateway.lastHumanContribution, contains('最終検証'));
+  });
+
+  testWidgets('staging records inactive product price and private path', (
+    tester,
+  ) async {
+    final candidate = _candidate(stage: ArtifactStage.approved);
+    final gateway = _FakeGateway(authorized: true, candidates: [candidate]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: AdminArtifactPublishingPage(gateway: gateway)),
+    );
+    await tester.pumpAndSettle();
+
+    final stageAction = find.text('商品ステージへ進む');
+    await tester.drag(find.byType(ListView), const Offset(0, -600));
+    await tester.pumpAndSettle();
+    await tester.tap(stageAction);
+    await tester.pumpAndSettle();
+    final fields = find.byType(TextField);
+    await tester.enterText(fields.at(0), 'template-product');
+    await tester.enterText(fields.at(1), '1200');
+    await tester.enterText(fields.at(2), 'template-product/v1.zip');
+    await tester.pump();
+    await tester.tap(find.text('照合情報を保存してステージ'));
+    await tester.pumpAndSettle();
+
+    expect(gateway.lastTarget, ArtifactStage.staged);
+    expect(gateway.lastProductId, 'template-product');
+    expect(gateway.lastPrice, 1200);
+    expect(gateway.lastStoragePath, 'template-product/v1.zip');
+  });
+}
+
+ArtifactCandidate _candidate({ArtifactStage stage = ArtifactStage.intake}) =>
+    ArtifactCandidate(
+      id: 'candidate-1',
+      title: 'draft-template.zip',
+      sha256:
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      mimeType: 'application/zip',
+      fileSizeBytes: 2048,
+      kind: 'template',
+      stage: stage,
+      checks: [
+        for (final key in const [
+          'secret_scan',
+          'pii_scan',
+          'third_party_license',
+          'face_voice_consent',
+          'chatgpt_voice_output',
+          'human_contribution',
+          'price_match',
+          'private_object',
+          'content_integrity',
+        ])
+          ArtifactCheck(
+            key: key,
+            kind: key.endsWith('scan') ? 'automated' : 'human',
+            status: key.endsWith('scan')
+                ? ArtifactCheckStatus.passed
+                : ArtifactCheckStatus.pending,
+            isHardGate: true,
+            evidenceSummary: key.endsWith('scan') ? 'local scan passed' : '',
+          ),
+      ],
+      sourceTools: const ['codex'],
+      productId: null,
+      productName: null,
+      productActive: false,
+      intendedPriceJpy: null,
+      proposedStorageBucket: null,
+      proposedStoragePath: null,
+      humanContributionSummary: '',
+      rejectionReason: '',
+      updatedAt: DateTime.utc(2026, 8, 22),
+    );
+
+class _FakeGateway implements ArtifactPublishingGateway {
+  _FakeGateway({required this.authorized, required this.candidates});
+
+  final bool authorized;
+  final List<ArtifactCandidate> candidates;
+  int fetchCount = 0;
+  ArtifactStage? lastTarget;
+  String? lastHumanContribution;
+  String? lastProductId;
+  int? lastPrice;
+  String? lastStoragePath;
+
+  @override
+  Future<List<ArtifactCandidate>> fetchCandidates() async {
+    fetchCount += 1;
+    return candidates;
+  }
+
+  @override
+  Future<bool> isCurrentUserAdmin() async => authorized;
+
+  @override
+  Future<void> reviewCheck({
+    required String candidateId,
+    required String checkKey,
+    required ArtifactCheckStatus status,
+    String? evidenceSummary,
+  }) async {}
+
+  @override
+  Future<void> transitionStage({
+    required String candidateId,
+    required ArtifactStage expectedStage,
+    required ArtifactStage targetStage,
+    String? rejectionReason,
+    String? humanContributionSummary,
+    String? productId,
+    int? intendedPriceJpy,
+    String? proposedStoragePath,
+  }) async {
+    lastTarget = targetStage;
+    lastHumanContribution = humanContributionSummary;
+    lastProductId = productId;
+    lastPrice = intendedPriceJpy;
+    lastStoragePath = proposedStoragePath;
+  }
+}

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -9,6 +9,7 @@ const List<String> kAllAppRoutes = <String>[
   '/activity-feed',
   '/address-book',
   '/admin',
+  '/admin/artifact-publishing',
   '/admin-feedback',
   '/admin-notifications',
   '/admin/blog/edit',

--- a/test/routes/artifact_publishing_route_test.dart
+++ b/test/routes/artifact_publishing_route_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+      'admin artifact publishing page has a stable named route and entry point',
+      () {
+    final mainSource = File(
+      'lib/main.dart',
+    ).readAsStringSync().replaceAll('\r\n', '\n');
+    final adminSource = File(
+      'lib/pages/admin_analytics_page.dart',
+    ).readAsStringSync().replaceAll('\r\n', '\n');
+
+    expect(mainSource, contains("case '/admin/artifact-publishing':"));
+    expect(mainSource, contains('const AdminArtifactPublishingPage()'));
+    expect(
+      adminSource,
+      contains(
+        "Navigator.pushNamed(\n                          context,\n                          '/admin/artifact-publishing'",
+      ),
+    );
+  });
+}

--- a/test/services/artifact_publishing_schema_test.dart
+++ b/test/services/artifact_publishing_schema_test.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260822074004_create_artifact_publishing_loop.sql';
+
+void main() {
+  late String sql;
+
+  setUpAll(() {
+    sql = File(
+      _migrationPath,
+    ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+  });
+
+  test('creates the complete provenance, check, run, and event model', () {
+    for (final table in const [
+      'artifact_candidates',
+      'artifact_provenance',
+      'artifact_checks',
+      'artifact_publication_runs',
+      'artifact_publication_events',
+    ]) {
+      expect(sql, contains('create table public.$table'));
+      expect(
+        sql,
+        contains('alter table public.$table enable row level security;'),
+      );
+    }
+    expect(sql, contains('artifact_sha256 text not null unique'));
+    expect(sql, contains('function public.intake_artifact_candidate('));
+    expect(sql, contains('on conflict (artifact_sha256) do update'));
+    expect(sql, contains('security invoker'));
+    expect(sql, contains('created_at timestamptz not null default now()'));
+    expect(sql, contains('artifact_candidates_review_queue_idx'));
+    expect(sql, contains("where stage not in ('published', 'rejected')"));
+    expect(sql, contains('artifact_private_object_exists'));
+    expect(sql, contains('from storage.objects as object'));
+  });
+
+  test('keeps candidates buyer-private and events append-only', () {
+    for (final table in const [
+      'artifact_candidates',
+      'artifact_provenance',
+      'artifact_checks',
+      'artifact_publication_runs',
+      'artifact_publication_events',
+    ]) {
+      expect(
+        sql,
+        contains('revoke all on table public.$table from anon, authenticated;'),
+      );
+    }
+    expect(
+      sql,
+      isNot(
+        contains(
+          'grant select on table public.artifact_candidates to anon',
+        ),
+      ),
+    );
+    expect(
+      sql,
+      contains(
+        'grant select on table public.artifact_publication_events to authenticated;',
+      ),
+    );
+    expect(
+      sql,
+      isNot(
+        contains(
+          'grant insert on table public.artifact_publication_events to authenticated',
+        ),
+      ),
+    );
+    expect(sql, contains('public.is_user_admin((select auth.uid()))'));
+  });
+
+  test('derives approval, audits transitions, and blocks premature activation',
+      () {
+    expect(sql, contains('human_admin_approval_required'));
+    expect(sql, contains('new.approved_by := actor'));
+    expect(sql, contains('invalid_artifact_stage_transition'));
+    expect(sql, contains('publication_hard_gates_not_satisfied'));
+    expect(sql, contains('artifact_check_wrong_stage'));
+    expect(sql, contains('chatgpt_voice_output_standalone_audio_blocked'));
+    expect(sql, contains('linked_artifact_product_not_publication_ready'));
+    expect(sql, contains('shop_products_artifact_activation_guard'));
+    expect(
+      sql,
+      contains('event_type, from_value, to_value, details, actor_id'),
+    );
+  });
+
+  test('privileged trigger functions stay private and non-callable', () {
+    expect(
+      sql,
+      isNot(contains('function public.seed_and_audit_artifact_candidate')),
+    );
+    expect(
+      sql,
+      isNot(contains('function public.audit_artifact_candidate_transition')),
+    );
+    expect(
+      sql,
+      contains(
+        'revoke execute on function private.seed_and_audit_artifact_candidate()',
+      ),
+    );
+    expect(sql, contains("security definer\nset search_path = ''"));
+    expect(sql, isNot(contains('grant execute on function private.')));
+  });
+}


### PR DESCRIPTION
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 新ルートは管理者専用かつ新DB migration前提のため、PR内では認証済みlive mutationを行わず、responsive widget testとCodex in-app browserのアクセス拒否確認で代替する。本番merge後にdeploy workflowと公開routeを再検証する。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1のlive review sessionはこのCodex実行環境で利用できない。AI Agent Code Review合格に加え、Codex leadがsecurity、rollback、prod smoke計画、監査eventのobservabilityを独立再確認した。

## 変更内容

- ChatGPTの明示export、およびCodex・Claude Code・Antigravityの指定workspace成果物をローカル取込するmanifest helperを追加
- 画像、音声、動画、デザイン、文章、プロンプト、アイデア、ゲーム、テンプレート、bundleを扱う管理者専用の閉ループを追加
- 9 hard gate、stage state machine、admin RLS、append-only audit、linked商品のactivation guardを追加
- `/admin/artifact-publishing`にループ図、候補、stage別check、人間の寄与、inactive商品照合UIを追加
- 設計docとrepository skill `.agents/skills/digital-product-publishing-loop`を同じ運用へ同期

Related to #4627

## 設計と安全境界

- `ready`は公開許可ではなくdecision packet。Stripe、charge、Storage upload、`is_active=true`は自動実行しない
- ChatGPTは明示exportのみ。指定外workspace、tool UI、auth cache、環境変数は探索しない
- matched secret/PIIやfile本文をDBへ保存しない
- 公開後の問題は先に商品をinactive化し、購入権利やprivate fileを削除せずrollbackする
- Security: admin RLS/privilege、private trigger helper、stage別check、activation guardをmigration contractで検証
- Rollback: `is_active=false`を先行し、`published → ready → staged`で再検証。購入履歴・entitlement・private objectは削除しない
- Prod smoke: deploy workflow、version、`/shop` checkout保持、新管理routeの非管理者拒否を確認
- Observability: candidate/check/product/runの変更をappend-only `artifact_publication_events`に記録
- Unresolved ultrareview findings: none / 0

## テスト結果

- `flutter test --no-pub test/models/artifact_publishing_test.dart test/pages/admin_artifact_publishing_page_test.dart test/routes/artifact_publishing_route_test.dart test/services/artifact_publishing_schema_test.dart` — 12 passed
- `flutter analyze --no-pub`（変更Dart 8対象）— 0 issues
- `python -m unittest scripts.tests.test_artifact_intake -v` — 5 passed
- skill `quick_validate.py` — passed
- `supabase db push --dry-run --linked --include-all` — 新migration 1件のみ
- pre-commit / pre-push hooks — passed

## Visual E2E Evidence

- Changed route: `/admin/artifact-publishing`; admin entry from `/admin`
- Codex in-app browser: desktop 1440x1000 / mobile 390x844
- Both viewports: `scrollWidth == viewport width`; unauthorized session showed only `管理者のみ利用できます` and no candidate data
- Console: application error 0; Flutter's existing duplicate viewport warning only
- Authorized loop, happy transition, human contribution, product staging, non-admin error state: Flutter widget tests
- Playwright file not added for the privileged route; manual equivalent was performed with the Codex in-app browser
- No generated image was used

## Subagent record

- Role: adaptive router-selected implementation worker (`gpt-5.6-sol`, xhigh)
- Scope: schema/UI/intake helper/tests/docs/repository skill only; no live mutation
- Result: initial closed-loop implementation and focused validation completed
- Lead review impact: fixed dialog controller ownership/overflow, added contribution and staging inputs, enforced stage-specific evidence, added explicit artifact-kind override
- Cleanup impact: generated plugin/temp diffs restored and no long-lived worker process remains

## デプロイメモ

- Database migration required: `20260822074004_create_artifact_publishing_loop.sql`
- Environment variable changes: none
- Main merge後の`deploy-prod.yml`でDB migrationとFlutter Webを反映し、workflow、version、`/shop`、新管理routeを確認する
- このPRは販売商品そのものをactive化せず、販売公開パイプラインだけを本番反映する

## Checklist

- [x] 新機能（breaking changeなし）
- [x] 単体・widget・route・schema contract test
- [x] `flutter analyze` 0 issues
- [x] desktop/mobile browser確認
- [x] 技術・運用ドキュメント更新
- [x] `docs/GROWTH_STRATEGY_ROADMAP.md`にセッション記録
- [x] 新規scriptは明示path限定の手動helperのためSessionStart/End hookへ接続しない（自動接続はscan境界に反する）
- [x] Breaking changeなし
