### PR TITLE
fix: 空の虎レビューIssue証跡を非表示にする

### DIFF
--- a/lib/models/tiger_review_lane_status.dart
+++ b/lib/models/tiger_review_lane_status.dart
@@ -303,7 +303,9 @@ List<Map<String, dynamic>> _list(Object? value) {
 
 TigerFollowUpIssue? _followUpIssue(Object? value) {
   final data = _nullableMap(value);
-  return data == null ? null : TigerFollowUpIssue.fromJson(data);
+  return data == null || data.isEmpty
+      ? null
+      : TigerFollowUpIssue.fromJson(data);
 }
 
 TigerReviewImplementation? _implementation(Object? value) {

--- a/test/models/tiger_review_lane_status_test.dart
+++ b/test/models/tiger_review_lane_status_test.dart
@@ -5,6 +5,14 @@ import 'package:my_web_app/models/tiger_review_lane_status.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  test('treats an empty Issue trace as not applicable', () {
+    final trace = TigerCountermeasureTrace.fromJson(<String, dynamic>{
+      'issue': <String, dynamic>{},
+    });
+
+    expect(trace.issue, isNull);
+  });
+
   for (final testCase in <(String, String, String)>[
     (
       'assets/data/tiger_reviewer_league_status.json',


### PR DESCRIPTION
## 概要

- 虎レビュー履歴の `issue: {}` を「Issue情報の形式エラー」と誤認する表示を修正
- 空の Issue 証跡は、対策済みなど Issue 不要のレビューとして扱う
- 空オブジェクトを対象にした回帰テストを追加

本番QAで、対策済みの機能レビューに「Issue情報の形式を確認できません。」が表示されることを確認したための追補修正です。未対策レビューの Issue リンク・追跡表示は維持します。

## 検証

- `flutter test test/models/tiger_review_lane_status_test.dart test/pages/tiger_review_lane_status_page_test.dart`（10件成功）
- `flutter analyze lib/models/tiger_review_lane_status.dart test/models/tiger_review_lane_status_test.dart`（問題なし）
- `git diff --check`（問題なし）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: This one-line JSON parser correction is covered by the new model regression test and the existing page widget tests; production browser QA will verify the visible warning is absent while Issue links remain available.