### PR TITLE
fix: restore note saves blocked by search trigger

### DIFF
--- a/supabase/migrations/20260823040700_fix_note_search_index_trigger_bigint.sql
+++ b/supabase/migrations/20260823040700_fix_note_search_index_trigger_bigint.sql
@@ -1,0 +1,23 @@
+-- public.notes.id is bigint, while the search index and its single-row sync
+-- function use integer note IDs. Without an explicit cast, the row trigger
+-- resolves sync_note_search_index_note(uuid, bigint), which does not exist and
+-- rolls back note inserts and updates.
+create or replace function public.refresh_note_search_index_row()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if tg_op = 'DELETE' then
+    delete from public.note_search_index where note_id = old.id;
+    return old;
+  end if;
+
+  perform public.sync_note_search_index_note(new.user_id, new.id::integer);
+  return new;
+end;
+$$;
+
+revoke execute on function public.refresh_note_search_index_row()
+  from public, anon, authenticated;

--- a/test/services/note_search_trigger_bigint_migration_test.dart
+++ b/test/services/note_search_trigger_bigint_migration_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260823040700_fix_note_search_index_trigger_bigint.sql';
+
+void main() {
+  group('note search trigger bigint compatibility migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _migrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test('casts the bigint note id to the existing integer RPC contract', () {
+      expect(
+        sql,
+        contains(
+          'perform public.sync_note_search_index_note('
+          'new.user_id, new.id::integer);',
+        ),
+      );
+    });
+
+    test('keeps the trigger function locked down', () {
+      expect(sql, contains("set search_path = ''"));
+      expect(
+        sql,
+        contains(
+          'revoke execute on function public.refresh_note_search_index_row()\n'
+          '  from public, anon, authenticated;',
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Restore note INSERT/UPDATE by explicitly casting the bigint notes.id to the existing integer search-index RPC contract inside the row trigger.
- Keep the SECURITY DEFINER trigger function on an empty search_path and revoke direct client execution.
- Add a regression test for the exact bigint/integer mismatch and privilege boundary.

## Root cause
The deployed trigger called public.sync_note_search_index_note(new.user_id, new.id). public.notes.id is bigint, while the installed function is public.sync_note_search_index_note(uuid, integer), so Postgres attempted to resolve a nonexistent uuid,bigint overload and rolled back every affected note write.

## Validation
- flutter test --no-pub test/services/note_search_trigger_bigint_migration_test.dart test/services/note_search_index_optimization_test.dart test/services/note_search_rpc_security_test.dart (10 passed)
- dart analyze test/services/note_search_trigger_bigint_migration_test.dart --fatal-infos (no issues)
- python scripts/check_migration_timestamps.py (1961 unique timestamps)
- python scripts/check_migration_time_relative_check.py (clean)
- supabase db push --linked --dry-run (only the new migration would be applied)

## Existing unrelated database findings
- Linked db lint still reports four pre-existing errors in generate_share_token, increment_points, increment_edge_function_call_count, and intake_artifact_candidate.
- Linked advisors report pre-existing exposed-auth/security-definer view findings. This migration adds none of those objects.

## Coordination
- No subagents used.
- Cleanup impact: isolated worktree; unrelated root-worktree changes untouched.




## High-risk rollout contract
- Security: no new grants; the trigger function keeps an empty search_path and direct client execution remains revoked.
- Data migration: no rows or columns are rewritten; this only replaces the existing trigger function body.
- Rollback: if unexpected behavior appears, disable notes_refresh_search_index first so note saves remain available, then restore the prior function body and rebuild the search index after diagnosis.
- Prod smoke: after merge and migration deployment, create, update, and delete a disposable authenticated note; confirm the note and search-index row change without a PostgREST 404.
- Observability: monitor PostgREST/database logs for sync_note_search_index_note resolution errors and confirm successful note POST/PATCH responses.
- Unresolved findings from Codex deterministic review: none.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: /ultrareview was not run because this Codex-only session has no user authorization for the billed workflow; merge remains pending Claude Code #1 or user review.
