### PR TITLE
fix: prevent production release tag reuse

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -149,7 +149,17 @@ jobs:
         id: version
         if: steps.changes.outputs.web == 'true'
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
+          # `git describe` only sees tags reachable from the checked-out commit.
+          # Release tags created on another merged branch can therefore be missed,
+          # causing an existing version/tag to be reused. Select the highest global
+          # three-part SemVer tag instead.
+          LATEST_TAG=$(
+            git tag --list 'v[0-9]*.[0-9]*.[0-9]*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1
+          )
+          LATEST_TAG=${LATEST_TAG:-v1.0.0}
           VERSION=${LATEST_TAG#v}
           IFS='.' read -ra VERSION_PARTS <<< "$VERSION"
           MAJOR=${VERSION_PARTS[0]}
@@ -869,8 +879,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           TAG=${{ steps.version.outputs.tag }}
-          if git ls-remote --tags origin "$TAG" | grep -q .; then
-            echo "Tag $TAG already exists remotely, skipping tag push."
+          REMOTE_TAG=$(git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}")
+          if [ -n "$REMOTE_TAG" ]; then
+            EXISTING_TARGET=$(printf '%s\n' "$REMOTE_TAG" | awk '$2 ~ /\^\{\}$/ {print $1; exit}')
+            if [ -z "$EXISTING_TARGET" ]; then
+              EXISTING_TARGET=$(printf '%s\n' "$REMOTE_TAG" | awk 'NR == 1 {print $1}')
+            fi
+            if [ "$EXISTING_TARGET" != "$GITHUB_SHA" ]; then
+              echo "::error::Existing tag $TAG points to $EXISTING_TARGET, expected $GITHUB_SHA"
+              exit 1
+            fi
+            echo "Tag $TAG already points to the current commit."
           else
             git tag -a "$TAG" -m "Release $TAG"
             if ! git push origin "$TAG" 2>&1; then

--- a/scripts/cicd_efficiency_test.py
+++ b/scripts/cicd_efficiency_test.py
@@ -29,6 +29,17 @@ class CicdEfficiencyTest(unittest.TestCase):
         self.assertIn("if: steps.changes.outputs.edge == 'true'", deploy)
         self.assertIn("if: steps.changes.outputs.migration == 'true'", deploy)
 
+    def test_deploy_uses_global_semver_and_rejects_tag_mismatch(self) -> None:
+        deploy = self.read(".github/workflows/deploy-prod.yml")
+        self.assertNotIn("git describe --tags", deploy)
+        self.assertIn("git tag --list 'v[0-9]*.[0-9]*.[0-9]*'", deploy)
+        self.assertIn("grep -E '^v[0-9]+\\.[0-9]+\\.[0-9]+$'", deploy)
+        self.assertIn("sort -V", deploy)
+        self.assertIn(
+            "Existing tag $TAG points to $EXISTING_TARGET, expected $GITHUB_SHA",
+            deploy,
+        )
+
     def test_minimal_gate_does_not_poll_ci(self) -> None:
         workflow = self.read(".github/workflows/minimal-e2e-gate.yml")
         self.assertNotIn("Wait for deterministic CI checks", workflow)


### PR DESCRIPTION
## Summary

- Select the next production version from the highest global three-part SemVer tag instead of the nearest reachable tag.
- Fail the deploy if a concurrently existing tag points to another commit; never silently reuse mismatched release evidence.
- Add a deterministic CI regression test for both guarantees.

## Root cause

`git describe --tags` only considers tags reachable from the checked-out commit. The existing `v1.0.1728` tag was on another merged history path, so the production workflow selected `v1.0.1727` and regenerated `1.0.1728`. Firebase correctly deployed the new commit, but the old tag remained on its original SHA.

This PR does not rewrite `v1.0.1728`. After merge, an operator-triggered protected deploy will create the next unique version/tag and verify it against the deployed commit.

## Validation

- `python scripts/cicd_efficiency_test.py`: 8 passed.
- Pre-commit workflow/static safety checks: passed for all 120 workflow files.
- `git diff --check`: clean.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Narrow deterministic release-tag correction only; no credentials, environment permissions, hosting target, database migration, or rollback path changed.