### PR TITLE
feat: 虎レビューの全履歴と対策Issueを追跡

### DIFF
--- a/assets/data/tiger_course_review_status.json
+++ b/assets/data/tiger_course_review_status.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "generated_at": "2026-08-23T08:57:36.644418+00:00",
+  "generated_at": "2026-08-23T09:36:35.581494+00:00",
   "disclaimer": "公開情報から構築した証拠付きシミュレーションです。本人による実レビュー、発言、推薦を示すものではありません。",
   "lane": "course_review",
   "publication_state": "latest_review",
@@ -66,6 +66,46 @@
         ]
       }
     ],
+    "countermeasure": {
+      "state": "issue_tracking",
+      "label": "未対策・Issue #4734 追跡中",
+      "detail": "両指摘は公開講座データまたは外部教材の内容・計測設計に関わり、共有の低リスク自動修正境界と保護対象の制約を満たさない。",
+      "summary": "",
+      "files": [],
+      "lines_changed": 0,
+      "resolved_finding_ids": [],
+      "validation_status": "passed",
+      "validation_messages": [
+        "validate_roster.py: passed (125 profiles)",
+        "validate_personas.py: passed (125 profiles)",
+        "public Data API catalog export: passed (active=1071, reviewable=526)",
+        "select_course.py: passed (division-5 excluded; deterministic winner preserved)",
+        "target validation: passed (active row; HTTPS source; HTTP 200)",
+        "select_reviewer.py: passed once (125 profiles; seat 9)",
+        "course_review_issue.py --execute: passed (Issue #4734; cycle dedupe evidence recorded)",
+        "validate_cycle_report.py: passed (schema 4; lane=course_review; one reviewer; two proposals)",
+        "build_lane_status.py --lane course_review: passed (course-only status; latest cycle 20260823T175240+0900)",
+        "flutter test test/models/tiger_review_lane_status_test.dart: passed (4 tests)",
+        "deploy_lane_to_production.py --lane course_review --execute: passed (workflow 32629724865; public JSON equality verified)"
+      ],
+      "issue": {
+        "number": 4734,
+        "url": "https://github.com/kanta13jp1/my_web_app/issues/4734",
+        "status": "existing",
+        "github_state": "OPEN",
+        "dedupe_key": "tiger-course-review:20260823T175240+0900:525273ba-539f-4dd4-b436-a6a74a5e8cc5"
+      },
+      "implementation": {
+        "commit_sha": "20b20d3ce18515752a09e11beb6efd32cee12e49",
+        "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32629724865",
+        "production_url": "https://my-web-app-b67f4.web.app/assets/assets/data/tiger_course_review_status.json",
+        "release_status": "passed"
+      },
+      "findings_without_individual_trace": [
+        "course-latest-dated-synthesis",
+        "course-latest-learner-proof"
+      ]
+    },
     "course": {
       "content_id": "525273ba-539f-4dd4-b436-a6a74a5e8cc5",
       "provider": "01ai",
@@ -77,6 +117,347 @@
       "division": 3
     }
   },
+  "history": [
+    {
+      "cycle_id": "20260823T175240+0900",
+      "started_at": "2026-08-23T17:54:10+09:00",
+      "source_format": "course_review",
+      "subject": {
+        "kind": "course",
+        "id": "525273ba-539f-4dd4-b436-a6a74a5e8cc5",
+        "title": "01.AI (Yi) 最新情報",
+        "url": "https://www.01.ai/"
+      },
+      "reviewer": {
+        "seat": 9,
+        "name": "平出 心",
+        "selection_score": 68.8967
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "course-latest-dated-synthesis",
+          "summary": "『最新情報』講座として、確認日・主要差分・日付付き一次情報を結ぶ講座固有の要約がない。",
+          "severity": "p1",
+          "suggested_action": "講座に確認日、前回からの主要変更、日付付き公式ページへのリンク、旧情報との扱いを明示する短い更新サマリーを追加する。"
+        },
+        {
+          "finding_id": "course-latest-learner-proof",
+          "summary": "最新情報を実務判断へ変換できたかを示す実在学習者の課題・成果証拠がない。",
+          "severity": "p2",
+          "suggested_action": "日付付き3点サマリーと旧情報との差分を作る短い課題を設け、匿名の完了率・正答率・自己評価を集計する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4734 追跡中",
+        "detail": "両指摘は公開講座データまたは外部教材の内容・計測設計に関わり、共有の低リスク自動修正境界と保護対象の制約を満たさない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed (125 profiles)",
+          "validate_personas.py: passed (125 profiles)",
+          "public Data API catalog export: passed (active=1071, reviewable=526)",
+          "select_course.py: passed (division-5 excluded; deterministic winner preserved)",
+          "target validation: passed (active row; HTTPS source; HTTP 200)",
+          "select_reviewer.py: passed once (125 profiles; seat 9)",
+          "course_review_issue.py --execute: passed (Issue #4734; cycle dedupe evidence recorded)",
+          "validate_cycle_report.py: passed (schema 4; lane=course_review; one reviewer; two proposals)",
+          "build_lane_status.py --lane course_review: passed (course-only status; latest cycle 20260823T175240+0900)",
+          "flutter test test/models/tiger_review_lane_status_test.dart: passed (4 tests)",
+          "deploy_lane_to_production.py --lane course_review --execute: passed (workflow 32629724865; public JSON equality verified)"
+        ],
+        "issue": {
+          "number": 4734,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4734",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-course-review:20260823T175240+0900:525273ba-539f-4dd4-b436-a6a74a5e8cc5"
+        },
+        "implementation": {
+          "commit_sha": "20b20d3ce18515752a09e11beb6efd32cee12e49",
+          "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32629724865",
+          "production_url": "https://my-web-app-b67f4.web.app/assets/assets/data/tiger_course_review_status.json",
+          "release_status": "passed"
+        },
+        "findings_without_individual_trace": [
+          "course-latest-dated-synthesis",
+          "course-latest-learner-proof"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T165404+0900",
+      "started_at": "2026-08-23T16:54:04+09:00",
+      "source_format": "course_review",
+      "subject": {
+        "kind": "course",
+        "id": "22befb67-6147-4a4b-999c-ee1ad6fa9615",
+        "title": "01.AI (Yi) モデル一覧",
+        "url": "https://platform.01.ai/docs"
+      },
+      "reviewer": {
+        "seat": 12,
+        "name": "迫 佑樹",
+        "selection_score": 73.0376
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "course-model-list-freshness",
+          "summary": "モデル一覧の現行性を検証できる更新日・稼働モデル証拠が講座出典にない。",
+          "severity": "p1",
+          "suggested_action": "公式の稼働モデルAPIまたは更新日のあるモデル表を定期確認し、講座に確認日と差分検証手順を明示する。"
+        },
+        {
+          "finding_id": "course-model-list-learner-proof",
+          "summary": "モデル比較後に学習者が適切なモデルを選べたかを示す実在学習者証拠がない。",
+          "severity": "p2",
+          "suggested_action": "用途・予算・文脈長からモデルを選ぶ短い課題と、匿名集計できる完了・正答指標を設計する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4737 追跡中",
+        "detail": "両指摘とも公開講座データまたは外部教材の内容・計測設計に関わり、共有の低リスク自動修正境界を満たさない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed (125 profiles)",
+          "validate_personas.py: passed (125 profiles)",
+          "public Data API catalog export: passed (active=1071, reviewable=526)",
+          "select_course.py: passed (division-5 excluded; deterministic winner preserved)",
+          "target validation: passed (active row; HTTPS source; reachable)",
+          "select_reviewer.py: passed once (125 profiles; seat 12)",
+          "validate_cycle_report.py: passed (schema 4; lane=course_review; one reviewer; two proposals)",
+          "build_lane_status.py --lane course_review: passed (course-only status; latest cycle 20260823T165404+0900)",
+          "flutter test test/models/tiger_review_lane_status_test.dart: passed (4 tests)",
+          "deploy_lane_to_production.py --lane course_review --execute: passed (workflow 32627164504; public JSON equality verified)"
+        ],
+        "issue": {
+          "number": 4737,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4737",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-course-review:20260823T165404+0900:22befb67-6147-4a4b-999c-ee1ad6fa9615"
+        },
+        "implementation": {
+          "commit_sha": "18eedc47ea0769b871ba191b7ff9162252afb8f3",
+          "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32627164504",
+          "production_url": "https://my-web-app-b67f4.web.app/assets/assets/data/tiger_course_review_status.json",
+          "release_status": "passed"
+        },
+        "findings_without_individual_trace": [
+          "course-model-list-freshness",
+          "course-model-list-learner-proof"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T153734+0900",
+      "started_at": "2026-08-23T15:38:16.4383006+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "course",
+        "id": "4ec30eda-d8f5-4cef-b88d-b5e18a34e914",
+        "title": "01.AI (Yi) API 利用方法",
+        "url": "https://platform.01.ai/docs"
+      },
+      "reviewer": {
+        "seat": 7,
+        "name": "榊󠄀原 清一",
+        "selection_score": 74.4337
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "comparison-claim-evidence",
+          "summary": "競合比較の公開主張に出典・確認時点を一貫して結び付ける必要がある。",
+          "severity": "p1",
+          "suggested_action": "競合別の価格・機能主張について、出典URLと最終確認日を管理する別レビューを行う。"
+        },
+        {
+          "finding_id": "comparison-funnel-evidence",
+          "summary": "比較流入から登録までの実測根拠が今回のレビュー入力にない。",
+          "severity": "p2",
+          "suggested_action": "既存計測の匿名集計を別運用で確認し、比較到達・CTA・登録のファネルを根拠化する。"
+        },
+        {
+          "finding_id": "comparison-maintainability",
+          "summary": "比較ページの巨大な単一ソースと専用試験不足が訴求変更の検証コストを高めている。",
+          "severity": "p2",
+          "suggested_action": "別タスクで競合データと表示部を分離し、代表ルートのCTA・比較表をウィジェット試験で固定する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4739 追跡中",
+        "detail": "3件はいずれも再現可能な証拠を持つが、公開比較主張、分析データ、または大規模な構造変更に関わる。安全な自動修正、低リスク、3ファイル・200行以内の全条件を満たす変更はない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "select_feature.py: passed (13 features)",
+          "select_reviewer.py: passed (125 profiles; JSON output saved)",
+          "public Data API catalog export: passed (active=1071, reviewable=526, excluded source URL=536)",
+          "select_course.py: passed",
+          "01.AI source URL inspection: reachable; only generic documentation navigation was observable",
+          "comparison source and test filename inspection: completed"
+        ],
+        "issue": {
+          "number": 4739,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4739",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-legacy-review:20260823T153734+0900:comparison"
+        },
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "comparison-claim-evidence",
+          "comparison-funnel-evidence",
+          "comparison-maintainability"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T152316+0900",
+      "started_at": "2026-08-23T15:24:30+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "course",
+        "id": "22befb67-6147-4a4b-999c-ee1ad6fa9615",
+        "title": "01.AI (Yi) モデル一覧",
+        "url": "https://platform.01.ai/docs"
+      },
+      "reviewer": {
+        "seat": 1,
+        "name": "ドラゴン細井",
+        "selection_score": 79.5059
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "course-freshness-review",
+          "summary": "選出講座に出典更新確認の運用が必要。",
+          "severity": "p2",
+          "suggested_action": "公式出典の確認日と更新検知を講座運用で記録し、再確認対象を明示する。"
+        },
+        {
+          "finding_id": "course-outcome-evidence",
+          "summary": "講座選定データに学習成果の根拠がない。",
+          "severity": "p2",
+          "suggested_action": "講座編集の別タスクで、対象者・到達行動・確認方法を根拠付きで管理する。"
+        },
+        {
+          "finding_id": "content-failure-observability",
+          "summary": "教材取得失敗時の事業影響を測定できない。",
+          "severity": "p2",
+          "suggested_action": "別の計測設計レビューで、失敗・再試行・フォールバック表示を匿名かつ最小限に観測する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4738 追跡中",
+        "detail": "3件はいずれも証拠に基づくが、講座運用・計測設計または利用データを要し、低リスク自動修正の条件を満たす変更はない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "public Data API catalog export: passed (active=1071, reviewable=526)",
+          "select_feature.py: passed",
+          "select_reviewer.py: passed (125 profiles)",
+          "select_course.py: passed",
+          "AI University browser inspection: blocked by browser URL safety policy; no workaround attempted"
+        ],
+        "issue": {
+          "number": 4738,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4738",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-legacy-review:20260823T152316+0900:ai_university"
+        },
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "course-freshness-review",
+          "course-outcome-evidence",
+          "content-failure-observability"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T152239+0900",
+      "started_at": "2026-08-23T15:22:47+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "course",
+        "id": "22befb67-6147-4a4b-999c-ee1ad6fa9615",
+        "title": "01.AI (Yi) モデル一覧",
+        "url": "https://platform.01.ai/docs"
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 73.5265
+      },
+      "status": "implemented",
+      "review_status": "fixed",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "ai_university_catalog_pagination",
+          "summary": "AI大学の主カタログ取得をページングし、PostgRESTの1,000行上限を超える有効講座も表示対象にする。",
+          "severity": "p2",
+          "suggested_action": "sort_orderとidで安定順序を付け、1,000件単位で全有効行を取得する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "implemented",
+        "label": "対策実施・検証済み",
+        "detail": "個別の指摘IDとの紐付けも記録済みです。",
+        "summary": "主カタログに安定順序のページングを追加し、回帰契約テストを更新した。",
+        "files": [
+          "lib/pages/gemini_university_v2_page.dart",
+          "test/pages/ai_university_published_video_fetch_contract_test.dart"
+        ],
+        "lines_changed": 27,
+        "resolved_finding_ids": [
+          "ai_university_catalog_pagination"
+        ],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "flutter test test/pages/ai_university_published_video_fetch_contract_test.dart: passed",
+          "dart analyze changed files: passed"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": []
+      }
+    }
+  ],
   "courses": [
     {
       "content_id": "525273ba-539f-4dd4-b436-a6a74a5e8cc5",

--- a/assets/data/tiger_feature_review_status.json
+++ b/assets/data/tiger_feature_review_status.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "generated_at": "2026-08-23T08:32:50.740445+00:00",
+  "generated_at": "2026-08-23T09:36:35.581494+00:00",
   "disclaimer": "公開情報から構築した証拠付きシミュレーションです。本人による実レビュー、発言、推薦を示すものではありません。",
   "lane": "feature_review",
   "publication_state": "latest_review",
@@ -13,10 +13,10 @@
   "pool": {
     "total": 13,
     "eligible": 13,
-    "provisional": 13,
+    "provisional": 11,
     "division_1": 0,
-    "division_2": 0,
-    "division_3": 13,
+    "division_2": 1,
+    "division_3": 12,
     "division_4": 0,
     "division_5": 0,
     "eliminated": 0
@@ -40,9 +40,9 @@
       "seat": 11,
       "name": "野口 功司",
       "selection_score": 78.0406,
-      "division": 3,
+      "division": 1,
       "cycle_utility": 95.5,
-      "aggregate_utility": 95.5
+      "aggregate_utility": 87.33
     },
     "status": "fixed",
     "validation": "passed",
@@ -76,17 +76,417 @@
         ]
       }
     ],
+    "countermeasure": {
+      "state": "production_verified",
+      "label": "本番対策済み",
+      "detail": "変更・検証・本番反映の証拠が記録されています。",
+      "summary": "",
+      "files": [
+        "lib/pages/gemini_university_v2_page.dart",
+        "test/pages/gemini_university_loading_semantics_test.dart"
+      ],
+      "lines_changed": 30,
+      "resolved_finding_ids": [
+        "ai-university-loading-semantics"
+      ],
+      "validation_status": "passed",
+      "validation_messages": [
+        "passed: 1 test",
+        "passed: No issues found",
+        "passed: 0 files changed",
+        "passed"
+      ],
+      "issue": {},
+      "implementation": {
+        "commit_sha": "087271567f2312c718f9695d0a81c51de07f5888",
+        "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32628679913",
+        "production_url": "https://my-web-app-b67f4.web.app/",
+        "release_status": "passed"
+      },
+      "findings_without_individual_trace": [
+        "ai-university-cold-entry-latency",
+        "ai-university-monolith-test-cost"
+      ]
+    },
     "feature": {
       "slug": "ai_university",
       "title": "AI大学入口ページ",
       "kind": "page",
       "reason": "個別講座の内容ではなく、AI大学の公開入口、初期読み込み、教材発見、継続学習導線だけを機能として評価した。利用分析データはなく、観測利用は中立50点とした。",
       "cycle_utility": 65.8,
-      "aggregate_utility": 65.8,
-      "division": 3
+      "aggregate_utility": 65.3,
+      "division": 2
     }
   },
+  "history": [
+    {
+      "cycle_id": "20260823T172138+0900",
+      "started_at": "2026-08-23T17:21:38+09:00",
+      "source_format": "feature_review",
+      "subject": {
+        "kind": "feature",
+        "id": "ai_university",
+        "title": "AI大学入口ページ",
+        "url": null
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 78.0406
+      },
+      "status": "production_verified",
+      "review_status": "fixed",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "ai-university-loading-semantics",
+          "summary": "読み込み中のspinnerが支援技術へ状態を通知しない",
+          "severity": "p1",
+          "suggested_action": "読み込みspinnerを、意味のある日本語labelとliveRegionを持つSemanticsで包み、状態を自動通知する。"
+        },
+        {
+          "finding_id": "ai-university-cold-entry-latency",
+          "summary": "SEOシェルから実AI大学画面への切り替えが遅い",
+          "severity": "p1",
+          "suggested_action": "実測の初回教材表示時間を計測し、bundle分割、初期データ量、provider描画範囲を別設計で最適化する。"
+        },
+        {
+          "finding_id": "ai-university-monolith-test-cost",
+          "summary": "8千行超の単一ページと専用widget test不足が改善速度を下げる",
+          "severity": "p2",
+          "suggested_action": "ロード状態、provider navigation、教材表示を独立widgetへ分割し、代表的なwidget testを段階的に追加する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "production_verified",
+        "label": "本番対策済み",
+        "detail": "変更・検証・本番反映の証拠が記録されています。",
+        "summary": "",
+        "files": [
+          "lib/pages/gemini_university_v2_page.dart",
+          "test/pages/gemini_university_loading_semantics_test.dart"
+        ],
+        "lines_changed": 30,
+        "resolved_finding_ids": [
+          "ai-university-loading-semantics"
+        ],
+        "validation_status": "passed",
+        "validation_messages": [
+          "passed: 1 test",
+          "passed: No issues found",
+          "passed: 0 files changed",
+          "passed"
+        ],
+        "issue": {},
+        "implementation": {
+          "commit_sha": "087271567f2312c718f9695d0a81c51de07f5888",
+          "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32628679913",
+          "production_url": "https://my-web-app-b67f4.web.app/",
+          "release_status": "passed"
+        },
+        "findings_without_individual_trace": [
+          "ai-university-cold-entry-latency",
+          "ai-university-monolith-test-cost"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T171300+0900",
+      "started_at": "2026-08-23T17:13:00+09:00",
+      "source_format": "feature_review",
+      "subject": {
+        "kind": "feature",
+        "id": "home",
+        "title": "ホーム",
+        "url": null
+      },
+      "reviewer": {
+        "seat": 9,
+        "name": "平出 心",
+        "selection_score": 71.5964
+      },
+      "status": "blocked",
+      "review_status": "blocked",
+      "validation_status": "failed",
+      "findings": [
+        {
+          "finding_id": "home-route-surface-alignment",
+          "summary": "ホーム設定の公開URLと実装サーフェスが一致していない",
+          "severity": "p1",
+          "suggested_action": "公開LPと認証後HomePageを別サーフェスとして定義し、各々の到達・登録・継続の計測責任を分離する。認証ルーティング変更は別途設計レビューで扱う。"
+        }
+      ],
+      "countermeasure": {
+        "state": "blocked",
+        "label": "対策状況を確認できません",
+        "detail": "レビューまたは検証が完了していません。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "failed",
+        "validation_messages": [
+          "passed: No issues found",
+          "failed: browser test did not finish loading and exited 1"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "home-route-surface-alignment"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T153734+0900",
+      "started_at": "2026-08-23T15:38:16.4383006+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "feature",
+        "id": "comparison",
+        "title": "comparison",
+        "url": null
+      },
+      "reviewer": {
+        "seat": 7,
+        "name": "榊󠄀原 清一",
+        "selection_score": 74.4337
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "comparison-claim-evidence",
+          "summary": "競合比較の公開主張に出典・確認時点を一貫して結び付ける必要がある。",
+          "severity": "p1",
+          "suggested_action": "競合別の価格・機能主張について、出典URLと最終確認日を管理する別レビューを行う。"
+        },
+        {
+          "finding_id": "comparison-funnel-evidence",
+          "summary": "比較流入から登録までの実測根拠が今回のレビュー入力にない。",
+          "severity": "p2",
+          "suggested_action": "既存計測の匿名集計を別運用で確認し、比較到達・CTA・登録のファネルを根拠化する。"
+        },
+        {
+          "finding_id": "comparison-maintainability",
+          "summary": "比較ページの巨大な単一ソースと専用試験不足が訴求変更の検証コストを高めている。",
+          "severity": "p2",
+          "suggested_action": "別タスクで競合データと表示部を分離し、代表ルートのCTA・比較表をウィジェット試験で固定する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4739 追跡中",
+        "detail": "3件はいずれも再現可能な証拠を持つが、公開比較主張、分析データ、または大規模な構造変更に関わる。安全な自動修正、低リスク、3ファイル・200行以内の全条件を満たす変更はない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "select_feature.py: passed (13 features)",
+          "select_reviewer.py: passed (125 profiles; JSON output saved)",
+          "public Data API catalog export: passed (active=1071, reviewable=526, excluded source URL=536)",
+          "select_course.py: passed",
+          "01.AI source URL inspection: reachable; only generic documentation navigation was observable",
+          "comparison source and test filename inspection: completed"
+        ],
+        "issue": {
+          "number": 4739,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4739",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-legacy-review:20260823T153734+0900:comparison"
+        },
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "comparison-claim-evidence",
+          "comparison-funnel-evidence",
+          "comparison-maintainability"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T152316+0900",
+      "started_at": "2026-08-23T15:24:30+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "feature",
+        "id": "ai_university",
+        "title": "ai_university",
+        "url": null
+      },
+      "reviewer": {
+        "seat": 1,
+        "name": "ドラゴン細井",
+        "selection_score": 79.5059
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "course-freshness-review",
+          "summary": "選出講座に出典更新確認の運用が必要。",
+          "severity": "p2",
+          "suggested_action": "公式出典の確認日と更新検知を講座運用で記録し、再確認対象を明示する。"
+        },
+        {
+          "finding_id": "course-outcome-evidence",
+          "summary": "講座選定データに学習成果の根拠がない。",
+          "severity": "p2",
+          "suggested_action": "講座編集の別タスクで、対象者・到達行動・確認方法を根拠付きで管理する。"
+        },
+        {
+          "finding_id": "content-failure-observability",
+          "summary": "教材取得失敗時の事業影響を測定できない。",
+          "severity": "p2",
+          "suggested_action": "別の計測設計レビューで、失敗・再試行・フォールバック表示を匿名かつ最小限に観測する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4738 追跡中",
+        "detail": "3件はいずれも証拠に基づくが、講座運用・計測設計または利用データを要し、低リスク自動修正の条件を満たす変更はない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "public Data API catalog export: passed (active=1071, reviewable=526)",
+          "select_feature.py: passed",
+          "select_reviewer.py: passed (125 profiles)",
+          "select_course.py: passed",
+          "AI University browser inspection: blocked by browser URL safety policy; no workaround attempted"
+        ],
+        "issue": {
+          "number": 4738,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4738",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-legacy-review:20260823T152316+0900:ai_university"
+        },
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "course-freshness-review",
+          "course-outcome-evidence",
+          "content-failure-observability"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T152239+0900",
+      "started_at": "2026-08-23T15:22:47+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "feature",
+        "id": "ai_university",
+        "title": "ai_university",
+        "url": null
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 73.5265
+      },
+      "status": "implemented",
+      "review_status": "fixed",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "ai_university_catalog_pagination",
+          "summary": "AI大学の主カタログ取得をページングし、PostgRESTの1,000行上限を超える有効講座も表示対象にする。",
+          "severity": "p2",
+          "suggested_action": "sort_orderとidで安定順序を付け、1,000件単位で全有効行を取得する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "implemented",
+        "label": "対策実施・検証済み",
+        "detail": "個別の指摘IDとの紐付けも記録済みです。",
+        "summary": "主カタログに安定順序のページングを追加し、回帰契約テストを更新した。",
+        "files": [
+          "lib/pages/gemini_university_v2_page.dart",
+          "test/pages/ai_university_published_video_fetch_contract_test.dart"
+        ],
+        "lines_changed": 27,
+        "resolved_finding_ids": [
+          "ai_university_catalog_pagination"
+        ],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "flutter test test/pages/ai_university_published_video_fetch_contract_test.dart: passed",
+          "dart analyze changed files: passed"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": []
+      }
+    },
+    {
+      "cycle_id": "20260823T150231+0900",
+      "started_at": "2026-08-23T15:02:31+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "feature",
+        "id": "home",
+        "title": "home",
+        "url": null
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 77.7529
+      },
+      "status": "blocked",
+      "review_status": "blocked",
+      "validation_status": "not_applicable",
+      "findings": [],
+      "countermeasure": {
+        "state": "blocked",
+        "label": "対策状況を確認できません",
+        "detail": "origin/main への fast-forward 同期不能と、アクティブ講座カタログの取得不能。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "not_applicable",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "course catalog export: unavailable",
+          "worktree fast-forward: unavailable"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": []
+      }
+    }
+  ],
   "features": [
+    {
+      "slug": "ai_university",
+      "kind": "page",
+      "title": "ai_university",
+      "path": "/ai-university",
+      "source": "lib/pages/gemini_university_v2_page.dart",
+      "priority": "high",
+      "division": 2,
+      "provisional": false,
+      "eligible": true,
+      "utility_score": 65.3,
+      "completed_cycles": 3,
+      "last_cycle_utility": 65.8,
+      "last_reviewed_at": "2026-08-23T08:21:38+00:00",
+      "reason": "機能レビュー3回・効用65.3点で2部"
+    },
     {
       "slug": "home",
       "kind": "page",
@@ -95,29 +495,13 @@
       "source": "lib/pages/home_page.dart",
       "priority": "high",
       "division": 3,
-      "provisional": true,
+      "provisional": false,
       "eligible": true,
-      "utility_score": 66.75,
-      "completed_cycles": 1,
+      "utility_score": 60.17,
+      "completed_cycles": 2,
       "last_cycle_utility": 66.75,
       "last_reviewed_at": "2026-08-23T08:13:00+00:00",
-      "reason": "機能レビュー実績が2回未満のため暫定3部"
-    },
-    {
-      "slug": "ai_university",
-      "kind": "page",
-      "title": "ai_university",
-      "path": "/ai-university",
-      "source": "lib/pages/gemini_university_v2_page.dart",
-      "priority": "high",
-      "division": 3,
-      "provisional": true,
-      "eligible": true,
-      "utility_score": 65.8,
-      "completed_cycles": 1,
-      "last_cycle_utility": 65.8,
-      "last_reviewed_at": "2026-08-23T08:21:38+00:00",
-      "reason": "機能レビュー実績が2回未満のため暫定3部"
+      "reason": "機能レビュー2回・効用60.2点で3部"
     },
     {
       "slug": "admin_analytics",
@@ -141,22 +525,6 @@
       "title": "ai-hub",
       "path": "",
       "source": "supabase/functions/ai-hub/index.ts",
-      "priority": "high",
-      "division": 3,
-      "provisional": true,
-      "eligible": true,
-      "utility_score": null,
-      "completed_cycles": 0,
-      "last_cycle_utility": null,
-      "last_reviewed_at": null,
-      "reason": "機能レビュー実績が2回未満のため暫定3部"
-    },
-    {
-      "slug": "comparison",
-      "kind": "page",
-      "title": "comparison",
-      "path": "/competitors",
-      "source": "lib/pages/comparison_page.dart",
       "priority": "high",
       "division": 3,
       "provisional": true,
@@ -293,6 +661,22 @@
       "completed_cycles": 0,
       "last_cycle_utility": null,
       "last_reviewed_at": null,
+      "reason": "機能レビュー実績が2回未満のため暫定3部"
+    },
+    {
+      "slug": "comparison",
+      "kind": "page",
+      "title": "comparison",
+      "path": "/competitors",
+      "source": "lib/pages/comparison_page.dart",
+      "priority": "high",
+      "division": 3,
+      "provisional": true,
+      "eligible": true,
+      "utility_score": 57.55,
+      "completed_cycles": 1,
+      "last_cycle_utility": 57.55,
+      "last_reviewed_at": "2026-08-23T06:38:16.438300+00:00",
       "reason": "機能レビュー実績が2回未満のため暫定3部"
     }
   ]

--- a/assets/data/tiger_reviewer_league_status.json
+++ b/assets/data/tiger_reviewer_league_status.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "generated_at": "2026-08-23T09:02:53.991646+00:00",
+  "generated_at": "2026-08-23T09:36:35.581494+00:00",
   "disclaimer": "公開情報から構築した証拠付きシミュレーションです。本人による実レビュー、発言、推薦を示すものではありません。",
   "lane": "reviewer_league",
   "publication_state": "latest_assignment",
@@ -13,10 +13,10 @@
   "pool": {
     "total": 125,
     "eligible": 125,
-    "provisional": 121,
-    "division_1": 4,
+    "provisional": 123,
+    "division_1": 2,
     "division_2": 0,
-    "division_3": 121,
+    "division_3": 123,
     "division_4": 0,
     "division_5": 0,
     "eliminated": 0,
@@ -70,38 +70,560 @@
           "unit_economics"
         ]
       }
-    ]
+    ],
+    "countermeasure": {
+      "state": "issue_tracking",
+      "label": "未対策・Issue #4734 追跡中",
+      "detail": "両指摘は公開講座データまたは外部教材の内容・計測設計に関わり、共有の低リスク自動修正境界と保護対象の制約を満たさない。",
+      "summary": "",
+      "files": [],
+      "lines_changed": 0,
+      "resolved_finding_ids": [],
+      "validation_status": "passed",
+      "validation_messages": [
+        "validate_roster.py: passed (125 profiles)",
+        "validate_personas.py: passed (125 profiles)",
+        "public Data API catalog export: passed (active=1071, reviewable=526)",
+        "select_course.py: passed (division-5 excluded; deterministic winner preserved)",
+        "target validation: passed (active row; HTTPS source; HTTP 200)",
+        "select_reviewer.py: passed once (125 profiles; seat 9)",
+        "course_review_issue.py --execute: passed (Issue #4734; cycle dedupe evidence recorded)",
+        "validate_cycle_report.py: passed (schema 4; lane=course_review; one reviewer; two proposals)",
+        "build_lane_status.py --lane course_review: passed (course-only status; latest cycle 20260823T175240+0900)",
+        "flutter test test/models/tiger_review_lane_status_test.dart: passed (4 tests)",
+        "deploy_lane_to_production.py --lane course_review --execute: passed (workflow 32629724865; public JSON equality verified)"
+      ],
+      "issue": {
+        "number": 4734,
+        "url": "https://github.com/kanta13jp1/my_web_app/issues/4734",
+        "status": "existing",
+        "github_state": "OPEN",
+        "dedupe_key": "tiger-course-review:20260823T175240+0900:525273ba-539f-4dd4-b436-a6a74a5e8cc5"
+      },
+      "implementation": {
+        "commit_sha": "20b20d3ce18515752a09e11beb6efd32cee12e49",
+        "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32629724865",
+        "production_url": "https://my-web-app-b67f4.web.app/assets/assets/data/tiger_course_review_status.json",
+        "release_status": "passed"
+      },
+      "findings_without_individual_trace": [
+        "course-latest-dated-synthesis",
+        "course-latest-learner-proof"
+      ]
+    }
   },
-  "reviewers": [
+  "history": [
     {
-      "seat": 11,
-      "name": "野口 功司",
-      "tier": "division_1",
-      "division": 1,
-      "provisional": false,
-      "eligible": true,
-      "floor_protected": false,
-      "utility_score": 95.88,
-      "completed_cycles": 5,
-      "low_utility_streak": 0,
-      "last_cycle_utility": 95.5,
-      "last_selected_at": "2026-08-23T08:21:38+00:00",
-      "reason": "担当5回・効用95.9点で1部"
+      "cycle_id": "20260823T175240+0900",
+      "started_at": "2026-08-23T17:54:10+09:00",
+      "source_format": "course_review",
+      "subject": {
+        "kind": "course",
+        "id": "525273ba-539f-4dd4-b436-a6a74a5e8cc5",
+        "title": "01.AI (Yi) 最新情報",
+        "url": "https://www.01.ai/"
+      },
+      "reviewer": {
+        "seat": 9,
+        "name": "平出 心",
+        "selection_score": 68.8967
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "course-latest-dated-synthesis",
+          "summary": "『最新情報』講座として、確認日・主要差分・日付付き一次情報を結ぶ講座固有の要約がない。",
+          "severity": "p1",
+          "suggested_action": "講座に確認日、前回からの主要変更、日付付き公式ページへのリンク、旧情報との扱いを明示する短い更新サマリーを追加する。"
+        },
+        {
+          "finding_id": "course-latest-learner-proof",
+          "summary": "最新情報を実務判断へ変換できたかを示す実在学習者の課題・成果証拠がない。",
+          "severity": "p2",
+          "suggested_action": "日付付き3点サマリーと旧情報との差分を作る短い課題を設け、匿名の完了率・正答率・自己評価を集計する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4734 追跡中",
+        "detail": "両指摘は公開講座データまたは外部教材の内容・計測設計に関わり、共有の低リスク自動修正境界と保護対象の制約を満たさない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed (125 profiles)",
+          "validate_personas.py: passed (125 profiles)",
+          "public Data API catalog export: passed (active=1071, reviewable=526)",
+          "select_course.py: passed (division-5 excluded; deterministic winner preserved)",
+          "target validation: passed (active row; HTTPS source; HTTP 200)",
+          "select_reviewer.py: passed once (125 profiles; seat 9)",
+          "course_review_issue.py --execute: passed (Issue #4734; cycle dedupe evidence recorded)",
+          "validate_cycle_report.py: passed (schema 4; lane=course_review; one reviewer; two proposals)",
+          "build_lane_status.py --lane course_review: passed (course-only status; latest cycle 20260823T175240+0900)",
+          "flutter test test/models/tiger_review_lane_status_test.dart: passed (4 tests)",
+          "deploy_lane_to_production.py --lane course_review --execute: passed (workflow 32629724865; public JSON equality verified)"
+        ],
+        "issue": {
+          "number": 4734,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4734",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-course-review:20260823T175240+0900:525273ba-539f-4dd4-b436-a6a74a5e8cc5"
+        },
+        "implementation": {
+          "commit_sha": "20b20d3ce18515752a09e11beb6efd32cee12e49",
+          "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32629724865",
+          "production_url": "https://my-web-app-b67f4.web.app/assets/assets/data/tiger_course_review_status.json",
+          "release_status": "passed"
+        },
+        "findings_without_individual_trace": [
+          "course-latest-dated-synthesis",
+          "course-latest-learner-proof"
+        ]
+      }
     },
+    {
+      "cycle_id": "20260823T172138+0900",
+      "started_at": "2026-08-23T17:21:38+09:00",
+      "source_format": "feature_review",
+      "subject": {
+        "kind": "feature",
+        "id": "ai_university",
+        "title": "AI大学入口ページ",
+        "url": null
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 78.0406
+      },
+      "status": "production_verified",
+      "review_status": "fixed",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "ai-university-loading-semantics",
+          "summary": "読み込み中のspinnerが支援技術へ状態を通知しない",
+          "severity": "p1",
+          "suggested_action": "読み込みspinnerを、意味のある日本語labelとliveRegionを持つSemanticsで包み、状態を自動通知する。"
+        },
+        {
+          "finding_id": "ai-university-cold-entry-latency",
+          "summary": "SEOシェルから実AI大学画面への切り替えが遅い",
+          "severity": "p1",
+          "suggested_action": "実測の初回教材表示時間を計測し、bundle分割、初期データ量、provider描画範囲を別設計で最適化する。"
+        },
+        {
+          "finding_id": "ai-university-monolith-test-cost",
+          "summary": "8千行超の単一ページと専用widget test不足が改善速度を下げる",
+          "severity": "p2",
+          "suggested_action": "ロード状態、provider navigation、教材表示を独立widgetへ分割し、代表的なwidget testを段階的に追加する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "production_verified",
+        "label": "本番対策済み",
+        "detail": "変更・検証・本番反映の証拠が記録されています。",
+        "summary": "",
+        "files": [
+          "lib/pages/gemini_university_v2_page.dart",
+          "test/pages/gemini_university_loading_semantics_test.dart"
+        ],
+        "lines_changed": 30,
+        "resolved_finding_ids": [
+          "ai-university-loading-semantics"
+        ],
+        "validation_status": "passed",
+        "validation_messages": [
+          "passed: 1 test",
+          "passed: No issues found",
+          "passed: 0 files changed",
+          "passed"
+        ],
+        "issue": {},
+        "implementation": {
+          "commit_sha": "087271567f2312c718f9695d0a81c51de07f5888",
+          "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32628679913",
+          "production_url": "https://my-web-app-b67f4.web.app/",
+          "release_status": "passed"
+        },
+        "findings_without_individual_trace": [
+          "ai-university-cold-entry-latency",
+          "ai-university-monolith-test-cost"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T171300+0900",
+      "started_at": "2026-08-23T17:13:00+09:00",
+      "source_format": "feature_review",
+      "subject": {
+        "kind": "feature",
+        "id": "home",
+        "title": "ホーム",
+        "url": null
+      },
+      "reviewer": {
+        "seat": 9,
+        "name": "平出 心",
+        "selection_score": 71.5964
+      },
+      "status": "blocked",
+      "review_status": "blocked",
+      "validation_status": "failed",
+      "findings": [
+        {
+          "finding_id": "home-route-surface-alignment",
+          "summary": "ホーム設定の公開URLと実装サーフェスが一致していない",
+          "severity": "p1",
+          "suggested_action": "公開LPと認証後HomePageを別サーフェスとして定義し、各々の到達・登録・継続の計測責任を分離する。認証ルーティング変更は別途設計レビューで扱う。"
+        }
+      ],
+      "countermeasure": {
+        "state": "blocked",
+        "label": "対策状況を確認できません",
+        "detail": "レビューまたは検証が完了していません。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "failed",
+        "validation_messages": [
+          "passed: No issues found",
+          "failed: browser test did not finish loading and exited 1"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "home-route-surface-alignment"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T165404+0900",
+      "started_at": "2026-08-23T16:54:04+09:00",
+      "source_format": "course_review",
+      "subject": {
+        "kind": "course",
+        "id": "22befb67-6147-4a4b-999c-ee1ad6fa9615",
+        "title": "01.AI (Yi) モデル一覧",
+        "url": "https://platform.01.ai/docs"
+      },
+      "reviewer": {
+        "seat": 12,
+        "name": "迫 佑樹",
+        "selection_score": 73.0376
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "course-model-list-freshness",
+          "summary": "モデル一覧の現行性を検証できる更新日・稼働モデル証拠が講座出典にない。",
+          "severity": "p1",
+          "suggested_action": "公式の稼働モデルAPIまたは更新日のあるモデル表を定期確認し、講座に確認日と差分検証手順を明示する。"
+        },
+        {
+          "finding_id": "course-model-list-learner-proof",
+          "summary": "モデル比較後に学習者が適切なモデルを選べたかを示す実在学習者証拠がない。",
+          "severity": "p2",
+          "suggested_action": "用途・予算・文脈長からモデルを選ぶ短い課題と、匿名集計できる完了・正答指標を設計する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4737 追跡中",
+        "detail": "両指摘とも公開講座データまたは外部教材の内容・計測設計に関わり、共有の低リスク自動修正境界を満たさない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed (125 profiles)",
+          "validate_personas.py: passed (125 profiles)",
+          "public Data API catalog export: passed (active=1071, reviewable=526)",
+          "select_course.py: passed (division-5 excluded; deterministic winner preserved)",
+          "target validation: passed (active row; HTTPS source; reachable)",
+          "select_reviewer.py: passed once (125 profiles; seat 12)",
+          "validate_cycle_report.py: passed (schema 4; lane=course_review; one reviewer; two proposals)",
+          "build_lane_status.py --lane course_review: passed (course-only status; latest cycle 20260823T165404+0900)",
+          "flutter test test/models/tiger_review_lane_status_test.dart: passed (4 tests)",
+          "deploy_lane_to_production.py --lane course_review --execute: passed (workflow 32627164504; public JSON equality verified)"
+        ],
+        "issue": {
+          "number": 4737,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4737",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-course-review:20260823T165404+0900:22befb67-6147-4a4b-999c-ee1ad6fa9615"
+        },
+        "implementation": {
+          "commit_sha": "18eedc47ea0769b871ba191b7ff9162252afb8f3",
+          "workflow_run": "https://github.com/kanta13jp1/my_web_app/actions/runs/32627164504",
+          "production_url": "https://my-web-app-b67f4.web.app/assets/assets/data/tiger_course_review_status.json",
+          "release_status": "passed"
+        },
+        "findings_without_individual_trace": [
+          "course-model-list-freshness",
+          "course-model-list-learner-proof"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T153734+0900",
+      "started_at": "2026-08-23T15:38:16.4383006+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "site",
+        "id": "comparison",
+        "title": "comparison",
+        "url": "https://my-web-app-b67f4.web.app/competitors"
+      },
+      "reviewer": {
+        "seat": 7,
+        "name": "榊󠄀原 清一",
+        "selection_score": 74.4337
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "comparison-claim-evidence",
+          "summary": "競合比較の公開主張に出典・確認時点を一貫して結び付ける必要がある。",
+          "severity": "p1",
+          "suggested_action": "競合別の価格・機能主張について、出典URLと最終確認日を管理する別レビューを行う。"
+        },
+        {
+          "finding_id": "comparison-funnel-evidence",
+          "summary": "比較流入から登録までの実測根拠が今回のレビュー入力にない。",
+          "severity": "p2",
+          "suggested_action": "既存計測の匿名集計を別運用で確認し、比較到達・CTA・登録のファネルを根拠化する。"
+        },
+        {
+          "finding_id": "comparison-maintainability",
+          "summary": "比較ページの巨大な単一ソースと専用試験不足が訴求変更の検証コストを高めている。",
+          "severity": "p2",
+          "suggested_action": "別タスクで競合データと表示部を分離し、代表ルートのCTA・比較表をウィジェット試験で固定する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4739 追跡中",
+        "detail": "3件はいずれも再現可能な証拠を持つが、公開比較主張、分析データ、または大規模な構造変更に関わる。安全な自動修正、低リスク、3ファイル・200行以内の全条件を満たす変更はない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "select_feature.py: passed (13 features)",
+          "select_reviewer.py: passed (125 profiles; JSON output saved)",
+          "public Data API catalog export: passed (active=1071, reviewable=526, excluded source URL=536)",
+          "select_course.py: passed",
+          "01.AI source URL inspection: reachable; only generic documentation navigation was observable",
+          "comparison source and test filename inspection: completed"
+        ],
+        "issue": {
+          "number": 4739,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4739",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-legacy-review:20260823T153734+0900:comparison"
+        },
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "comparison-claim-evidence",
+          "comparison-funnel-evidence",
+          "comparison-maintainability"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T152316+0900",
+      "started_at": "2026-08-23T15:24:30+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "site",
+        "id": "ai_university",
+        "title": "ai_university",
+        "url": "https://my-web-app-b67f4.web.app/#/ai-university"
+      },
+      "reviewer": {
+        "seat": 1,
+        "name": "ドラゴン細井",
+        "selection_score": 79.5059
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "course-freshness-review",
+          "summary": "選出講座に出典更新確認の運用が必要。",
+          "severity": "p2",
+          "suggested_action": "公式出典の確認日と更新検知を講座運用で記録し、再確認対象を明示する。"
+        },
+        {
+          "finding_id": "course-outcome-evidence",
+          "summary": "講座選定データに学習成果の根拠がない。",
+          "severity": "p2",
+          "suggested_action": "講座編集の別タスクで、対象者・到達行動・確認方法を根拠付きで管理する。"
+        },
+        {
+          "finding_id": "content-failure-observability",
+          "summary": "教材取得失敗時の事業影響を測定できない。",
+          "severity": "p2",
+          "suggested_action": "別の計測設計レビューで、失敗・再試行・フォールバック表示を匿名かつ最小限に観測する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4738 追跡中",
+        "detail": "3件はいずれも証拠に基づくが、講座運用・計測設計または利用データを要し、低リスク自動修正の条件を満たす変更はない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "public Data API catalog export: passed (active=1071, reviewable=526)",
+          "select_feature.py: passed",
+          "select_reviewer.py: passed (125 profiles)",
+          "select_course.py: passed",
+          "AI University browser inspection: blocked by browser URL safety policy; no workaround attempted"
+        ],
+        "issue": {
+          "number": 4738,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4738",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-legacy-review:20260823T152316+0900:ai_university"
+        },
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "course-freshness-review",
+          "course-outcome-evidence",
+          "content-failure-observability"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T152239+0900",
+      "started_at": "2026-08-23T15:22:47+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "site",
+        "id": "ai_university",
+        "title": "ai_university",
+        "url": "https://my-web-app-b67f4.web.app/ai-university"
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 73.5265
+      },
+      "status": "implemented",
+      "review_status": "fixed",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "ai_university_catalog_pagination",
+          "summary": "AI大学の主カタログ取得をページングし、PostgRESTの1,000行上限を超える有効講座も表示対象にする。",
+          "severity": "p2",
+          "suggested_action": "sort_orderとidで安定順序を付け、1,000件単位で全有効行を取得する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "implemented",
+        "label": "対策実施・検証済み",
+        "detail": "個別の指摘IDとの紐付けも記録済みです。",
+        "summary": "主カタログに安定順序のページングを追加し、回帰契約テストを更新した。",
+        "files": [
+          "lib/pages/gemini_university_v2_page.dart",
+          "test/pages/ai_university_published_video_fetch_contract_test.dart"
+        ],
+        "lines_changed": 27,
+        "resolved_finding_ids": [
+          "ai_university_catalog_pagination"
+        ],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "flutter test test/pages/ai_university_published_video_fetch_contract_test.dart: passed",
+          "dart analyze changed files: passed"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": []
+      }
+    },
+    {
+      "cycle_id": "20260823T150231+0900",
+      "started_at": "2026-08-23T15:02:31+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "site",
+        "id": "home",
+        "title": "home",
+        "url": "https://my-web-app-b67f4.web.app/"
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 77.7529
+      },
+      "status": "blocked",
+      "review_status": "blocked",
+      "validation_status": "not_applicable",
+      "findings": [],
+      "countermeasure": {
+        "state": "blocked",
+        "label": "対策状況を確認できません",
+        "detail": "origin/main への fast-forward 同期不能と、アクティブ講座カタログの取得不能。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "not_applicable",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "course catalog export: unavailable",
+          "worktree fast-forward: unavailable"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": []
+      }
+    }
+  ],
+  "reviewers": [
     {
       "seat": 7,
       "name": "榊󠄀原 清一",
-      "tier": "division_1",
-      "division": 1,
-      "provisional": false,
+      "tier": "division_3",
+      "division": 3,
+      "provisional": true,
       "eligible": true,
       "floor_protected": false,
       "utility_score": 90.17,
-      "completed_cycles": 2,
+      "completed_cycles": 1,
       "low_utility_streak": 0,
       "last_cycle_utility": 90.17,
       "last_selected_at": "2026-08-23T06:38:16.438300+00:00",
-      "reason": "担当2回・効用90.2点で1部"
+      "reason": "担当実績が2回未満のため暫定3部"
     },
     {
       "seat": 12,
@@ -121,17 +643,32 @@
     {
       "seat": 1,
       "name": "ドラゴン細井",
+      "tier": "division_3",
+      "division": 3,
+      "provisional": true,
+      "eligible": true,
+      "floor_protected": false,
+      "utility_score": 89.75,
+      "completed_cycles": 1,
+      "low_utility_streak": 0,
+      "last_cycle_utility": 89.75,
+      "last_selected_at": "2026-08-23T06:24:30+00:00",
+      "reason": "担当実績が2回未満のため暫定3部"
+    },
+    {
+      "seat": 11,
+      "name": "野口 功司",
       "tier": "division_1",
       "division": 1,
       "provisional": false,
       "eligible": true,
       "floor_protected": false,
-      "utility_score": 89.75,
-      "completed_cycles": 2,
+      "utility_score": 87.33,
+      "completed_cycles": 3,
       "low_utility_streak": 0,
-      "last_cycle_utility": 89.75,
-      "last_selected_at": "2026-08-23T06:24:30+00:00",
-      "reason": "担当2回・効用89.8点で1部"
+      "last_cycle_utility": 95.5,
+      "last_selected_at": "2026-08-23T08:21:38+00:00",
+      "reason": "担当3回・効用87.3点で1部"
     },
     {
       "seat": 9,

--- a/assets/data/tiger_site_review_status.json
+++ b/assets/data/tiger_site_review_status.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "generated_at": "2026-08-23T07:30:49.914416+00:00",
+  "generated_at": "2026-08-23T09:36:35.581494+00:00",
   "disclaimer": "公開情報から構築した証拠付きシミュレーションです。本人による実レビュー、発言、推薦を示すものではありません。",
   "lane": "site_review",
   "publication_state": "latest_review",
@@ -10,7 +10,7 @@
     "status": "ACTIVE",
     "schedule": "毎時25分（1時間ごと）"
   },
-  "review_count": 8,
+  "review_count": 4,
   "latest_review": {
     "cycle_id": "20260823T153734+0900",
     "started_at": "2026-08-23T15:38:16.4383006+09:00",
@@ -23,7 +23,7 @@
       "seat": 7,
       "name": "榊󠄀原 清一",
       "selection_score": 74.4337,
-      "division": 1,
+      "division": 3,
       "cycle_utility": 90.17,
       "aggregate_utility": 90.17
     },
@@ -55,6 +55,274 @@
           "founder_execution"
         ]
       }
-    ]
-  }
+    ],
+    "countermeasure": {
+      "state": "issue_tracking",
+      "label": "未対策・Issue #4739 追跡中",
+      "detail": "3件はいずれも再現可能な証拠を持つが、公開比較主張、分析データ、または大規模な構造変更に関わる。安全な自動修正、低リスク、3ファイル・200行以内の全条件を満たす変更はない。",
+      "summary": "",
+      "files": [],
+      "lines_changed": 0,
+      "resolved_finding_ids": [],
+      "validation_status": "passed",
+      "validation_messages": [
+        "validate_roster.py: passed",
+        "validate_personas.py: passed",
+        "select_feature.py: passed (13 features)",
+        "select_reviewer.py: passed (125 profiles; JSON output saved)",
+        "public Data API catalog export: passed (active=1071, reviewable=526, excluded source URL=536)",
+        "select_course.py: passed",
+        "01.AI source URL inspection: reachable; only generic documentation navigation was observable",
+        "comparison source and test filename inspection: completed"
+      ],
+      "issue": {
+        "number": 4739,
+        "url": "https://github.com/kanta13jp1/my_web_app/issues/4739",
+        "status": "existing",
+        "github_state": "OPEN",
+        "dedupe_key": "tiger-legacy-review:20260823T153734+0900:comparison"
+      },
+      "implementation": null,
+      "findings_without_individual_trace": [
+        "comparison-claim-evidence",
+        "comparison-funnel-evidence",
+        "comparison-maintainability"
+      ]
+    }
+  },
+  "history": [
+    {
+      "cycle_id": "20260823T153734+0900",
+      "started_at": "2026-08-23T15:38:16.4383006+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "site",
+        "id": "comparison",
+        "title": "comparison",
+        "url": "https://my-web-app-b67f4.web.app/competitors"
+      },
+      "reviewer": {
+        "seat": 7,
+        "name": "榊󠄀原 清一",
+        "selection_score": 74.4337
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "comparison-claim-evidence",
+          "summary": "競合比較の公開主張に出典・確認時点を一貫して結び付ける必要がある。",
+          "severity": "p1",
+          "suggested_action": "競合別の価格・機能主張について、出典URLと最終確認日を管理する別レビューを行う。"
+        },
+        {
+          "finding_id": "comparison-funnel-evidence",
+          "summary": "比較流入から登録までの実測根拠が今回のレビュー入力にない。",
+          "severity": "p2",
+          "suggested_action": "既存計測の匿名集計を別運用で確認し、比較到達・CTA・登録のファネルを根拠化する。"
+        },
+        {
+          "finding_id": "comparison-maintainability",
+          "summary": "比較ページの巨大な単一ソースと専用試験不足が訴求変更の検証コストを高めている。",
+          "severity": "p2",
+          "suggested_action": "別タスクで競合データと表示部を分離し、代表ルートのCTA・比較表をウィジェット試験で固定する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4739 追跡中",
+        "detail": "3件はいずれも再現可能な証拠を持つが、公開比較主張、分析データ、または大規模な構造変更に関わる。安全な自動修正、低リスク、3ファイル・200行以内の全条件を満たす変更はない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "select_feature.py: passed (13 features)",
+          "select_reviewer.py: passed (125 profiles; JSON output saved)",
+          "public Data API catalog export: passed (active=1071, reviewable=526, excluded source URL=536)",
+          "select_course.py: passed",
+          "01.AI source URL inspection: reachable; only generic documentation navigation was observable",
+          "comparison source and test filename inspection: completed"
+        ],
+        "issue": {
+          "number": 4739,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4739",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-legacy-review:20260823T153734+0900:comparison"
+        },
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "comparison-claim-evidence",
+          "comparison-funnel-evidence",
+          "comparison-maintainability"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T152316+0900",
+      "started_at": "2026-08-23T15:24:30+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "site",
+        "id": "ai_university",
+        "title": "ai_university",
+        "url": "https://my-web-app-b67f4.web.app/#/ai-university"
+      },
+      "reviewer": {
+        "seat": 1,
+        "name": "ドラゴン細井",
+        "selection_score": 79.5059
+      },
+      "status": "issue_tracking",
+      "review_status": "review_only",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "course-freshness-review",
+          "summary": "選出講座に出典更新確認の運用が必要。",
+          "severity": "p2",
+          "suggested_action": "公式出典の確認日と更新検知を講座運用で記録し、再確認対象を明示する。"
+        },
+        {
+          "finding_id": "course-outcome-evidence",
+          "summary": "講座選定データに学習成果の根拠がない。",
+          "severity": "p2",
+          "suggested_action": "講座編集の別タスクで、対象者・到達行動・確認方法を根拠付きで管理する。"
+        },
+        {
+          "finding_id": "content-failure-observability",
+          "summary": "教材取得失敗時の事業影響を測定できない。",
+          "severity": "p2",
+          "suggested_action": "別の計測設計レビューで、失敗・再試行・フォールバック表示を匿名かつ最小限に観測する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "issue_tracking",
+        "label": "未対策・Issue #4738 追跡中",
+        "detail": "3件はいずれも証拠に基づくが、講座運用・計測設計または利用データを要し、低リスク自動修正の条件を満たす変更はない。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "public Data API catalog export: passed (active=1071, reviewable=526)",
+          "select_feature.py: passed",
+          "select_reviewer.py: passed (125 profiles)",
+          "select_course.py: passed",
+          "AI University browser inspection: blocked by browser URL safety policy; no workaround attempted"
+        ],
+        "issue": {
+          "number": 4738,
+          "url": "https://github.com/kanta13jp1/my_web_app/issues/4738",
+          "status": "existing",
+          "github_state": "OPEN",
+          "dedupe_key": "tiger-legacy-review:20260823T152316+0900:ai_university"
+        },
+        "implementation": null,
+        "findings_without_individual_trace": [
+          "course-freshness-review",
+          "course-outcome-evidence",
+          "content-failure-observability"
+        ]
+      }
+    },
+    {
+      "cycle_id": "20260823T152239+0900",
+      "started_at": "2026-08-23T15:22:47+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "site",
+        "id": "ai_university",
+        "title": "ai_university",
+        "url": "https://my-web-app-b67f4.web.app/ai-university"
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 73.5265
+      },
+      "status": "implemented",
+      "review_status": "fixed",
+      "validation_status": "passed",
+      "findings": [
+        {
+          "finding_id": "ai_university_catalog_pagination",
+          "summary": "AI大学の主カタログ取得をページングし、PostgRESTの1,000行上限を超える有効講座も表示対象にする。",
+          "severity": "p2",
+          "suggested_action": "sort_orderとidで安定順序を付け、1,000件単位で全有効行を取得する。"
+        }
+      ],
+      "countermeasure": {
+        "state": "implemented",
+        "label": "対策実施・検証済み",
+        "detail": "個別の指摘IDとの紐付けも記録済みです。",
+        "summary": "主カタログに安定順序のページングを追加し、回帰契約テストを更新した。",
+        "files": [
+          "lib/pages/gemini_university_v2_page.dart",
+          "test/pages/ai_university_published_video_fetch_contract_test.dart"
+        ],
+        "lines_changed": 27,
+        "resolved_finding_ids": [
+          "ai_university_catalog_pagination"
+        ],
+        "validation_status": "passed",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "flutter test test/pages/ai_university_published_video_fetch_contract_test.dart: passed",
+          "dart analyze changed files: passed"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": []
+      }
+    },
+    {
+      "cycle_id": "20260823T150231+0900",
+      "started_at": "2026-08-23T15:02:31+09:00",
+      "source_format": "legacy_combined",
+      "subject": {
+        "kind": "site",
+        "id": "home",
+        "title": "home",
+        "url": "https://my-web-app-b67f4.web.app/"
+      },
+      "reviewer": {
+        "seat": 11,
+        "name": "野口 功司",
+        "selection_score": 77.7529
+      },
+      "status": "blocked",
+      "review_status": "blocked",
+      "validation_status": "not_applicable",
+      "findings": [],
+      "countermeasure": {
+        "state": "blocked",
+        "label": "対策状況を確認できません",
+        "detail": "origin/main への fast-forward 同期不能と、アクティブ講座カタログの取得不能。",
+        "summary": "",
+        "files": [],
+        "lines_changed": 0,
+        "resolved_finding_ids": [],
+        "validation_status": "not_applicable",
+        "validation_messages": [
+          "validate_roster.py: passed",
+          "validate_personas.py: passed",
+          "course catalog export: unavailable",
+          "worktree fast-forward: unavailable"
+        ],
+        "issue": {},
+        "implementation": null,
+        "findings_without_individual_trace": []
+      }
+    }
+  ]
 }

--- a/lib/models/tiger_review_lane_status.dart
+++ b/lib/models/tiger_review_lane_status.dart
@@ -9,6 +9,7 @@ class TigerReviewLaneStatus {
     required this.automation,
     required this.pool,
     required this.latest,
+    required this.history,
     required this.entries,
     required this.disclaimer,
   });
@@ -20,6 +21,7 @@ class TigerReviewLaneStatus {
   final TigerLaneAutomation automation;
   final Map<String, dynamic> pool;
   final Map<String, dynamic>? latest;
+  final List<Map<String, dynamic>> history;
   final List<Map<String, dynamic>> entries;
   final String disclaimer;
 
@@ -58,6 +60,7 @@ class TigerReviewLaneStatus {
             ? json['latest_assignment']
             : json['latest_review'],
       ),
+      history: _mapList(json['history']),
       entries: rawEntries is List
           ? rawEntries
               .whereType<Map>()
@@ -67,6 +70,15 @@ class TigerReviewLaneStatus {
       disclaimer: json['disclaimer']?.toString() ?? '',
     );
   }
+}
+
+List<Map<String, dynamic>> _mapList(Object? value) {
+  return value is List
+      ? value
+          .whereType<Map>()
+          .map((entry) => Map<String, dynamic>.from(entry))
+          .toList(growable: false)
+      : const <Map<String, dynamic>>[];
 }
 
 class TigerLaneAutomation {

--- a/lib/pages/tiger_review_lane_status_page.dart
+++ b/lib/pages/tiger_review_lane_status_page.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../models/tiger_review_lane_status.dart';
 
@@ -70,9 +73,9 @@ class TigerReviewHubPage extends StatelessWidget {
         children: <Widget>[
           Text(
             '4系統は独立して実行・集計・公開されます',
-            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.w800,
-                ),
+            style: Theme.of(
+              context,
+            ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
           ),
           const SizedBox(height: 8),
           const Text('各レビューは125名から現在の状況に合う虎1名だけを選出します。'),
@@ -95,11 +98,7 @@ class TigerReviewHubPage extends StatelessWidget {
 }
 
 class TigerReviewLaneStatusPage extends StatefulWidget {
-  const TigerReviewLaneStatusPage({
-    super.key,
-    required this.kind,
-    this.loader,
-  });
+  const TigerReviewLaneStatusPage({super.key, required this.kind, this.loader});
 
   final TigerReviewLane kind;
   final TigerLaneStatusLoader? loader;
@@ -218,20 +217,46 @@ class _LaneContent extends StatelessWidget {
                           if (status.pool.isNotEmpty)
                             const SizedBox(height: 12),
                           _LatestCard(kind: kind, latest: status.latest),
-                          if (status.entries.isNotEmpty) ...<Widget>[
-                            const SizedBox(height: 18),
-                            Text(
-                              _entriesTitle(kind),
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .titleLarge
-                                  ?.copyWith(fontWeight: FontWeight.w800),
-                            ),
-                            const SizedBox(height: 8),
-                          ],
+                          const SizedBox(height: 18),
+                          _SectionHeading(
+                            title: 'レビュー履歴',
+                            count: status.history.length,
+                            emptyLabel: '公開済みのレビュー履歴はありません。',
+                          ),
                         ],
                       ),
                     ),
+                    if (status.history.isNotEmpty)
+                      SliverPadding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: horizontalPadding,
+                        ),
+                        sliver: SliverList.builder(
+                          itemCount: status.history.length,
+                          itemBuilder: (context, index) => _HistoryReviewCard(
+                            kind: kind,
+                            review: status.history[index],
+                          ),
+                        ),
+                      ),
+                    if (status.entries.isNotEmpty)
+                      SliverPadding(
+                        padding: EdgeInsets.fromLTRB(
+                          horizontalPadding,
+                          18,
+                          horizontalPadding,
+                          8,
+                        ),
+                        sliver: SliverToBoxAdapter(
+                          child: Text(
+                            _entriesTitle(kind),
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleLarge
+                                ?.copyWith(fontWeight: FontWeight.w800),
+                          ),
+                        ),
+                      ),
                     if (status.entries.isNotEmpty)
                       SliverPadding(
                         padding: EdgeInsets.symmetric(
@@ -270,6 +295,346 @@ class _LaneContent extends StatelessWidget {
       },
     );
   }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({
+    required this.title,
+    required this.count,
+    required this.emptyLabel,
+  });
+
+  final String title;
+  final int count;
+  final String emptyLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Wrap(
+          spacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: <Widget>[
+            Text(
+              title,
+              style: Theme.of(
+                context,
+              ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
+            ),
+            Chip(label: Text('全$count件')),
+          ],
+        ),
+        if (count == 0) ...<Widget>[
+          const SizedBox(height: 8),
+          Text(emptyLabel),
+        ] else
+          const SizedBox(height: 8),
+      ],
+    );
+  }
+}
+
+class _HistoryReviewCard extends StatelessWidget {
+  const _HistoryReviewCard({required this.kind, required this.review});
+
+  final TigerReviewLane kind;
+  final Map<String, dynamic> review;
+
+  @override
+  Widget build(BuildContext context) {
+    final subject = _asMap(review['subject']);
+    final reviewer = _asMap(review['reviewer']);
+    final countermeasure = _asMap(review['countermeasure']);
+    final findings = _asMapList(review['findings']);
+    final resolvedIds = (countermeasure['resolved_finding_ids'] as List?)
+            ?.map((value) => value.toString())
+            .toSet() ??
+        <String>{};
+    final state = countermeasure['state']?.toString() ??
+        review['status']?.toString() ??
+        'unverified';
+    final cycleId = review['cycle_id']?.toString() ?? 'unknown';
+    final title = subject['title']?.toString().trim();
+    final subjectLabel = title == null || title.isEmpty
+        ? subject['id']?.toString() ?? '対象不明'
+        : title;
+    final reviewerName = reviewer['name']?.toString() ?? '担当虎不明';
+    final seat = reviewer['seat'];
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: ExpansionTile(
+        key: Key('tiger-history-${kind.lane}-$cycleId'),
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 18),
+        title: Text(
+          subjectLabel,
+          style: const TextStyle(fontWeight: FontWeight.w700),
+        ),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 6),
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 6,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: <Widget>[
+              Text(_formatTimestamp(review['started_at'])),
+              Text('$reviewerName${seat == null ? '' : '（席 $seat）'}'),
+              _TraceBadge(state: state, label: countermeasure['label']),
+            ],
+          ),
+        ),
+        children: <Widget>[
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _HistoryDetails(
+              cycleId: cycleId,
+              review: review,
+              countermeasure: countermeasure,
+              findings: findings,
+              resolvedIds: resolvedIds,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HistoryDetails extends StatelessWidget {
+  const _HistoryDetails({
+    required this.cycleId,
+    required this.review,
+    required this.countermeasure,
+    required this.findings,
+    required this.resolvedIds,
+  });
+
+  final String cycleId;
+  final Map<String, dynamic> review;
+  final Map<String, dynamic> countermeasure;
+  final List<Map<String, dynamic>> findings;
+  final Set<String> resolvedIds;
+
+  @override
+  Widget build(BuildContext context) {
+    final issue = _asMap(countermeasure['issue']);
+    final issueUrl = Uri.tryParse(issue['url']?.toString() ?? '');
+    final files = (countermeasure['files'] as List?)
+            ?.map((value) => value.toString())
+            .where((value) => value.isNotEmpty)
+            .toList(growable: false) ??
+        const <String>[];
+    final validationMessages = (countermeasure['validation_messages'] as List?)
+            ?.map((value) => value.toString())
+            .where((value) => value.isNotEmpty)
+            .toList(growable: false) ??
+        const <String>[];
+    final state = countermeasure['state']?.toString() ?? 'unverified';
+    final issueRequired = state == 'issue_required' || state == 'missing_issue';
+    final requiresFollowUp = <String>{
+      'follow_up_issued',
+      'issue_tracking',
+      'issue_closed',
+      'issue_required',
+      'missing_issue',
+    }.contains(state);
+    final implementation = _asMap(countermeasure['implementation']);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Divider(),
+        Text('レビューID: $cycleId'),
+        Text('レビュー結果: ${review['review_status'] ?? '—'}'),
+        Text('検証: ${review['validation_status'] ?? '—'}'),
+        if ((countermeasure['detail']?.toString() ?? '')
+            .isNotEmpty) ...<Widget>[
+          const SizedBox(height: 8),
+          Text(countermeasure['detail'].toString()),
+        ],
+        if ((countermeasure['summary']?.toString() ?? '')
+            .isNotEmpty) ...<Widget>[
+          const SizedBox(height: 6),
+          Text('対策記録: ${countermeasure['summary']}'),
+        ],
+        if (files.isNotEmpty) ...<Widget>[
+          const SizedBox(height: 6),
+          Text('変更ファイル: ${files.join('、')}'),
+        ],
+        if (validationMessages.isNotEmpty) ...<Widget>[
+          const SizedBox(height: 6),
+          Text('検証記録: ${validationMessages.join(' / ')}'),
+        ],
+        if (implementation.isNotEmpty) ...<Widget>[
+          const SizedBox(height: 6),
+          Text('本番反映コミット: ${implementation['commit_sha'] ?? '—'}'),
+          Text('リリース検証: ${implementation['release_status'] ?? '—'}'),
+          if ((implementation['workflow_run']?.toString() ?? '').isNotEmpty)
+            Text('Workflow: ${implementation['workflow_run']}'),
+          if ((implementation['production_url']?.toString() ?? '').isNotEmpty)
+            Text('公開先: ${implementation['production_url']}'),
+        ],
+        const SizedBox(height: 14),
+        Text(
+          '指摘と対策状況',
+          style: Theme.of(
+            context,
+          ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 6),
+        if (findings.isEmpty)
+          const Text('有効な指摘は記録されていません。')
+        else
+          for (final finding in findings)
+            _FindingTrace(
+              finding: finding,
+              implemented: resolvedIds.contains(
+                finding['finding_id']?.toString(),
+              ),
+              requiresFollowUp: requiresFollowUp,
+            ),
+        const SizedBox(height: 12),
+        if (issueUrl != null && issueUrl.isAbsolute)
+          FilledButton.tonalIcon(
+            key: Key('tiger-history-issue-$cycleId'),
+            onPressed: () => unawaited(
+              launchUrl(issueUrl, mode: LaunchMode.externalApplication),
+            ),
+            icon: const Icon(Icons.open_in_new),
+            label: Text(
+              '対応Issue #${issue['number'] ?? ''}を開く'
+              '${issue['github_state'] == 'CLOSED' ? '（終了）' : ''}',
+            ),
+          )
+        else if (issueRequired)
+          Text(
+            'Issue未発行（公開データ不整合）',
+            key: Key('tiger-history-issue-missing-$cycleId'),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.error,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _FindingTrace extends StatelessWidget {
+  const _FindingTrace({
+    required this.finding,
+    required this.implemented,
+    required this.requiresFollowUp,
+  });
+
+  final Map<String, dynamic> finding;
+  final bool implemented;
+  final bool requiresFollowUp;
+
+  @override
+  Widget build(BuildContext context) {
+    final action = finding['suggested_action']?.toString() ?? '';
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(
+            implemented ? Icons.check_circle_outline : Icons.pending_actions,
+            size: 20,
+            color: implemented
+                ? Colors.green.shade700
+                : Theme.of(context).colorScheme.tertiary,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(finding['summary']?.toString() ?? '指摘内容なし'),
+                if (action.isNotEmpty)
+                  Text(
+                    '推奨対策: $action',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                Text(
+                  implemented
+                      ? '対策実施済み'
+                      : requiresFollowUp
+                          ? '未対策'
+                          : '個別対策の紐付けなし',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w700),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TraceBadge extends StatelessWidget {
+  const _TraceBadge({required this.state, required this.label});
+
+  final String state;
+  final Object? label;
+
+  @override
+  Widget build(BuildContext context) {
+    final (background, foreground) = switch (state) {
+      'production_verified' || 'implemented' => (
+          Colors.green.shade100,
+          Colors.green.shade900
+        ),
+      'partially_implemented' => (
+          Colors.orange.shade100,
+          Colors.orange.shade900,
+        ),
+      'follow_up_issued' || 'issue_tracking' => (
+          Colors.amber.shade100,
+          Colors.amber.shade900
+        ),
+      'issue_closed' => (Colors.blue.shade100, Colors.blue.shade900),
+      'issue_required' || 'missing_issue' => (
+          Theme.of(context).colorScheme.errorContainer,
+          Theme.of(context).colorScheme.onErrorContainer,
+        ),
+      _ => (
+          Theme.of(context).colorScheme.surfaceContainerHighest,
+          Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label?.toString() ?? state,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: foreground,
+              fontWeight: FontWeight.w800,
+            ),
+      ),
+    );
+  }
+}
+
+String _formatTimestamp(Object? value) {
+  final raw = value?.toString() ?? '';
+  final parsed = DateTime.tryParse(raw);
+  if (parsed == null) return raw.isEmpty ? '日時不明' : raw;
+  final local = parsed.toLocal();
+  String two(int number) => number.toString().padLeft(2, '0');
+  return '${local.year}/${two(local.month)}/${two(local.day)} '
+      '${two(local.hour)}:${two(local.minute)}';
 }
 
 class _Hero extends StatelessWidget {
@@ -355,9 +720,9 @@ class _Metric extends StatelessWidget {
           Text(label, style: Theme.of(context).textTheme.bodySmall),
           Text(
             value?.toString() ?? '—',
-            style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.w800,
-                ),
+            style: Theme.of(
+              context,
+            ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
           ),
         ],
       ),
@@ -470,4 +835,13 @@ String _entriesTitle(TigerReviewLane kind) => switch (kind) {
 
 Map<String, dynamic> _asMap(Object? value) {
   return value is Map ? Map<String, dynamic>.from(value) : <String, dynamic>{};
+}
+
+List<Map<String, dynamic>> _asMapList(Object? value) {
+  return value is List
+      ? value
+          .whereType<Map>()
+          .map((entry) => Map<String, dynamic>.from(entry))
+          .toList(growable: false)
+      : const <Map<String, dynamic>>[];
 }

--- a/test/models/tiger_review_lane_status_test.dart
+++ b/test/models/tiger_review_lane_status_test.dart
@@ -25,6 +25,23 @@ void main() {
 
       expect(status.schemaVersion, 3);
       expect(status.lane, testCase.$2);
+      expect(status.history, isNotEmpty);
+      expect(
+        status.history.first['cycle_id'],
+        status.latest?['cycle_id'],
+      );
+      for (final review in status.history) {
+        final countermeasure = review['countermeasure'];
+        expect(countermeasure, isA<Map>());
+        if (review['review_status'] == 'review_only' &&
+            review['validation_status'] == 'passed') {
+          expect(
+            (countermeasure as Map)['issue'],
+            isNotEmpty,
+            reason: '${review['cycle_id']} must have follow-up Issue evidence',
+          );
+        }
+      }
       if (testCase.$3 == 'reviewers') {
         expect(status.entries, hasLength(125));
       }

--- a/test/pages/tiger_review_lane_status_page_test.dart
+++ b/test/pages/tiger_review_lane_status_page_test.dart
@@ -56,6 +56,77 @@ void main() {
     expect(find.text('公開データの系統が一致しません。'), findsOneWidget);
   });
 
+  testWidgets('lane exposes every review and its countermeasure Issue', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TigerReviewLaneStatusPage(
+          kind: TigerReviewLane.courses,
+          loader: () async => _status(
+            lane: 'course_review',
+            history: <Map<String, dynamic>>[
+              _history(
+                cycleId: 'cycle-new',
+                state: 'follow_up_issued',
+                issueNumber: 4737,
+              ),
+              _history(
+                cycleId: 'cycle-old',
+                state: 'implemented',
+                resolved: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('全2件'), findsOneWidget);
+    expect(
+      find.byKey(const Key('tiger-history-course_review-cycle-new')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('tiger-history-course_review-cycle-old')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('tiger-history-course_review-cycle-new')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('未対策'), findsOneWidget);
+    expect(find.text('対応Issue #4737を開く'), findsOneWidget);
+  });
+
+  testWidgets('untracked countermeasure is surfaced as a data error', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TigerReviewLaneStatusPage(
+          kind: TigerReviewLane.site,
+          loader: () async => _status(
+            lane: 'site_review',
+            history: <Map<String, dynamic>>[
+              _history(cycleId: 'missing-issue', state: 'issue_required'),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('tiger-history-site_review-missing-issue')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Issue未発行（公開データ不整合）'), findsOneWidget);
+  });
+
   testWidgets('narrow lane reloads without a layout exception', (tester) async {
     tester.view.physicalSize = const Size(360, 800);
     tester.view.devicePixelRatio = 1;
@@ -69,7 +140,16 @@ void main() {
           kind: TigerReviewLane.features,
           loader: () async {
             loadCount += 1;
-            return _status(lane: 'feature_review');
+            return _status(
+              lane: 'feature_review',
+              history: <Map<String, dynamic>>[
+                _history(
+                  cycleId: 'narrow-history',
+                  state: 'follow_up_issued',
+                  issueNumber: 99,
+                ),
+              ],
+            );
           },
         ),
       ),
@@ -86,12 +166,19 @@ void main() {
 
     expect(loadCount, 2);
     expect(tester.takeException(), isNull);
+
+    await tester.tap(
+      find.byKey(const Key('tiger-history-feature_review-narrow-history')),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
   });
 }
 
 TigerReviewLaneStatus _status({
   required String lane,
   List<Map<String, dynamic>> entries = const <Map<String, dynamic>>[],
+  List<Map<String, dynamic>> history = const <Map<String, dynamic>>[],
 }) {
   return TigerReviewLaneStatus(
     schemaVersion: 3,
@@ -114,7 +201,52 @@ TigerReviewLaneStatus _status({
       'division_5': 0,
     },
     latest: null,
+    history: history,
     entries: entries,
     disclaimer: 'simulation',
   );
+}
+
+Map<String, dynamic> _history({
+  required String cycleId,
+  required String state,
+  int? issueNumber,
+  bool resolved = false,
+}) {
+  return <String, dynamic>{
+    'cycle_id': cycleId,
+    'started_at': '2026-08-23T18:00:00+09:00',
+    'subject': <String, dynamic>{
+      'kind': 'course',
+      'id': 'course-1',
+      'title': 'レビュー対象',
+    },
+    'reviewer': <String, dynamic>{'seat': 12, 'name': '担当虎'},
+    'review_status': resolved ? 'fixed' : 'review_only',
+    'validation_status': 'passed',
+    'findings': <Map<String, dynamic>>[
+      <String, dynamic>{
+        'finding_id': 'finding-1',
+        'summary': '改善が必要です。',
+        'suggested_action': '根拠を追加する。',
+      },
+    ],
+    'countermeasure': <String, dynamic>{
+      'state': state,
+      'label': switch (state) {
+        'implemented' => '対策実施・検証済み',
+        'follow_up_issued' => '未実施・Issue起票済み',
+        _ => '未対策・Issue未発行',
+      },
+      'detail': '対策状況の詳細',
+      'resolved_finding_ids': resolved ? <String>['finding-1'] : <String>[],
+      'validation_messages': <String>['flutter test: passed'],
+      if (issueNumber != null)
+        'issue': <String, dynamic>{
+          'number': issueNumber,
+          'url': 'https://github.com/kanta13jp1/my_web_app/issues/$issueNumber',
+          'status': 'created',
+        },
+    },
+  };
 }


### PR DESCRIPTION
## 概要

虎レビューの4画面で、最新結果だけでなく公開済みの全レビュー履歴を確認できるようにしました。各履歴から対策状況、検証証拠、指摘単位の対応、GitHub Issueを追跡できます。

## 変更内容

- レビュアー8件、サイト4件、講座5件、機能6件の履歴を公開JSONへ収録
- 4画面共通の折りたたみ式履歴UIを追加
- 対策済み・未対策・Issue追跡中・確認不可を表示
- 対策ファイル、検証結果、コミット・Workflow・公開先の証拠を表示
- review_onlyなのにIssue証拠がない公開JSON生成を拒否
- 過去の未対策レビューを #4734、#4737、#4738、#4739 で追跡

## 検証

- `flutter test test/pages/tiger_review_lane_status_page_test.dart test/models/tiger_review_lane_status_test.dart` — 10件成功
- 対象4ファイルの `flutter analyze` — 警告0件
- `flutter build web --release` — 成功
- 共有Pythonテスト — 15件成功
- 共有スキル4件のquick validation — 成功
- GitHub Issue 4件の実在・OPEN状態を照合
- デスクトップおよび390px幅で履歴展開、対策バッジ、Issue導線、スクロールを確認
- ブラウザの新規エラーなし（既存のNotoフォント警告のみ）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

## リスクと復旧

読み取り専用の公開履歴UIとJSON追加です。認証、決済、DB、migration、secret、workflow、インフラは変更していません。問題時はこの単一コミットをrevertし、従来の最新結果表示へ戻せます。