### PR TITLE
fix: bind production release tags to deployed commit

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -871,14 +871,11 @@ jobs:
       - name: Push Release Tag
         if: steps.changes.outputs.web == 'true'
         id: push_tag
-        # Win版#131 part 15: tag push が GitHub App workflow protection で reject される場合
-        # (commit range に .github/workflows/*.yml 変更含む + GH_PAT 未設定) は warning に
-        # して deploy 続行 (Firebase Hosting reflection が本体・tag は補助)
-        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          TAG=${{ steps.version.outputs.tag }}
+          set -euo pipefail
           REMOTE_TAG=$(git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}")
           if [ -n "$REMOTE_TAG" ]; then
             EXISTING_TARGET=$(printf '%s\n' "$REMOTE_TAG" | awk '$2 ~ /\^\{\}$/ {print $1; exit}')
@@ -891,11 +888,13 @@ jobs:
             fi
             echo "Tag $TAG already points to the current commit."
           else
-            git tag -a "$TAG" -m "Release $TAG"
-            if ! git push origin "$TAG" 2>&1; then
-              echo "::warning::Tag push rejected (GH_PAT 未設定 or workflow scope 不足)。Firebase Hosting deploy は成功済の可能性高い。GH_PAT を Settings>Secrets に設定すれば次回から成功する"
-              exit 0
-            fi
+            # The custom checkout intentionally has no persisted Git credentials.
+            # Create the ref through the authenticated API so it always targets
+            # the commit that was actually built and deployed, even if main moves.
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$TAG" \
+              -f sha="$GITHUB_SHA" \
+              --silent
           fi
 
       - name: Create GitHub Release
@@ -903,6 +902,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           name: Release ${{ steps.version.outputs.version }}
           body: |
             ## Release ${{ steps.version.outputs.version }}
@@ -914,6 +914,24 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify Release Tag Target
+        if: steps.changes.outputs.web == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          REF_TYPE=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.type')
+          REF_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.sha')
+          if [ "$REF_TYPE" = "tag" ]; then
+            REF_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$REF_SHA" --jq '.object.sha')
+          fi
+          if [ "$REF_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::Release tag $TAG points to $REF_SHA, expected $GITHUB_SHA"
+            exit 1
+          fi
+          echo "Release tag $TAG verified at $GITHUB_SHA."
 
       - name: Broadcast release notification
         if: steps.changes.outputs.web == 'true'

--- a/scripts/cicd_efficiency_test.py
+++ b/scripts/cicd_efficiency_test.py
@@ -40,6 +40,22 @@ class CicdEfficiencyTest(unittest.TestCase):
             deploy,
         )
 
+        tag_step = deploy.split("- name: Push Release Tag", 1)[1].split(
+            "- name: Create GitHub Release", 1
+        )[0]
+        self.assertNotIn("continue-on-error", tag_step)
+        self.assertIn(
+            'gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs"',
+            tag_step,
+        )
+        self.assertIn('-f sha="$GITHUB_SHA"', tag_step)
+        self.assertIn("target_commitish: ${{ github.sha }}", deploy)
+        self.assertIn("- name: Verify Release Tag Target", deploy)
+        self.assertIn(
+            "Release tag $TAG points to $REF_SHA, expected $GITHUB_SHA",
+            deploy,
+        )
+
     def test_minimal_gate_does_not_poll_ci(self) -> None:
         workflow = self.read(".github/workflows/minimal-e2e-gate.yml")
         self.assertNotIn("Wait for deterministic CI checks", workflow)


### PR DESCRIPTION
Summary  - Create production release tags through the authenticated GitHub API at the exact deployed GITHUB_SHA. - Fail deployment when tag creation or target verification fails. - Pass the exact commit to the GitHub Release action and verify the final tag ref.  Why  The v1.0.1729 release was created after main advanced, so its tag points to 9c4d3f3e while production correctly serves c7bf8c76. The custom checkout has no persisted Git credentials; the old tag push was allowed to fail, after which the release action created the tag from moving main.  Existing tags are not rewritten. The next deployment will create a new SemVer tag.  Validation  - python scripts/pre_commit_quality_gate.py - 19 Python regression tests passed - 120 workflow files passed static checks - 196 GitHub Actions runtime-sensitive uses checked - git diff --check 

 ## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Codex #1-owned deterministic release-tag repair; no application, schema, migration, secret, or rollback-path changes, with repository CI gates passed.