### PR TITLE
feat: 生活基盤を最優先する借金完済ガードを追加

### DIFF
--- a/.agents/skills/life-foundations-improvement-loop/SKILL.md
+++ b/.agents/skills/life-foundations-improvement-loop/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: life-foundations-improvement-loop
+description: Incrementally improve an existing service by stabilizing its smallest safety, reliability, accessibility, or daily-use foundation before adding nonessential expansion.
+---
+
+# Life Foundations Improvement Loop
+
+Use the ordering **stabilize -> sustain today -> advance one step**. Preserve the
+user's objective, but defer optional ambition, surface-area growth, and polish
+when a more basic gap prevents safe, reliable daily use.
+
+## Loop
+
+1. Inspect current behavior, repository guidance, tests, production evidence
+   already in scope, and uncommitted changes. Do not assume a gap from copy or
+   plans alone.
+2. Read [references/foundation-priorities.md](references/foundation-priorities.md)
+   when choosing among multiple gaps or defining a measurement.
+3. Choose one smallest foundation gap whose repair produces an observable user
+   benefit. State the evidence, baseline, intended signal, and allowed scope.
+4. Implement the narrowest reversible change. Preserve unrelated work and
+   existing safety paths.
+5. Verify with the closest deterministic checks, then observe the chosen signal
+   using only data and systems already authorized for the task.
+6. Record the result and remaining risk. Repeat only if the first change is
+   verified and another in-scope foundation gap is clearly supported.
+
+## Boundaries and stop conditions
+
+- Never block or degrade essential access, safety, medical help, authentication
+  recovery, data recovery, payments already owed, or necessary communication.
+- Do not infer permission to deploy, contact users, alter production data,
+  purchase services, change schemas, or broaden product scope. Ask immediately
+  before an action needs authority not already granted.
+- Stop when the intended signal improves and acceptance criteria pass; when the
+  next step is optional expansion; when a deterministic check fails for an
+  unclear reason; or when evidence is insufficient, risk increases, or the
+  smallest fix crosses an authorization boundary.
+- Never call an interrupted, skipped, or observationally ambiguous check a
+  pass. Report the exact result and a safe recovery step.

--- a/.agents/skills/life-foundations-improvement-loop/agents/openai.yaml
+++ b/.agents/skills/life-foundations-improvement-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Life Foundations Improvement Loop"
+  short_description: "Prioritize safe, incremental service foundations"
+  default_prompt: "Use $life-foundations-improvement-loop to improve one smallest foundational gap in this service."

--- a/.agents/skills/life-foundations-improvement-loop/references/foundation-priorities.md
+++ b/.agents/skills/life-foundations-improvement-loop/references/foundation-priorities.md
@@ -1,0 +1,33 @@
+# Foundation priorities and measures
+
+Use this reference only when several improvements compete or the success signal
+is unclear.
+
+## Choose in this order
+
+1. Safety and essential access: prevent harm, lockout, data loss, or blocked
+   critical user actions.
+2. Daily continuity: make the core path complete reliably on ordinary devices,
+   connections, and assistive technology.
+3. Recovery and clarity: expose failure, preserve user input, provide a safe
+   retry or escape, and explain the next action without blame.
+4. Efficiency: remove the smallest repeated delay or manual burden on the core
+   path.
+5. Nonessential expansion: new surfaces, integrations, automation, and polish
+   only after higher priorities meet their minimum threshold.
+
+Prefer the candidate with the strongest direct evidence, smallest reversible
+change, and clearest user-visible result. Treat severity before frequency when
+an infrequent failure can cause material harm.
+
+## Measure proportionally
+
+Pick one primary signal and an explicit baseline. Useful signals include a
+focused regression test, core-path completion rate, error rate, recovery rate,
+latency at a named percentile, accessibility result, or repeated manual steps
+removed. Pair it with a guardrail signal when the improvement could shift harm
+elsewhere.
+
+For local-only work, deterministic tests and static checks can be the observed
+signal. Do not invent production outcomes. If production observation was not
+authorized or available, say so and define what would be measured later.

--- a/lib/domain/models/debt_guard_rule.dart
+++ b/lib/domain/models/debt_guard_rule.dart
@@ -40,6 +40,191 @@ class DebtGuardRule {
   final String? requiredAction;
 }
 
+/// Shared ordering and safety boundary for the payoff guard.
+///
+/// The guard may defer nonessential expansion, but it never defers the actions
+/// needed to keep a person safe and able to continue daily life.
+class DebtGuardFoundationPolicy {
+  const DebtGuardFoundationPolicy._();
+
+  static const motto = '整える → 生き抜く → 一歩進む';
+
+  static const essentialActions = <String>[
+    '睡眠',
+    '食事',
+    '水分補給',
+    '医療',
+    '衛生',
+    '仕事',
+    '緊急対応',
+    '借金返済',
+    '必要な連絡',
+  ];
+
+  static const dailyFoundationCopy = '今日を生き抜くために考え、必要なことを行い、'
+      'してはいけない衝動はやり過ごします。'
+      '責めるためではなく、今日の生活の土台を取り戻すための順番です。';
+
+  static const expansionCopy = '新しい挑戦・事業拡大・必須でない買い物などは、'
+      '今日の土台が整ってから最小の一歩だけ進めます。';
+
+  static const routineCopy = '完璧を求めず、毎日すべてを確認して、'
+      'その日に必要な項目を最小単位で行います。'
+      '体調不良や危険があるときは、達成数より休息・食事・医療を優先します。';
+
+  static const safetyCopy = '睡眠・食事・水分補給・医療・衛生・仕事・緊急対応・'
+      '借金返済・必要な連絡は、このガードより常に優先し、'
+      '決して制限しません。危険・強い痛み・体調不良がある場合は、'
+      '休息・医療・支援を優先してください。';
+}
+
+enum DebtGuardFoundationCadence { daily, whenDue, recoveryAware }
+
+extension DebtGuardFoundationCadenceCopy on DebtGuardFoundationCadence {
+  String get label => switch (this) {
+        DebtGuardFoundationCadence.daily => '毎日行う',
+        DebtGuardFoundationCadence.whenDue => '毎日確認し、必要日に行う',
+        DebtGuardFoundationCadence.recoveryAware => '体調と回復に合わせて行う',
+      };
+}
+
+class DebtGuardFoundationTask {
+  const DebtGuardFoundationTask({
+    required this.id,
+    required this.title,
+    required this.cadence,
+    required this.minimumAction,
+  });
+
+  final String id;
+  final String title;
+  final DebtGuardFoundationCadence cadence;
+  final String minimumAction;
+}
+
+const debtGuardFoundationTasks = <DebtGuardFoundationTask>[
+  DebtGuardFoundationTask(
+    id: 'cleaning',
+    title: '掃除',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '床・机・水回りのどれか1か所を2分だけ掃除する',
+  ),
+  DebtGuardFoundationTask(
+    id: 'laundry',
+    title: '洗濯',
+    cadence: DebtGuardFoundationCadence.whenDue,
+    minimumAction: '洗濯物を確認し、必要なら洗濯機を回す',
+  ),
+  DebtGuardFoundationTask(
+    id: 'dishes',
+    title: '洗い物',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '皿かコップを1つだけ洗う',
+  ),
+  DebtGuardFoundationTask(
+    id: 'tidying',
+    title: '整理整頓',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '物を1つだけ元の場所へ戻す',
+  ),
+  DebtGuardFoundationTask(
+    id: 'bath',
+    title: '風呂',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '体調に合わせて入浴かシャワーの準備を始める',
+  ),
+  DebtGuardFoundationTask(
+    id: 'home_cooking',
+    title: '自炊',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '米を炊くか、次の食事の食材を1つ準備する',
+  ),
+  DebtGuardFoundationTask(
+    id: 'meals',
+    title: '食事',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '食事を抜かず、必要な栄養と水分を確保する',
+  ),
+  DebtGuardFoundationTask(
+    id: 'expiry_management',
+    title: '食料品・調味料の賞味期限管理',
+    cadence: DebtGuardFoundationCadence.whenDue,
+    minimumAction: '食品を1つ確認し、期限が近いものを手前に置く',
+  ),
+  DebtGuardFoundationTask(
+    id: 'discard_unused_items',
+    title: '不用品の廃棄',
+    cadence: DebtGuardFoundationCadence.whenDue,
+    minimumAction: '不要な物を1つだけ分別する',
+  ),
+  DebtGuardFoundationTask(
+    id: 'brush_teeth',
+    title: '歯磨き',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '歯ブラシを手に取り、30秒だけ磨き始める',
+  ),
+  DebtGuardFoundationTask(
+    id: 'change_clothes',
+    title: '毎日着替える',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '清潔な服を1組用意して着替える',
+  ),
+  DebtGuardFoundationTask(
+    id: 'shave',
+    title: '髭を剃る',
+    cadence: DebtGuardFoundationCadence.whenDue,
+    minimumAction: '鏡で確認し、必要なら髭剃りを準備する',
+  ),
+  DebtGuardFoundationTask(
+    id: 'haircut',
+    title: '髪を切る',
+    cadence: DebtGuardFoundationCadence.whenDue,
+    minimumAction: '長さを確認し、必要なら予約か日程決めをする',
+  ),
+  DebtGuardFoundationTask(
+    id: 'trim_nails',
+    title: '爪を切る',
+    cadence: DebtGuardFoundationCadence.whenDue,
+    minimumAction: '爪を確認し、必要なら爪切りを用意する',
+  ),
+  DebtGuardFoundationTask(
+    id: 'asset_management',
+    title: '資産管理',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '残高・支払予定・当日の利用を1分だけ確認する',
+  ),
+  DebtGuardFoundationTask(
+    id: 'journal',
+    title: '日記をつける',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '今日の事実を1行だけ書く',
+  ),
+  DebtGuardFoundationTask(
+    id: 'reading',
+    title: '読書',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '本を開き、1ページだけ読む',
+  ),
+  DebtGuardFoundationTask(
+    id: 'learning',
+    title: '学習',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '教材を開き、2分だけ取り組む',
+  ),
+  DebtGuardFoundationTask(
+    id: 'exercise',
+    title: '運動',
+    cadence: DebtGuardFoundationCadence.daily,
+    minimumAction: '体調に合わせて歩くか、軽くストレッチする',
+  ),
+  DebtGuardFoundationTask(
+    id: 'strength_training',
+    title: '筋トレ',
+    cadence: DebtGuardFoundationCadence.recoveryAware,
+    minimumAction: '痛みや疲労を確認し、回復していれば1種目だけ行う',
+  ),
+];
+
 /// The canonical payoff-guard catalog.
 ///
 /// The user's duplicate gambling entries are intentionally represented by one

--- a/lib/widgets/debt_guard_panel.dart
+++ b/lib/widgets/debt_guard_panel.dart
@@ -42,6 +42,8 @@ class DebtGuardPanel extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
+                    _buildFoundationMindset(context),
+                    const SizedBox(height: 12),
                     _buildBugMindset(context),
                     const SizedBox(height: 12),
                     _buildSafetyNotice(context),
@@ -153,6 +155,80 @@ class DebtGuardPanel extends StatelessWidget {
     );
   }
 
+  Widget _buildFoundationMindset(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final essentialActions =
+        DebtGuardFoundationPolicy.essentialActions.join('・');
+    return DecoratedBox(
+      key: const Key('debt-guard-foundation-mindset'),
+      decoration: BoxDecoration(
+        color: colors.secondaryContainer.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              DebtGuardFoundationPolicy.motto,
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w900),
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              DebtGuardFoundationPolicy.dailyFoundationCopy,
+              style: TextStyle(fontSize: 12, height: 1.55),
+            ),
+            const SizedBox(height: 10),
+            const Text(
+              '先に守る土台（制限しない）',
+              style: TextStyle(fontWeight: FontWeight.w900),
+            ),
+            const SizedBox(height: 3),
+            Text(essentialActions, style: const TextStyle(fontSize: 12)),
+            const SizedBox(height: 8),
+            const Text(
+              '毎日の生活基盤チェック',
+              style: TextStyle(fontWeight: FontWeight.w900),
+            ),
+            const SizedBox(height: 3),
+            const Text(
+              DebtGuardFoundationPolicy.routineCopy,
+              style: TextStyle(fontSize: 12, height: 1.55),
+            ),
+            const SizedBox(height: 8),
+            for (final cadence in DebtGuardFoundationCadence.values) ...[
+              Text(
+                cadence.label,
+                style:
+                    const TextStyle(fontSize: 12, fontWeight: FontWeight.w800),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                debtGuardFoundationTasks
+                    .where((task) => task.cadence == cadence)
+                    .map((task) => task.title)
+                    .join('・'),
+                style: const TextStyle(fontSize: 12, height: 1.5),
+              ),
+              const SizedBox(height: 6),
+            ],
+            const SizedBox(height: 2),
+            const Text(
+              'その後の一歩（必須でない拡大）',
+              style: TextStyle(fontWeight: FontWeight.w900),
+            ),
+            const SizedBox(height: 3),
+            const Text(
+              DebtGuardFoundationPolicy.expansionCopy,
+              style: TextStyle(fontSize: 12, height: 1.55),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildBugMindset(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     return DecoratedBox(
@@ -178,11 +254,12 @@ class DebtGuardPanel extends StatelessWidget {
                   ),
                   SizedBox(height: 4),
                   Text(
-                    '「やってはいけないことをしたい」「すべきことをできない」は、'
-                    'あなた自身ではなく一時的な脳内バグの命令だと考えます。'
-                    '命令に少し従わない、または逆の小さな行動を無理やり始めるたびに、'
-                    '虫は弱り、繰り返すほど死んで消えていく、と考えます。'
-                    'これは行動を切り替えるための比喩です。',
+                    '「やってはいけないことをしたい」「すべきことをできない」を、'
+                    'あなた自身ではなく一時的な「脳内の虫（バグ）」の命令に見立てます。'
+                    '命令に少し従わない、または逆の小さな行動を始めるたびに、'
+                    '虫が弱り、やがて死んで消えるイメージです。'
+                    'これは行動を切り替えるための動機づけの比喩であり、'
+                    '脳が物理的に変化するという説明ではありません。',
                     style: TextStyle(fontSize: 12, height: 1.55),
                   ),
                 ],
@@ -210,8 +287,7 @@ class DebtGuardPanel extends StatelessWidget {
             SizedBox(width: 10),
             Expanded(
               child: Text(
-                '睡眠・食事・医療・緊急連絡・仕事・返済先や支援者との連絡など、'
-                '生命と生活の維持に必要な行動は制限しません。必要な睡眠は毎日確保してください。',
+                DebtGuardFoundationPolicy.safetyCopy,
                 style: TextStyle(fontSize: 12, height: 1.55),
               ),
             ),
@@ -258,6 +334,17 @@ class DebtGuardPanel extends StatelessWidget {
       runSpacing: 10,
       children: [
         FilledButton.icon(
+          key: const Key('debt-guard-start-foundation'),
+          onPressed: viewModel.isSaving
+              ? null
+              : () => _showUrgeDialog(
+                    context,
+                    initialMode: _BugResponseMode.startRequiredAction,
+                  ),
+          icon: const Icon(Icons.play_arrow_rounded),
+          label: const Text('まず生活を1つ整える'),
+        ),
+        FilledButton.tonalIcon(
           key: const Key('debt-guard-check-in-all'),
           onPressed: viewModel.isSaving ? null : () => _checkInAll(context),
           icon: const Icon(Icons.done_all),
@@ -446,11 +533,13 @@ class DebtGuardPanel extends StatelessWidget {
   Future<void> _showUrgeDialog(
     BuildContext context, {
     DebtGuardRule? rule,
+    _BugResponseMode initialMode = _BugResponseMode.resistProhibitedAction,
   }) async {
     final result = await _showActionDialog(
       context,
       fixedRule: rule,
       showPausePlan: true,
+      initialBugMode: initialMode,
     );
     if (result == null || !context.mounted) return;
     await _record(
@@ -483,6 +572,7 @@ class DebtGuardPanel extends StatelessWidget {
     BuildContext context, {
     required DebtGuardRule? fixedRule,
     required bool showPausePlan,
+    _BugResponseMode initialBugMode = _BugResponseMode.resistProhibitedAction,
   }) async {
     var selectedRuleId = fixedRule?.id ?? debtGuardRules.first.id;
     final requiredActionRules = debtGuardRules
@@ -491,7 +581,7 @@ class DebtGuardPanel extends StatelessWidget {
     var requiredActionRuleId = fixedRule?.requiredAction != null
         ? fixedRule!.id
         : requiredActionRules.first.id;
-    var bugMode = _BugResponseMode.resistProhibitedAction;
+    var bugMode = initialBugMode;
     final noteController = TextEditingController();
     try {
       return await showDialog<_DebtGuardActionResult>(
@@ -513,7 +603,13 @@ class DebtGuardPanel extends StatelessWidget {
             final selectableRules =
                 isRequiredActionMode ? requiredActionRules : debtGuardRules;
             return AlertDialog(
-              title: Text(showPausePlan ? '脳内バグ退治' : '違反を記録'),
+              title: Text(
+                showPausePlan
+                    ? isRequiredActionMode
+                        ? '生活を1つ整える'
+                        : '脳内バグ退治'
+                    : '違反を記録',
+              ),
               content: SizedBox(
                 width: 520,
                 child: SingleChildScrollView(
@@ -524,8 +620,9 @@ class DebtGuardPanel extends StatelessWidget {
                       if (showPausePlan) ...[
                         const Text(
                           'いまの衝動や抵抗を、あなた自身ではなく一時的な'
-                          '「脳内の虫（バグ）」の命令として扱います。'
-                          '命令と逆の行動を1回するたびに、虫は弱ります。',
+                          '「脳内の虫（バグ）」の命令に見立てます。'
+                          'これは動機づけの比喩です。'
+                          '命令と逆の安全な行動を1回するたびに、虫は弱ります。',
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
                             height: 1.5,

--- a/test/domain/debt_guard_rule_test.dart
+++ b/test/domain/debt_guard_rule_test.dart
@@ -44,6 +44,88 @@ void main() {
     });
   });
 
+  group('DebtGuardFoundationPolicy', () {
+    test('puts the daily foundation before nonessential expansion', () {
+      expect(DebtGuardFoundationPolicy.motto, '整える → 生き抜く → 一歩進む');
+      expect(
+        DebtGuardFoundationPolicy.dailyFoundationCopy,
+        contains('今日を生き抜く'),
+      );
+      expect(DebtGuardFoundationPolicy.expansionCopy, contains('土台が整ってから'));
+    });
+
+    test('protects every essential action from the guard', () {
+      expect(
+        DebtGuardFoundationPolicy.essentialActions,
+        containsAll(<String>[
+          '睡眠',
+          '食事',
+          '水分補給',
+          '医療',
+          '衛生',
+          '仕事',
+          '緊急対応',
+          '借金返済',
+          '必要な連絡',
+        ]),
+      );
+      expect(DebtGuardFoundationPolicy.safetyCopy, contains('決して制限しません'));
+    });
+
+    test('defines the requested 20 concrete foundation tasks once each', () {
+      expect(debtGuardFoundationTasks, hasLength(20));
+      expect(
+        debtGuardFoundationTasks.map((task) => task.id).toSet(),
+        hasLength(20),
+      );
+      expect(
+        debtGuardFoundationTasks.map((task) => task.title),
+        containsAll(<String>[
+          '掃除',
+          '洗濯',
+          '洗い物',
+          '整理整頓',
+          '風呂',
+          '自炊',
+          '食事',
+          '食料品・調味料の賞味期限管理',
+          '不用品の廃棄',
+          '歯磨き',
+          '毎日着替える',
+          '髭を剃る',
+          '髪を切る',
+          '爪を切る',
+          '資産管理',
+          '日記をつける',
+          '読書',
+          '学習',
+          '運動',
+          '筋トレ',
+        ]),
+      );
+    });
+
+    test('uses safe frequencies for periodic care and training', () {
+      final haircut = debtGuardFoundationTasks.firstWhere(
+        (task) => task.id == 'haircut',
+      );
+      final strengthTraining = debtGuardFoundationTasks.firstWhere(
+        (task) => task.id == 'strength_training',
+      );
+      final meals = debtGuardFoundationTasks.firstWhere(
+        (task) => task.id == 'meals',
+      );
+
+      expect(haircut.cadence, DebtGuardFoundationCadence.whenDue);
+      expect(
+        strengthTraining.cadence,
+        DebtGuardFoundationCadence.recoveryAware,
+      );
+      expect(strengthTraining.minimumAction, contains('回復'));
+      expect(meals.minimumAction, contains('食事を抜かず'));
+    });
+  });
+
   group('DebtGuardDailySnapshot', () {
     test('a violation cannot be overwritten by a later check-in', () {
       final events = [

--- a/test/widgets/debt_guard_panel_test.dart
+++ b/test/widgets/debt_guard_panel_test.dart
@@ -17,6 +17,10 @@ void main() {
 
     expect(find.text('完済までの禁止事項'), findsOneWidget);
     expect(find.text('25項目'), findsOneWidget);
+    expect(find.text(DebtGuardFoundationPolicy.motto), findsOneWidget);
+    expect(find.text('先に守る土台（制限しない）'), findsOneWidget);
+    expect(find.text('毎日の生活基盤チェック'), findsOneWidget);
+    expect(find.text('その後の一歩（必須でない拡大）'), findsOneWidget);
     expect(find.text('脳内の虫（バグ）を弱らせる'), findsOneWidget);
     expect(
       find.byKey(const Key('debt-guard-rule-gambling')),
@@ -33,6 +37,32 @@ void main() {
     expect(repository.events.single.type, DebtGuardEventType.checkIn);
   });
 
+  testWidgets('shows the complete essential-action safety boundary', (
+    tester,
+  ) async {
+    final repository = _PanelRepository();
+    final viewModel = _viewModel(repository);
+    addTearDown(viewModel.dispose);
+    await viewModel.load();
+    await _pump(tester, viewModel, width: 430);
+
+    expect(
+      find.byKey(const Key('debt-guard-foundation-mindset')),
+      findsOneWidget,
+    );
+    for (final action in DebtGuardFoundationPolicy.essentialActions) {
+      expect(find.textContaining(action), findsWidgets);
+    }
+    expect(find.textContaining('決して制限しません'), findsOneWidget);
+    expect(find.textContaining('動機づけの比喩'), findsOneWidget);
+    for (final task in debtGuardFoundationTasks) {
+      expect(find.textContaining(task.title), findsWidgets);
+    }
+    for (final cadence in DebtGuardFoundationCadence.values) {
+      expect(find.text(cadence.label), findsOneWidget);
+    }
+  });
+
   testWidgets('bug help records resisting a prohibited action', (tester) async {
     final repository = _PanelRepository();
     final viewModel = _viewModel(repository);
@@ -44,13 +74,48 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('脳内バグ退治'), findsOneWidget);
-    expect(find.textContaining('一時的な「脳内の虫（バグ）」'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.textContaining('一時的な「脳内の虫（バグ）」'),
+      ),
+      findsOneWidget,
+    );
     expect(find.textContaining('10分待つ'), findsOneWidget);
     await tester.tap(find.text('バグを弱めた'));
     await tester.pumpAndSettle();
 
     expect(find.text('バグを弱めた 1'), findsOneWidget);
     expect(repository.events.single.type, DebtGuardEventType.urgeResisted);
+  });
+
+  testWidgets('starts a minimum foundation action in one tap', (tester) async {
+    final repository = _PanelRepository();
+    final viewModel = _viewModel(repository);
+    addTearDown(viewModel.dispose);
+    await viewModel.load();
+    await _pump(tester, viewModel, width: 430);
+
+    await tester.tap(find.byKey(const Key('debt-guard-start-foundation')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('生活を1つ整える'), findsOneWidget);
+    expect(
+      tester
+          .widget<ChoiceChip>(find.byKey(const Key('bug-mode-start')))
+          .selected,
+      isTrue,
+    );
+    expect(find.textContaining('皿かコップを1つだけ洗う'), findsOneWidget);
+
+    await tester.tap(find.text('バグを弱めた'));
+    await tester.pumpAndSettle();
+
+    expect(
+      repository.events.single.type,
+      DebtGuardEventType.requiredActionStarted,
+    );
+    expect(repository.events.single.ruleId, 'dishes_left_unwashed');
   });
 
   testWidgets('bug help starts a required action in a minimum unit', (


### PR DESCRIPTION
## 目的

借金完済までの禁止事項ガードに「生活を整える → 今日を生き抜く → 一歩進む」という基盤思想を加え、毎日の生活基盤20項目と脳内バグへの最小行動を明確にします。

## 変更内容

- 生活基盤を最優先する方針と、安全上決して制限しない必須行動を追加
- 掃除・洗濯・食事・衛生・資産管理・学習・運動など20項目を3つの頻度に整理
- 「まず生活を1つ整える」の一タップ導線を追加
- 脳内の虫（バグ）を、本人を責めず衝動と距離を取るための比喩として明示
- 継続改善用の life-foundations-improvement-loop スキルを追加
- ドメインテストとレスポンシブなウィジェットテストを追加

## 安全境界

睡眠・食事・水分補給・医療・衛生・仕事・緊急対応・借金返済・必要な連絡は、ガードで制限しません。体調不良や危険時は休息・医療・支援を優先します。

## 検証

- dart format --output=none --set-exit-if-changed: 4ファイル、変更なし
- dart analyze（変更したDart/テスト4ファイル）: No issues found
- flutter test test/domain/debt_guard_rule_test.dart test/widgets/debt_guard_panel_test.dart: 17件成功
- git diff --check: 成功
- Flutter Webローカル起動: 成功
- 実画面QA:
  - 1280x900: 20項目の3区分、安全説明、禁止項目2列表示を確認
  - 390x844: 1列表示、横方向のはみ出しなし
  - ブラウザエラー0件
- 未ログイン時は記録操作を表示しないため、操作遷移はウィジェットテストで確認

## 既知事項

Flutter Webの既存viewport警告とNotoフォント警告が各1件あります。対象画面の日本語表示や操作には支障を確認していません。




## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: 今回は既存画面内の生活基盤表示と一タップ導線に限定され、認証・ルーティング・永続化の新規フローはありません。ユーザー可視の正常系・安全境界・レスポンシブ表示は対象ウィジェットテスト17件とローカルブラウザQAで確認済みです。
