### PR TITLE
fix: separate digital and real-world danshari routes

### DIFF
--- a/lib/data/design_compliance_data.dart
+++ b/lib/data/design_compliance_data.dart
@@ -717,7 +717,7 @@ const List<PageComplianceRecord> kDesignComplianceData = [
     category: DesignCategory.ai,
   ),
   PageComplianceRecord(
-    route: '/danshari',
+    route: '/digital-danshari',
     name: '断捨離ガイド',
     category: DesignCategory.personal,
   ),

--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -321,7 +321,7 @@ Future<void> _pushPage(BuildContext context, Widget page) {
 String? _homeToolRoutePathForId(String id) {
   switch (id) {
     case 'digital-danshari':
-      return '/real-world-danshari';
+      return '/digital-danshari';
     case 'agent-org':
       return '/agents';
     case 'admin-analytics':

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -598,6 +598,7 @@ Route<dynamic> generateAppRoute(
         ),
       );
     case '/danshari':
+    case '/digital-danshari':
       return MaterialPageRoute(builder: (_) => const DanshariPage());
     case '/memory-drill':
       return MaterialPageRoute(builder: (_) => const MemoryDrillPage());

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -293,7 +293,8 @@ void main() {
       expect(find.byType(AiUniversityPage), findsOneWidget);
     });
 
-    testWidgets('ルーティング: /danshari へ遷移できること', (WidgetTester tester) async {
+    testWidgets('ルーティング: /digital-danshari へ遷移できること',
+        (WidgetTester tester) async {
       // Arrange
       when(mockGoTrueClient.currentSession).thenReturn(null);
 
@@ -324,7 +325,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final BuildContext context = tester.element(find.byType(LandingPage));
-      Navigator.of(context).pushNamed('/danshari');
+      Navigator.of(context).pushNamed('/digital-danshari');
       await tester.pumpAndSettle();
 
       // Assert

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -103,6 +103,7 @@ const List<String> kAllAppRoutes = <String>[
   '/dev/claude-design-importer',
   '/development-achievements',
   '/digest-queue',
+  '/digital-danshari',
   '/digital-wallet',
   '/discord-notifications',
   '/dns-domain-manager',

--- a/test/routes/route_url_sync_test.dart
+++ b/test/routes/route_url_sync_test.dart
@@ -264,6 +264,32 @@ void main() {
       reason: 'URL の無いトップ画面機能:\n${offenders.join('\n')}',
     );
   });
+
+  test('distinct home catalog features do not share a route', () {
+    final catalog = File('lib/data/home_tool_catalog.dart').readAsStringSync();
+    final ids = RegExp(
+      r"^      id: '([^']+)',",
+      multiLine: true,
+    ).allMatches(catalog).map((match) => match.group(1)!).toList();
+    final idsByRoute = <String, List<String>>{};
+
+    for (final id in ids) {
+      final route = _catalogRouteForId(id);
+      if (route == null) continue;
+      idsByRoute.putIfAbsent(route, () => <String>[]).add(id);
+    }
+
+    final duplicates = idsByRoute.entries
+        .where((entry) => entry.value.length > 1)
+        .map((entry) => '${entry.key}: ${entry.value.join(', ')}')
+        .toList(growable: false);
+
+    expect(
+      duplicates,
+      isEmpty,
+      reason: '異なるホーム機能が同じ URL を共有している:\n${duplicates.join('\n')}',
+    );
+  });
 }
 
 /// 引数が無いと画面を復元できないため、意図的に別 route へ落とすもの。

--- a/test/routes/route_url_sync_test.dart
+++ b/test/routes/route_url_sync_test.dart
@@ -278,7 +278,7 @@ const Map<String?, String> _intentionalFallbacks = <String?, String>{
 
 /// `_homeToolRoutePathForId` (home_tool_catalog.dart) と同じ対応表。
 String? _catalogRouteForId(String id) => switch (id) {
-      'digital-danshari' => '/real-world-danshari',
+      'digital-danshari' => '/digital-danshari',
       'agent-org' => '/agents',
       'admin-analytics' => '/admin',
       'edge-function-status' => '/edge-functions',


### PR DESCRIPTION
## Summary

- Add `/digital-danshari` as the canonical direct route for `DanshariPage` while preserving legacy `/danshari` compatibility.
- Keep `/real-world-danshari` mapped only to `RealWorldDanshariPage`.
- Correct the home catalog route, design-compliance metadata, route inventory, and route synchronization test plus a unique-route regression guard so the two distinct features can no longer collide.

## Route integrity ledger

| Item | Before | After |
| --- | --- | --- |
| `digital-danshari` catalog route | `/real-world-danshari` | `/digital-danshari` |
| Digital page | `DanshariPage` opened with the wrong announced URL | `DanshariPage` at `/digital-danshari` |
| Real-world page | `RealWorldDanshariPage` at `/real-world-danshari` | unchanged |
| Legacy compatibility | `/danshari` | preserved |

## Minimal E2E Gate

- Implementation-detail independent: route tests assert registered user-facing URLs and browser QA asserts visible page headings.
- Minimal scope: the canonical digital route and the existing real-world route are compared at desktop and mobile widths.
- E2E-Exception: deterministic Flutter route/catalog tests plus controlled release-build browser QA cover this URL-only repair; no new write flow or remote side effect was introduced.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: This route integrity repair changes no auth policy, schema, secrets, migrations, permissions, AI prompt/model contract, or remote write path.

## Validation

- `flutter test --no-pub test/routes/route_url_sync_test.dart test/routes/direct_path_routes_test.dart test/data/home_tool_catalog_consolidation_test.dart`: 18 passed.
- `flutter build web --release --no-pub`: passed in 196.7 seconds, including the existing Wasm dry-run advisory only.
- `git diff --check`: passed.
- Local Windows `flutter analyze` did not complete because the analysis-server process stopped responding; required PR CI is the authoritative static-analysis gate.

### Browser QA

Controlled Chrome against the local release build:

| Route | 1440x900 | 390x844 | Console warnings/errors |
| --- | --- | --- | --- |
| `/digital-danshari` | `断捨離クエスト` (`DanshariPage`) | responsive header/body | 0 |
| `/real-world-danshari` | `リアル断捨離クエスト` (`RealWorldDanshariPage`) | responsive camera/image actions | 0 |

The digital page keeps its existing unauthenticated loading behavior; this PR changes route integrity only.

## Risk and deployment

- No database migration or service configuration change.
- Existing `/danshari` bookmarks remain valid.
- Normal release workflow only; verify exact SHA/tag/readiness and both live routes after merge.

## Checklist

- [x] Route/catalog tests updated and passing.
- [x] Release web build passed.
- [x] Desktop and mobile browser QA completed.
- [x] No breaking change.
- [x] Legacy route retained.
