### PR TITLE
feat: add AI photo action advisor

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -638,11 +638,11 @@ List<HomeToolEntry> buildHomeToolCatalog({
     HomeToolEntry(
       id: 'real-world-danshari',
       sectionId: 'personal',
-      title: '断捨離 (リアル)',
-      subtitle: '現実の持ち物を写真付きで整理する',
-      icon: Icons.camera_alt_outlined,
+      title: 'AIフォト行動アドバイザー',
+      subtitle: '写真から今すべきことを優先順に整理する',
+      icon: Icons.auto_awesome_outlined,
       color: const Color(0xFFFF6B35),
-      keywords: const <String>['断捨離', 'リアル', '持ち物'],
+      keywords: const <String>['AI', '写真', '行動', '片付け', '断捨離', 'リアル', '持ち物'],
       onOpen: (context) => _pushPage(
         context,
         RealWorldDanshariPage(supabaseClient: supabaseClient),

--- a/lib/domain/models/photo_action_advice.dart
+++ b/lib/domain/models/photo_action_advice.dart
@@ -1,0 +1,128 @@
+enum PhotoActionPriority {
+  urgent(1, '最優先'),
+  high(2, '優先'),
+  normal(3, 'できれば');
+
+  const PhotoActionPriority(this.rank, this.label);
+
+  final int rank;
+  final String label;
+
+  static PhotoActionPriority fromJson(Object? value) {
+    final rank = switch (value) {
+      final num value => value.toInt(),
+      final String value => int.tryParse(value),
+      _ => null,
+    };
+    return switch (rank) {
+      1 => PhotoActionPriority.urgent,
+      2 => PhotoActionPriority.high,
+      _ => PhotoActionPriority.normal,
+    };
+  }
+}
+
+class PhotoRecommendedAction {
+  const PhotoRecommendedAction({
+    required this.priority,
+    required this.title,
+    required this.reason,
+    required this.estimatedMinutes,
+    this.caution,
+  });
+
+  final PhotoActionPriority priority;
+  final String title;
+  final String reason;
+  final int estimatedMinutes;
+  final String? caution;
+
+  factory PhotoRecommendedAction.fromJson(Map<String, dynamic> json) {
+    final title = _requiredString(json['title'], 'title');
+    final reason = _requiredString(json['reason'], 'reason');
+    final rawMinutes = switch (json['estimated_minutes']) {
+      final num value => value.toInt(),
+      final String value => int.tryParse(value),
+      _ => null,
+    };
+    return PhotoRecommendedAction(
+      priority: PhotoActionPriority.fromJson(json['priority']),
+      title: title,
+      reason: reason,
+      estimatedMinutes: (rawMinutes ?? 5).clamp(1, 180),
+      caution: _optionalString(json['caution']),
+    );
+  }
+}
+
+class PhotoActionAdvice {
+  const PhotoActionAdvice({
+    required this.sceneSummary,
+    required this.observations,
+    required this.actions,
+    required this.confidenceNote,
+    this.safetyNote,
+  });
+
+  final String sceneSummary;
+  final List<String> observations;
+  final List<PhotoRecommendedAction> actions;
+  final String confidenceNote;
+  final String? safetyNote;
+
+  factory PhotoActionAdvice.fromJson(Map<String, dynamic> json) {
+    final rawActions = json['actions'];
+    if (rawActions is! List) {
+      throw const FormatException('AIの行動提案を読み取れませんでした。');
+    }
+    final actions = <PhotoRecommendedAction>[];
+    for (final rawAction in rawActions.take(6)) {
+      if (rawAction is! Map) continue;
+      try {
+        actions.add(
+          PhotoRecommendedAction.fromJson(
+            Map<String, dynamic>.from(rawAction),
+          ),
+        );
+      } on FormatException {
+        // One malformed suggestion must not hide the remaining useful actions.
+      }
+    }
+    if (actions.isEmpty) {
+      throw const FormatException('具体的な行動提案を生成できませんでした。');
+    }
+    actions.sort((a, b) => a.priority.rank.compareTo(b.priority.rank));
+
+    final rawObservations = json['observations'];
+    final observations = rawObservations is List
+        ? rawObservations
+            .map(_optionalString)
+            .whereType<String>()
+            .take(5)
+            .toList(growable: false)
+        : const <String>[];
+
+    return PhotoActionAdvice(
+      sceneSummary: _requiredString(json['scene_summary'], 'scene_summary'),
+      observations: observations,
+      actions: List<PhotoRecommendedAction>.unmodifiable(actions),
+      confidenceNote:
+          _optionalString(json['confidence_note']) ?? '写真に写っている範囲だけをもとにした提案です。',
+      safetyNote: _optionalString(json['safety_note']),
+    );
+  }
+}
+
+String _requiredString(Object? value, String fieldName) {
+  final normalized = _optionalString(value);
+  if (normalized == null) {
+    throw FormatException('$fieldName is required');
+  }
+  return normalized;
+}
+
+String? _optionalString(Object? value) {
+  if (value is! String) return null;
+  final normalized = value.trim();
+  return normalized.isEmpty ? null : normalized;
+}

--- a/lib/pages/real_world_danshari_page.dart
+++ b/lib/pages/real_world_danshari_page.dart
@@ -1,368 +1,434 @@
-import 'dart:convert';
-import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:my_web_app/services/theme_service.dart';
 import 'package:provider/provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../domain/models/photo_action_advice.dart';
+import '../services/photo_action_advisor_service.dart';
+import '../services/theme_service.dart';
+import '../view_models/photo_action_advisor_view_model.dart';
 
 class RealWorldDanshariPage extends StatefulWidget {
-  // テスト用にSupabaseClientを注入できるようにする
-  final SupabaseClient? supabaseClient;
-  // テスト用にImagePickerを注入できるようにする
-  final ImagePicker imagePicker;
-
-  // ↓ 【修正点】ここにあった 'const' を削除しました
   RealWorldDanshariPage({
     super.key,
-    required this.supabaseClient,
+    this.supabaseClient,
     ImagePicker? imagePicker,
+    this.viewModel,
   }) : imagePicker = imagePicker ?? ImagePicker();
+
+  final SupabaseClient? supabaseClient;
+  final ImagePicker imagePicker;
+  final PhotoActionAdvisorViewModel? viewModel;
 
   @override
   State<RealWorldDanshariPage> createState() => _RealWorldDanshariPageState();
 }
 
 class _RealWorldDanshariPageState extends State<RealWorldDanshariPage> {
-  Uint8List? _imageBytes;
-  bool _isLoading = false;
-  Map<String, dynamic>? _result;
+  late final PhotoActionAdvisorViewModel _viewModel;
+  late final bool _ownsViewModel;
 
-  // テスト時は注入されたクライアントを使い、通常時はシングルトンを使う
-  SupabaseClient get _supabase =>
-      widget.supabaseClient ?? Supabase.instance.client;
-
-  Future<void> _pickImage(ImageSource source) async {
-    try {
-      final XFile? image = await widget.imagePicker.pickImage(
-        source: source,
-        maxWidth: 800,
-        imageQuality: 80,
-      );
-
-      if (image != null) {
-        final bytes = await image.readAsBytes();
-        if (!mounted) return;
-        setState(() {
-          _imageBytes = bytes;
-          _result = null;
-        });
-        // bytesを直接渡す形に変更なし
-        _analyzeImage(bytes);
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('画像の取得に失敗しました: $e')),
+  @override
+  void initState() {
+    super.initState();
+    _ownsViewModel = widget.viewModel == null;
+    _viewModel = widget.viewModel ??
+        PhotoActionAdvisorViewModel(
+          imagePicker: ImagePickerPhotoActionImagePicker(
+            imagePicker: widget.imagePicker,
+          ),
+          analyzer: SupabasePhotoActionAnalyzer(
+            widget.supabaseClient ?? Supabase.instance.client,
+          ),
         );
-      }
-    }
   }
 
-  Future<void> _analyzeImage(Uint8List bytes) async {
-    if (_supabase.auth.currentUser == null) {
-      setState(() => _isLoading = false);
-      return;
-    }
-    setState(() {
-      _isLoading = true;
-    });
-
-    try {
-      final base64Image = base64Encode(bytes);
-
-      // ここでゲッター(_supabase)経由でアクセスする
-      final response = await _supabase.functions.invoke(
-        'ai-assistant',
-        body: {
-          'action': 'analyze_danshari_item',
-          'imageBase64': base64Image,
-          'mimeType': 'image/jpeg',
-        },
-      );
-
-      final dynamic rawData = response.data;
-      final Map<String, dynamic> data = rawData is String
-          ? jsonDecode(rawData) as Map<String, dynamic>
-          : rawData as Map<String, dynamic>;
-
-      if (data['success'] == true) {
-        setState(() {
-          _result = data['result'];
-        });
-      } else {
-        throw Exception(data['error'] ?? 'Unknown error');
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('AI分析エラー: $e')),
-        );
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-      }
-    }
+  @override
+  void dispose() {
+    if (_ownsViewModel) _viewModel.dispose();
+    super.dispose();
   }
 
-// ... 以下、buildメソッド等は変更なし ...
   @override
   Widget build(BuildContext context) {
-    // ... (元のコードのまま) ...
-    final themeService = Provider.of<ThemeService>(context);
-    final isDark = themeService.isDarkMode;
-
+    final isDark = context.watch<ThemeService>().isDarkMode;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('リアル断捨離クエスト'),
+        title: const Text('AIフォト行動アドバイザー'),
         backgroundColor: const Color(0xFFFF6B35),
+        foregroundColor: Colors.white,
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Instructions
-            Card(
-              color: isDark ? const Color(0xFF1F2937) : const Color(0xFFFFF3E0),
-              child: const Padding(
-                padding: EdgeInsets.all(16.0),
-                child: Column(
-                  children: [
-                    Icon(
-                      Icons.camera_alt,
-                      size: 48,
-                      color: Color(0xFFFF6B35),
-                    ),
-                    SizedBox(height: 12),
-                    Text(
-                      'あなたの部屋にある「捨てるか迷っているモノ」を撮影してください。\nCSOが容赦なく判定します。',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 16,
-                        height: 1.5,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(height: 24),
-
-            // Image Preview Area
-            if (_imageBytes != null)
-              Container(
-                height: 300,
-                decoration: BoxDecoration(
-                  border: Border.all(color: const Color(0xFFFF6B35)),
-                  borderRadius: BorderRadius.circular(12),
-                  image: DecorationImage(
-                    image: MemoryImage(_imageBytes!),
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              )
-            else
-              Container(
-                height: 200,
-                decoration: BoxDecoration(
-                  color: isDark
-                      ? const Color(0xFF111827)
-                      : const Color(0xFFE5E7EB),
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: const Color(0xFF9CA3AF)),
-                ),
+      body: SafeArea(
+        child: AnimatedBuilder(
+          animation: _viewModel,
+          builder: (context, _) => LayoutBuilder(
+            builder: (context, constraints) {
+              final isWide = constraints.maxWidth >= 900;
+              return SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
                 child: Center(
-                  child: Text(
-                    'ここに写真が表示されます',
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      height: 1.5,
-                    ),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 1120),
+                    child: isWide
+                        ? Row(
+                            key: const Key('photo-action-wide-layout'),
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Expanded(child: _buildInputPanel(isDark)),
+                              const SizedBox(width: 24),
+                              Expanded(child: _buildResultPanel(isDark)),
+                            ],
+                          )
+                        : Column(
+                            key: const Key('photo-action-narrow-layout'),
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              _buildInputPanel(isDark),
+                              const SizedBox(height: 24),
+                              _buildResultPanel(isDark),
+                            ],
+                          ),
                   ),
                 ),
-              ),
-
-            const SizedBox(height: 24),
-
-            // Action Buttons
-            Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              alignment: WrapAlignment.center,
-              children: [
-                ElevatedButton.icon(
-                  onPressed:
-                      _isLoading ? null : () => _pickImage(ImageSource.camera),
-                  icon: const Icon(Icons.camera),
-                  label: const Text('カメラで撮影'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFFFF6B35),
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 12,
-                    ),
-                  ),
-                ),
-                ElevatedButton.icon(
-                  onPressed:
-                      _isLoading ? null : () => _pickImage(ImageSource.gallery),
-                  icon: const Icon(Icons.photo_library),
-                  label: const Text('アルバムから選択'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFFFF6B35),
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 12,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-
-            const SizedBox(height: 32),
-
-            // Result Area
-            if (_isLoading)
-              const Center(
-                child: CircularProgressIndicator(color: Color(0xFFFF6B35)),
-              )
-            else if (_result != null)
-              _buildResultCard(isDark),
-          ],
+              );
+            },
+          ),
         ),
       ),
     );
   }
 
-  Widget _buildResultCard(bool isDark) {
-    // ... (元のコードのまま) ...
-    final decision = _result!['decision'] as String;
-    final isDiscard = decision == 'DISCARD';
-    final color = isDiscard
-        ? const Color(0xFF3D5AFE)
-        : const Color(0xFF4CAF50); // Discard=Blue(Cool), Keep=Green(Safe)
-
-    return Card(
-      elevation: 4,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Column(
-        children: [
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: color,
-              borderRadius:
-                  const BorderRadius.vertical(top: Radius.circular(16)),
-            ),
-            child: Text(
-              isDiscard ? ' 廃棄推奨 (DISCARD)' : ' 維持 (KEEP)',
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
-                height: 1.5,
-              ),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(20.0),
+  Widget _buildInputPanel(bool isDark) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Card(
+          color: isDark ? const Color(0xFF1F2937) : const Color(0xFFFFF3E0),
+          child: const Padding(
+            padding: EdgeInsets.all(16),
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                Icon(Icons.auto_awesome, size: 44, color: Color(0xFFFF6B35)),
+                SizedBox(height: 12),
                 Text(
-                  _result!['item_name'] ?? '不明なアイテム',
-                  style: const TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    height: 1.5,
-                  ),
+                  '片付けたい場所や、次に何をすべきか迷う場面を撮影してください。\nAIが写真から確認できる範囲で、優先行動を整理します。',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 16, height: 1.5),
                 ),
-                const Divider(),
-                const SizedBox(height: 8),
-                Row(
-                  children: [
-                    const Text(
-                      'ときめきスコア: ',
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        height: 1.5,
-                      ),
-                    ),
-                    Text(
-                      '${_result!['spark_joy_score']} / 100',
-                      style: TextStyle(
-                        fontSize: 18,
-                        color: (_result!['spark_joy_score'] as int) < 50
-                            ? const Color(0xFF3D5AFE)
-                            : const Color(0xFFE53935),
-                        fontWeight: FontWeight.bold,
-                        height: 1.5,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                const Text(
-                  ' 判定理由:',
-                  style: TextStyle(
-                    fontWeight: FontWeight.bold,
-                    height: 1.5,
-                  ),
-                ),
+                SizedBox(height: 8),
                 Text(
-                  _result!['reason'] ?? '',
-                  style: const TextStyle(
-                    fontSize: 16,
-                    height: 1.5,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: isDark
-                        ? const Color(0xFF1F2937)
-                        : const Color(0xFFFFF3E0),
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(
-                      color: const Color(0xFFFF6B35).withValues(alpha: 0.3),
-                    ),
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Icon(
-                        Icons.format_quote,
-                        color: Color(0xFFFF6B35),
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          _result!['witty_comment'] ?? '',
-                          style: TextStyle(
-                            fontStyle: FontStyle.italic,
-                            color: isDark
-                                ? const Color(0xFFD1D5DB)
-                                : const Color(0xFF1F2937),
-                            height: 1.5,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
+                  '顔、住所、書類などの個人情報が写らないようご注意ください。',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 12, height: 1.4),
                 ),
               ],
             ),
           ),
+        ),
+        const SizedBox(height: 16),
+        _buildImagePreview(isDark),
+        const SizedBox(height: 16),
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          alignment: WrapAlignment.center,
+          children: [
+            ElevatedButton.icon(
+              onPressed: _viewModel.isAnalyzing
+                  ? null
+                  : () => _viewModel.pickAndAnalyze(
+                        PhotoActionImageSource.camera,
+                      ),
+              icon: const Icon(Icons.camera_alt_outlined),
+              label: const Text('カメラで撮影'),
+              style: _actionButtonStyle(),
+            ),
+            ElevatedButton.icon(
+              onPressed: _viewModel.isAnalyzing
+                  ? null
+                  : () => _viewModel.pickAndAnalyze(
+                        PhotoActionImageSource.gallery,
+                      ),
+              icon: const Icon(Icons.photo_library_outlined),
+              label: const Text('写真をアップロード'),
+              style: _actionButtonStyle(),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildImagePreview(bool isDark) {
+    final image = _viewModel.selectedImage;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(16),
+      child: AspectRatio(
+        aspectRatio: 4 / 3,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: isDark ? const Color(0xFF111827) : const Color(0xFFE5E7EB),
+            border: Border.all(color: const Color(0xFFFF6B35)),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: image == null
+              ? const Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.add_photo_alternate_outlined, size: 48),
+                      SizedBox(height: 8),
+                      Text('ここに写真が表示されます'),
+                    ],
+                  ),
+                )
+              : Semantics(
+                  label: '解析する写真',
+                  image: true,
+                  child: Image.memory(
+                    image.bytes,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, __, ___) => const Center(
+                      child: Text('写真を表示できませんでした'),
+                    ),
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResultPanel(bool isDark) {
+    if (_viewModel.isAnalyzing) {
+      return const Card(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 48, horizontal: 24),
+          child: Column(
+            children: [
+              CircularProgressIndicator(color: Color(0xFFFF6B35)),
+              SizedBox(height: 16),
+              Text('写真を確認して、行動を組み立てています…'),
+            ],
+          ),
+        ),
+      );
+    }
+    if (_viewModel.errorMessage != null) {
+      return Card(
+        color: isDark ? const Color(0xFF3F1D1D) : const Color(0xFFFFEBEE),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            children: [
+              Icon(
+                _viewModel.requiresLogin ? Icons.login : Icons.error_outline,
+                color: const Color(0xFFD32F2F),
+                size: 36,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                _viewModel.errorMessage!,
+                textAlign: TextAlign.center,
+                style: const TextStyle(height: 1.5),
+              ),
+              if (!_viewModel.requiresLogin &&
+                  _viewModel.selectedImage != null) ...[
+                const SizedBox(height: 16),
+                OutlinedButton.icon(
+                  onPressed: _viewModel.analyzeSelected,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('もう一度分析'),
+                ),
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+    final advice = _viewModel.advice;
+    if (advice == null) {
+      return const Card(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 36, horizontal: 24),
+          child: Column(
+            children: [
+              Icon(
+                Icons.checklist_outlined,
+                size: 44,
+                color: Color(0xFFFF6B35),
+              ),
+              SizedBox(height: 12),
+              Text(
+                '写真を選ぶと、ここに優先行動が表示されます。',
+                textAlign: TextAlign.center,
+                style: TextStyle(height: 1.5),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    return _buildAdvice(advice, isDark);
+  }
+
+  Widget _buildAdvice(PhotoActionAdvice advice, bool isDark) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '写真から確認できる状況',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8),
+                Text(advice.sceneSummary, style: const TextStyle(height: 1.5)),
+                if (advice.observations.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  for (final observation in advice.observations)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 6),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Padding(
+                            padding: EdgeInsets.only(top: 6),
+                            child: Icon(Icons.circle, size: 7),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              observation,
+                              style: const TextStyle(height: 1.45),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          'おすすめの順番',
+          style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        for (var index = 0; index < advice.actions.length; index++) ...[
+          _PhotoActionCard(action: advice.actions[index], index: index),
+          const SizedBox(height: 10),
         ],
+        Card(
+          color: isDark ? const Color(0xFF1F2937) : const Color(0xFFEFF6FF),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  advice.confidenceNote,
+                  style: const TextStyle(fontSize: 12, height: 1.45),
+                ),
+                if (advice.safetyNote != null) ...[
+                  const SizedBox(height: 8),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Icon(Icons.health_and_safety_outlined, size: 18),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          advice.safetyNote!,
+                          style: const TextStyle(fontSize: 12, height: 1.45),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  ButtonStyle _actionButtonStyle() => ElevatedButton.styleFrom(
+        backgroundColor: const Color(0xFFFF6B35),
+        foregroundColor: Colors.white,
+        minimumSize: const Size(180, 48),
+      );
+}
+
+class _PhotoActionCard extends StatelessWidget {
+  const _PhotoActionCard({required this.action, required this.index});
+
+  final PhotoRecommendedAction action;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = switch (action.priority) {
+      PhotoActionPriority.urgent => const Color(0xFFD32F2F),
+      PhotoActionPriority.high => const Color(0xFFF57C00),
+      PhotoActionPriority.normal => const Color(0xFF1976D2),
+    };
+    return Card(
+      key: Key('photo-action-$index'),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                Chip(
+                  label: Text(
+                    '${action.priority.rank}. ${action.priority.label}',
+                  ),
+                  side: BorderSide(color: color),
+                  avatar: Icon(Icons.flag_outlined, color: color, size: 18),
+                ),
+                Chip(
+                  avatar: const Icon(Icons.schedule, size: 18),
+                  label: Text('約${action.estimatedMinutes}分'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              action.title,
+              style: const TextStyle(fontSize: 17, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 6),
+            Text(action.reason, style: const TextStyle(height: 1.5)),
+            if (action.caution != null) ...[
+              const SizedBox(height: 10),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.warning_amber_rounded, color: color, size: 20),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      action.caution!,
+                      style: const TextStyle(fontSize: 13, height: 1.45),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/services/photo_action_advisor_service.dart
+++ b/lib/services/photo_action_advisor_service.dart
@@ -1,0 +1,149 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:image_picker/image_picker.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../domain/models/photo_action_advice.dart';
+
+const int photoActionMaxImageBytes = 8 * 1024 * 1024;
+
+enum PhotoActionImageSource { camera, gallery }
+
+class PhotoActionImage {
+  const PhotoActionImage({
+    required this.bytes,
+    required this.fileName,
+    required this.mimeType,
+  });
+
+  final Uint8List bytes;
+  final String fileName;
+  final String mimeType;
+}
+
+class PhotoActionAdvisorException implements Exception {
+  const PhotoActionAdvisorException(
+    this.message, {
+    this.requiresLogin = false,
+  });
+
+  final String message;
+  final bool requiresLogin;
+
+  @override
+  String toString() => message;
+}
+
+abstract interface class PhotoActionImagePicker {
+  Future<PhotoActionImage?> pick(PhotoActionImageSource source);
+}
+
+abstract interface class PhotoActionAnalyzer {
+  Future<PhotoActionAdvice> analyze(PhotoActionImage image);
+}
+
+class ImagePickerPhotoActionImagePicker implements PhotoActionImagePicker {
+  ImagePickerPhotoActionImagePicker({ImagePicker? imagePicker})
+      : _imagePicker = imagePicker ?? ImagePicker();
+
+  final ImagePicker _imagePicker;
+
+  @override
+  Future<PhotoActionImage?> pick(PhotoActionImageSource source) async {
+    final file = await _imagePicker.pickImage(
+      source: source == PhotoActionImageSource.camera
+          ? ImageSource.camera
+          : ImageSource.gallery,
+      maxWidth: 1600,
+      imageQuality: 85,
+    );
+    if (file == null) return null;
+    final bytes = await file.readAsBytes();
+    if (bytes.isEmpty) {
+      throw const PhotoActionAdvisorException('空の画像は解析できません。');
+    }
+    if (bytes.length > photoActionMaxImageBytes) {
+      throw const PhotoActionAdvisorException(
+        '画像が大きすぎます。8MB以下の画像を選んでください。',
+      );
+    }
+    return PhotoActionImage(
+      bytes: bytes,
+      fileName: file.name.trim().isEmpty ? 'photo.jpg' : file.name,
+      mimeType: _safeMimeType(file.mimeType, file.name),
+    );
+  }
+
+  static String _safeMimeType(String? suppliedMimeType, String fileName) {
+    final normalized = suppliedMimeType?.toLowerCase().trim();
+    if (normalized == 'image/png' ||
+        normalized == 'image/jpeg' ||
+        normalized == 'image/webp') {
+      return normalized!;
+    }
+    final extension = fileName.toLowerCase();
+    if (extension.endsWith('.png')) return 'image/png';
+    if (extension.endsWith('.webp')) return 'image/webp';
+    return 'image/jpeg';
+  }
+}
+
+class SupabasePhotoActionAnalyzer implements PhotoActionAnalyzer {
+  const SupabasePhotoActionAnalyzer(this._client);
+
+  final SupabaseClient _client;
+
+  @override
+  Future<PhotoActionAdvice> analyze(PhotoActionImage image) async {
+    if (_client.auth.currentUser == null) {
+      throw const PhotoActionAdvisorException(
+        'AIで写真を解析するにはログインが必要です。',
+        requiresLogin: true,
+      );
+    }
+    try {
+      final response = await _client.functions.invoke(
+        'ai-assistant',
+        body: <String, dynamic>{
+          'action': 'analyze_photo_actions',
+          'imageBase64': base64Encode(image.bytes),
+          'mimeType': image.mimeType,
+          'fileName': image.fileName,
+        },
+      );
+      final data = _responseMap(response.data);
+      if (data['success'] != true) {
+        throw PhotoActionAdvisorException(
+          _message(data['error']) ?? 'AIが写真を解析できませんでした。',
+        );
+      }
+      final rawResult = data['result'];
+      if (rawResult is! Map) {
+        throw const PhotoActionAdvisorException('AIの回答形式が正しくありません。');
+      }
+      return PhotoActionAdvice.fromJson(Map<String, dynamic>.from(rawResult));
+    } on PhotoActionAdvisorException {
+      rethrow;
+    } on FormatException catch (error) {
+      throw PhotoActionAdvisorException(error.message);
+    } catch (_) {
+      throw const PhotoActionAdvisorException(
+        'AI分析に失敗しました。通信状態を確認して、もう一度お試しください。',
+      );
+    }
+  }
+
+  static Map<String, dynamic> _responseMap(Object? rawData) {
+    final decoded = rawData is String ? jsonDecode(rawData) : rawData;
+    if (decoded is! Map) {
+      throw const PhotoActionAdvisorException('AIの回答形式が正しくありません。');
+    }
+    return Map<String, dynamic>.from(decoded);
+  }
+
+  static String? _message(Object? value) {
+    if (value is! String || value.trim().isEmpty) return null;
+    return value.trim();
+  }
+}

--- a/lib/view_models/photo_action_advisor_view_model.dart
+++ b/lib/view_models/photo_action_advisor_view_model.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/foundation.dart';
+
+import '../domain/models/photo_action_advice.dart';
+import '../services/photo_action_advisor_service.dart';
+
+class PhotoActionAdvisorViewModel extends ChangeNotifier {
+  PhotoActionAdvisorViewModel({
+    required PhotoActionImagePicker imagePicker,
+    required PhotoActionAnalyzer analyzer,
+  })  : _imagePicker = imagePicker,
+        _analyzer = analyzer;
+
+  final PhotoActionImagePicker _imagePicker;
+  final PhotoActionAnalyzer _analyzer;
+
+  PhotoActionImage? _selectedImage;
+  PhotoActionAdvice? _advice;
+  String? _errorMessage;
+  bool _requiresLogin = false;
+  bool _isAnalyzing = false;
+  int _requestSequence = 0;
+  bool _disposed = false;
+
+  PhotoActionImage? get selectedImage => _selectedImage;
+  PhotoActionAdvice? get advice => _advice;
+  String? get errorMessage => _errorMessage;
+  bool get requiresLogin => _requiresLogin;
+  bool get isAnalyzing => _isAnalyzing;
+
+  Future<void> pickAndAnalyze(PhotoActionImageSource source) async {
+    if (_isAnalyzing) return;
+    _clearError();
+    PhotoActionImage? image;
+    try {
+      image = await _imagePicker.pick(source);
+    } on PhotoActionAdvisorException catch (error) {
+      _setError(error);
+      return;
+    } catch (_) {
+      _setError(const PhotoActionAdvisorException('画像を選択できませんでした。'));
+      return;
+    }
+    if (image == null) return;
+    _selectedImage = image;
+    _advice = null;
+    _notifyListeners();
+    await analyzeSelected();
+  }
+
+  Future<void> analyzeSelected() async {
+    final image = _selectedImage;
+    if (image == null || _isAnalyzing) return;
+    final sequence = ++_requestSequence;
+    _isAnalyzing = true;
+    _clearError(notify: false);
+    _notifyListeners();
+    try {
+      final result = await _analyzer.analyze(image);
+      if (sequence != _requestSequence || _disposed) return;
+      _advice = result;
+    } on PhotoActionAdvisorException catch (error) {
+      if (sequence != _requestSequence || _disposed) return;
+      _setError(error, notify: false);
+    } catch (_) {
+      if (sequence != _requestSequence || _disposed) return;
+      _setError(
+        const PhotoActionAdvisorException(
+          'AI分析に失敗しました。時間をおいて、もう一度お試しください。',
+        ),
+        notify: false,
+      );
+    } finally {
+      if (sequence == _requestSequence && !_disposed) {
+        _isAnalyzing = false;
+        _notifyListeners();
+      }
+    }
+  }
+
+  void _clearError({bool notify = true}) {
+    _errorMessage = null;
+    _requiresLogin = false;
+    if (notify) _notifyListeners();
+  }
+
+  void _setError(
+    PhotoActionAdvisorException error, {
+    bool notify = true,
+  }) {
+    _errorMessage = error.message;
+    _requiresLogin = error.requiresLogin;
+    if (notify) _notifyListeners();
+  }
+
+  void _notifyListeners() {
+    if (!_disposed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _requestSequence++;
+    super.dispose();
+  }
+}

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -392,7 +392,116 @@ serve(async (req) => {
       }
     }
 
-    // --- 2. リアル断捨離クエスト ---
+    // --- 2. AIフォト行動アドバイザー ---
+    if (action === "analyze_photo_actions") {
+      const imageBase64 = requestData.imageBase64?.trim();
+      if (!imageBase64) throw new Error("Image required");
+      if (imageBase64.length > 11_200_000) {
+        throw new Error("Image must be 8MB or smaller");
+      }
+      const mimeType = requestData.mimeType?.toLowerCase().trim() ||
+        "image/jpeg";
+      if (!["image/jpeg", "image/png", "image/webp"].includes(mimeType)) {
+        throw new Error("JPEG, PNG, or WebP image required");
+      }
+
+      const prompt = `
+あなたは、写真から「今すべき行動」を整理する生活支援アシスタントです。
+添付写真に実際に見えているものだけを観察し、日本語で優先順位付きの具体的な行動を3〜5件提案してください。
+
+必須ルール:
+- 写真にない事実、賞味期限、故障、衛生状態、所有者の意図を断定しない。不鮮明な点は不確実だと明記する。
+- 人物の特定、属性推測、医療診断はしない。顔、住所、書類などの個人情報を回答に書き起こさない。
+- 食品、電気、火気、薬品、カビ、害虫、構造物などの危険が疑われる場合は、無理に触らず表示や取扱説明書を確認し、必要なら専門家へ相談する注意を含める。
+- 行動は「何を」「どの順で」「なぜ行うか」が分かる短い表現にする。画像だけでは判断できない確認作業も行動としてよい。
+- JSON以外の文章やMarkdownコードフェンスを出力しない。
+
+出力JSON:
+{
+  "scene_summary": "写真から確認できる状況の短い要約",
+  "observations": ["目視できる事実（最大5件）"],
+  "actions": [
+    {
+      "priority": 1,
+      "title": "具体的な行動",
+      "reason": "この順番で行う理由",
+      "estimated_minutes": 5,
+      "caution": "注意が必要な場合のみ。なければnull"
+    }
+  ],
+  "confidence_note": "写真だけでは判断できない点を含む短い注記",
+  "safety_note": "安全上の注意があれば記載。なければnull"
+}
+
+priorityは1（最優先）、2（優先）、3（できれば）のいずれか、estimated_minutesは1〜180の整数にしてください。
+`;
+
+      const resultStr = await runFallbackChain(prompt, {
+        base64: imageBase64,
+        mime: mimeType,
+      });
+      const cleanJson = resultStr.replace(/```json|```/g, "").trim();
+      const parsed: unknown = JSON.parse(cleanJson);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("AI returned an invalid action plan");
+      }
+      const raw = parsed as Record<string, unknown>;
+      const cleanText = (value: unknown, fallback = ""): string =>
+        typeof value === "string" && value.trim()
+          ? value.trim().slice(0, 600)
+          : fallback;
+      const rawActions = Array.isArray(raw.actions) ? raw.actions : [];
+      const actions = rawActions.slice(0, 6).flatMap((value, index) => {
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          return [];
+        }
+        const row = value as Record<string, unknown>;
+        const title = cleanText(row.title);
+        const reason = cleanText(row.reason);
+        if (!title || !reason) return [];
+        const parsedPriority = Number(row.priority);
+        const priority = Number.isFinite(parsedPriority)
+          ? Math.max(1, Math.min(3, Math.round(parsedPriority)))
+          : Math.min(index + 1, 3);
+        const parsedMinutes = Number(row.estimated_minutes);
+        const estimatedMinutes = Number.isFinite(parsedMinutes)
+          ? Math.max(1, Math.min(180, Math.round(parsedMinutes)))
+          : 5;
+        return [{
+          priority,
+          title,
+          reason,
+          estimated_minutes: estimatedMinutes,
+          caution: cleanText(row.caution) || null,
+        }];
+      }).sort((a, b) => a.priority - b.priority);
+      if (actions.length === 0) {
+        throw new Error("AI did not return actionable suggestions");
+      }
+      const observations =
+        (Array.isArray(raw.observations) ? raw.observations : []).map((value) =>
+          cleanText(value)
+        ).filter(Boolean).slice(0, 5);
+      const result = {
+        scene_summary: cleanText(
+          raw.scene_summary,
+          "写真に写っている状況を確認しました。",
+        ),
+        observations,
+        actions,
+        confidence_note: cleanText(
+          raw.confidence_note,
+          "写真に写っている範囲だけをもとにした提案です。",
+        ),
+        safety_note: cleanText(raw.safety_note) || null,
+      };
+      return new Response(
+        JSON.stringify({ success: true, result, image_persisted: false }),
+        { headers: corsHeaders },
+      );
+    }
+
+    // --- 2b. リアル断捨離クエスト（後方互換） ---
     if (action === "analyze_danshari_item") {
       if (!requestData.imageBase64) throw new Error("Image required");
 
@@ -1096,6 +1205,7 @@ ${entryData}`;
           "get_models",
           "test_model",
           "generate",
+          "analyze_photo_actions",
           "analyze_danshari_item",
           "hold_board_meeting",
           "my_struggle_column",

--- a/test/domain/models/photo_action_advice_test.dart
+++ b/test/domain/models/photo_action_advice_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/domain/models/photo_action_advice.dart';
+
+void main() {
+  test('parses, clamps, and orders safe action advice', () {
+    final advice = PhotoActionAdvice.fromJson({
+      'scene_summary': ' 冷蔵庫内に食品と調味料が見えます。 ',
+      'observations': ['棚に汚れが見えます', '', 12, '容器が複数あります'],
+      'actions': [
+        {
+          'priority': 3,
+          'title': '容器をまとめる',
+          'reason': '空間を把握しやすくするため',
+          'estimated_minutes': 999,
+        },
+        {
+          'priority': '1',
+          'title': '食品表示を確認する',
+          'reason': '写真だけでは期限を判断できないため',
+          'estimated_minutes': 0,
+          'caution': 'においや見た目だけで安全を断定しない',
+        },
+        {'priority': 2, 'title': '', 'reason': 'invalid'},
+      ],
+    });
+
+    expect(advice.sceneSummary, '冷蔵庫内に食品と調味料が見えます。');
+    expect(advice.observations, ['棚に汚れが見えます', '容器が複数あります']);
+    expect(advice.actions, hasLength(2));
+    expect(advice.actions.first.priority, PhotoActionPriority.urgent);
+    expect(advice.actions.first.estimatedMinutes, 1);
+    expect(advice.actions.last.estimatedMinutes, 180);
+    expect(advice.confidenceNote, contains('写真に写っている範囲'));
+  });
+
+  test('rejects a response without any usable action', () {
+    expect(
+      () => PhotoActionAdvice.fromJson({
+        'scene_summary': 'scene',
+        'actions': [
+          {'title': '', 'reason': ''},
+        ],
+      }),
+      throwsFormatException,
+    );
+  });
+}

--- a/test/pages/real_world_danshari_page_test.dart
+++ b/test/pages/real_world_danshari_page_test.dart
@@ -1,209 +1,186 @@
-// ignore_for_file: argument_type_not_assignable
-@TestOn('browser')
-
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
-import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:my_web_app/domain/models/photo_action_advice.dart';
 import 'package:my_web_app/pages/real_world_danshari_page.dart';
+import 'package:my_web_app/services/photo_action_advisor_service.dart';
 import 'package:my_web_app/services/theme_service.dart';
+import 'package:my_web_app/view_models/photo_action_advisor_view_model.dart';
 import 'package:provider/provider.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
-@GenerateMocks(
-  [SupabaseClient, FunctionsClient, FunctionResponse, ThemeService],
-)
 import 'real_world_danshari_page_test.mocks.dart';
 
-// --- 追加: 有効な1x1ピクセルのPNG画像データ ---
-final _kTransparentImage = base64Decode(
+final _transparentImage = base64Decode(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
 );
 
-class MockImagePickerPlatform extends ImagePickerPlatform {
-  XFile? pickedFile;
+final _image = PhotoActionImage(
+  bytes: _transparentImage,
+  fileName: 'refrigerator.png',
+  mimeType: 'image/png',
+);
 
-  @override
-  Future<XFile?> getImageFromSource({
-    required ImageSource source,
-    ImagePickerOptions? options,
-  }) async {
-    return pickedFile;
-  }
-}
-
-// 異常系テスト用のモック
-class ErrorMockImagePickerPlatform extends ImagePickerPlatform {
-  @override
-  Future<XFile?> getImageFromSource({
-    required ImageSource source,
-    ImagePickerOptions? options,
-  }) async {
-    throw Exception('Picker Failed');
-  }
-}
+const _advice = PhotoActionAdvice(
+  sceneSummary: '冷蔵庫内に食品、調味料、棚の汚れが見えます。',
+  observations: ['棚にこぼれ跡が見えます', '複数の容器が置かれています'],
+  actions: [
+    PhotoRecommendedAction(
+      priority: PhotoActionPriority.urgent,
+      title: '食品の表示を1点ずつ確認する',
+      reason: '写真だけでは期限や開封日を判断できないためです。',
+      estimatedMinutes: 5,
+      caution: '見た目やにおいだけで安全を断定しないでください。',
+    ),
+    PhotoRecommendedAction(
+      priority: PhotoActionPriority.high,
+      title: '棚のこぼれ跡を拭く',
+      reason: '食品を戻す前に拭くと二度手間を防げます。',
+      estimatedMinutes: 10,
+    ),
+  ],
+  confidenceNote: '写真に写っている範囲だけを確認しました。',
+  safetyNote: '異臭や液漏れがある場合は無理に触らないでください。',
+);
 
 void main() {
-  late MockSupabaseClient mockSupabaseClient;
-  late MockFunctionsClient mockFunctionsClient;
-  late MockThemeService mockThemeService;
-  late MockImagePickerPlatform mockImagePickerPlatform;
+  late MockThemeService themeService;
 
   setUp(() {
-    mockSupabaseClient = MockSupabaseClient();
-    mockFunctionsClient = MockFunctionsClient();
-    mockThemeService = MockThemeService();
-    mockImagePickerPlatform = MockImagePickerPlatform();
-
-    when(mockSupabaseClient.functions).thenReturn(mockFunctionsClient);
-    when(mockThemeService.isDarkMode).thenReturn(false);
-
-    ImagePickerPlatform.instance = mockImagePickerPlatform;
+    themeService = MockThemeService();
+    when(themeService.isDarkMode).thenReturn(false);
   });
 
-  Widget createTestWidget() {
+  Widget buildPage(PhotoActionAdvisorViewModel viewModel) {
+    addTearDown(viewModel.dispose);
     return ChangeNotifierProvider<ThemeService>.value(
-      value: mockThemeService,
+      value: themeService,
       child: MaterialApp(
-        home: RealWorldDanshariPage(
-          supabaseClient: mockSupabaseClient,
+        home: RealWorldDanshariPage(viewModel: viewModel),
+      ),
+    );
+  }
+
+  testWidgets('shows the general photo action advisor entry state',
+      (tester) async {
+    await tester.pumpWidget(
+      buildPage(
+        PhotoActionAdvisorViewModel(
+          imagePicker: _FakePicker(),
+          analyzer: _QueueAnalyzer([_advice]),
         ),
       ),
     );
-  }
 
-  testWidgets('初期表示: 説明文とボタンが表示されること', (WidgetTester tester) async {
-    await tester.pumpWidget(createTestWidget());
-
-    expect(find.text('リアル断捨離クエスト'), findsOneWidget);
-    expect(find.textContaining('あなたの部屋にある'), findsOneWidget);
+    expect(find.text('AIフォト行動アドバイザー'), findsOneWidget);
+    expect(find.textContaining('次に何をすべきか迷う場面'), findsOneWidget);
     expect(find.text('カメラで撮影'), findsOneWidget);
-    expect(find.text('アルバムから選択'), findsOneWidget);
+    expect(find.text('写真をアップロード'), findsOneWidget);
     expect(find.text('ここに写真が表示されます'), findsOneWidget);
   });
 
-  testWidgets('画像選択キャンセル時は何も起こらないこと', (WidgetTester tester) async {
-    mockImagePickerPlatform.pickedFile = null;
-
-    await tester.pumpWidget(createTestWidget());
-    await tester.tap(find.text('カメラで撮影'));
-    await tester.pumpAndSettle();
-
-    verifyNever(mockFunctionsClient.invoke(any, body: anyNamed('body')));
-    expect(find.text('ここに写真が表示されます'), findsOneWidget);
-  });
-
-  testWidgets('正常系: 画像選択後、分析が成功し結果が表示されること (JSON Stringレスポンス)',
-      (WidgetTester tester) async {
-    // 修正: 有効な画像データを使用
-    mockImagePickerPlatform.pickedFile = XFile.fromData(
-      _kTransparentImage,
-      name: 'test.jpg',
-      mimeType: 'image/jpeg',
-    );
-
-    final successResponse = {
-      'success': true,
-      'result': {
-        'decision': 'DISCARD',
-        'item_name': '古いジャケット',
-        'spark_joy_score': 30,
-        'reason': 'ボロボロです',
-        'witty_comment': 'タイムマシンがあれば...',
-      },
-    };
-    final mockResponse = MockFunctionResponse();
-    when(mockResponse.data).thenReturn(jsonEncode(successResponse));
-
-    when(
-      mockFunctionsClient.invoke(
-        'ai-assistant',
-        body: anyNamed('body'),
+  testWidgets('uploads a photo and renders ordered concrete actions',
+      (tester) async {
+    final picker = _FakePicker(image: _image);
+    await tester.pumpWidget(
+      buildPage(
+        PhotoActionAdvisorViewModel(
+          imagePicker: picker,
+          analyzer: _QueueAnalyzer([_advice]),
+        ),
       ),
-    ).thenAnswer((_) async => mockResponse);
-
-    await tester.pumpWidget(createTestWidget());
-    await tester.tap(find.text('アルバムから選択'));
-
-    // 画像描画の完了を待つ
-    await tester.pump();
-
-    // APIコールの完了を待つ
-    await tester.pumpAndSettle();
-
-    expect(find.text('古いジャケット'), findsOneWidget);
-    expect(find.text(' 廃棄推奨 (DISCARD)'), findsOneWidget);
-    expect(find.text('30 / 100'), findsOneWidget);
-  });
-
-  testWidgets('正常系: 画像選択後、分析が成功し結果が表示されること (Mapレスポンス)',
-      (WidgetTester tester) async {
-    // 修正: 有効な画像データを使用
-    mockImagePickerPlatform.pickedFile = XFile.fromData(
-      _kTransparentImage,
     );
 
-    final successResponse = {
-      'success': true,
-      'result': {
-        'decision': 'KEEP',
-        'item_name': '大切な時計',
-        'spark_joy_score': 90,
-        'reason': '輝いています',
-        'witty_comment': '素晴らしい！',
-      },
-    };
-    final mockResponse = MockFunctionResponse();
-    when(mockResponse.data).thenReturn(successResponse);
-
-    when(mockFunctionsClient.invoke(any, body: anyNamed('body')))
-        .thenAnswer((_) async => mockResponse);
-
-    await tester.pumpWidget(createTestWidget());
-    await tester.tap(find.text('カメラで撮影'));
-    await tester.pump(); // 画像ロード待ち
+    await tester.ensureVisible(find.text('写真をアップロード'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('写真をアップロード'));
     await tester.pumpAndSettle();
 
-    expect(find.text('大切な時計'), findsOneWidget);
-    expect(find.text(' 維持 (KEEP)'), findsOneWidget);
+    expect(picker.lastSource, PhotoActionImageSource.gallery);
+    expect(find.text('写真から確認できる状況'), findsOneWidget);
+    expect(find.text(_advice.sceneSummary), findsOneWidget);
+    expect(find.text('食品の表示を1点ずつ確認する'), findsOneWidget);
+    expect(find.text('棚のこぼれ跡を拭く'), findsOneWidget);
+    expect(find.text('約5分'), findsOneWidget);
+    expect(find.byKey(const Key('photo-action-0')), findsOneWidget);
   });
 
-  testWidgets('異常系: APIがエラー(success: false)を返した場合',
-      (WidgetTester tester) async {
-    // 修正: 有効な画像データを使用
-    mockImagePickerPlatform.pickedFile = XFile.fromData(_kTransparentImage);
-
-    final errorResponse = {'success': false, 'error': 'AI Error occurred'};
-    final mockResponse = MockFunctionResponse();
-    when(mockResponse.data).thenReturn(errorResponse);
-
-    when(mockFunctionsClient.invoke(any, body: anyNamed('body')))
-        .thenAnswer((_) async => mockResponse);
-
-    await tester.pumpWidget(createTestWidget());
-    await tester.tap(find.text('カメラで撮影'));
-    await tester.pump(); // 画像ロード待ち
-    await tester.pumpAndSettle();
-
-    expect(
-      find.textContaining('AI分析エラー: Exception: AI Error occurred'),
-      findsOneWidget,
+  testWidgets('keeps the image and retries after an analysis failure',
+      (tester) async {
+    final analyzer = _QueueAnalyzer([
+      const PhotoActionAdvisorException('一時的に解析できませんでした。'),
+      _advice,
+    ]);
+    await tester.pumpWidget(
+      buildPage(
+        PhotoActionAdvisorViewModel(
+          imagePicker: _FakePicker(image: _image),
+          analyzer: analyzer,
+        ),
+      ),
     );
-  });
 
-  testWidgets('異常系: 画像取得時に例外が発生した場合', (WidgetTester tester) async {
-    // 一時的にモックをエラー発生版に差し替え
-    ImagePickerPlatform.instance = ErrorMockImagePickerPlatform();
-
-    await tester.pumpWidget(createTestWidget());
-    await tester.tap(find.text('カメラで撮影'));
+    await tester.ensureVisible(find.text('写真をアップロード'));
     await tester.pumpAndSettle();
+    await tester.tap(find.text('写真をアップロード'));
+    await tester.pumpAndSettle();
+    expect(find.text('一時的に解析できませんでした。'), findsOneWidget);
+    expect(find.text('もう一度分析'), findsOneWidget);
 
-    expect(find.textContaining('画像の取得に失敗しました'), findsOneWidget);
-
-    // 後始末: 元に戻す（他のテストへの影響防止）
-    ImagePickerPlatform.instance = mockImagePickerPlatform;
+    await tester.ensureVisible(find.text('もう一度分析'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('もう一度分析'));
+    await tester.pumpAndSettle();
+    expect(find.text('食品の表示を1点ずつ確認する'), findsOneWidget);
+    expect(analyzer.calls, 2);
   });
+
+  testWidgets('switches between narrow and wide layouts without overflow',
+      (tester) async {
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    final viewModel = PhotoActionAdvisorViewModel(
+      imagePicker: _FakePicker(),
+      analyzer: _QueueAnalyzer([_advice]),
+    );
+
+    tester.view.physicalSize = const Size(390, 844);
+    await tester.pumpWidget(buildPage(viewModel));
+    expect(find.byKey(const Key('photo-action-narrow-layout')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    tester.view.physicalSize = const Size(1200, 900);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('photo-action-wide-layout')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class _FakePicker implements PhotoActionImagePicker {
+  _FakePicker({this.image});
+
+  final PhotoActionImage? image;
+  PhotoActionImageSource? lastSource;
+
+  @override
+  Future<PhotoActionImage?> pick(PhotoActionImageSource source) async {
+    lastSource = source;
+    return image;
+  }
+}
+
+class _QueueAnalyzer implements PhotoActionAnalyzer {
+  _QueueAnalyzer(this.results);
+
+  final List<Object> results;
+  int calls = 0;
+
+  @override
+  Future<PhotoActionAdvice> analyze(PhotoActionImage image) async {
+    final result = results[calls++];
+    if (result is PhotoActionAdvisorException) throw result;
+    return result as PhotoActionAdvice;
+  }
 }

--- a/test/view_models/photo_action_advisor_view_model_test.dart
+++ b/test/view_models/photo_action_advisor_view_model_test.dart
@@ -1,0 +1,121 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/domain/models/photo_action_advice.dart';
+import 'package:my_web_app/services/photo_action_advisor_service.dart';
+import 'package:my_web_app/view_models/photo_action_advisor_view_model.dart';
+
+void main() {
+  const advice = PhotoActionAdvice(
+    sceneSummary: '棚に食品と汚れが見えます。',
+    observations: ['棚に汚れが見えます'],
+    actions: [
+      PhotoRecommendedAction(
+        priority: PhotoActionPriority.urgent,
+        title: '食品表示を確認する',
+        reason: '写真だけでは期限を判断できないため',
+        estimatedMinutes: 5,
+      ),
+    ],
+    confidenceNote: '写真の範囲だけを確認しました。',
+  );
+
+  test('selects an image and exposes analysis results', () async {
+    final picker = _FakePicker(image: _image);
+    final analyzer = _FakeAnalyzer(result: advice);
+    final viewModel = PhotoActionAdvisorViewModel(
+      imagePicker: picker,
+      analyzer: analyzer,
+    );
+
+    await viewModel.pickAndAnalyze(PhotoActionImageSource.gallery);
+
+    expect(picker.lastSource, PhotoActionImageSource.gallery);
+    expect(analyzer.calls, 1);
+    expect(viewModel.selectedImage, _image);
+    expect(viewModel.advice, advice);
+    expect(viewModel.isAnalyzing, isFalse);
+    expect(viewModel.errorMessage, isNull);
+  });
+
+  test('picker cancellation does not start analysis', () async {
+    final analyzer = _FakeAnalyzer(result: advice);
+    final viewModel = PhotoActionAdvisorViewModel(
+      imagePicker: _FakePicker(),
+      analyzer: analyzer,
+    );
+
+    await viewModel.pickAndAnalyze(PhotoActionImageSource.camera);
+
+    expect(analyzer.calls, 0);
+    expect(viewModel.selectedImage, isNull);
+    expect(viewModel.errorMessage, isNull);
+  });
+
+  test('keeps selected image and exposes a retryable analysis error', () async {
+    final analyzer = _FakeAnalyzer(
+      error: const PhotoActionAdvisorException('解析できませんでした。'),
+    );
+    final viewModel = PhotoActionAdvisorViewModel(
+      imagePicker: _FakePicker(image: _image),
+      analyzer: analyzer,
+    );
+
+    await viewModel.pickAndAnalyze(PhotoActionImageSource.gallery);
+
+    expect(viewModel.selectedImage, _image);
+    expect(viewModel.errorMessage, '解析できませんでした。');
+    expect(viewModel.requiresLogin, isFalse);
+  });
+
+  test('exposes login-required state separately', () async {
+    final viewModel = PhotoActionAdvisorViewModel(
+      imagePicker: _FakePicker(image: _image),
+      analyzer: _FakeAnalyzer(
+        error: const PhotoActionAdvisorException(
+          'ログインが必要です。',
+          requiresLogin: true,
+        ),
+      ),
+    );
+
+    await viewModel.pickAndAnalyze(PhotoActionImageSource.gallery);
+
+    expect(viewModel.requiresLogin, isTrue);
+    expect(viewModel.errorMessage, 'ログインが必要です。');
+  });
+}
+
+final _image = PhotoActionImage(
+  bytes: Uint8List.fromList([1, 2, 3]),
+  fileName: 'photo.jpg',
+  mimeType: 'image/jpeg',
+);
+
+class _FakePicker implements PhotoActionImagePicker {
+  _FakePicker({this.image});
+
+  final PhotoActionImage? image;
+  PhotoActionImageSource? lastSource;
+
+  @override
+  Future<PhotoActionImage?> pick(PhotoActionImageSource source) async {
+    lastSource = source;
+    return image;
+  }
+}
+
+class _FakeAnalyzer implements PhotoActionAnalyzer {
+  _FakeAnalyzer({this.result, this.error});
+
+  final PhotoActionAdvice? result;
+  final PhotoActionAdvisorException? error;
+  int calls = 0;
+
+  @override
+  Future<PhotoActionAdvice> analyze(PhotoActionImage image) async {
+    calls++;
+    if (error != null) throw error!;
+    return result!;
+  }
+}


### PR DESCRIPTION
## Summary
- add a camera/gallery flow that turns a photo into prioritized, concrete next actions
- route authenticated image analysis through the existing `ai-assistant` Edge Function using the new `analyze_photo_actions` action
- add responsive loading, retry, login-required, safety, privacy, and uncertainty states
- preserve the existing `analyze_danshari_item` action for backwards compatibility

## Architecture and safety
- keep image picking, Supabase invocation, state transitions, and UI rendering behind separate service/view-model/domain boundaries
- accept JPEG, PNG, or WebP images up to 8 MB
- do not persist uploaded image bytes in this feature; the response reports `image_persisted: false`
- constrain AI output to visible facts, sanitized Japanese action fields, at most six actions, and explicit uncertainty/safety notes

## Validation
- `dart format --output=none --set-exit-if-changed` on the eight changed Dart/test files
- `deno fmt --check supabase/functions/ai-assistant/index.ts`
- `deno lint supabase/functions/ai-assistant/index.ts`
- focused Flutter model, view-model, and widget tests: 10 passed
- desktop browser QA: wide two-column result layout rendered without horizontal overflow
- mobile layout: 390 px widget test passed without overflow
- `git diff --check origin/main...HEAD`

## Resource note
A local aggregate `flutter analyze` run was stopped after the Windows host fell below the resource-safety memory threshold. GitHub CI remains the authoritative full analysis and release-build gate before merge.

## Production path
Merging to `main` triggers `Deploy to Production`; its existing deploy list already includes `ai-assistant` and Firebase Hosting. Production will be verified only after that workflow completes successfully.



## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: The authenticated camera or gallery picker is unavailable in the current CI browser harness; implementation-independent input/output states are covered by focused widget and view-model tests, and production smoke is required after deployment.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: No Claude Code #1 session was available in this Codex task; the user explicitly authorized production deployment, AI Agent Code Review passed, and green security, CI, deployment, rollback readiness, data-migration assessment, observability, and production-smoke evidence are required before completion.


