### PR TITLE
feat: add guarded Notion migration center

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -678,6 +678,9 @@ jobs:
           deploy_function growth-weekly-digest --no-verify-jwt
           deploy_function guitar-recording-studio --no-verify-jwt
           deploy_function autonomous-ops --no-verify-jwt
+          # Owner-only Notion inventory. Browser JWT + user_profiles.is_admin
+          # are both checked in-function before NOTION_API_TOKEN is used.
+          deploy_function notion-migration-hub --no-verify-jwt
 
           # --- Macro-Hub (6本: 旧Tier1全統合) ---
           deploy_function core-hub --no-verify-jwt
@@ -719,7 +722,7 @@ jobs:
           deploy_function memory-search-hub --no-verify-jwt
           deploy_function mcp-well-known --no-verify-jwt
 
-          # Total: 25 functions deployed (ハードキャップ50本に対し25本 — 余裕25本)
+          # Total: 26 functions deployed (ハードキャップ50本に対し26本 — 余裕24本)
           # memo-reactions → core-hub に統合済み (b4c91bc2 2026-04-24)
           #
           # Hub対応表:

--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -158,6 +158,7 @@ import '../pages/subscription_billing_page.dart';
 import '../pages/digital_product_store_pages.dart';
 import '../pages/viral_ad_generator_page.dart';
 import '../ui/features/video_studio/video_studio_feature.dart';
+import '../ui/features/notion_migration/notion_migration_feature.dart';
 import '../pages/youtube_stats_page.dart';
 import '../pages/virtual_pet_page.dart';
 import '../pages/work_menu_page.dart';
@@ -1052,6 +1053,26 @@ List<HomeToolEntry> buildHomeToolCatalog({
       color: const Color(0xFF3D5AFE),
       keywords: const <String>['インポート', '移行', 'import'],
       onOpen: (context) => _pushPage(context, const ImportPage()),
+    ),
+    HomeToolEntry(
+      id: 'notion-migration',
+      sectionId: 'knowledge',
+      title: 'Notion移行センター',
+      subtitle: '全件棚卸し・段階移行・7項目照合・Notion側削除を追跡する',
+      icon: Icons.move_to_inbox_outlined,
+      color: const Color(0xFF4F46E5),
+      keywords: const <String>[
+        'Notion',
+        '移行',
+        'インポート',
+        'バックアップ',
+        '検証',
+        '解約',
+      ],
+      onOpen: (context) => _pushPage(
+        context,
+        const NotionMigrationFeature(),
+      ),
     ),
     HomeToolEntry(
       id: 'growth-mission',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -220,6 +220,7 @@ import 'package:my_web_app/pages/viral_ad_generator_page.dart';
 import 'package:my_web_app/pages/growth_automation_controller_page.dart';
 import 'package:my_web_app/pages/landing_ab_test_page.dart';
 import 'package:my_web_app/ui/features/video_studio/video_studio_feature.dart';
+import 'package:my_web_app/ui/features/notion_migration/notion_migration_feature.dart';
 import 'package:my_web_app/pages/youtube_stats_page.dart';
 import 'package:my_web_app/pages/audio_effects_processor_page.dart';
 import 'package:my_web_app/pages/fitness_health_tracker_page.dart';
@@ -1341,6 +1342,11 @@ Route<dynamic> generateAppRoute(
     case '/video-studio':
       return MaterialPageRoute(
         builder: (_) => VideoStudioFeature(initialUri: uri),
+        settings: RouteSettings(name: settings.name),
+      );
+    case '/notion-migration':
+      return MaterialPageRoute(
+        builder: (_) => const NotionMigrationFeature(),
         settings: RouteSettings(name: settings.name),
       );
     case '/youtube-stats':

--- a/lib/ui/features/notion_migration/data/notion_migration_gateway.dart
+++ b/lib/ui/features/notion_migration/data/notion_migration_gateway.dart
@@ -1,0 +1,231 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../domain/notion_migration_models.dart';
+
+class NotionMigrationException implements Exception {
+  const NotionMigrationException(this.code, [this.message]);
+
+  final String code;
+  final String? message;
+
+  @override
+  String toString() => message ?? code;
+}
+
+abstract class NotionMigrationGateway {
+  Future<NotionMigrationSnapshot> loadLatest();
+
+  Future<NotionMigrationBatch> createBatch({
+    required String workspaceId,
+    required String workspaceName,
+    required String name,
+  });
+
+  Future<NotionInventoryActionResult> startInventory(String batchId);
+
+  Future<NotionInventoryActionResult> expandInventory(String batchId);
+
+  Future<NotionWbsReconciliation> reconcileWbs(String batchId);
+
+  Future<NotionWbsStageSummary> stageWbs(String batchId);
+}
+
+class SupabaseNotionMigrationGateway implements NotionMigrationGateway {
+  SupabaseNotionMigrationGateway({SupabaseClient? client})
+      : _client = client ?? Supabase.instance.client;
+
+  final SupabaseClient _client;
+
+  String get _userId {
+    final id = _client.auth.currentUser?.id;
+    if (id == null) {
+      throw const NotionMigrationException('authentication_required');
+    }
+    return id;
+  }
+
+  @override
+  Future<NotionMigrationSnapshot> loadLatest() async {
+    final userId = _userId;
+    final rows = await _client
+        .from('notion_migration_batches')
+        .select()
+        .eq('user_id', userId)
+        .isFilter('archived_at', null)
+        .order('created_at', ascending: false)
+        .limit(1);
+    if (rows.isEmpty) return const NotionMigrationSnapshot();
+
+    final batch = NotionMigrationBatch.fromJson(
+      Map<String, dynamic>.from(rows.first),
+    );
+    final results = await Future.wait<List<Map<String, dynamic>>>([
+      _client
+          .from('notion_migration_batch_progress')
+          .select()
+          .eq('batch_id', batch.id)
+          .limit(1),
+      _client
+          .from('notion_migration_items')
+          .select()
+          .eq('batch_id', batch.id)
+          .order('source_path')
+          .limit(500),
+      _client
+          .from('notion_migration_checks')
+          .select('item_id,status')
+          .eq('user_id', userId)
+          .eq('status', 'passed'),
+      _client
+          .from('notion_migration_items')
+          .select('metadata')
+          .eq('batch_id', batch.id)
+          .eq('source_kind', 'data_source')
+          .order('updated_at', ascending: false)
+          .limit(100),
+      _client
+          .from('notion_migration_capabilities')
+          .select()
+          .eq('batch_id', batch.id)
+          .order('capability_key'),
+      _client
+          .from('notion_migration_wbs_stage_progress')
+          .select()
+          .eq('batch_id', batch.id)
+          .limit(1),
+    ]);
+
+    final progressRows = results[0];
+    final itemRows = results[1];
+    final checkRows = results[2];
+    final dataSourceRows = results[3];
+    final capabilityRows = results[4];
+    final stageRows = results[5];
+    final checksByItem = <String, int>{};
+    for (final check in checkRows) {
+      final itemId = check['item_id']?.toString();
+      if (itemId != null) {
+        checksByItem.update(itemId, (count) => count + 1, ifAbsent: () => 1);
+      }
+    }
+
+    NotionWbsReconciliation? reconciliation;
+    for (final row in dataSourceRows) {
+      final metadata = row['metadata'];
+      if (metadata is! Map) continue;
+      final value = metadata['wbs_reconciliation'];
+      if (value is Map) {
+        reconciliation = NotionWbsReconciliation.fromJson(
+          Map<String, dynamic>.from(value),
+        );
+        break;
+      }
+    }
+
+    return NotionMigrationSnapshot(
+      batch: batch,
+      progress: progressRows.isEmpty
+          ? const NotionMigrationProgress()
+          : NotionMigrationProgress.fromJson(progressRows.first),
+      items: itemRows
+          .map(
+            (row) => NotionMigrationItem.fromJson(
+              row,
+              passedChecks: checksByItem[row['id']?.toString()] ?? 0,
+            ),
+          )
+          .toList(growable: false),
+      capabilities:
+          capabilityRows.map(NotionCapability.fromJson).toList(growable: false),
+      wbsReconciliation: reconciliation,
+      wbsStageSummary: stageRows.isEmpty
+          ? null
+          : NotionWbsStageSummary.fromJson(stageRows.first),
+    );
+  }
+
+  @override
+  Future<NotionMigrationBatch> createBatch({
+    required String workspaceId,
+    required String workspaceName,
+    required String name,
+  }) async {
+    final row = await _client
+        .from('notion_migration_batches')
+        .insert({
+          'user_id': _userId,
+          'workspace_id': workspaceId.trim(),
+          'workspace_name': workspaceName.trim(),
+          'name': name.trim(),
+        })
+        .select()
+        .single();
+    return NotionMigrationBatch.fromJson(row);
+  }
+
+  @override
+  Future<NotionInventoryActionResult> startInventory(String batchId) {
+    return _runInventoryAction('inventory.start', batchId);
+  }
+
+  @override
+  Future<NotionInventoryActionResult> expandInventory(String batchId) {
+    return _runInventoryAction('inventory.expand', batchId);
+  }
+
+  @override
+  Future<NotionWbsReconciliation> reconcileWbs(String batchId) async {
+    final data = await _runAction('reconcile.wbs', batchId);
+    return NotionWbsReconciliation.fromJson(data);
+  }
+
+  @override
+  Future<NotionWbsStageSummary> stageWbs(String batchId) async {
+    final data = await _runAction('stage.wbs', batchId);
+    return NotionWbsStageSummary.fromJson(data);
+  }
+
+  Future<NotionInventoryActionResult> _runInventoryAction(
+    String action,
+    String batchId,
+  ) async {
+    final data = await _runAction(action, batchId);
+    return NotionInventoryActionResult.fromJson(data);
+  }
+
+  Future<Map<String, dynamic>> _runAction(
+    String action,
+    String batchId,
+  ) async {
+    _userId;
+    try {
+      final response = await _client.functions.invoke(
+        'notion-migration-hub',
+        body: <String, dynamic>{
+          'action': action,
+          'batch_id': batchId,
+          if (action == 'inventory.expand') 'limit': 2,
+        },
+      );
+      final data = response.data is Map
+          ? Map<String, dynamic>.from(response.data as Map)
+          : const <String, dynamic>{};
+      if (response.status < 200 ||
+          response.status >= 300 ||
+          data['success'] != true) {
+        throw NotionMigrationException(
+          data['error']?.toString() ?? 'inventory_failed',
+        );
+      }
+      return data;
+    } on FunctionException catch (error) {
+      final details = error.details is Map
+          ? Map<String, dynamic>.from(error.details as Map)
+          : const <String, dynamic>{};
+      throw NotionMigrationException(
+        details['error']?.toString() ?? 'http_${error.status}',
+        error.reasonPhrase,
+      );
+    }
+  }
+}

--- a/lib/ui/features/notion_migration/domain/notion_migration_models.dart
+++ b/lib/ui/features/notion_migration/domain/notion_migration_models.dart
@@ -1,0 +1,354 @@
+enum NotionMigrationBatchStatus {
+  inventory,
+  migrating,
+  verifying,
+  awaitingSourceDeletion,
+  completed,
+  paused,
+  failed;
+
+  static NotionMigrationBatchStatus fromStorage(String? value) =>
+      switch (value) {
+        'migrating' => migrating,
+        'verifying' => verifying,
+        'awaiting_source_deletion' => awaitingSourceDeletion,
+        'completed' => completed,
+        'paused' => paused,
+        'failed' => failed,
+        _ => inventory,
+      };
+
+  String get label => switch (this) {
+        inventory => '棚卸し中',
+        migrating => '移行中',
+        verifying => '照合中',
+        awaitingSourceDeletion => 'Notion側削除待ち',
+        completed => '完了',
+        paused => '一時停止',
+        failed => '要対応',
+      };
+}
+
+enum NotionMigrationItemStatus {
+  inventoried,
+  queued,
+  exporting,
+  imported,
+  verifying,
+  verified,
+  readyForSourceDeletion,
+  sourceDeleted,
+  failed,
+  skipped;
+
+  static NotionMigrationItemStatus fromStorage(String? value) =>
+      switch (value) {
+        'queued' => queued,
+        'exporting' => exporting,
+        'imported' => imported,
+        'verifying' => verifying,
+        'verified' => verified,
+        'ready_for_source_deletion' => readyForSourceDeletion,
+        'source_deleted' => sourceDeleted,
+        'failed' => failed,
+        'skipped' => skipped,
+        _ => inventoried,
+      };
+
+  String get label => switch (this) {
+        inventoried => '棚卸し済み',
+        queued => '移行待ち',
+        exporting => '書き出し中',
+        imported => '取込済み',
+        verifying => '照合中',
+        verified => '照合済み',
+        readyForSourceDeletion => 'Notion側削除可能',
+        sourceDeleted => 'Notion側削除済み',
+        failed => '要対応',
+        skipped => '対象外',
+      };
+}
+
+class NotionMigrationBatch {
+  const NotionMigrationBatch({
+    required this.id,
+    required this.workspaceId,
+    required this.workspaceName,
+    required this.name,
+    required this.status,
+    required this.createdAt,
+  });
+
+  factory NotionMigrationBatch.fromJson(Map<String, dynamic> json) {
+    return NotionMigrationBatch(
+      id: json['id']?.toString() ?? '',
+      workspaceId: json['workspace_id']?.toString() ?? '',
+      workspaceName: json['workspace_name']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      status: NotionMigrationBatchStatus.fromStorage(
+        json['status']?.toString(),
+      ),
+      createdAt: DateTime.tryParse(json['created_at']?.toString() ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+    );
+  }
+
+  final String id;
+  final String workspaceId;
+  final String workspaceName;
+  final String name;
+  final NotionMigrationBatchStatus status;
+  final DateTime createdAt;
+}
+
+class NotionMigrationItem {
+  const NotionMigrationItem({
+    required this.id,
+    required this.sourceId,
+    required this.sourceKind,
+    required this.title,
+    required this.sourcePath,
+    required this.status,
+    required this.passedChecks,
+  });
+
+  factory NotionMigrationItem.fromJson(
+    Map<String, dynamic> json, {
+    int passedChecks = 0,
+  }) {
+    return NotionMigrationItem(
+      id: json['id']?.toString() ?? '',
+      sourceId: json['source_id']?.toString() ?? '',
+      sourceKind: json['source_kind']?.toString() ?? 'page',
+      title: json['title']?.toString() ?? '',
+      sourcePath: json['source_path']?.toString() ?? '',
+      status: NotionMigrationItemStatus.fromStorage(json['status']?.toString()),
+      passedChecks: passedChecks,
+    );
+  }
+
+  final String id;
+  final String sourceId;
+  final String sourceKind;
+  final String title;
+  final String sourcePath;
+  final NotionMigrationItemStatus status;
+  final int passedChecks;
+}
+
+class NotionMigrationProgress {
+  const NotionMigrationProgress({
+    this.totalItems = 0,
+    this.importedItems = 0,
+    this.verifiedItems = 0,
+    this.deletionReadyItems = 0,
+    this.sourceDeletedItems = 0,
+    this.failedItems = 0,
+  });
+
+  factory NotionMigrationProgress.fromJson(Map<String, dynamic> json) {
+    int count(String key) => _notionMigrationInt(json[key]);
+    return NotionMigrationProgress(
+      totalItems: count('total_items'),
+      importedItems: count('imported_items'),
+      verifiedItems: count('verified_items'),
+      deletionReadyItems: count('deletion_ready_items'),
+      sourceDeletedItems: count('source_deleted_items'),
+      failedItems: count('failed_items'),
+    );
+  }
+
+  final int totalItems;
+  final int importedItems;
+  final int verifiedItems;
+  final int deletionReadyItems;
+  final int sourceDeletedItems;
+  final int failedItems;
+
+  double get importedRatio => totalItems == 0 ? 0 : importedItems / totalItems;
+  double get verifiedRatio => totalItems == 0 ? 0 : verifiedItems / totalItems;
+  double get deletedRatio =>
+      totalItems == 0 ? 0 : sourceDeletedItems / totalItems;
+}
+
+class NotionMigrationSnapshot {
+  const NotionMigrationSnapshot({
+    this.batch,
+    this.progress = const NotionMigrationProgress(),
+    this.items = const <NotionMigrationItem>[],
+    this.capabilities = const <NotionCapability>[],
+    this.wbsReconciliation,
+    this.wbsStageSummary,
+  });
+
+  final NotionMigrationBatch? batch;
+  final NotionMigrationProgress progress;
+  final List<NotionMigrationItem> items;
+  final List<NotionCapability> capabilities;
+  final NotionWbsReconciliation? wbsReconciliation;
+  final NotionWbsStageSummary? wbsStageSummary;
+}
+
+class NotionInventoryActionResult {
+  const NotionInventoryActionResult({
+    required this.discovered,
+    required this.remainingToExpand,
+    required this.inventoryComplete,
+  });
+
+  factory NotionInventoryActionResult.fromJson(Map<String, dynamic> json) {
+    return NotionInventoryActionResult(
+      discovered: _notionMigrationInt(json['discovered']),
+      remainingToExpand: _notionMigrationInt(json['remaining_to_expand']),
+      inventoryComplete: json['inventory_complete'] == true,
+    );
+  }
+
+  final int discovered;
+  final int remainingToExpand;
+  final bool inventoryComplete;
+}
+
+class NotionWbsReconciliation {
+  const NotionWbsReconciliation({
+    required this.siteRows,
+    required this.notionRows,
+    required this.siteDistinctIds,
+    required this.notionDistinctIds,
+    required this.notionDuplicateRows,
+    required this.onlyInSite,
+    required this.onlyInNotion,
+    required this.exactMatches,
+    required this.mismatchedRecords,
+    required this.deletionGatePassed,
+    required this.inventoryComplete,
+    this.checkedAt,
+  });
+
+  factory NotionWbsReconciliation.fromJson(Map<String, dynamic> json) {
+    return NotionWbsReconciliation(
+      siteRows: _notionMigrationInt(json['site_rows']),
+      notionRows: _notionMigrationInt(json['notion_rows']),
+      siteDistinctIds: _notionMigrationInt(json['site_distinct_ids']),
+      notionDistinctIds: _notionMigrationInt(json['notion_distinct_ids']),
+      notionDuplicateRows: _notionMigrationInt(json['notion_duplicate_rows']),
+      onlyInSite: _notionMigrationInt(json['only_in_site']),
+      onlyInNotion: _notionMigrationInt(json['only_in_notion']),
+      exactMatches: _notionMigrationInt(json['exact_matches']),
+      mismatchedRecords: _notionMigrationInt(json['mismatched_records']),
+      deletionGatePassed: json['deletion_gate_passed'] == true,
+      inventoryComplete: json['inventory_complete'] == true,
+      checkedAt: DateTime.tryParse(json['checked_at']?.toString() ?? ''),
+    );
+  }
+
+  final int siteRows;
+  final int notionRows;
+  final int siteDistinctIds;
+  final int notionDistinctIds;
+  final int notionDuplicateRows;
+  final int onlyInSite;
+  final int onlyInNotion;
+  final int exactMatches;
+  final int mismatchedRecords;
+  final bool deletionGatePassed;
+  final bool inventoryComplete;
+  final DateTime? checkedAt;
+}
+
+class NotionWbsStageSummary {
+  const NotionWbsStageSummary({
+    required this.stagedRows,
+    required this.distinctTaskIds,
+    required this.duplicateRows,
+    required this.invalidTaskIds,
+    this.stagedAt,
+  });
+
+  factory NotionWbsStageSummary.fromJson(Map<String, dynamic> json) {
+    return NotionWbsStageSummary(
+      stagedRows: _notionMigrationInt(json['staged_rows']),
+      distinctTaskIds: _notionMigrationInt(json['distinct_task_ids']),
+      duplicateRows: _notionMigrationInt(json['duplicate_rows']),
+      invalidTaskIds: _notionMigrationInt(json['invalid_task_ids']),
+      stagedAt: DateTime.tryParse(json['staged_at']?.toString() ?? ''),
+    );
+  }
+
+  final int stagedRows;
+  final int distinctTaskIds;
+  final int duplicateRows;
+  final int invalidTaskIds;
+  final DateTime? stagedAt;
+}
+
+enum NotionParityStatus {
+  inventory,
+  planned,
+  implemented,
+  verifying,
+  verified,
+  gap,
+  blocked;
+
+  static NotionParityStatus fromStorage(String? value) => switch (value) {
+        'planned' => planned,
+        'implemented' => implemented,
+        'verifying' => verifying,
+        'verified' => verified,
+        'gap' => gap,
+        'blocked' => blocked,
+        _ => inventory,
+      };
+
+  String get label => switch (this) {
+        inventory => '棚卸し待ち',
+        planned => '実装予定',
+        implemented => '実装済み',
+        verifying => '実データ検証中',
+        verified => '検証済み',
+        gap => '不足',
+        blocked => '要対応',
+      };
+}
+
+class NotionCapability {
+  const NotionCapability({
+    required this.key,
+    required this.name,
+    required this.notionScope,
+    required this.siteRoutes,
+    required this.status,
+    this.isRequired = true,
+    this.evidenceSummary = '',
+  });
+
+  factory NotionCapability.fromJson(Map<String, dynamic> json) {
+    final routes = json['site_routes'];
+    return NotionCapability(
+      key: json['capability_key']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      notionScope: json['notion_scope']?.toString() ?? '',
+      siteRoutes: routes is List
+          ? routes.map((route) => route.toString()).toList(growable: false)
+          : const <String>[],
+      status: NotionParityStatus.fromStorage(json['status']?.toString()),
+      isRequired: json['is_required'] != false,
+      evidenceSummary: json['evidence_summary']?.toString() ?? '',
+    );
+  }
+
+  final String key;
+  final String name;
+  final String notionScope;
+  final List<String> siteRoutes;
+  final NotionParityStatus status;
+  final bool isRequired;
+  final String evidenceSummary;
+}
+
+int _notionMigrationInt(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(value?.toString() ?? '') ?? 0;
+}

--- a/lib/ui/features/notion_migration/notion_migration_feature.dart
+++ b/lib/ui/features/notion_migration/notion_migration_feature.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import 'data/notion_migration_gateway.dart';
+import 'view_models/notion_migration_view_model.dart';
+import 'views/notion_migration_page.dart';
+
+class NotionMigrationFeature extends StatelessWidget {
+  const NotionMigrationFeature({super.key, this.gateway});
+
+  final NotionMigrationGateway? gateway;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<NotionMigrationViewModel>(
+      create: (_) => NotionMigrationViewModel(
+        gateway: gateway ?? SupabaseNotionMigrationGateway(),
+      )..load(),
+      child: const NotionMigrationPage(),
+    );
+  }
+}

--- a/lib/ui/features/notion_migration/view_models/notion_migration_view_model.dart
+++ b/lib/ui/features/notion_migration/view_models/notion_migration_view_model.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/notion_migration_gateway.dart';
+import '../domain/notion_migration_models.dart';
+
+enum NotionMigrationLoadStatus { initial, loading, ready, failure }
+
+class NotionMigrationViewModel extends ChangeNotifier {
+  NotionMigrationViewModel({required NotionMigrationGateway gateway})
+      : _gateway = gateway;
+
+  final NotionMigrationGateway _gateway;
+
+  NotionMigrationLoadStatus _loadStatus = NotionMigrationLoadStatus.initial;
+  NotionMigrationSnapshot _snapshot = const NotionMigrationSnapshot();
+  bool _isCreating = false;
+  bool _isInventoryRunning = false;
+  bool _isReconciliationRunning = false;
+  bool _isWbsStaging = false;
+  bool _authenticationRequired = false;
+  String? _errorMessage;
+  String? _noticeMessage;
+
+  NotionMigrationLoadStatus get loadStatus => _loadStatus;
+  NotionMigrationSnapshot get snapshot => _snapshot;
+  bool get isCreating => _isCreating;
+  bool get isInventoryRunning => _isInventoryRunning;
+  bool get isReconciliationRunning => _isReconciliationRunning;
+  bool get isWbsStaging => _isWbsStaging;
+  bool get authenticationRequired => _authenticationRequired;
+  String? get errorMessage => _errorMessage;
+  String? get noticeMessage => _noticeMessage;
+
+  Future<void> load() async {
+    _loadStatus = NotionMigrationLoadStatus.loading;
+    _authenticationRequired = false;
+    _errorMessage = null;
+    _noticeMessage = null;
+    notifyListeners();
+    try {
+      _snapshot = await _gateway.loadLatest();
+      _loadStatus = NotionMigrationLoadStatus.ready;
+    } catch (error) {
+      _setFailure(error);
+    }
+    notifyListeners();
+  }
+
+  Future<bool> createBatch({
+    required String workspaceId,
+    required String workspaceName,
+    required String name,
+  }) async {
+    if (_isCreating ||
+        workspaceId.trim().isEmpty ||
+        workspaceName.trim().isEmpty ||
+        name.trim().isEmpty) {
+      return false;
+    }
+    _isCreating = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      await _gateway.createBatch(
+        workspaceId: workspaceId,
+        workspaceName: workspaceName,
+        name: name,
+      );
+      _snapshot = await _gateway.loadLatest();
+      _loadStatus = NotionMigrationLoadStatus.ready;
+      return true;
+    } catch (error) {
+      _setFailure(error, keepReady: true);
+      return false;
+    } finally {
+      _isCreating = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> startInventory() => _runInventory(expand: false);
+
+  Future<bool> expandInventory() => _runInventory(expand: true);
+
+  Future<bool> reconcileWbs() async {
+    final batch = _snapshot.batch;
+    if (batch == null || _isReconciliationRunning) return false;
+    _isReconciliationRunning = true;
+    _errorMessage = null;
+    _noticeMessage = null;
+    notifyListeners();
+    try {
+      final result = await _gateway.reconcileWbs(batch.id);
+      final refreshed = await _gateway.loadLatest();
+      _snapshot = NotionMigrationSnapshot(
+        batch: refreshed.batch,
+        progress: refreshed.progress,
+        items: refreshed.items,
+        capabilities: refreshed.capabilities,
+        wbsReconciliation: result,
+        wbsStageSummary: refreshed.wbsStageSummary,
+      );
+      _noticeMessage = result.deletionGatePassed
+          ? 'WBSの全ID・全ミラー項目が一致しました。7項目の残りの検証が終わるまでNotion側は保持します。'
+          : 'WBSに差分があります。重複・片側のみ・属性不一致を解消するまでNotion側は削除しません。';
+      return true;
+    } catch (error) {
+      _errorMessage = _reconciliationError(error);
+      return false;
+    } finally {
+      _isReconciliationRunning = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> stageWbs() async {
+    final batch = _snapshot.batch;
+    if (batch == null || _isWbsStaging) return false;
+    _isWbsStaging = true;
+    _errorMessage = null;
+    _noticeMessage = null;
+    notifyListeners();
+    try {
+      final result = await _gateway.stageWbs(batch.id);
+      final refreshed = await _gateway.loadLatest();
+      _snapshot = NotionMigrationSnapshot(
+        batch: refreshed.batch,
+        progress: refreshed.progress,
+        items: refreshed.items,
+        capabilities: refreshed.capabilities,
+        wbsReconciliation: refreshed.wbsReconciliation,
+        wbsStageSummary: result,
+      );
+      _noticeMessage =
+          'WBS ${result.stagedRows}行を安全領域へ保存しました。重複${result.duplicateRows}行と属性差分を解決するまで本番WBS・Notion側は変更しません。';
+      return true;
+    } catch (error) {
+      _errorMessage = _stagingError(error);
+      return false;
+    } finally {
+      _isWbsStaging = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> _runInventory({required bool expand}) async {
+    final batch = _snapshot.batch;
+    if (batch == null || _isInventoryRunning) return false;
+    _isInventoryRunning = true;
+    _errorMessage = null;
+    _noticeMessage = null;
+    notifyListeners();
+    try {
+      final result = expand
+          ? await _gateway.expandInventory(batch.id)
+          : await _gateway.startInventory(batch.id);
+      _snapshot = await _gateway.loadLatest();
+      _noticeMessage = result.inventoryComplete
+          ? 'APIで参照できる範囲の再帰棚卸しが完了しました。次はエクスポートとの全件照合です。'
+          : '${result.discovered}件を発見しました。残り${result.remainingToExpand}件を再帰棚卸しします。';
+      return true;
+    } catch (error) {
+      _errorMessage = _inventoryError(error);
+      return false;
+    } finally {
+      _isInventoryRunning = false;
+      notifyListeners();
+    }
+  }
+
+  void _setFailure(Object error, {bool keepReady = false}) {
+    _loadStatus = keepReady
+        ? NotionMigrationLoadStatus.ready
+        : NotionMigrationLoadStatus.failure;
+    _authenticationRequired = error is NotionMigrationException &&
+        error.code == 'authentication_required';
+    _errorMessage = _authenticationRequired
+        ? 'この機能を使うにはログインしてください。'
+        : '移行台帳を読み込めませんでした。時間をおいて再試行してください。';
+  }
+
+  String _inventoryError(Object error) {
+    if (error is NotionMigrationException) {
+      return switch (error.code) {
+        'admin_required' => 'Notion接続の棚卸しは管理者だけが実行できます。',
+        'notion_not_configured' => 'サーバー側のNotion接続が未設定です。',
+        'batch_not_found' => '移行台帳が見つかりません。再読み込みしてください。',
+        _ => 'Notion棚卸しに失敗しました。接続権限と共有範囲を確認してください。',
+      };
+    }
+    return 'Notion棚卸しに失敗しました。接続権限と共有範囲を確認してください。';
+  }
+
+  String _reconciliationError(Object error) {
+    if (error is NotionMigrationException) {
+      return switch (error.code) {
+        'admin_required' => 'WBS照合は管理者だけが実行できます。',
+        'notion_not_configured' ||
+        'wbs_source_not_configured' =>
+          'サーバー側のNotion WBS接続が未設定です。',
+        'wbs_database_has_multiple_data_sources' =>
+          'WBSデータベースに複数のデータソースがあります。対象IDをサーバー設定で明示してください。',
+        'batch_not_found' => '移行台帳が見つかりません。再読み込みしてください。',
+        _ => 'WBS全件照合に失敗しました。Notion共有範囲と接続状態を確認してください。',
+      };
+    }
+    return 'WBS全件照合に失敗しました。Notion共有範囲と接続状態を確認してください。';
+  }
+
+  String _stagingError(Object error) {
+    if (error is NotionMigrationException) {
+      return switch (error.code) {
+        'admin_required' => 'WBS取込は管理者だけが実行できます。',
+        'notion_not_configured' ||
+        'wbs_source_not_configured' =>
+          'サーバー側のNotion WBS接続が未設定です。',
+        'wbs_stage_inventory_incomplete' =>
+          'Notion WBSの全ページを取得できなかったため、安全領域への取込を中止しました。',
+        'batch_not_found' => '移行台帳が見つかりません。再読み込みしてください。',
+        _ => 'WBSの安全領域への取込に失敗しました。本番WBSとNotion側は変更していません。',
+      };
+    }
+    return 'WBSの安全領域への取込に失敗しました。本番WBSとNotion側は変更していません。';
+  }
+}

--- a/lib/ui/features/notion_migration/views/notion_migration_page.dart
+++ b/lib/ui/features/notion_migration/views/notion_migration_page.dart
@@ -1,0 +1,898 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../domain/notion_migration_models.dart';
+import '../view_models/notion_migration_view_model.dart';
+
+class NotionMigrationPage extends StatelessWidget {
+  const NotionMigrationPage({super.key});
+
+  static const _wideBreakpoint = 900.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.read<NotionMigrationViewModel>();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Notion移行センター'),
+        actions: [
+          IconButton(
+            tooltip: '再読み込み',
+            onPressed: () => unawaited(viewModel.load()),
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: ListenableBuilder(
+          listenable: viewModel,
+          builder: (context, _) => switch (viewModel.loadStatus) {
+            NotionMigrationLoadStatus.initial ||
+            NotionMigrationLoadStatus.loading =>
+              const Center(
+                child: CircularProgressIndicator(),
+              ),
+            NotionMigrationLoadStatus.failure => _LoadFailure(
+                viewModel: viewModel,
+              ),
+            NotionMigrationLoadStatus.ready => LayoutBuilder(
+                builder: (context, constraints) {
+                  final wide = constraints.maxWidth >= _wideBreakpoint;
+                  return SingleChildScrollView(
+                    padding: const EdgeInsets.all(20),
+                    child: Center(
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 1240),
+                        child: Column(
+                          key: Key(
+                            wide
+                                ? 'notion-migration-wide'
+                                : 'notion-migration-compact',
+                          ),
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            const _MigrationHero(),
+                            const SizedBox(height: 16),
+                            if (viewModel.errorMessage != null)
+                              _InlineMessage(message: viewModel.errorMessage!),
+                            if (viewModel.noticeMessage != null)
+                              _InlineMessage(
+                                message: viewModel.noticeMessage!,
+                                isSuccess: true,
+                              ),
+                            if (viewModel.snapshot.batch == null)
+                              _EmptyLedger(viewModel: viewModel)
+                            else
+                              _MigrationLedger(
+                                snapshot: viewModel.snapshot,
+                                wide: wide,
+                                viewModel: viewModel,
+                              ),
+                            const SizedBox(height: 20),
+                            const _SafetyGate(),
+                            const SizedBox(height: 20),
+                            _FeatureMatrix(
+                              capabilities: viewModel.snapshot.capabilities,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _MigrationHero extends StatelessWidget {
+  const _MigrationHero();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [colors.primaryContainer, colors.tertiaryContainer],
+        ),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: const Padding(
+        padding: EdgeInsets.all(24),
+        child: Row(
+          children: [
+            Icon(Icons.move_to_inbox_outlined, size: 44),
+            SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'コピーではなく、検証できる段階移行',
+                    style: TextStyle(fontSize: 23, fontWeight: FontWeight.w800),
+                  ),
+                  SizedBox(height: 8),
+                  Text(
+                    'Notionの全件棚卸し、サイトへの取込、件数・内容・添付・権限の照合、'
+                    'Notion側削除、最終解約までを1件単位で記録します。',
+                    style: TextStyle(height: 1.55),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyLedger extends StatefulWidget {
+  const _EmptyLedger({required this.viewModel});
+
+  final NotionMigrationViewModel viewModel;
+
+  @override
+  State<_EmptyLedger> createState() => _EmptyLedgerState();
+}
+
+class _EmptyLedgerState extends State<_EmptyLedger> {
+  final _workspaceId = TextEditingController();
+  final _workspaceName = TextEditingController();
+  final _batchName = TextEditingController(text: 'Notion全件移行');
+
+  @override
+  void dispose() {
+    _workspaceId.dispose();
+    _workspaceName.dispose();
+    _batchName.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(top: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '移行台帳を作成',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 8),
+            const Text('台帳には機密データそのものではなく、所有者、移行状態、照合証跡、移行先IDを記録します。'),
+            const SizedBox(height: 16),
+            TextField(
+              key: const Key('notion-migration-workspace-name'),
+              controller: _workspaceName,
+              decoration: const InputDecoration(
+                labelText: 'Notionワークスペース名',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              key: const Key('notion-migration-workspace-id'),
+              controller: _workspaceId,
+              decoration: const InputDecoration(
+                labelText: 'NotionワークスペースID',
+                helperText: 'コードやテストデータには埋め込みません。',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              key: const Key('notion-migration-batch-name'),
+              controller: _batchName,
+              decoration: const InputDecoration(
+                labelText: '移行名',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              key: const Key('notion-migration-create-batch'),
+              onPressed: widget.viewModel.isCreating
+                  ? null
+                  : () => unawaited(_create()),
+              icon: widget.viewModel.isCreating
+                  ? const SizedBox.square(
+                      dimension: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.playlist_add_check_circle_outlined),
+              label: Text(widget.viewModel.isCreating ? '作成中…' : '移行台帳を開始'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _create() async {
+    final created = await widget.viewModel.createBatch(
+      workspaceId: _workspaceId.text,
+      workspaceName: _workspaceName.text,
+      name: _batchName.text,
+    );
+    if (!created && mounted && widget.viewModel.errorMessage == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('3項目をすべて入力してください。')));
+    }
+  }
+}
+
+class _MigrationLedger extends StatelessWidget {
+  const _MigrationLedger({
+    required this.snapshot,
+    required this.wide,
+    required this.viewModel,
+  });
+
+  final NotionMigrationSnapshot snapshot;
+  final bool wide;
+  final NotionMigrationViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final batch = snapshot.batch!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 16),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 8,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    Text(
+                      batch.name,
+                      style: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    Chip(label: Text(batch.status.label)),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text('対象: ${batch.workspaceName}'),
+                const SizedBox(height: 16),
+                _ProgressStrip(progress: snapshot.progress),
+                const SizedBox(height: 16),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 10,
+                  children: [
+                    FilledButton.icon(
+                      key: const Key('notion-migration-inventory-start'),
+                      onPressed: viewModel.isInventoryRunning
+                          ? null
+                          : () => unawaited(viewModel.startInventory()),
+                      icon: const Icon(Icons.manage_search),
+                      label: Text(
+                        snapshot.progress.totalItems == 0
+                            ? 'Notion接続を棚卸し'
+                            : '接続範囲を再確認',
+                      ),
+                    ),
+                    OutlinedButton.icon(
+                      key: const Key('notion-migration-inventory-expand'),
+                      onPressed: viewModel.isInventoryRunning ||
+                              snapshot.progress.totalItems == 0
+                          ? null
+                          : () => unawaited(viewModel.expandInventory()),
+                      icon: viewModel.isInventoryRunning
+                          ? const SizedBox.square(
+                              dimension: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.account_tree_outlined),
+                      label: const Text('再帰棚卸しを続ける'),
+                    ),
+                    OutlinedButton.icon(
+                      key: const Key('notion-migration-reconcile-wbs'),
+                      onPressed: viewModel.isReconciliationRunning ||
+                              viewModel.isInventoryRunning ||
+                              snapshot.progress.totalItems == 0
+                          ? null
+                          : () => unawaited(viewModel.reconcileWbs()),
+                      icon: viewModel.isReconciliationRunning
+                          ? const SizedBox.square(
+                              dimension: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.rule_folder_outlined),
+                      label: const Text('WBSを全件照合'),
+                    ),
+                    FilledButton.tonalIcon(
+                      key: const Key('notion-migration-stage-wbs'),
+                      onPressed: viewModel.isWbsStaging ||
+                              viewModel.isReconciliationRunning ||
+                              viewModel.isInventoryRunning ||
+                              snapshot.wbsReconciliation == null
+                          ? null
+                          : () => unawaited(viewModel.stageWbs()),
+                      icon: viewModel.isWbsStaging
+                          ? const SizedBox.square(
+                              dimension: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.inventory_2_outlined),
+                      label: const Text('WBSを安全領域へ取込'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  '接続APIで見える範囲だけでは全件保証になりません。ワークスペース書き出し・ブラウザ棚卸しとの照合が終わるまで削除不可です。',
+                  style: TextStyle(fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (snapshot.wbsReconciliation case final reconciliation?) ...[
+          const SizedBox(height: 16),
+          _WbsReconciliationCard(reconciliation: reconciliation),
+        ],
+        if (snapshot.wbsStageSummary case final stage?)
+          if (stage.stagedRows > 0) ...[
+            const SizedBox(height: 16),
+            _WbsStageCard(summary: stage),
+          ],
+        const SizedBox(height: 16),
+        if (wide)
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(child: _StageTimeline(progress: snapshot.progress)),
+              const SizedBox(width: 16),
+              Expanded(child: _ItemPanel(items: snapshot.items)),
+            ],
+          )
+        else ...[
+          _StageTimeline(progress: snapshot.progress),
+          const SizedBox(height: 16),
+          _ItemPanel(items: snapshot.items),
+        ],
+      ],
+    );
+  }
+}
+
+class _WbsStageCard extends StatelessWidget {
+  const _WbsStageCard({required this.summary});
+
+  final NotionWbsStageSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('notion-migration-wbs-stage-summary'),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Row(
+              children: [
+                Icon(Icons.inventory_2_outlined),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'WBS安全領域',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+                  ),
+                ),
+                Chip(label: Text('本番未反映')),
+              ],
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Notionの元ページIDと元JSONを保持しています。重複の採用行と属性競合を確定するまで、'
+              '本番WBSへの反映やNotion側削除は行いません。',
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                _Metric(label: '保存行', value: summary.stagedRows),
+                _Metric(label: '一意ID', value: summary.distinctTaskIds),
+                _Metric(
+                  label: '重複行',
+                  value: summary.duplicateRows,
+                  isWarning: summary.duplicateRows > 0,
+                ),
+                _Metric(
+                  label: 'ID不正',
+                  value: summary.invalidTaskIds,
+                  isWarning: summary.invalidTaskIds > 0,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WbsReconciliationCard extends StatelessWidget {
+  const _WbsReconciliationCard({required this.reconciliation});
+
+  final NotionWbsReconciliation reconciliation;
+
+  @override
+  Widget build(BuildContext context) {
+    final passed = reconciliation.deletionGatePassed;
+    final colors = Theme.of(context).colorScheme;
+    return Card(
+      key: const Key('notion-migration-wbs-reconciliation'),
+      color: passed ? colors.primaryContainer : colors.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(passed ? Icons.verified_outlined : Icons.block_outlined),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    'WBS全件照合',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+                  ),
+                ),
+                Chip(label: Text(passed ? '属性照合 合格' : '削除不可')),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              passed
+                  ? '全IDとミラー属性は一致しています。バックアップ・添付・権限など残りの安全確認後に削除候補になります。'
+                  : '差分が残っています。値は上書きせず、原因を確定してから同期または移行します。',
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                _Metric(label: 'サイト行', value: reconciliation.siteRows),
+                _Metric(label: 'Notion行', value: reconciliation.notionRows),
+                _Metric(label: '完全一致', value: reconciliation.exactMatches),
+                _Metric(
+                  label: 'Notion重複',
+                  value: reconciliation.notionDuplicateRows,
+                  isWarning: reconciliation.notionDuplicateRows > 0,
+                ),
+                _Metric(
+                  label: 'サイトのみ',
+                  value: reconciliation.onlyInSite,
+                  isWarning: reconciliation.onlyInSite > 0,
+                ),
+                _Metric(
+                  label: 'Notionのみ',
+                  value: reconciliation.onlyInNotion,
+                  isWarning: reconciliation.onlyInNotion > 0,
+                ),
+                _Metric(
+                  label: '属性不一致',
+                  value: reconciliation.mismatchedRecords,
+                  isWarning: reconciliation.mismatchedRecords > 0,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProgressStrip extends StatelessWidget {
+  const _ProgressStrip({required this.progress});
+
+  final NotionMigrationProgress progress;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: [
+        _Metric(label: '棚卸し', value: progress.totalItems),
+        _Metric(label: '取込済み', value: progress.importedItems),
+        _Metric(label: '照合済み', value: progress.verifiedItems),
+        _Metric(label: '削除可能', value: progress.deletionReadyItems),
+        _Metric(label: 'Notion削除済み', value: progress.sourceDeletedItems),
+        if (progress.failedItems > 0)
+          _Metric(label: '要対応', value: progress.failedItems, isWarning: true),
+      ],
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({
+    required this.label,
+    required this.value,
+    this.isWarning = false,
+  });
+
+  final String label;
+  final int value;
+  final bool isWarning;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Container(
+      width: 142,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isWarning ? colors.errorContainer : colors.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.labelMedium),
+          const SizedBox(height: 4),
+          Text(
+            '$value',
+            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w800),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StageTimeline extends StatelessWidget {
+  const _StageTimeline({required this.progress});
+
+  final NotionMigrationProgress progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final stages = <(String, int, double)>[
+      ('1. 棚卸し', progress.totalItems, progress.totalItems == 0 ? 0 : 1),
+      ('2. サイトへ取込', progress.importedItems, progress.importedRatio),
+      ('3. 7項目照合', progress.verifiedItems, progress.verifiedRatio),
+      ('4. Notion側削除', progress.sourceDeletedItems, progress.deletedRatio),
+      ('5. サブスク解約', 0, 0),
+    ];
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '段階進捗',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 16),
+            for (final stage in stages) ...[
+              Row(
+                children: [
+                  Expanded(child: Text(stage.$1)),
+                  Text('${stage.$2}件'),
+                ],
+              ),
+              const SizedBox(height: 6),
+              LinearProgressIndicator(value: stage.$3.clamp(0, 1)),
+              const SizedBox(height: 14),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ItemPanel extends StatelessWidget {
+  const _ItemPanel({required this.items});
+
+  final List<NotionMigrationItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '移行項目',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 12),
+            if (items.isEmpty)
+              const Text('再帰棚卸しの取込待ちです。Notion側のデータはまだ削除しません。')
+            else
+              for (final item in items.take(30))
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(_iconFor(item.sourceKind)),
+                  title: Text(item.title.isEmpty ? '名称なし' : item.title),
+                  subtitle: Text(
+                    '${item.status.label} • 照合 ${item.passedChecks}/7',
+                  ),
+                  trailing: item.status ==
+                          NotionMigrationItemStatus.readyForSourceDeletion
+                      ? const Icon(Icons.verified, color: Colors.green)
+                      : null,
+                ),
+            if (items.length > 30) Text('ほか ${items.length - 30} 件'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  IconData _iconFor(String kind) => switch (kind) {
+        'database' || 'data_source' => Icons.table_chart_outlined,
+        'attachment' => Icons.attach_file,
+        'comment' => Icons.comment_outlined,
+        'teamspace' => Icons.groups_outlined,
+        _ => Icons.description_outlined,
+      };
+}
+
+class _SafetyGate extends StatelessWidget {
+  const _SafetyGate();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Container(
+      key: const Key('notion-migration-safety-gate'),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: colors.tertiaryContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.shield_outlined),
+              SizedBox(width: 8),
+              Text(
+                '削除安全ゲート',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+              ),
+            ],
+          ),
+          SizedBox(height: 10),
+          Text(
+            'バックアップ・本文・階層・プロパティ・添付・コメント・権限の7項目がすべて合格し、'
+            '対象を明示した実行直前の承認が記録されるまで、Notion側削除には進めません。'
+            'サブスク解約は全件削除後の最終検収とは別の承認です。',
+            style: TextStyle(height: 1.55),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FeatureMatrix extends StatelessWidget {
+  const _FeatureMatrix({required this.capabilities});
+
+  final List<NotionCapability> capabilities;
+
+  @override
+  Widget build(BuildContext context) {
+    final required = capabilities
+        .where((capability) => capability.isRequired)
+        .toList(growable: false);
+    final verified = required
+        .where(
+          (capability) => capability.status == NotionParityStatus.verified,
+        )
+        .length;
+    return Column(
+      key: const Key('notion-migration-feature-matrix'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          'Notion機能同等性の検証台帳',
+          style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 6),
+        const Text('ルートが存在するだけでは完了扱いにせず、実データで互換性を確認します。'),
+        if (capabilities.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          Text(
+            '必須 $verified/${required.length} 検証済み',
+            key: const Key('notion-migration-capability-progress'),
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+        ],
+        const SizedBox(height: 12),
+        if (capabilities.isEmpty)
+          const Text('移行台帳を作成すると、Notion機能の必須検証項目が登録されます。')
+        else
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final columns = constraints.maxWidth >= 1000
+                  ? 3
+                  : constraints.maxWidth >= 620
+                      ? 2
+                      : 1;
+              final width =
+                  (constraints.maxWidth - (columns - 1) * 12) / columns;
+              return Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: [
+                  for (final capability in capabilities)
+                    SizedBox(
+                      width: width,
+                      child: _CapabilityCard(capability: capability),
+                    ),
+                ],
+              );
+            },
+          ),
+      ],
+    );
+  }
+}
+
+class _CapabilityCard extends StatelessWidget {
+  const _CapabilityCard({required this.capability});
+
+  final NotionCapability capability;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    capability.name,
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                ),
+                Chip(
+                  avatar: Icon(
+                    _statusIcon(capability.status),
+                    size: 18,
+                  ),
+                  label: Text(capability.status.label),
+                  backgroundColor: _statusColor(context, capability.status),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(capability.notionScope),
+            const SizedBox(height: 10),
+            Text(
+              capability.siteRoutes.isEmpty
+                  ? '対応ルート未割当'
+                  : capability.siteRoutes.join('  '),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            if (capability.evidenceSummary.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                '証跡: ${capability.evidenceSummary}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _statusColor(BuildContext context, NotionParityStatus status) {
+    final colors = Theme.of(context).colorScheme;
+    return switch (status) {
+      NotionParityStatus.verified => colors.primaryContainer,
+      NotionParityStatus.gap ||
+      NotionParityStatus.blocked =>
+        colors.errorContainer,
+      NotionParityStatus.verifying => colors.tertiaryContainer,
+      _ => colors.surfaceContainerHighest,
+    };
+  }
+
+  IconData _statusIcon(NotionParityStatus status) => switch (status) {
+        NotionParityStatus.verified => Icons.verified_outlined,
+        NotionParityStatus.gap => Icons.warning_amber_outlined,
+        NotionParityStatus.blocked => Icons.block_outlined,
+        NotionParityStatus.verifying => Icons.fact_check_outlined,
+        NotionParityStatus.implemented => Icons.code_outlined,
+        NotionParityStatus.planned => Icons.event_note_outlined,
+        NotionParityStatus.inventory => Icons.inventory_2_outlined,
+      };
+}
+
+class _LoadFailure extends StatelessWidget {
+  const _LoadFailure({required this.viewModel});
+
+  final NotionMigrationViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.cloud_off_outlined, size: 48),
+            const SizedBox(height: 12),
+            Text(viewModel.errorMessage ?? '読み込みに失敗しました。'),
+            const SizedBox(height: 16),
+            if (viewModel.authenticationRequired)
+              FilledButton(
+                key: const Key('notion-migration-login'),
+                onPressed: () => Navigator.of(context).pushNamed('/login'),
+                child: const Text('ログイン'),
+              )
+            else
+              FilledButton.icon(
+                onPressed: () => unawaited(viewModel.load()),
+                icon: const Icon(Icons.refresh),
+                label: const Text('再試行'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineMessage extends StatelessWidget {
+  const _InlineMessage({required this.message, this.isSuccess = false});
+
+  final String message;
+  final bool isSuccess;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: MaterialBanner(
+        backgroundColor: isSuccess
+            ? Theme.of(context).colorScheme.primaryContainer
+            : Theme.of(context).colorScheme.errorContainer,
+        content: Text(message),
+        actions: const [SizedBox.shrink()],
+      ),
+    );
+  }
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -203,6 +203,14 @@ enabled = true
 verify_jwt = false
 entrypoint = "./functions/autonomous-ops/index.ts"
 
+[functions.notion-migration-hub]
+enabled = true
+# Browser CORS preflight has no JWT, so gateway verification is disabled.
+# The handler still requires auth.getUser() plus user_profiles.is_admin before
+# using the owner-only NOTION_API_TOKEN or writing migration inventory rows.
+verify_jwt = false
+entrypoint = "./functions/notion-migration-hub/index.ts"
+
 [functions.video-generation-hub]
 enabled = true
 # Browser CORS preflight has no JWT, so gateway verification is disabled.

--- a/supabase/functions/notion-migration-hub/index.ts
+++ b/supabase/functions/notion-migration-hub/index.ts
@@ -1,0 +1,970 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+import { externalFetch } from "../_shared/external_fetch.ts";
+import {
+  asNotionRecord,
+  countNotionKinds,
+  NOTION_MIGRATION_API_VERSION,
+  notionAttachmentRows,
+  notionDurablePayload,
+  type NotionInventoryRow,
+  notionInventoryRow,
+  type NotionObject,
+  notionPlainText,
+  notionSourceId,
+} from "./inventory_model.ts";
+import {
+  prepareWbsStagingRows,
+  reconcileWbsMirror,
+  type WbsMirrorRecord,
+  wbsMirrorRecord,
+} from "./wbs_reconciliation_model.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Max-Age": "86400",
+};
+
+type PageResult = {
+  results: NotionObject[];
+  hasMore: boolean;
+  nextCursor: string | null;
+  incompleteReason: string | null;
+};
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function boundedInt(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+) {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(parsed)));
+}
+
+function rawNotionId(sourceId: string): string {
+  const separator = sourceId.indexOf(":");
+  return separator < 0 ? sourceId : sourceId.slice(separator + 1);
+}
+
+function normalizeNotionId(value: unknown): string {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "";
+  const compactIds = raw.replace(/-/g, "").match(/[0-9a-fA-F]{32}/g);
+  const compact = compactIds?.at(-1)?.toLowerCase();
+  if (!compact) return raw.replace(/^['"]|['"]$/g, "");
+  return [
+    compact.slice(0, 8),
+    compact.slice(8, 12),
+    compact.slice(12, 16),
+    compact.slice(16, 20),
+    compact.slice(20),
+  ].join("-");
+}
+
+function notionHeaders(token: string): Record<string, string> {
+  return {
+    "Authorization": `Bearer ${token}`,
+    "Notion-Version": NOTION_MIGRATION_API_VERSION,
+    "Content-Type": "application/json",
+  };
+}
+
+async function notionJson(
+  token: string,
+  path: string,
+  init: RequestInit = {},
+): Promise<NotionObject> {
+  const url = path.startsWith("http")
+    ? path
+    : `https://api.notion.com/v1${path}`;
+  let response: Response | null = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    response = await externalFetch(
+      "notion",
+      url,
+      {
+        ...init,
+        headers: { ...notionHeaders(token), ...(init.headers ?? {}) },
+      },
+      { traceId: `notion-migration-hub.${path.split("?")[0]}` },
+    );
+    if (response.status !== 429) break;
+    const retryAfter = boundedInt(
+      response.headers.get("retry-after"),
+      attempt + 1,
+      1,
+      8,
+    );
+    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+  }
+  if (!response?.ok) {
+    const detail = await response?.text().catch(() => "") ?? "";
+    throw new Error(
+      `notion_api_failed:${response?.status ?? 0}:${detail.slice(0, 300)}`,
+    );
+  }
+  return await response.json() as NotionObject;
+}
+
+function listPage(payload: NotionObject): PageResult {
+  const requestStatus = asNotionRecord(payload.request_status);
+  return {
+    results: Array.isArray(payload.results)
+      ? payload.results.map(asNotionRecord).filter((
+        value,
+      ): value is NotionObject => value !== null)
+      : [],
+    hasMore: payload.has_more === true,
+    nextCursor: typeof payload.next_cursor === "string"
+      ? payload.next_cursor
+      : null,
+    incompleteReason: typeof requestStatus?.incomplete_reason === "string"
+      ? requestStatus.incomplete_reason
+      : null,
+  };
+}
+
+async function notionPostPages(
+  token: string,
+  path: string,
+  body: Record<string, unknown>,
+  maxPages: number,
+): Promise<PageResult> {
+  const results: NotionObject[] = [];
+  let cursor = typeof body.start_cursor === "string" ? body.start_cursor : null;
+  let last: PageResult = {
+    results: [],
+    hasMore: false,
+    nextCursor: null,
+    incompleteReason: null,
+  };
+  for (let page = 0; page < maxPages; page++) {
+    const payload = await notionJson(token, path, {
+      method: "POST",
+      body: JSON.stringify({
+        ...body,
+        page_size: 100,
+        ...(cursor ? { start_cursor: cursor } : {}),
+      }),
+    });
+    last = listPage(payload);
+    results.push(...last.results);
+    if (!last.hasMore || !last.nextCursor) break;
+    cursor = last.nextCursor;
+  }
+  return { ...last, results };
+}
+
+async function notionGetPages(
+  token: string,
+  path: string,
+  maxPages: number,
+  startCursor: string | null = null,
+): Promise<PageResult> {
+  const results: NotionObject[] = [];
+  let cursor = startCursor;
+  let last: PageResult = {
+    results: [],
+    hasMore: false,
+    nextCursor: null,
+    incompleteReason: null,
+  };
+  for (let page = 0; page < maxPages; page++) {
+    const url = new URL(`https://api.notion.com/v1${path}`);
+    url.searchParams.set("page_size", "100");
+    if (cursor) url.searchParams.set("start_cursor", cursor);
+    const payload = await notionJson(token, url.toString());
+    last = listPage(payload);
+    results.push(...last.results);
+    if (!last.hasMore || !last.nextCursor) break;
+    cursor = last.nextCursor;
+  }
+  return { ...last, results };
+}
+
+async function authenticatedAdmin(
+  req: Request,
+): Promise<
+  {
+    admin: SupabaseClient;
+    userId: string;
+  } | Response
+> {
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ??
+    Deno.env.get("SERVICE_ROLE_KEY") ?? "";
+  const authorization = req.headers.get("Authorization") ?? "";
+  if (!supabaseUrl || !anonKey || !serviceRoleKey || !authorization) {
+    return json({ success: false, error: "Unauthorized" }, 401);
+  }
+
+  const session = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authorization } },
+  });
+  const { data: authData, error: authError } = await session.auth.getUser();
+  if (authError || !authData.user) {
+    return json({ success: false, error: "Unauthorized" }, 401);
+  }
+
+  const admin = createClient(supabaseUrl, serviceRoleKey);
+  const { data: profile, error: profileError } = await admin
+    .from("user_profiles")
+    .select("is_admin, role")
+    .eq("user_id", authData.user.id)
+    .maybeSingle();
+  if (profileError) {
+    return json({ success: false, error: profileError.message }, 500);
+  }
+  if (profile?.is_admin !== true && profile?.role !== "admin") {
+    return json({ success: false, error: "admin_required" }, 403);
+  }
+  return { admin, userId: authData.user.id };
+}
+
+async function ownedBatch(
+  admin: SupabaseClient,
+  userId: string,
+  batchId: unknown,
+) {
+  const id = String(batchId ?? "").trim();
+  if (!/^[0-9a-f-]{36}$/i.test(id)) {
+    throw new Error("batch_id_required");
+  }
+  const { data, error } = await admin
+    .from("notion_migration_batches")
+    .select("id, workspace_id, workspace_name, status")
+    .eq("id", id)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("batch_not_found");
+  if (data.status === "completed") throw new Error("batch_already_completed");
+  return data as {
+    id: string;
+    workspace_id: string;
+    workspace_name: string;
+    status: string;
+  };
+}
+
+async function insertNewRows(
+  admin: SupabaseClient,
+  rows: readonly NotionInventoryRow[],
+): Promise<void> {
+  for (let offset = 0; offset < rows.length; offset += 200) {
+    const chunk = rows.slice(offset, offset + 200);
+    const { error } = await admin
+      .from("notion_migration_items")
+      .upsert(chunk, {
+        onConflict: "batch_id,source_id",
+        ignoreDuplicates: true,
+      });
+    if (error) throw new Error(error.message);
+  }
+}
+
+async function countRemaining(
+  admin: SupabaseClient,
+  batchId: string,
+  userId: string,
+): Promise<number> {
+  const { count, error } = await admin
+    .from("notion_migration_items")
+    .select("id", { count: "exact", head: true })
+    .eq("batch_id", batchId)
+    .eq("user_id", userId)
+    .in("source_kind", ["page", "database", "data_source"])
+    .filter("metadata->>inventory_expanded", "eq", "false");
+  if (error) throw new Error(error.message);
+  return count ?? 0;
+}
+
+async function startInventory(
+  admin: SupabaseClient,
+  userId: string,
+  body: Record<string, unknown>,
+) {
+  const batch = await ownedBatch(admin, userId, body.batch_id);
+  const token = Deno.env.get("NOTION_API_TOKEN")?.trim() ?? "";
+  if (!token) throw new Error("notion_not_configured");
+
+  const seenAt = new Date().toISOString();
+  const [search, users] = await Promise.all([
+    notionPostPages(token, "/search", {
+      sort: { direction: "ascending", timestamp: "last_edited_time" },
+    }, 100),
+    notionGetPages(token, "/users", 20),
+  ]);
+
+  const workspaceRow: NotionInventoryRow = {
+    batch_id: batch.id,
+    user_id: userId,
+    source_id: notionSourceId("workspace", batch.workspace_id),
+    parent_source_id: null,
+    source_kind: "workspace",
+    title: batch.workspace_name,
+    source_path: batch.workspace_name,
+    source_updated_at: null,
+    metadata: {
+      inventory_expanded: true,
+      inventory_seen_at: seenAt,
+      api_version: NOTION_MIGRATION_API_VERSION,
+    },
+  };
+  const rows = [workspaceRow];
+  for (const object of [...search.results, ...users.results]) {
+    const row = notionInventoryRow({
+      batchId: batch.id,
+      userId,
+      object,
+      seenAt,
+      parentSourceId: object.object === "user"
+        ? workspaceRow.source_id
+        : undefined,
+    });
+    if (row) rows.push(row);
+  }
+  await insertNewRows(admin, rows);
+
+  const { error: updateError } = await admin
+    .from("notion_migration_batches")
+    .update({ status: "inventory", started_at: seenAt })
+    .eq("id", batch.id)
+    .eq("user_id", userId);
+  if (updateError) throw new Error(updateError.message);
+
+  const remaining = await countRemaining(admin, batch.id, userId);
+
+  return {
+    success: true,
+    batch_id: batch.id,
+    api_version: NOTION_MIGRATION_API_VERSION,
+    discovered: rows.length,
+    counts: countNotionKinds(rows),
+    remaining_to_expand: remaining,
+    inventory_complete: remaining === 0,
+    request_incomplete_reason: search.incompleteReason,
+    integration_scope_warning:
+      "Only pages and data sources shared with NOTION_API_TOKEN are visible. Compare against the browser/export inventory before deletion.",
+  };
+}
+
+async function databaseExpansionRows(args: {
+  token: string;
+  batchId: string;
+  userId: string;
+  databaseId: string;
+  seenAt: string;
+}): Promise<NotionInventoryRow[]> {
+  const database = await notionJson(
+    args.token,
+    `/databases/${args.databaseId}`,
+  );
+  if (!Array.isArray(database.data_sources)) return [];
+  const rows: NotionInventoryRow[] = [];
+  for (const value of database.data_sources) {
+    const reference = asNotionRecord(value);
+    if (!reference) continue;
+    const row = notionInventoryRow({
+      batchId: args.batchId,
+      userId: args.userId,
+      object: {
+        ...reference,
+        object: "data_source",
+        parent: {
+          type: "database_id",
+          database_id: args.databaseId,
+        },
+      },
+      seenAt: args.seenAt,
+      parentSourceId: notionSourceId("database", args.databaseId),
+    });
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+async function pageExpansionRows(args: {
+  token: string;
+  batchId: string;
+  userId: string;
+  pageId: string;
+  pageSourceId: string;
+  seenAt: string;
+}): Promise<{ rows: NotionInventoryRow[]; complete: boolean }> {
+  const rows: NotionInventoryRow[] = [];
+  const queue: Array<{ id: string; parentSourceId: string }> = [{
+    id: args.pageId,
+    parentSourceId: args.pageSourceId,
+  }];
+  let apiCalls = 0;
+  while (queue.length > 0 && apiCalls < 80 && rows.length < 5000) {
+    const parent = queue.shift()!;
+    const children = await notionGetPages(
+      args.token,
+      `/blocks/${parent.id}/children`,
+      10,
+    );
+    apiCalls += 1;
+    for (const block of children.results) {
+      const row = notionInventoryRow({
+        batchId: args.batchId,
+        userId: args.userId,
+        object: block,
+        seenAt: args.seenAt,
+        parentSourceId: parent.parentSourceId,
+      });
+      if (!row) continue;
+      rows.push(row);
+      rows.push(...notionAttachmentRows({
+        batchId: args.batchId,
+        userId: args.userId,
+        block,
+        seenAt: args.seenAt,
+      }));
+      if (
+        block.has_children === true && row.source_kind === "block" && block.id
+      ) {
+        queue.push({
+          id: String(block.id),
+          parentSourceId: row.source_id,
+        });
+      }
+    }
+    if (children.hasMore) return { rows, complete: false };
+  }
+
+  const comments = await notionGetPages(
+    args.token,
+    `/comments?block_id=${encodeURIComponent(args.pageId)}`,
+    10,
+  );
+  for (const comment of comments.results) {
+    const row = notionInventoryRow({
+      batchId: args.batchId,
+      userId: args.userId,
+      object: comment,
+      seenAt: args.seenAt,
+      parentSourceId: args.pageSourceId,
+    });
+    if (row) rows.push(row);
+  }
+  return {
+    rows,
+    complete: queue.length === 0 && !comments.hasMore,
+  };
+}
+
+async function dataSourceExpansionRows(args: {
+  token: string;
+  batchId: string;
+  userId: string;
+  sourceId: string;
+  cursor: string | null;
+  seenAt: string;
+}): Promise<{
+  rows: NotionInventoryRow[];
+  complete: boolean;
+  nextCursor: string | null;
+}> {
+  const rows: NotionInventoryRow[] = [];
+  const query = await notionPostPages(
+    args.token,
+    `/data_sources/${args.sourceId}/query`,
+    args.cursor ? { start_cursor: args.cursor } : {},
+    20,
+  );
+  for (const object of query.results) {
+    const row = notionInventoryRow({
+      batchId: args.batchId,
+      userId: args.userId,
+      object,
+      seenAt: args.seenAt,
+      parentSourceId: notionSourceId("data_source", args.sourceId),
+    });
+    if (row) rows.push(row);
+  }
+
+  if (!args.cursor) {
+    const views = await notionGetPages(
+      args.token,
+      `/views?data_source_id=${encodeURIComponent(args.sourceId)}`,
+      10,
+    );
+    for (const viewReference of views.results) {
+      const viewId = String(viewReference.id ?? "").trim();
+      const object = viewId
+        ? await notionJson(args.token, `/views/${viewId}`)
+        : viewReference;
+      const row = notionInventoryRow({
+        batchId: args.batchId,
+        userId: args.userId,
+        object,
+        seenAt: args.seenAt,
+        parentSourceId: notionSourceId("data_source", args.sourceId),
+      });
+      if (row) rows.push(row);
+    }
+  }
+  return {
+    rows,
+    complete: !query.hasMore,
+    nextCursor: query.nextCursor,
+  };
+}
+
+async function expandInventory(
+  admin: SupabaseClient,
+  userId: string,
+  body: Record<string, unknown>,
+) {
+  const batch = await ownedBatch(admin, userId, body.batch_id);
+  const token = Deno.env.get("NOTION_API_TOKEN")?.trim() ?? "";
+  if (!token) throw new Error("notion_not_configured");
+  const limit = boundedInt(body.limit, 2, 1, 5);
+  const { data: candidates, error } = await admin
+    .from("notion_migration_items")
+    .select("id,source_id,source_kind,metadata")
+    .eq("batch_id", batch.id)
+    .eq("user_id", userId)
+    .in("source_kind", ["page", "database", "data_source"])
+    .filter("metadata->>inventory_expanded", "eq", "false")
+    .order("created_at")
+    .limit(limit);
+  if (error) throw new Error(error.message);
+
+  const seenAt = new Date().toISOString();
+  let discovered = 0;
+  for (const candidate of candidates ?? []) {
+    const metadata = asNotionRecord(candidate.metadata) ?? {};
+    let result: {
+      rows: NotionInventoryRow[];
+      complete: boolean;
+      nextCursor?: string | null;
+    };
+    if (candidate.source_kind === "data_source") {
+      result = await dataSourceExpansionRows({
+        token,
+        batchId: batch.id,
+        userId,
+        sourceId: rawNotionId(candidate.source_id),
+        cursor: typeof metadata.inventory_cursor === "string"
+          ? metadata.inventory_cursor
+          : null,
+        seenAt,
+      });
+    } else if (candidate.source_kind === "page") {
+      result = await pageExpansionRows({
+        token,
+        batchId: batch.id,
+        userId,
+        pageId: rawNotionId(candidate.source_id),
+        pageSourceId: candidate.source_id,
+        seenAt,
+      });
+    } else if (candidate.source_kind === "database") {
+      result = {
+        rows: await databaseExpansionRows({
+          token,
+          batchId: batch.id,
+          userId,
+          databaseId: rawNotionId(candidate.source_id),
+          seenAt,
+        }),
+        complete: true,
+      };
+    } else {
+      result = { rows: [], complete: true };
+    }
+    await insertNewRows(admin, result.rows);
+    discovered += result.rows.length;
+    const { error: markError } = await admin
+      .from("notion_migration_items")
+      .update({
+        metadata: {
+          ...metadata,
+          inventory_expanded: result.complete,
+          inventory_cursor: result.nextCursor ?? null,
+          inventory_expanded_at: result.complete ? seenAt : null,
+          block_comment_scope_complete: false,
+        },
+      })
+      .eq("id", candidate.id)
+      .eq("user_id", userId);
+    if (markError) throw new Error(markError.message);
+  }
+
+  const remaining = await countRemaining(admin, batch.id, userId);
+  return {
+    success: true,
+    batch_id: batch.id,
+    api_version: NOTION_MIGRATION_API_VERSION,
+    expanded: candidates?.length ?? 0,
+    discovered,
+    remaining_to_expand: remaining,
+    inventory_complete: remaining === 0,
+    limitation:
+      "Block-level comments and objects not shared with the integration remain unverified until export/browser reconciliation.",
+  };
+}
+
+function notionProperty(
+  page: NotionObject,
+  name: string,
+): NotionObject | null {
+  return asNotionRecord(asNotionRecord(page.properties)?.[name]);
+}
+
+function notionSelectName(property: NotionObject | null): string {
+  const value = asNotionRecord(property?.select) ??
+    asNotionRecord(property?.status);
+  return typeof value?.name === "string" ? value.name : "";
+}
+
+function notionDateStart(property: NotionObject | null): string | null {
+  const date = asNotionRecord(property?.date);
+  return typeof date?.start === "string" ? date.start : null;
+}
+
+function notionWbsRecord(page: NotionObject): WbsMirrorRecord {
+  const id = notionProperty(page, "id");
+  const title = notionProperty(page, "task_title");
+  return wbsMirrorRecord({
+    id: notionPlainText(id?.title),
+    title: notionPlainText(title?.rich_text),
+    instance: notionSelectName(notionProperty(page, "instance")),
+    status: notionSelectName(notionProperty(page, "status")),
+    progress: notionProperty(page, "progress")?.number,
+    deadline: notionDateStart(notionProperty(page, "deadline")),
+    updatedAt: notionDateStart(notionProperty(page, "updated_at")),
+  });
+}
+
+function siteWbsRecord(row: NotionObject): WbsMirrorRecord {
+  return wbsMirrorRecord({
+    id: row.id,
+    title: row.title,
+    instance: row.instance,
+    status: row.status,
+    progress: row.progress,
+    deadline: row.end_date,
+    updatedAt: row.updated_at,
+  });
+}
+
+async function resolveWbsDataSourceId(token: string): Promise<string> {
+  const configuredDataSource = normalizeNotionId(
+    Deno.env.get("NOTION_WBS_DATA_SOURCE_ID"),
+  );
+  if (configuredDataSource) return configuredDataSource;
+
+  const databaseId = normalizeNotionId(
+    Deno.env.get("NOTION_WBS_DATABASE_ID"),
+  );
+  if (!databaseId) throw new Error("wbs_source_not_configured");
+  const database = await notionJson(token, `/databases/${databaseId}`);
+  const dataSources = Array.isArray(database.data_sources)
+    ? database.data_sources.map(asNotionRecord).filter((
+      value,
+    ): value is NotionObject => value !== null)
+    : [];
+  const ids = dataSources.map((source) => normalizeNotionId(source.id)).filter(
+    Boolean,
+  );
+  if (ids.length === 0) throw new Error("wbs_data_source_not_found");
+  if (ids.length > 1) {
+    throw new Error("wbs_database_has_multiple_data_sources");
+  }
+  return ids[0];
+}
+
+async function siteWbsRows(admin: SupabaseClient): Promise<WbsMirrorRecord[]> {
+  const rows: WbsMirrorRecord[] = [];
+  const pageSize = 1000;
+  for (let offset = 0; offset < 100000; offset += pageSize) {
+    const { data, error } = await admin
+      .from("wbs_tasks")
+      .select("id,title,instance,status,progress,end_date,updated_at")
+      .order("id", { ascending: true })
+      .range(offset, offset + pageSize - 1);
+    if (error) throw new Error(`wbs_site_fetch_failed:${error.message}`);
+    const page = (data ?? []).map((row) =>
+      siteWbsRecord(asNotionRecord(row) ?? {})
+    );
+    rows.push(...page);
+    if (page.length < pageSize) return rows;
+  }
+  throw new Error("wbs_site_inventory_limit_exceeded");
+}
+
+async function persistWbsReconciliation(args: {
+  admin: SupabaseClient;
+  batchId: string;
+  userId: string;
+  dataSourceId: string;
+  checkedAt: string;
+  reconciliation: Record<string, unknown>;
+}): Promise<void> {
+  const sourceId = notionSourceId("data_source", args.dataSourceId);
+  const { data: item, error } = await args.admin
+    .from("notion_migration_items")
+    .select("id,metadata")
+    .eq("batch_id", args.batchId)
+    .eq("user_id", args.userId)
+    .eq("source_id", sourceId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!item) return;
+
+  const metadata = asNotionRecord(item.metadata) ?? {};
+  const { error: itemError } = await args.admin
+    .from("notion_migration_items")
+    .update({
+      metadata: {
+        ...metadata,
+        wbs_reconciliation: {
+          ...args.reconciliation,
+          checked_at: args.checkedAt,
+        },
+      },
+    })
+    .eq("id", item.id)
+    .eq("user_id", args.userId);
+  if (itemError) throw new Error(itemError.message);
+
+  const passed = args.reconciliation.deletion_gate_passed === true;
+  const evidence = JSON.stringify({
+    mirror: "wbs_tasks",
+    ...args.reconciliation,
+  });
+  const { error: checkError } = await args.admin
+    .from("notion_migration_checks")
+    .upsert({
+      item_id: item.id,
+      user_id: args.userId,
+      check_key: "properties",
+      status: passed ? "passed" : "failed",
+      source_count: args.reconciliation.notion_rows,
+      destination_count: args.reconciliation.site_rows,
+      checked_at: args.checkedAt,
+      evidence_summary: evidence.slice(0, 4000),
+    }, { onConflict: "item_id,check_key" });
+  if (checkError) throw new Error(checkError.message);
+}
+
+async function reconcileWbs(
+  admin: SupabaseClient,
+  userId: string,
+  body: Record<string, unknown>,
+) {
+  const batch = await ownedBatch(admin, userId, body.batch_id);
+  const token = Deno.env.get("NOTION_API_TOKEN")?.trim() ?? "";
+  if (!token) throw new Error("notion_not_configured");
+  const dataSourceId = await resolveWbsDataSourceId(token);
+
+  const [notion, siteRows] = await Promise.all([
+    notionPostPages(token, `/data_sources/${dataSourceId}/query`, {}, 200),
+    siteWbsRows(admin),
+  ]);
+  const notionRows = notion.results.map(notionWbsRecord);
+  const result = reconcileWbsMirror(siteRows, notionRows);
+  const inventoryComplete = !notion.hasMore && !notion.incompleteReason;
+  const deletionGatePassed = inventoryComplete && result.deletionGatePassed;
+  const checkedAt = new Date().toISOString();
+  const reconciliation = {
+    site_rows: result.siteRows,
+    notion_rows: result.notionRows,
+    site_distinct_ids: result.siteDistinctIds,
+    notion_distinct_ids: result.notionDistinctIds,
+    site_duplicate_rows: result.siteDuplicateRows,
+    notion_duplicate_rows: result.notionDuplicateRows,
+    site_invalid_ids: result.siteInvalidIds,
+    notion_invalid_ids: result.notionInvalidIds,
+    only_in_site: result.onlyInSite,
+    only_in_notion: result.onlyInNotion,
+    exact_matches: result.exactMatches,
+    mismatched_records: result.mismatchedRecords,
+    mismatched_fields: result.mismatchedFields,
+    inventory_complete: inventoryComplete,
+    deletion_gate_passed: deletionGatePassed,
+  };
+  await persistWbsReconciliation({
+    admin,
+    batchId: batch.id,
+    userId,
+    dataSourceId,
+    checkedAt,
+    reconciliation,
+  });
+
+  return {
+    success: true,
+    batch_id: batch.id,
+    checked_at: checkedAt,
+    ...reconciliation,
+    deletion_block_reason: deletionGatePassed
+      ? null
+      : "WBS is retained in Notion until every ID and mirrored field matches and duplicates are zero.",
+  };
+}
+
+async function stageWbs(
+  admin: SupabaseClient,
+  userId: string,
+  body: Record<string, unknown>,
+) {
+  const batch = await ownedBatch(admin, userId, body.batch_id);
+  const token = Deno.env.get("NOTION_API_TOKEN")?.trim() ?? "";
+  if (!token) throw new Error("notion_not_configured");
+  const dataSourceId = await resolveWbsDataSourceId(token);
+  const notion = await notionPostPages(
+    token,
+    `/data_sources/${dataSourceId}/query`,
+    {},
+    200,
+  );
+  if (notion.hasMore || notion.incompleteReason) {
+    throw new Error("wbs_stage_inventory_incomplete");
+  }
+
+  const rows = prepareWbsStagingRows(notion.results.map((page) => ({
+    sourcePageId: normalizeNotionId(page.id),
+    record: notionWbsRecord(page),
+    sourceLastEditedAt: page.last_edited_time,
+    sourcePayload: notionDurablePayload(page) as NotionObject,
+  })));
+  const stageRunId = crypto.randomUUID();
+  const stagedAt = new Date().toISOString();
+  const chunkSize = 100;
+  for (let offset = 0; offset < rows.length; offset += chunkSize) {
+    const payload = rows.slice(offset, offset + chunkSize).map((row) => ({
+      batch_id: batch.id,
+      user_id: userId,
+      source_page_id: row.sourcePageId,
+      task_id: row.taskId,
+      duplicate_ordinal: row.duplicateOrdinal,
+      title: row.title,
+      instance: row.instance,
+      status: row.status,
+      progress: row.progress,
+      deadline: row.deadline,
+      source_updated_at: row.sourceUpdatedAt,
+      source_last_edited_at: row.sourceLastEditedAt,
+      source_payload: row.sourcePayload,
+      stage_run_id: stageRunId,
+      is_current: true,
+      staged_at: stagedAt,
+    }));
+    const { error } = await admin
+      .from("notion_migration_wbs_staging")
+      .upsert(payload, { onConflict: "batch_id,source_page_id" });
+    if (error) throw new Error(`wbs_stage_upsert_failed:${error.message}`);
+  }
+
+  const { error: staleError } = await admin
+    .from("notion_migration_wbs_staging")
+    .update({ is_current: false })
+    .eq("batch_id", batch.id)
+    .eq("user_id", userId)
+    .eq("is_current", true)
+    .neq("stage_run_id", stageRunId);
+  if (staleError) {
+    throw new Error(`wbs_stage_finalize_failed:${staleError.message}`);
+  }
+
+  const validTaskIds = new Set(
+    rows.map((row) => row.taskId).filter(Boolean),
+  );
+  return {
+    success: true,
+    batch_id: batch.id,
+    staged_at: stagedAt,
+    staged_rows: rows.length,
+    distinct_task_ids: validTaskIds.size,
+    duplicate_rows: rows.filter((row) => row.duplicateOrdinal > 1).length,
+    invalid_task_ids: rows.filter((row) => !row.taskId).length,
+    production_rows_changed: 0,
+    next_gate:
+      "Resolve duplicate and field-conflict decisions before applying staged rows to wbs_tasks.",
+  };
+}
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return json({ success: false, error: "method_not_allowed" }, 405);
+  }
+  try {
+    const authorization = await authenticatedAdmin(req);
+    if (authorization instanceof Response) return authorization;
+    const body = await req.json().catch(() => ({})) as Record<string, unknown>;
+    let result: Record<string, unknown>;
+    switch (String(body.action ?? "")) {
+      case "inventory.start":
+        result = await startInventory(
+          authorization.admin,
+          authorization.userId,
+          body,
+        );
+        break;
+      case "inventory.expand":
+        result = await expandInventory(
+          authorization.admin,
+          authorization.userId,
+          body,
+        );
+        break;
+      case "reconcile.wbs":
+        result = await reconcileWbs(
+          authorization.admin,
+          authorization.userId,
+          body,
+        );
+        break;
+      case "stage.wbs":
+        result = await stageWbs(
+          authorization.admin,
+          authorization.userId,
+          body,
+        );
+        break;
+      default:
+        throw new Error("unknown_action");
+    }
+    return json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status =
+      message === "batch_id_required" || message === "unknown_action"
+        ? 400
+        : message === "batch_not_found"
+        ? 404
+        : message === "batch_already_completed"
+        ? 409
+        : message === "notion_not_configured" ||
+            message === "wbs_source_not_configured"
+        ? 503
+        : message === "wbs_database_has_multiple_data_sources"
+        ? 409
+        : message === "wbs_stage_inventory_incomplete"
+        ? 409
+        : 500;
+    console.error("notion-migration-hub", { status, message });
+    return json({ success: false, error: message }, status);
+  }
+});

--- a/supabase/functions/notion-migration-hub/inventory_model.ts
+++ b/supabase/functions/notion-migration-hub/inventory_model.ts
@@ -1,0 +1,206 @@
+export const NOTION_MIGRATION_API_VERSION = "2026-03-11";
+
+export type NotionObject = Record<string, unknown>;
+
+export type NotionInventoryRow = {
+  batch_id: string;
+  user_id: string;
+  source_id: string;
+  parent_source_id: string | null;
+  source_kind: string;
+  title: string;
+  source_path: string;
+  source_updated_at: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export function asNotionRecord(value: unknown): NotionObject | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as NotionObject
+    : null;
+}
+
+export function notionDurablePayload(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(notionDurablePayload);
+  const record = asNotionRecord(value);
+  if (!record) return value;
+
+  const hasExpiringUrl = typeof record.expiry_time === "string" &&
+    typeof record.url === "string";
+  return Object.fromEntries(
+    Object.entries(record)
+      .filter(([key]) => !(hasExpiringUrl && key === "url"))
+      .map(([key, child]) => [key, notionDurablePayload(child)]),
+  );
+}
+
+export function notionPlainText(value: unknown): string {
+  if (!Array.isArray(value)) return "";
+  return value.map((entry) => {
+    const record = asNotionRecord(entry);
+    if (!record) return "";
+    if (typeof record.plain_text === "string") return record.plain_text;
+    const text = asNotionRecord(record.text);
+    return typeof text?.content === "string" ? text.content : "";
+  }).join("").trim();
+}
+
+export function notionObjectTitle(object: NotionObject): string {
+  if (typeof object.name === "string" && object.name.trim()) {
+    return object.name.trim().slice(0, 1000);
+  }
+  const directTitle = notionPlainText(object.title);
+  if (directTitle) return directTitle.slice(0, 1000);
+
+  const properties = asNotionRecord(object.properties);
+  if (properties) {
+    for (const value of Object.values(properties)) {
+      const property = asNotionRecord(value);
+      if (!property || property.type !== "title") continue;
+      const title = notionPlainText(property.title);
+      if (title) return title.slice(0, 1000);
+    }
+  }
+
+  const childPage = asNotionRecord(object.child_page);
+  if (typeof childPage?.title === "string" && childPage.title.trim()) {
+    return childPage.title.trim().slice(0, 1000);
+  }
+  const childDatabase = asNotionRecord(object.child_database);
+  if (
+    typeof childDatabase?.title === "string" && childDatabase.title.trim()
+  ) {
+    return childDatabase.title.trim().slice(0, 1000);
+  }
+
+  const type = typeof object.type === "string" ? object.type : "item";
+  return `${type} ${String(object.id ?? "").slice(0, 8)}`.trim();
+}
+
+export function notionSourceKind(object: NotionObject): string {
+  if (object.type === "child_page") return "page";
+  if (object.type === "child_database") return "database";
+  const objectType = String(object.object ?? object.type ?? "block");
+  if (objectType === "data_source") return "data_source";
+  if (objectType === "database" || objectType === "child_database") {
+    return "database";
+  }
+  if (objectType === "page" || objectType === "child_page") return "page";
+  if (objectType === "comment") return "comment";
+  if (objectType === "user") return "user";
+  if (objectType === "view") return object.type === "form" ? "form" : "view";
+  return "block";
+}
+
+export function notionSourceId(kind: string, rawId: unknown): string {
+  return `${kind}:${String(rawId ?? "").trim()}`;
+}
+
+export function notionParentSourceId(object: NotionObject): string | null {
+  const parent = asNotionRecord(object.parent);
+  if (!parent) return null;
+  const type = String(parent.type ?? "");
+  const rawId = parent[type];
+  if (!rawId) return type === "workspace" ? "workspace:root" : null;
+  const prefix = type.replace(/_id$/, "");
+  return notionSourceId(prefix, rawId);
+}
+
+export function notionInventoryRow(args: {
+  batchId: string;
+  userId: string;
+  object: NotionObject;
+  seenAt: string;
+  parentSourceId?: string | null;
+}): NotionInventoryRow | null {
+  const rawId = String(args.object.id ?? "").trim();
+  if (!rawId) return null;
+  const sourceKind = notionSourceKind(args.object);
+  const title = notionObjectTitle(args.object);
+  const properties = asNotionRecord(args.object.properties);
+  return {
+    batch_id: args.batchId,
+    user_id: args.userId,
+    source_id: notionSourceId(sourceKind, rawId),
+    parent_source_id: args.parentSourceId === undefined
+      ? notionParentSourceId(args.object)
+      : args.parentSourceId,
+    source_kind: sourceKind,
+    title,
+    source_path: title,
+    source_updated_at: typeof args.object.last_edited_time === "string"
+      ? args.object.last_edited_time
+      : null,
+    metadata: {
+      notion_object: String(args.object.object ?? args.object.type ?? ""),
+      notion_type: String(args.object.type ?? ""),
+      created_time: args.object.created_time ?? null,
+      in_trash: args.object.in_trash === true,
+      has_children: args.object.has_children === true,
+      property_names: properties ? Object.keys(properties) : [],
+      inventory_expanded: sourceKind === "page" ||
+          sourceKind === "data_source" || sourceKind === "database"
+        ? false
+        : true,
+      inventory_seen_at: args.seenAt,
+      api_version: NOTION_MIGRATION_API_VERSION,
+    },
+  };
+}
+
+export function notionAttachmentRows(args: {
+  batchId: string;
+  userId: string;
+  block: NotionObject;
+  seenAt: string;
+}): NotionInventoryRow[] {
+  const blockId = String(args.block.id ?? "").trim();
+  const blockType = String(args.block.type ?? "");
+  if (!blockId || !notionFileBlockTypes.has(blockType)) return [];
+  const payload = asNotionRecord(args.block[blockType]);
+  if (!payload) return [];
+
+  const file = asNotionRecord(payload.file) ?? asNotionRecord(payload.external);
+  const caption = notionPlainText(payload.caption);
+  const title = typeof payload.name === "string" && payload.name.trim()
+    ? payload.name.trim()
+    : caption || `${blockType} attachment`;
+  return [{
+    batch_id: args.batchId,
+    user_id: args.userId,
+    source_id: notionSourceId("attachment", blockId),
+    parent_source_id: notionSourceId("block", blockId),
+    source_kind: "attachment",
+    title: title.slice(0, 1000),
+    source_path: title.slice(0, 1000),
+    source_updated_at: typeof args.block.last_edited_time === "string"
+      ? args.block.last_edited_time
+      : null,
+    metadata: {
+      media_type: blockType,
+      source_type: payload.type ?? (payload.file ? "file" : "external"),
+      expiry_time: file?.expiry_time ?? null,
+      inventory_expanded: true,
+      inventory_seen_at: args.seenAt,
+      api_version: NOTION_MIGRATION_API_VERSION,
+    },
+  }];
+}
+
+export function countNotionKinds(
+  rows: readonly NotionInventoryRow[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const row of rows) {
+    counts[row.source_kind] = (counts[row.source_kind] ?? 0) + 1;
+  }
+  return counts;
+}
+
+const notionFileBlockTypes = new Set([
+  "audio",
+  "file",
+  "image",
+  "pdf",
+  "video",
+]);

--- a/supabase/functions/notion-migration-hub/inventory_model_test.ts
+++ b/supabase/functions/notion-migration-hub/inventory_model_test.ts
@@ -1,0 +1,138 @@
+import {
+  assertEquals,
+  assertMatch,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  countNotionKinds,
+  NOTION_MIGRATION_API_VERSION,
+  notionAttachmentRows,
+  notionDurablePayload,
+  notionInventoryRow,
+  notionObjectTitle,
+  notionParentSourceId,
+} from "./inventory_model.ts";
+
+Deno.test("uses the current Notion API and extracts page titles", () => {
+  assertEquals(NOTION_MIGRATION_API_VERSION, "2026-03-11");
+  const page = {
+    object: "page",
+    id: "page-1",
+    parent: { type: "page_id", page_id: "parent-1" },
+    properties: {
+      Name: {
+        type: "title",
+        title: [{ plain_text: "Migration page" }],
+      },
+    },
+  };
+
+  assertEquals(notionObjectTitle(page), "Migration page");
+  assertEquals(notionParentSourceId(page), "page:parent-1");
+  const row = notionInventoryRow({
+    batchId: "batch-1",
+    userId: "user-1",
+    object: page,
+    seenAt: "2026-08-23T00:00:00.000Z",
+  });
+  assertEquals(row?.source_id, "page:page-1");
+  assertEquals(row?.metadata.inventory_expanded, false);
+});
+
+Deno.test("does not persist expiring Notion file URLs in inventory", () => {
+  const rows = notionAttachmentRows({
+    batchId: "batch-1",
+    userId: "user-1",
+    seenAt: "2026-08-23T00:00:00.000Z",
+    block: {
+      object: "block",
+      id: "block-1",
+      type: "image",
+      image: {
+        type: "file",
+        caption: [{ plain_text: "Architecture" }],
+        file: {
+          url: "https://temporary.example/private-token",
+          expiry_time: "2026-08-23T01:00:00.000Z",
+        },
+      },
+    },
+  });
+
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].title, "Architecture");
+  assertEquals(rows[0].metadata.expiry_time, "2026-08-23T01:00:00.000Z");
+  assertMatch(JSON.stringify(rows), /^((?!private-token).)*$/);
+});
+
+Deno.test("removes only expiring URLs from durable source payloads", () => {
+  const payload = notionDurablePayload({
+    public_url: "https://example.com/keep",
+    properties: {
+      Files: {
+        files: [
+          {
+            name: "private.pdf",
+            file: {
+              url: "https://temporary.example/private-token",
+              expiry_time: "2026-08-23T01:00:00.000Z",
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  assertMatch(JSON.stringify(payload), /^((?!private-token).)*$/);
+  assertEquals(
+    (payload as Record<string, unknown>).public_url,
+    "https://example.com/keep",
+  );
+});
+
+Deno.test("counts inventory kinds for progress summaries", () => {
+  const base = {
+    batch_id: "batch-1",
+    user_id: "user-1",
+    source_id: "page:1",
+    parent_source_id: null,
+    source_kind: "page",
+    title: "Page",
+    source_path: "Page",
+    source_updated_at: null,
+    metadata: {},
+  };
+  assertEquals(
+    countNotionKinds([
+      base,
+      { ...base, source_id: "page:2" },
+      { ...base, source_id: "block:1", source_kind: "block" },
+    ]),
+    { page: 2, block: 1 },
+  );
+});
+
+Deno.test("classifies form views and child pages as first-class items", () => {
+  const form = notionInventoryRow({
+    batchId: "batch-1",
+    userId: "user-1",
+    seenAt: "2026-08-23T00:00:00.000Z",
+    object: { object: "view", id: "view-1", type: "form", name: "Intake" },
+  });
+  const child = notionInventoryRow({
+    batchId: "batch-1",
+    userId: "user-1",
+    seenAt: "2026-08-23T00:00:00.000Z",
+    object: {
+      object: "block",
+      id: "page-2",
+      type: "child_page",
+      child_page: { title: "Nested" },
+    },
+  });
+
+  assertEquals(form?.source_kind, "form");
+  assertEquals(form?.title, "Intake");
+  assertEquals(child?.source_kind, "page");
+  assertEquals(child?.metadata.inventory_expanded, false);
+});

--- a/supabase/functions/notion-migration-hub/wbs_reconciliation_model.ts
+++ b/supabase/functions/notion-migration-hub/wbs_reconciliation_model.ts
@@ -1,0 +1,257 @@
+export type WbsMirrorRecord = {
+  id: string;
+  title: string;
+  instance: string;
+  status: string;
+  progress: number;
+  deadline: string | null;
+  updatedAt: string | null;
+};
+
+export type WbsMirrorField =
+  | "title"
+  | "instance"
+  | "status"
+  | "progress"
+  | "deadline"
+  | "updated_at";
+
+export type WbsMirrorReconciliation = {
+  siteRows: number;
+  notionRows: number;
+  siteDistinctIds: number;
+  notionDistinctIds: number;
+  siteDuplicateRows: number;
+  notionDuplicateRows: number;
+  siteInvalidIds: number;
+  notionInvalidIds: number;
+  onlyInSite: number;
+  onlyInNotion: number;
+  exactMatches: number;
+  mismatchedRecords: number;
+  mismatchedFields: Record<WbsMirrorField, number>;
+  deletionGatePassed: boolean;
+};
+
+export type WbsStagingInput = {
+  sourcePageId: string;
+  record: WbsMirrorRecord;
+  sourceLastEditedAt: unknown;
+  sourcePayload: Record<string, unknown>;
+};
+
+export type WbsStagingRow = {
+  sourcePageId: string;
+  taskId: string;
+  duplicateOrdinal: number;
+  title: string;
+  instance: string;
+  status: string;
+  progress: number;
+  deadline: string | null;
+  sourceUpdatedAt: string | null;
+  sourceLastEditedAt: string | null;
+  sourcePayload: Record<string, unknown>;
+};
+
+const mirrorFields: readonly WbsMirrorField[] = [
+  "title",
+  "instance",
+  "status",
+  "progress",
+  "deadline",
+  "updated_at",
+];
+
+function normalizeId(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function normalizeInstance(value: unknown): string {
+  const instance = String(value ?? "win").trim();
+  if (instance === "all") return "codex";
+  if (instance === "copilot" || instance === "github-copilot") {
+    return "co-pilot";
+  }
+  return instance || "win";
+}
+
+function normalizeStatus(value: unknown): string {
+  const status = String(value ?? "pending").trim();
+  if (status === "in-progress") return "in_progress";
+  if (status === "not_started" || status === "draft") return "pending";
+  if (status === "done") return "completed";
+  return status || "pending";
+}
+
+function normalizeProgress(value: unknown): number {
+  const progress = Number(value ?? 0);
+  return Number.isFinite(progress) ? progress : 0;
+}
+
+function normalizeDate(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const parsed = new Date(text);
+  return Number.isNaN(parsed.getTime()) ? text : parsed.toISOString();
+}
+
+function normalizeDeadline(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text.slice(0, 10) : null;
+}
+
+export function wbsMirrorRecord(input: {
+  id: unknown;
+  title: unknown;
+  instance: unknown;
+  status: unknown;
+  progress: unknown;
+  deadline: unknown;
+  updatedAt: unknown;
+}): WbsMirrorRecord {
+  return {
+    id: normalizeId(input.id),
+    title: String(input.title ?? ""),
+    instance: normalizeInstance(input.instance),
+    status: normalizeStatus(input.status),
+    progress: normalizeProgress(input.progress),
+    deadline: normalizeDeadline(input.deadline),
+    updatedAt: normalizeDate(input.updatedAt),
+  };
+}
+
+export function prepareWbsStagingRows(
+  inputs: readonly WbsStagingInput[],
+): WbsStagingRow[] {
+  const sourcePageIds = new Set<string>();
+  const taskOccurrences = new Map<string, number>();
+
+  return inputs.map((input) => {
+    const sourcePageId = String(input.sourcePageId ?? "").trim();
+    if (!sourcePageId) throw new Error("wbs_stage_source_page_id_required");
+    if (sourcePageIds.has(sourcePageId)) {
+      throw new Error("wbs_stage_duplicate_source_page_id");
+    }
+    sourcePageIds.add(sourcePageId);
+
+    const taskId = input.record.id;
+    const duplicateOrdinal = taskId
+      ? (taskOccurrences.get(taskId) ?? 0) + 1
+      : 1;
+    if (taskId) taskOccurrences.set(taskId, duplicateOrdinal);
+
+    return {
+      sourcePageId,
+      taskId,
+      duplicateOrdinal,
+      title: input.record.title,
+      instance: input.record.instance,
+      status: input.record.status,
+      progress: input.record.progress,
+      deadline: input.record.deadline,
+      sourceUpdatedAt: input.record.updatedAt,
+      sourceLastEditedAt: normalizeDate(input.sourceLastEditedAt),
+      sourcePayload: input.sourcePayload,
+    };
+  });
+}
+
+function indexById(records: readonly WbsMirrorRecord[]): {
+  records: Map<string, WbsMirrorRecord>;
+  duplicateRows: number;
+  invalidIds: number;
+} {
+  const indexed = new Map<string, WbsMirrorRecord>();
+  let duplicateRows = 0;
+  let invalidIds = 0;
+  for (const record of records) {
+    if (!record.id) {
+      invalidIds += 1;
+      continue;
+    }
+    if (indexed.has(record.id)) {
+      duplicateRows += 1;
+      continue;
+    }
+    indexed.set(record.id, record);
+  }
+  return { records: indexed, duplicateRows, invalidIds };
+}
+
+function differingFields(
+  site: WbsMirrorRecord,
+  notion: WbsMirrorRecord,
+): WbsMirrorField[] {
+  const fields: WbsMirrorField[] = [];
+  if (site.title !== notion.title) fields.push("title");
+  if (site.instance !== notion.instance) fields.push("instance");
+  if (site.status !== notion.status) fields.push("status");
+  if (site.progress !== notion.progress) fields.push("progress");
+  if (site.deadline !== notion.deadline) fields.push("deadline");
+  if (site.updatedAt !== notion.updatedAt) fields.push("updated_at");
+  return fields;
+}
+
+export function reconcileWbsMirror(
+  siteRows: readonly WbsMirrorRecord[],
+  notionRows: readonly WbsMirrorRecord[],
+): WbsMirrorReconciliation {
+  const site = indexById(siteRows);
+  const notion = indexById(notionRows);
+  const mismatchedFields = Object.fromEntries(
+    mirrorFields.map((field) => [field, 0]),
+  ) as Record<WbsMirrorField, number>;
+  let onlyInSite = 0;
+  let exactMatches = 0;
+  let mismatchedRecords = 0;
+
+  for (const [id, siteRecord] of site.records) {
+    const notionRecord = notion.records.get(id);
+    if (!notionRecord) {
+      onlyInSite += 1;
+      continue;
+    }
+    const differences = differingFields(siteRecord, notionRecord);
+    if (differences.length === 0) {
+      exactMatches += 1;
+      continue;
+    }
+    mismatchedRecords += 1;
+    for (const field of differences) mismatchedFields[field] += 1;
+  }
+
+  let onlyInNotion = 0;
+  for (const id of notion.records.keys()) {
+    if (!site.records.has(id)) onlyInNotion += 1;
+  }
+
+  const deletionGatePassed = siteRows.length > 0 &&
+    notionRows.length > 0 &&
+    site.duplicateRows === 0 &&
+    notion.duplicateRows === 0 &&
+    site.invalidIds === 0 &&
+    notion.invalidIds === 0 &&
+    onlyInSite === 0 &&
+    onlyInNotion === 0 &&
+    mismatchedRecords === 0 &&
+    exactMatches === site.records.size &&
+    exactMatches === notion.records.size;
+
+  return {
+    siteRows: siteRows.length,
+    notionRows: notionRows.length,
+    siteDistinctIds: site.records.size,
+    notionDistinctIds: notion.records.size,
+    siteDuplicateRows: site.duplicateRows,
+    notionDuplicateRows: notion.duplicateRows,
+    siteInvalidIds: site.invalidIds,
+    notionInvalidIds: notion.invalidIds,
+    onlyInSite,
+    onlyInNotion,
+    exactMatches,
+    mismatchedRecords,
+    mismatchedFields,
+    deletionGatePassed,
+  };
+}

--- a/supabase/functions/notion-migration-hub/wbs_reconciliation_model_test.ts
+++ b/supabase/functions/notion-migration-hub/wbs_reconciliation_model_test.ts
@@ -1,0 +1,147 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  prepareWbsStagingRows,
+  reconcileWbsMirror,
+  type WbsMirrorRecord,
+  wbsMirrorRecord,
+} from "./wbs_reconciliation_model.ts";
+
+const base = wbsMirrorRecord({
+  id: "A0E77981-441D-41E1-A470-59C9FC632ED1",
+  title: "Migrate the WBS mirror",
+  instance: "all",
+  status: "in-progress",
+  progress: "50",
+  deadline: "2026-08-30T00:00:00.000Z",
+  updatedAt: "2026-08-23T09:00:00+09:00",
+});
+
+Deno.test("passes only when every WBS ID and mirrored field is equal", () => {
+  const notion = wbsMirrorRecord({
+    id: "a0e77981-441d-41e1-a470-59c9fc632ed1",
+    title: "Migrate the WBS mirror",
+    instance: "codex",
+    status: "in_progress",
+    progress: 50,
+    deadline: "2026-08-30",
+    updatedAt: "2026-08-23T00:00:00.000Z",
+  });
+
+  assertEquals(reconcileWbsMirror([base], [notion]), {
+    siteRows: 1,
+    notionRows: 1,
+    siteDistinctIds: 1,
+    notionDistinctIds: 1,
+    siteDuplicateRows: 0,
+    notionDuplicateRows: 0,
+    siteInvalidIds: 0,
+    notionInvalidIds: 0,
+    onlyInSite: 0,
+    onlyInNotion: 0,
+    exactMatches: 1,
+    mismatchedRecords: 0,
+    mismatchedFields: {
+      title: 0,
+      instance: 0,
+      status: 0,
+      progress: 0,
+      deadline: 0,
+      updated_at: 0,
+    },
+    deletionGatePassed: true,
+  });
+});
+
+Deno.test("blocks deletion for duplicate, invalid, or one-sided IDs", () => {
+  const extra = { ...base, id: "site-only" };
+  const invalid = { ...base, id: "" };
+  const result = reconcileWbsMirror(
+    [base, extra, invalid],
+    [base, base, { ...base, id: "notion-only" }],
+  );
+
+  assertEquals(result.siteDuplicateRows, 0);
+  assertEquals(result.notionDuplicateRows, 1);
+  assertEquals(result.siteInvalidIds, 1);
+  assertEquals(result.onlyInSite, 1);
+  assertEquals(result.onlyInNotion, 1);
+  assertEquals(result.deletionGatePassed, false);
+});
+
+Deno.test("reports every differing field without exposing record contents", () => {
+  const notion: WbsMirrorRecord = {
+    ...base,
+    title: "Different",
+    instance: "user",
+    status: "completed",
+    progress: 100,
+    deadline: null,
+    updatedAt: "2026-08-24T00:00:00.000Z",
+  };
+  const result = reconcileWbsMirror([base], [notion]);
+
+  assertEquals(result.mismatchedRecords, 1);
+  assertEquals(result.exactMatches, 0);
+  assertEquals(result.mismatchedFields, {
+    title: 1,
+    instance: 1,
+    status: 1,
+    progress: 1,
+    deadline: 1,
+    updated_at: 1,
+  });
+  assertEquals(result.deletionGatePassed, false);
+});
+
+Deno.test("stages duplicate WBS rows losslessly by Notion page ID", () => {
+  const rows = prepareWbsStagingRows([
+    {
+      sourcePageId: "notion-page-1",
+      record: base,
+      sourceLastEditedAt: "2026-08-23T09:00:00+09:00",
+      sourcePayload: { id: "notion-page-1", properties: { sample: true } },
+    },
+    {
+      sourcePageId: "notion-page-2",
+      record: { ...base, title: "Duplicate mirror row" },
+      sourceLastEditedAt: null,
+      sourcePayload: { id: "notion-page-2", properties: { sample: false } },
+    },
+    {
+      sourcePageId: "notion-page-3",
+      record: { ...base, id: "" },
+      sourceLastEditedAt: "invalid-date",
+      sourcePayload: { id: "notion-page-3" },
+    },
+  ]);
+
+  assertEquals(rows.map((row) => row.duplicateOrdinal), [1, 2, 1]);
+  assertEquals(rows[1].sourcePageId, "notion-page-2");
+  assertEquals(rows[1].sourcePayload.properties, { sample: false });
+  assertEquals(rows[2].taskId, "");
+  assertEquals(rows[2].sourceLastEditedAt, "invalid-date");
+});
+
+Deno.test("rejects staging rows that would overwrite a source page", () => {
+  let error = "";
+  try {
+    prepareWbsStagingRows([
+      {
+        sourcePageId: "same-page",
+        record: base,
+        sourceLastEditedAt: null,
+        sourcePayload: {},
+      },
+      {
+        sourcePageId: "same-page",
+        record: base,
+        sourceLastEditedAt: null,
+        sourcePayload: {},
+      },
+    ]);
+  } catch (caught) {
+    error = caught instanceof Error ? caught.message : String(caught);
+  }
+  assertEquals(error, "wbs_stage_duplicate_source_page_id");
+});

--- a/supabase/migrations/20260823032746_create_notion_migration_control_plane.sql
+++ b/supabase/migrations/20260823032746_create_notion_migration_control_plane.sql
@@ -1,0 +1,806 @@
+-- Track a Notion workspace migration without exposing workspace contents to
+-- other users. Source deletion is intentionally gated by seven verification
+-- checks and a separately recorded owner authorization timestamp.
+
+create table public.notion_migration_batches (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null default auth.uid()
+    references auth.users(id) on delete cascade,
+  workspace_id text not null check (char_length(workspace_id) between 1 and 200),
+  workspace_name text not null check (
+    char_length(workspace_name) between 1 and 200
+  ),
+  name text not null check (char_length(name) between 1 and 200),
+  status text not null default 'inventory' check (
+    status in (
+      'inventory',
+      'migrating',
+      'verifying',
+      'awaiting_source_deletion',
+      'completed',
+      'paused',
+      'failed'
+    )
+  ),
+  source_export_sha256 text check (
+    source_export_sha256 is null
+    or source_export_sha256 ~ '^[0-9a-f]{64}$'
+  ),
+  source_export_storage_path text check (
+    source_export_storage_path is null
+    or char_length(source_export_storage_path) between 1 and 1024
+  ),
+  started_at timestamptz,
+  completed_at timestamptz,
+  archived_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (id, user_id)
+);
+
+create unique index notion_migration_one_active_workspace_idx
+  on public.notion_migration_batches (user_id, workspace_id)
+  where archived_at is null and status <> 'completed';
+
+create table public.notion_migration_items (
+  id uuid primary key default gen_random_uuid(),
+  batch_id uuid not null,
+  user_id uuid not null default auth.uid(),
+  source_id text not null check (char_length(source_id) between 1 and 512),
+  parent_source_id text check (
+    parent_source_id is null
+    or char_length(parent_source_id) between 1 and 512
+  ),
+  source_kind text not null check (
+    source_kind in (
+      'workspace',
+      'teamspace',
+      'page',
+      'database',
+      'data_source',
+      'view',
+      'block',
+      'comment',
+      'attachment',
+      'automation',
+      'form',
+      'user'
+    )
+  ),
+  title text not null default '' check (char_length(title) <= 1000),
+  source_path text not null default '' check (
+    char_length(source_path) <= 4000
+  ),
+  status text not null default 'inventoried' check (
+    status in (
+      'inventoried',
+      'queued',
+      'exporting',
+      'imported',
+      'verifying',
+      'verified',
+      'ready_for_source_deletion',
+      'source_deleted',
+      'failed',
+      'skipped'
+    )
+  ),
+  destination_kind text check (
+    destination_kind is null
+    or char_length(destination_kind) between 1 and 100
+  ),
+  destination_id text check (
+    destination_id is null
+    or char_length(destination_id) between 1 and 512
+  ),
+  source_hash text check (
+    source_hash is null or source_hash ~ '^[0-9a-f]{64}$'
+  ),
+  destination_hash text check (
+    destination_hash is null or destination_hash ~ '^[0-9a-f]{64}$'
+  ),
+  source_updated_at timestamptz,
+  imported_at timestamptz,
+  verified_at timestamptz,
+  deletion_authorized_at timestamptz,
+  source_deleted_at timestamptz,
+  last_error text check (last_error is null or char_length(last_error) <= 4000),
+  metadata jsonb not null default '{}'::jsonb check (
+    jsonb_typeof(metadata) = 'object'
+  ),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (id, user_id),
+  unique (batch_id, source_id),
+  foreign key (batch_id, user_id)
+    references public.notion_migration_batches(id, user_id)
+    on delete cascade
+);
+
+create index notion_migration_items_batch_status_idx
+  on public.notion_migration_items (batch_id, status);
+create index notion_migration_items_parent_idx
+  on public.notion_migration_items (batch_id, parent_source_id);
+
+create table public.notion_migration_checks (
+  id uuid primary key default gen_random_uuid(),
+  item_id uuid not null,
+  user_id uuid not null default auth.uid(),
+  check_key text not null check (
+    check_key in (
+      'backup',
+      'content',
+      'hierarchy',
+      'properties',
+      'attachments',
+      'comments',
+      'permissions'
+    )
+  ),
+  status text not null default 'pending' check (
+    status in ('pending', 'passed', 'failed')
+  ),
+  source_count bigint check (source_count is null or source_count >= 0),
+  destination_count bigint check (
+    destination_count is null or destination_count >= 0
+  ),
+  source_hash text check (
+    source_hash is null or source_hash ~ '^[0-9a-f]{64}$'
+  ),
+  destination_hash text check (
+    destination_hash is null or destination_hash ~ '^[0-9a-f]{64}$'
+  ),
+  checked_at timestamptz,
+  evidence_summary text not null default '' check (
+    char_length(evidence_summary) <= 4000
+    and (status <> 'passed' or char_length(trim(evidence_summary)) > 0)
+    and (status <> 'passed' or checked_at is not null)
+  ),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (item_id, check_key),
+  foreign key (item_id, user_id)
+    references public.notion_migration_items(id, user_id)
+    on delete cascade
+);
+
+create index notion_migration_checks_item_status_idx
+  on public.notion_migration_checks (item_id, status);
+
+create table public.notion_migration_capabilities (
+  id uuid primary key default gen_random_uuid(),
+  batch_id uuid not null,
+  user_id uuid not null default auth.uid(),
+  capability_key text not null check (
+    char_length(capability_key) between 1 and 100
+  ),
+  name text not null check (char_length(name) between 1 and 200),
+  notion_scope text not null check (
+    char_length(notion_scope) between 1 and 1000
+  ),
+  site_routes text[] not null default '{}'::text[],
+  is_required boolean not null default true,
+  status text not null default 'inventory' check (
+    status in (
+      'inventory',
+      'planned',
+      'implemented',
+      'verifying',
+      'verified',
+      'gap',
+      'blocked'
+    )
+  ),
+  evidence_summary text not null default '' check (
+    char_length(evidence_summary) <= 4000
+    and (
+      status <> 'verified'
+      or (
+        char_length(trim(evidence_summary)) > 0
+        and verified_at is not null
+      )
+    )
+  ),
+  verified_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (id, user_id),
+  unique (batch_id, capability_key),
+  foreign key (batch_id, user_id)
+    references public.notion_migration_batches(id, user_id)
+    on delete cascade
+);
+
+create index notion_migration_capabilities_batch_status_idx
+  on public.notion_migration_capabilities (batch_id, status);
+create index notion_migration_capabilities_owner_batch_idx
+  on public.notion_migration_capabilities (user_id, batch_id);
+
+create table public.notion_migration_wbs_staging (
+  id uuid primary key default gen_random_uuid(),
+  batch_id uuid not null,
+  user_id uuid not null,
+  source_page_id text not null check (
+    char_length(source_page_id) between 1 and 512
+  ),
+  task_id text not null default '' check (char_length(task_id) <= 512),
+  duplicate_ordinal integer not null default 1 check (
+    duplicate_ordinal >= 1
+  ),
+  title text not null default '' check (char_length(title) <= 2000),
+  instance text not null default '' check (char_length(instance) <= 100),
+  status text not null default '' check (char_length(status) <= 100),
+  progress numeric not null default 0,
+  deadline date,
+  source_updated_at timestamptz,
+  source_last_edited_at timestamptz,
+  source_payload jsonb not null check (jsonb_typeof(source_payload) = 'object'),
+  stage_run_id uuid not null,
+  is_current boolean not null default true,
+  staged_at timestamptz not null default now(),
+  unique (id, user_id),
+  unique (batch_id, source_page_id),
+  foreign key (batch_id, user_id)
+    references public.notion_migration_batches(id, user_id)
+    on delete cascade
+);
+
+create index notion_migration_wbs_staging_current_idx
+  on public.notion_migration_wbs_staging (batch_id, is_current, task_id);
+create index notion_migration_wbs_staging_owner_batch_idx
+  on public.notion_migration_wbs_staging (user_id, batch_id);
+
+alter table public.notion_migration_batches enable row level security;
+alter table public.notion_migration_items enable row level security;
+alter table public.notion_migration_checks enable row level security;
+alter table public.notion_migration_capabilities enable row level security;
+alter table public.notion_migration_wbs_staging enable row level security;
+
+create policy notion_migration_batches_select_own
+  on public.notion_migration_batches
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+create policy notion_migration_batches_insert_own
+  on public.notion_migration_batches
+  for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+create policy notion_migration_batches_update_own
+  on public.notion_migration_batches
+  for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+create policy notion_migration_items_select_own
+  on public.notion_migration_items
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+create policy notion_migration_items_insert_own
+  on public.notion_migration_items
+  for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+create policy notion_migration_items_update_own
+  on public.notion_migration_items
+  for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+create policy notion_migration_checks_select_own
+  on public.notion_migration_checks
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+create policy notion_migration_checks_insert_own
+  on public.notion_migration_checks
+  for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+create policy notion_migration_checks_update_own
+  on public.notion_migration_checks
+  for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+create policy notion_migration_capabilities_select_own
+  on public.notion_migration_capabilities
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+create policy notion_migration_capabilities_insert_own
+  on public.notion_migration_capabilities
+  for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+create policy notion_migration_capabilities_update_own
+  on public.notion_migration_capabilities
+  for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+create policy notion_migration_wbs_staging_select_own
+  on public.notion_migration_wbs_staging
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+revoke all on table public.notion_migration_batches from anon, authenticated;
+revoke all on table public.notion_migration_items from anon, authenticated;
+revoke all on table public.notion_migration_checks from anon, authenticated;
+revoke all on table public.notion_migration_capabilities from anon, authenticated;
+revoke all on table public.notion_migration_wbs_staging
+  from anon, authenticated;
+grant select, insert, update on table public.notion_migration_batches
+  to authenticated;
+grant select, insert, update on table public.notion_migration_items
+  to authenticated;
+grant select, insert, update on table public.notion_migration_checks
+  to authenticated;
+grant select, insert, update on table public.notion_migration_capabilities
+  to authenticated;
+grant select on table public.notion_migration_wbs_staging to authenticated;
+grant select, insert, update, delete on table public.notion_migration_batches
+  to service_role;
+grant select, insert, update, delete on table public.notion_migration_items
+  to service_role;
+grant select, insert, update, delete on table public.notion_migration_checks
+  to service_role;
+grant select, insert, update, delete
+  on table public.notion_migration_capabilities to service_role;
+grant select, insert, update, delete
+  on table public.notion_migration_wbs_staging to service_role;
+
+create or replace function public.notion_migration_touch_updated_at()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger notion_migration_batches_touch_updated_at
+  before update on public.notion_migration_batches
+  for each row execute function public.notion_migration_touch_updated_at();
+create trigger notion_migration_items_touch_updated_at
+  before update on public.notion_migration_items
+  for each row execute function public.notion_migration_touch_updated_at();
+create trigger notion_migration_checks_touch_updated_at
+  before update on public.notion_migration_checks
+  for each row execute function public.notion_migration_touch_updated_at();
+create trigger notion_migration_capabilities_touch_updated_at
+  before update on public.notion_migration_capabilities
+  for each row execute function public.notion_migration_touch_updated_at();
+
+create or replace function public.notion_migration_seed_capabilities()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  insert into public.notion_migration_capabilities (
+    batch_id,
+    user_id,
+    capability_key,
+    name,
+    notion_scope,
+    site_routes
+  )
+  values
+    (
+      new.id, new.user_id, 'page_tree_blocks', 'ページ階層・ブロック',
+      '階層ページ、同期ブロック、コールアウト、埋め込み、リンクドページ',
+      array['/notes', '/wiki-database']
+    ),
+    (
+      new.id, new.user_id, 'rich_text_embeds', 'リッチテキスト・埋め込み',
+      '書式、数式、コード、ブックマーク、動画、音声、外部埋め込み',
+      array['/notes', '/asset-management']
+    ),
+    (
+      new.id, new.user_id, 'page_history_trash', '履歴・復元・ゴミ箱',
+      'ページ履歴、変更追跡、削除済みデータの復元、保持期間',
+      array['/notes', '/data-backup']
+    ),
+    (
+      new.id, new.user_id, 'wiki_verified_pages', 'Wiki・検証済みページ',
+      'Wikiホーム、所有者、検証期限、ページ認証',
+      array['/wiki-database', '/knowledge-base']
+    ),
+    (
+      new.id, new.user_id, 'database_data_sources', 'データベース・データソース',
+      '単一・複数データソース、リンクドDB、行ページ、データソース切替',
+      array['/table-data', '/spreadsheet-database']
+    ),
+    (
+      new.id, new.user_id, 'database_properties_relations_formulas',
+      'プロパティ・リレーション・数式',
+      '全プロパティ型、リレーション、ロールアップ、数式、ユニークID',
+      array['/table-data', '/spreadsheet-database']
+    ),
+    (
+      new.id, new.user_id, 'table_list_gallery_views',
+      'テーブル・リスト・ギャラリー',
+      'フィルター、並び替え、グループ、表示項目、保存済みビュー',
+      array['/table-data']
+    ),
+    (
+      new.id, new.user_id, 'board_calendar_timeline_views',
+      'ボード・カレンダー・タイムライン',
+      'ボード、カレンダー、タイムライン、依存関係、日付範囲',
+      array['/kanban', '/calendar-events', '/gantt-timeline']
+    ),
+    (
+      new.id, new.user_id, 'chart_dashboard_map_feed_views',
+      'チャート・ダッシュボード・マップ・フィード',
+      'チャート、ダッシュボード、地図、フィードとビュー固有設定',
+      array['/personal-dashboard', '/activity-feed']
+    ),
+    (
+      new.id, new.user_id, 'projects_tasks_sprints',
+      'プロジェクト・タスク・スプリント',
+      'サブタスク、依存関係、マイルストーン、スプリント、進捗集計',
+      array['/kanban', '/project-gantt', '/user-tasks']
+    ),
+    (
+      new.id, new.user_id, 'templates', 'テンプレート',
+      'ページ・DBテンプレート、繰り返しテンプレート、テンプレート共有',
+      array['/templates', '/workflow-templates']
+    ),
+    (
+      new.id, new.user_id, 'forms', 'フォーム',
+      '公開・限定フォーム、条件分岐、回答DB、フォーム分析',
+      array['/form-builder', '/poll-survey']
+    ),
+    (
+      new.id, new.user_id, 'comments_mentions_notifications',
+      'コメント・メンション・通知',
+      'ページ・ブロックコメント、@メンション、フォロー、受信箱、通知設定',
+      array['/note-comments', '/notifications']
+    ),
+    (
+      new.id, new.user_id, 'realtime_collaboration_presence',
+      'リアルタイム共同編集',
+      '同時編集、カーソル・プレゼンス、競合解決、チームチャット',
+      array['/team-workspace', '/team-chat']
+    ),
+    (
+      new.id, new.user_id, 'sharing_permissions_guests_teamspaces',
+      '共有・権限・ゲスト・チームスペース',
+      '所有者、メンバー、ゲスト、グループ、ページ権限、チームスペース',
+      array['/team-workspace', '/access-control']
+    ),
+    (
+      new.id, new.user_id, 'search_backlinks', '検索・バックリンク',
+      '全文検索、絞り込み、最近のページ、バックリンク、関連ページ',
+      array['/semantic-search', '/knowledge-graph']
+    ),
+    (
+      new.id, new.user_id, 'files_media', 'ファイル・メディア',
+      '添付、プレビュー、容量制限、画像・動画・音声、外部ファイル',
+      array['/asset-management', '/import']
+    ),
+    (
+      new.id, new.user_id, 'import_export_backup',
+      'インポート・エクスポート・バックアップ',
+      'HTML・Markdown・CSV・PDFの入出力、全体バックアップ、復元検証',
+      array['/import', '/analytics-export', '/data-backup']
+    ),
+    (
+      new.id, new.user_id, 'offline_mobile', 'オフライン・モバイル',
+      'オフライン閲覧・編集、再同期、モバイル操作、競合時の保全',
+      array['/offline-secure-mode']
+    ),
+    (
+      new.id, new.user_id, 'automations_buttons_webhooks',
+      'オートメーション・ボタン・Webhook',
+      'DBオートメーション、ボタン、定期実行、Webhook、実行履歴',
+      array['/workflow-automation', '/ai-workflow-automation']
+    ),
+    (
+      new.id, new.user_id, 'integrations_api_mcp', '外部連携・API・MCP',
+      '公開API、OAuth連携、インテグレーション権限、Webhook、MCP',
+      array['/api-playground', '/mcp-file-search']
+    ),
+    (
+      new.id, new.user_id, 'public_sites_domains_seo',
+      '公開サイト・独自ドメイン・SEO',
+      '公開ページ、サイトナビ、独自ドメイン、SEO、アクセス制御',
+      array['/public-memos', '/dns-domain-manager', '/sitemap-analytics']
+    ),
+    (
+      new.id, new.user_id, 'ai_writing_database', 'AI文章・DB支援',
+      '作成、要約、翻訳、校正、AIプロパティ、タグ・入力補助',
+      array['/ai-writing-assistant', '/ai-summarizer', '/ai-suggest-tags']
+    ),
+    (
+      new.id, new.user_id, 'ai_agent_search_research',
+      'AIエージェント・横断検索・調査',
+      'Notion Agent、Enterprise Search、Research Mode、コネクター検索',
+      array['/my-ai-agent', '/ai-search', '/semantic-search']
+    ),
+    (
+      new.id, new.user_id, 'meeting_notes_transcription',
+      '会議ノート・文字起こし',
+      '会議音声、文字起こし、要約、アクション項目、参加者同意',
+      array['/video-meeting', '/voice-memo']
+    ),
+    (
+      new.id, new.user_id, 'analytics_audit_sso_scim',
+      '分析・監査・SSO・SCIM',
+      'ワークスペース分析、監査ログ、SAML SSO、SCIM、管理者統制',
+      array['/app-analytics-dashboard', '/access-control']
+    ),
+    (
+      new.id, new.user_id, 'calendar_mail_connections',
+      'カレンダー・メール連携',
+      'Notion Calendar、メール・予定連携、受信箱、データベース同期',
+      array['/google-calendar-sync', '/smart-inbox']
+    )
+  on conflict (batch_id, capability_key) do nothing;
+
+  return new;
+end;
+$$;
+
+create trigger notion_migration_batches_seed_capabilities
+  after insert on public.notion_migration_batches
+  for each row execute function public.notion_migration_seed_capabilities();
+
+create or replace function public.notion_migration_guard_item_status()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  passed_checks integer;
+begin
+  if tg_op = 'UPDATE'
+     and new.status is distinct from old.status
+     and not (
+       (old.status = 'inventoried' and new.status in (
+         'queued', 'exporting', 'failed', 'skipped'
+       ))
+       or (old.status = 'queued' and new.status in (
+         'exporting', 'failed', 'skipped'
+       ))
+       or (old.status = 'exporting' and new.status in ('imported', 'failed'))
+       or (old.status = 'imported' and new.status in ('verifying', 'failed'))
+       or (old.status = 'verifying' and new.status in ('verified', 'failed'))
+       or (old.status = 'verified' and new.status in (
+         'ready_for_source_deletion', 'failed'
+       ))
+       or (old.status = 'ready_for_source_deletion' and new.status in (
+         'source_deleted', 'failed'
+       ))
+       or (old.status = 'failed' and new.status in (
+         'queued', 'exporting', 'verifying'
+       ))
+       or (old.status = 'skipped' and new.status = 'queued')
+     ) then
+    raise exception 'notion_migration_invalid_item_transition'
+      using errcode = '23514';
+  end if;
+
+  if new.status in (
+    'imported',
+    'verifying',
+    'verified',
+    'ready_for_source_deletion',
+    'source_deleted'
+  ) and (
+    new.destination_kind is null
+    or new.destination_id is null
+    or new.imported_at is null
+  ) then
+    raise exception 'notion_migration_destination_evidence_required'
+      using errcode = '23514';
+  end if;
+
+  if new.status in (
+    'verified',
+    'ready_for_source_deletion',
+    'source_deleted'
+  ) then
+    select count(*)::integer
+      into passed_checks
+      from public.notion_migration_checks as migration_check
+      where migration_check.item_id = new.id
+        and migration_check.user_id = new.user_id
+        and migration_check.status = 'passed';
+
+    if passed_checks <> 7 then
+      raise exception 'notion_migration_seven_checks_required'
+        using errcode = '23514';
+    end if;
+
+    if new.verified_at is null then
+      raise exception 'notion_migration_verification_timestamp_required'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.status = 'ready_for_source_deletion'
+     and new.deletion_authorized_at is null then
+    raise exception 'notion_migration_deletion_authorization_required'
+      using errcode = '23514';
+  end if;
+
+  if new.status = 'source_deleted' then
+    if tg_op = 'INSERT'
+       or old.status <> 'ready_for_source_deletion'
+       or new.deletion_authorized_at is null
+       or new.source_deleted_at is null then
+      raise exception 'notion_migration_source_deletion_not_ready'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger notion_migration_items_guard_status
+  before insert or update on public.notion_migration_items
+  for each row execute function public.notion_migration_guard_item_status();
+
+create or replace function public.notion_migration_guard_batch_completion()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if new.status = 'completed' then
+    if not exists (
+      select 1
+      from public.notion_migration_capabilities as capability
+      where capability.batch_id = new.id
+        and capability.user_id = new.user_id
+        and capability.is_required
+    ) or exists (
+      select 1
+      from public.notion_migration_capabilities as capability
+      where capability.batch_id = new.id
+        and capability.user_id = new.user_id
+        and capability.is_required
+        and capability.status <> 'verified'
+    ) then
+      raise exception 'notion_migration_capabilities_incomplete'
+        using errcode = '23514';
+    end if;
+
+    if not exists (
+      select 1
+      from public.notion_migration_items as item
+      where item.batch_id = new.id and item.user_id = new.user_id
+    ) or exists (
+      select 1
+      from public.notion_migration_items as item
+      where item.batch_id = new.id
+        and item.user_id = new.user_id
+        and item.status <> 'source_deleted'
+    ) then
+      raise exception 'notion_migration_batch_items_incomplete'
+        using errcode = '23514';
+    end if;
+    new.completed_at = coalesce(new.completed_at, now());
+  end if;
+  return new;
+end;
+$$;
+
+create trigger notion_migration_batches_guard_completion
+  before insert or update on public.notion_migration_batches
+  for each row execute function public.notion_migration_guard_batch_completion();
+
+create view public.notion_migration_batch_progress
+with (security_invoker = true)
+as
+select
+  batch.id as batch_id,
+  batch.user_id,
+  count(item.id)::bigint as total_items,
+  count(item.id) filter (
+    where item.status in (
+      'imported',
+      'verifying',
+      'verified',
+      'ready_for_source_deletion',
+      'source_deleted'
+    )
+  )::bigint as imported_items,
+  count(item.id) filter (
+    where item.status in (
+      'verified',
+      'ready_for_source_deletion',
+      'source_deleted'
+    )
+  )::bigint as verified_items,
+  count(item.id) filter (
+    where item.status = 'ready_for_source_deletion'
+  )::bigint as deletion_ready_items,
+  count(item.id) filter (
+    where item.status = 'source_deleted'
+  )::bigint as source_deleted_items,
+  count(item.id) filter (where item.status = 'failed')::bigint
+    as failed_items
+from public.notion_migration_batches as batch
+left join public.notion_migration_items as item
+  on item.batch_id = batch.id and item.user_id = batch.user_id
+group by batch.id, batch.user_id;
+
+revoke all on table public.notion_migration_batch_progress
+  from anon, authenticated;
+grant select on table public.notion_migration_batch_progress to authenticated;
+grant select on table public.notion_migration_batch_progress to service_role;
+
+create view public.notion_migration_capability_progress
+with (security_invoker = true)
+as
+select
+  batch.id as batch_id,
+  batch.user_id,
+  count(capability.id) filter (
+    where capability.is_required
+  )::bigint as required_capabilities,
+  count(capability.id) filter (
+    where capability.is_required and capability.status = 'verified'
+  )::bigint as verified_capabilities,
+  count(capability.id) filter (
+    where capability.is_required and capability.status = 'gap'
+  )::bigint as gap_capabilities,
+  count(capability.id) filter (
+    where capability.is_required and capability.status = 'blocked'
+  )::bigint as blocked_capabilities
+from public.notion_migration_batches as batch
+left join public.notion_migration_capabilities as capability
+  on capability.batch_id = batch.id and capability.user_id = batch.user_id
+group by batch.id, batch.user_id;
+
+revoke all on table public.notion_migration_capability_progress
+  from anon, authenticated;
+grant select on table public.notion_migration_capability_progress
+  to authenticated;
+grant select on table public.notion_migration_capability_progress
+  to service_role;
+
+create view public.notion_migration_wbs_stage_progress
+with (security_invoker = true)
+as
+select
+  batch.id as batch_id,
+  batch.user_id,
+  count(staged.id) filter (
+    where staged.is_current
+  )::bigint as staged_rows,
+  count(distinct staged.task_id) filter (
+    where staged.is_current and staged.task_id <> ''
+  )::bigint as distinct_task_ids,
+  count(staged.id) filter (
+    where staged.is_current and staged.duplicate_ordinal > 1
+  )::bigint as duplicate_rows,
+  count(staged.id) filter (
+    where staged.is_current and staged.task_id = ''
+  )::bigint as invalid_task_ids,
+  max(staged.staged_at) filter (
+    where staged.is_current
+  ) as staged_at
+from public.notion_migration_batches as batch
+left join public.notion_migration_wbs_staging as staged
+  on staged.batch_id = batch.id and staged.user_id = batch.user_id
+group by batch.id, batch.user_id;
+
+revoke all on table public.notion_migration_wbs_stage_progress
+  from anon, authenticated;
+grant select on table public.notion_migration_wbs_stage_progress
+  to authenticated;
+grant select on table public.notion_migration_wbs_stage_progress
+  to service_role;
+
+revoke execute on function public.notion_migration_touch_updated_at()
+  from public, anon, authenticated;
+revoke execute on function public.notion_migration_seed_capabilities()
+  from public, anon, authenticated;
+revoke execute on function public.notion_migration_guard_item_status()
+  from public, anon, authenticated;
+revoke execute on function public.notion_migration_guard_batch_completion()
+  from public, anon, authenticated;

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -229,6 +229,7 @@ const List<String> kAllAppRoutes = <String>[
   '/note-editor',
   '/note-list',
   '/notes',
+  '/notion-migration',
   '/notification-digest',
   '/notifications',
   '/offline-secure-mode',

--- a/test/services/notion_migration_schema_test.dart
+++ b/test/services/notion_migration_schema_test.dart
@@ -1,0 +1,203 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../routes/app_route_names.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260823032746_create_notion_migration_control_plane.sql';
+
+void main() {
+  late String sql;
+
+  setUpAll(() {
+    sql = File(
+      _migrationPath,
+    ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+  });
+
+  test('creates owner-scoped batch, item, verification, and capability records',
+      () {
+    for (final table in const [
+      'notion_migration_batches',
+      'notion_migration_items',
+      'notion_migration_checks',
+      'notion_migration_capabilities',
+    ]) {
+      expect(sql, contains('create table public.$table'));
+      expect(
+        sql,
+        contains('alter table public.$table enable row level security;'),
+      );
+      expect(
+        sql,
+        contains('revoke all on table public.$table from anon, authenticated;'),
+      );
+    }
+
+    expect(sql, contains('foreign key (batch_id, user_id)'));
+    expect(sql, contains('foreign key (item_id, user_id)'));
+    expect(sql, contains('with (security_invoker = true)'));
+  });
+
+  test('requires all seven verification dimensions before source deletion', () {
+    for (final key in const [
+      'backup',
+      'content',
+      'hierarchy',
+      'properties',
+      'attachments',
+      'comments',
+      'permissions',
+    ]) {
+      expect(sql, contains("'$key'"));
+    }
+
+    expect(sql, contains('if passed_checks <> 7 then'));
+    expect(sql, contains('notion_migration_seven_checks_required'));
+    expect(sql, contains('notion_migration_invalid_item_transition'));
+    expect(sql, contains('notion_migration_destination_evidence_required'));
+    expect(
+      sql,
+      contains('notion_migration_verification_timestamp_required'),
+    );
+    expect(
+      sql,
+      contains('notion_migration_deletion_authorization_required'),
+    );
+    expect(sql, contains('notion_migration_source_deletion_not_ready'));
+    expect(sql, contains("old.status <> 'ready_for_source_deletion'"));
+  });
+
+  test('keeps hard delete and trigger execution away from clients', () {
+    expect(
+      sql,
+      isNot(
+        contains(
+          'grant select, insert, update, delete on table '
+          'public.notion_migration_items\n  to authenticated',
+        ),
+      ),
+    );
+    expect(
+      sql,
+      contains(
+        'revoke execute on function public.'
+        'notion_migration_guard_item_status()\n  from public, anon, authenticated;',
+      ),
+    );
+    expect(sql, contains('security invoker'));
+    expect(sql, isNot(contains('security definer')));
+  });
+
+  test('does not allow an empty or partially deleted batch to complete', () {
+    expect(sql, contains('notion_migration_batch_items_incomplete'));
+    expect(
+      sql,
+      contains("item.status <> 'source_deleted'"),
+    );
+  });
+
+  test('seeds the full parity registry and requires every capability', () {
+    for (final key in const [
+      'page_tree_blocks',
+      'rich_text_embeds',
+      'page_history_trash',
+      'wiki_verified_pages',
+      'database_data_sources',
+      'database_properties_relations_formulas',
+      'table_list_gallery_views',
+      'board_calendar_timeline_views',
+      'chart_dashboard_map_feed_views',
+      'projects_tasks_sprints',
+      'templates',
+      'forms',
+      'comments_mentions_notifications',
+      'realtime_collaboration_presence',
+      'sharing_permissions_guests_teamspaces',
+      'search_backlinks',
+      'files_media',
+      'import_export_backup',
+      'offline_mobile',
+      'automations_buttons_webhooks',
+      'integrations_api_mcp',
+      'public_sites_domains_seo',
+      'ai_writing_database',
+      'ai_agent_search_research',
+      'meeting_notes_transcription',
+      'analytics_audit_sso_scim',
+      'calendar_mail_connections',
+    ]) {
+      expect(sql, contains("'$key'"));
+    }
+
+    expect(sql, contains('notion_migration_seed_capabilities'));
+    expect(sql, contains('notion_migration_capabilities_incomplete'));
+    expect(sql, contains("capability.status <> 'verified'"));
+    expect(
+      sql,
+      contains('create view public.notion_migration_capability_progress'),
+    );
+  });
+
+  test('maps every seeded capability route to a registered site route', () {
+    final seedStart = sql.indexOf('notion_migration_seed_capabilities');
+    final guardStart = sql.indexOf(
+      'notion_migration_guard_item_status',
+      seedStart,
+    );
+    expect(seedStart, greaterThanOrEqualTo(0));
+    expect(guardStart, greaterThan(seedStart));
+
+    final seedSql = sql.substring(seedStart, guardStart);
+    final routes = RegExp(
+      r"'/[^']+'",
+    ).allMatches(seedSql).map(
+          (match) => match.group(0)!.substring(1, match.group(0)!.length - 1),
+        );
+
+    expect(routes, isNotEmpty);
+    for (final route in routes) {
+      expect(
+        kAllAppRoutes,
+        contains(route),
+        reason: '$route must be registered before it can be parity evidence',
+      );
+    }
+  });
+
+  test('keeps lossless WBS staging owner-readable and service-write-only', () {
+    expect(
+      sql,
+      contains('create table public.notion_migration_wbs_staging'),
+    );
+    expect(
+      sql,
+      contains(
+        'alter table public.notion_migration_wbs_staging enable row level security;',
+      ),
+    );
+    expect(sql, contains('source_page_id text not null'));
+    expect(sql, contains('duplicate_ordinal integer not null'));
+    expect(sql, contains('source_payload jsonb not null'));
+    expect(sql, contains('unique (batch_id, source_page_id)'));
+    expect(
+      sql,
+      contains(
+        'grant select on table public.notion_migration_wbs_staging to authenticated;',
+      ),
+    );
+    expect(
+      sql,
+      isNot(
+        contains(
+          'grant select, insert, update on table public.notion_migration_wbs_staging',
+        ),
+      ),
+    );
+    expect(
+      sql,
+      contains('create view public.notion_migration_wbs_stage_progress'),
+    );
+  });
+}

--- a/test/ui/features/notion_migration/notion_migration_test.dart
+++ b/test/ui/features/notion_migration/notion_migration_test.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/notion_migration/data/notion_migration_gateway.dart';
+import 'package:my_web_app/ui/features/notion_migration/domain/notion_migration_models.dart';
+import 'package:my_web_app/ui/features/notion_migration/notion_migration_feature.dart';
+import 'package:my_web_app/ui/features/notion_migration/view_models/notion_migration_view_model.dart';
+
+void main() {
+  group('Notion migration models', () {
+    test('progress ratios stay finite for an empty inventory', () {
+      const progress = NotionMigrationProgress();
+
+      expect(progress.importedRatio, 0);
+      expect(progress.verifiedRatio, 0);
+      expect(progress.deletedRatio, 0);
+    });
+
+    test('storage statuses map to deletion-safe states', () {
+      expect(
+        NotionMigrationItemStatus.fromStorage('ready_for_source_deletion'),
+        NotionMigrationItemStatus.readyForSourceDeletion,
+      );
+      expect(
+        NotionMigrationBatchStatus.fromStorage('awaiting_source_deletion'),
+        NotionMigrationBatchStatus.awaitingSourceDeletion,
+      );
+    });
+
+    test('WBS reconciliation remains deletion-blocked for any difference', () {
+      final result = NotionWbsReconciliation.fromJson(const {
+        'site_rows': 10,
+        'notion_rows': 11,
+        'site_distinct_ids': 10,
+        'notion_distinct_ids': 10,
+        'notion_duplicate_rows': 1,
+        'only_in_site': 0,
+        'only_in_notion': 0,
+        'exact_matches': 9,
+        'mismatched_records': 1,
+        'inventory_complete': true,
+        'deletion_gate_passed': false,
+      });
+
+      expect(result.notionDuplicateRows, 1);
+      expect(result.deletionGatePassed, isFalse);
+    });
+
+    test('capability rows preserve persisted verification state', () {
+      final capability = NotionCapability.fromJson(const {
+        'capability_key': 'page_tree_blocks',
+        'name': 'ページ階層・ブロック',
+        'notion_scope': '階層ページとブロック',
+        'site_routes': ['/notes'],
+        'status': 'verified',
+        'is_required': true,
+        'evidence_summary': '実データ3件で往復照合済み',
+      });
+
+      expect(capability.status, NotionParityStatus.verified);
+      expect(capability.siteRoutes, ['/notes']);
+      expect(capability.evidenceSummary, contains('往復照合'));
+    });
+
+    test('WBS staging summary reports retained duplicates', () {
+      final summary = NotionWbsStageSummary.fromJson(const {
+        'staged_rows': 12,
+        'distinct_task_ids': 10,
+        'duplicate_rows': 2,
+        'invalid_task_ids': 0,
+        'staged_at': '2026-08-23T00:00:00Z',
+      });
+
+      expect(summary.stagedRows, 12);
+      expect(summary.duplicateRows, 2);
+      expect(summary.stagedAt, DateTime.utc(2026, 8, 23));
+    });
+  });
+
+  group('NotionMigrationViewModel', () {
+    test('loads the current migration snapshot', () async {
+      final gateway = _FakeGateway(snapshot: _sampleSnapshot());
+      final viewModel = NotionMigrationViewModel(gateway: gateway);
+
+      await viewModel.load();
+
+      expect(viewModel.loadStatus, NotionMigrationLoadStatus.ready);
+      expect(viewModel.snapshot.progress.totalItems, 2);
+      expect(viewModel.snapshot.items.single.passedChecks, 7);
+      expect(viewModel.snapshot.capabilities, hasLength(2));
+    });
+
+    test('recognizes authentication failure', () async {
+      final viewModel = NotionMigrationViewModel(
+        gateway: _AuthenticationRequiredGateway(),
+      );
+
+      await viewModel.load();
+
+      expect(viewModel.loadStatus, NotionMigrationLoadStatus.failure);
+      expect(viewModel.authenticationRequired, isTrue);
+    });
+  });
+
+  testWidgets('compact empty state exposes ledger and safety gate', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(420, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(_app(_FakeGateway()));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('notion-migration-compact')), findsOneWidget);
+    expect(
+      find.byKey(const Key('notion-migration-create-batch')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('notion-migration-safety-gate')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('7項目'), findsWidgets);
+  });
+
+  testWidgets('wide state shows counts and feature parity matrix', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 1100);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(_app(_FakeGateway(snapshot: _sampleSnapshot())));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('notion-migration-wide')), findsOneWidget);
+    expect(find.text('Notion全件移行'), findsOneWidget);
+    expect(find.textContaining('照合 7/7'), findsOneWidget);
+    expect(
+      find.byKey(const Key('notion-migration-inventory-start')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('notion-migration-inventory-expand')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('notion-migration-reconcile-wbs')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('notion-migration-stage-wbs')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('notion-migration-wbs-reconciliation')),
+      findsOneWidget,
+    );
+    expect(find.text('削除不可'), findsOneWidget);
+    expect(
+      find.byKey(const Key('notion-migration-feature-matrix')),
+      findsOneWidget,
+    );
+    expect(find.text('必須 1/2 検証済み'), findsOneWidget);
+    expect(find.text('検証済み'), findsWidgets);
+    expect(find.text('不足'), findsOneWidget);
+    expect(
+      find.byKey(const Key('notion-migration-wbs-stage-summary')),
+      findsOneWidget,
+    );
+    expect(find.text('本番未反映'), findsOneWidget);
+  });
+
+  testWidgets('authentication failure offers login route', (tester) async {
+    await tester.pumpWidget(_app(_AuthenticationRequiredGateway()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('notion-migration-login')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('login-page')), findsOneWidget);
+  });
+}
+
+Widget _app(NotionMigrationGateway gateway) {
+  return MaterialApp(
+    routes: {
+      '/login': (_) =>
+          const Scaffold(body: Text('Login', key: Key('login-page'))),
+    },
+    home: NotionMigrationFeature(gateway: gateway),
+  );
+}
+
+NotionMigrationSnapshot _sampleSnapshot() {
+  return NotionMigrationSnapshot(
+    batch: NotionMigrationBatch(
+      id: '11111111-1111-4111-8111-111111111111',
+      workspaceId: 'workspace-test',
+      workspaceName: 'テスト用ワークスペース',
+      name: 'Notion全件移行',
+      status: NotionMigrationBatchStatus.verifying,
+      createdAt: DateTime.utc(2026, 8, 23),
+    ),
+    progress: const NotionMigrationProgress(
+      totalItems: 2,
+      importedItems: 2,
+      verifiedItems: 1,
+      deletionReadyItems: 1,
+    ),
+    items: const [
+      NotionMigrationItem(
+        id: '22222222-2222-4222-8222-222222222222',
+        sourceId: 'source-test',
+        sourceKind: 'page',
+        title: 'テストページ',
+        sourcePath: '/テストページ',
+        status: NotionMigrationItemStatus.readyForSourceDeletion,
+        passedChecks: 7,
+      ),
+    ],
+    capabilities: const [
+      NotionCapability(
+        key: 'page_tree_blocks',
+        name: 'ページ階層・ブロック',
+        notionScope: '階層ページとブロック',
+        siteRoutes: ['/notes', '/wiki-database'],
+        status: NotionParityStatus.verified,
+        evidenceSummary: '実データ3件で往復照合済み',
+      ),
+      NotionCapability(
+        key: 'database_data_sources',
+        name: 'データベース・データソース',
+        notionScope: '複数データソースと保存済みビュー',
+        siteRoutes: ['/table-data'],
+        status: NotionParityStatus.gap,
+      ),
+    ],
+    wbsReconciliation: const NotionWbsReconciliation(
+      siteRows: 9,
+      notionRows: 10,
+      siteDistinctIds: 9,
+      notionDistinctIds: 9,
+      notionDuplicateRows: 1,
+      onlyInSite: 0,
+      onlyInNotion: 0,
+      exactMatches: 8,
+      mismatchedRecords: 1,
+      deletionGatePassed: false,
+      inventoryComplete: true,
+    ),
+    wbsStageSummary: const NotionWbsStageSummary(
+      stagedRows: 10,
+      distinctTaskIds: 9,
+      duplicateRows: 1,
+      invalidTaskIds: 0,
+      stagedAt: null,
+    ),
+  );
+}
+
+class _FakeGateway implements NotionMigrationGateway {
+  _FakeGateway({NotionMigrationSnapshot? snapshot})
+      : _snapshot = snapshot ?? const NotionMigrationSnapshot();
+
+  NotionMigrationSnapshot _snapshot;
+
+  @override
+  Future<NotionMigrationSnapshot> loadLatest() async => _snapshot;
+
+  @override
+  Future<NotionMigrationBatch> createBatch({
+    required String workspaceId,
+    required String workspaceName,
+    required String name,
+  }) async {
+    final batch = NotionMigrationBatch(
+      id: '33333333-3333-4333-8333-333333333333',
+      workspaceId: workspaceId,
+      workspaceName: workspaceName,
+      name: name,
+      status: NotionMigrationBatchStatus.inventory,
+      createdAt: DateTime.utc(2026, 8, 23),
+    );
+    _snapshot = NotionMigrationSnapshot(batch: batch);
+    return batch;
+  }
+
+  @override
+  Future<NotionInventoryActionResult> startInventory(String batchId) async {
+    return const NotionInventoryActionResult(
+      discovered: 3,
+      remainingToExpand: 2,
+      inventoryComplete: false,
+    );
+  }
+
+  @override
+  Future<NotionInventoryActionResult> expandInventory(String batchId) async {
+    return const NotionInventoryActionResult(
+      discovered: 2,
+      remainingToExpand: 0,
+      inventoryComplete: true,
+    );
+  }
+
+  @override
+  Future<NotionWbsReconciliation> reconcileWbs(String batchId) async {
+    return const NotionWbsReconciliation(
+      siteRows: 9,
+      notionRows: 10,
+      siteDistinctIds: 9,
+      notionDistinctIds: 9,
+      notionDuplicateRows: 1,
+      onlyInSite: 0,
+      onlyInNotion: 0,
+      exactMatches: 8,
+      mismatchedRecords: 1,
+      deletionGatePassed: false,
+      inventoryComplete: true,
+    );
+  }
+
+  @override
+  Future<NotionWbsStageSummary> stageWbs(String batchId) async {
+    return const NotionWbsStageSummary(
+      stagedRows: 10,
+      distinctTaskIds: 9,
+      duplicateRows: 1,
+      invalidTaskIds: 0,
+    );
+  }
+}
+
+class _AuthenticationRequiredGateway extends _FakeGateway {
+  @override
+  Future<NotionMigrationSnapshot> loadLatest() =>
+      Future.error(const NotionMigrationException('authentication_required'));
+}


### PR DESCRIPTION
## Outcome
- Adds a guarded Notion migration control plane at `/notion-migration`.
- Inventories Notion pages, databases, data sources, views, forms, comments, and attachments through a dedicated Edge Function.
- Stages WBS records durably while preserving duplicate source rows and raw payloads.
- Persists a 27-capability parity registry with evidence-backed verification.
- Blocks source deletion until all seven migration checks and every required capability pass.

## Architecture and safety
- Owner-scoped RLS for batches, items, checks, capability status, and staged WBS data.
- Authenticated admin operations in the Edge Function; no client-side Notion token exposure.
- No authenticated DELETE policy for source/staging records.
- Completion and deletion gates reject incomplete inventory, counts, attachments, links, permissions, search, and parity evidence.
- No Notion source data is deleted and no subscription action is performed by this PR.

## Validation
- `flutter analyze --no-pub`: passed
- Targeted Flutter schema/widget tests: 17 passed
- Deno lint/check: passed
- Deno tests: 10 passed
- Disposable PostgreSQL migration/RLS/gate verification: passed
- `git diff --check`: passed
- Production Supabase secret names `NOTION_API_TOKEN` and `NOTION_WBS_DATABASE_ID`: confirmed present without exposing values

## Deployment
Merging to `main` triggers the existing production workflow to:
1. apply the Supabase migration,
2. deploy `notion-migration-hub`,
3. build and publish Flutter Web to Firebase Hosting,
4. verify the deployed commit SHA.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1 (review owner; not executed in this Codex-only lane)
- High-Risk-Ultrareview-Exception: Claude Code #1 runtime is unavailable in this Codex-only release lane; deterministic coverage is recorded below.
- Security: owner-scoped RLS, authenticated Edge operations, server-side Notion secrets, and absence of authenticated DELETE policies were verified.
- Rollback: the schema is additive; revert the merge and redeploy the prior Firebase release, while retaining staged migration records for audit.
- Prod smoke: verify deployed commit SHA, `/notion-migration`, and the authenticated Edge Function boundary after merge.
- Observability: migration batches, per-item state, seven checks, capability evidence, and Edge logs expose failures without deleting source data.
- Unresolved deterministic review findings: none.

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Playwright `test/e2e/` route semantics are used for the deployed production smoke.
- E2E-Exception: Local Playwright startup was skipped after a system RAM emergency; 17 widget/schema tests cover the states and production-route browser smoke runs immediately after deploy.
