### PR TITLE
feat: 虎レビュアーの年齢・事業内容・肩書きを表示

### DIFF
--- a/assets/data/tiger_reviewer_profiles.json
+++ b/assets/data/tiger_reviewer_profiles.json
@@ -1,0 +1,2202 @@
+{
+  "schema_version": 1,
+  "snapshot_date": "2026-08-23",
+    "source_snapshot": "canonical tiger-personas.json (2026-08-23)",
+  "reviewer_count": 125,
+  "disclaimer": "年齢は生年月日を公開一次情報で確認できた場合のみ、スナップショット日時点で表示します。未確認の年齢は推測していません。肩書き・事業内容・出演実績は公開情報から構成したスナップショットです。",
+  "profiles": [
+    {
+      "seat": 1,
+      "name": "ドラゴン細井",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "アマソラクリニック 院長",
+      "business_summary": "医学部受験塾、美容クリニック、インドアゴルフ場、D2Cサプリ事業",
+      "business_domains": [
+        "教育・スクール",
+        "美容・ウェルネス",
+        "医療・介護・福祉",
+        "フランチャイズ・多店舗展開"
+      ],
+      "appearances": 151,
+      "investment_count": 56,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、愛のゴリ詰めタイプ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/hosoi-ryu/"
+    },
+    {
+      "seat": 2,
+      "name": "林 尚弘",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社FCチャンネル代表取締役、令和の虎二代目主宰、武田塾創業者",
+      "business_summary": "株式会社FCチャンネル：フランチャイズの本部支援、 林顧問制度：お茶だけ60分50万円の顧問制度、 とろり天使のわらび餅／癒し〜ぷ／開業チーター社長",
+      "business_domains": [
+        "フランチャイズ・多店舗展開",
+        "教育・スクール",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 558,
+      "investment_count": 211,
+      "public_viewpoint_summary": "直営事業をFC化して大規模展開した経験を背景に、再現可能な仕組み、加盟店採算、拡大速度を重視する。",
+      "profile_url": "https://reiwanotora.jp/hayashi/"
+    },
+    {
+      "seat": 3,
+      "name": "谷本 吉紹",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社エースタイルホールディングス代表",
+      "business_summary": "介護・障害福祉・医療・WEB・飲食・美容サロン・化粧品開発・美容機器開発販売・人材派遣・SNSマーケティング・AI活用支援",
+      "business_domains": [
+        "医療・介護・福祉",
+        "美容・ウェルネス",
+        "人材・採用・組織",
+        "マーケティング・メディア"
+      ],
+      "appearances": 102,
+      "investment_count": 41,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/tanimoto-yoshitsugu/"
+    },
+    {
+      "seat": 4,
+      "name": "桑田 龍征",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社組織の左腕代表株式会社通販の虎代表",
+      "business_summary": "通販事業、組織コンサル事業、塾事業、飲食事業etc…",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "小売・通販・EC",
+        "人材・採用・組織",
+        "教育・スクール"
+      ],
+      "appearances": 244,
+      "investment_count": 76,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、同じ経営者として対等な立場で議論する。 令和の虎の四文字【心数知愛】を持っている者なら出資は確実。 心＝情熱、発想力 数＝応援される力 知＝知識、伝える力 愛＝相手のことを考えられる力、向き合い力と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/kuwata-ryusei/"
+    },
+    {
+      "seat": 5,
+      "name": "安藤 功一郎",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "GA technologies（Thailand）代表取締役CEO",
+      "business_summary": "・株式会社Next Mission、 元自衛官特化型の人材紹介プラットフォーム、人材紹介業 / ・株式会社STEAD Technology/代表取締役CEO、 機能性アパレル（アパテック）の開発・販売",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "人材・採用・組織",
+        "営業・販売組織",
+        "美容・ウェルネス"
+      ],
+      "appearances": 155,
+      "investment_count": 64,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、我が事と思い、向き合い、寄り添いますと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/ando-koichiro/"
+    },
+    {
+      "seat": 6,
+      "name": "三浦 哲郎",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "トリアイナグループ会長",
+      "business_summary": "多角経営 メインはリユース",
+      "business_domains": [
+        "小売・通販・EC",
+        "教育・スクール",
+        "人材・採用・組織"
+      ],
+      "appearances": 64,
+      "investment_count": 27,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、伴走タイプ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/miura-tetsurou/"
+    },
+    {
+      "seat": 7,
+      "name": "榊󠄀原 清一",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社EMOLVA代表",
+      "business_summary": "11期目になる、企業SNSマーケティングの総合的なコンサルティングから実務までをを行う会社でございます。 / 具体的には企業のInstagram, TikTok, X(旧Twitter), YouTube等のSNSアカウントの運用代行やインフルエンサーを使ったプロモーションなど、SNSマーケティングの総合的な戦略立てから実行まで行なっております。",
+      "business_domains": [
+        "マーケティング・メディア",
+        "飲食・宿泊・接客",
+        "経営支援・コンサルティング",
+        "IT・SaaS・プラットフォーム"
+      ],
+      "appearances": 12,
+      "investment_count": 0,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、理詰めで本質を問うタイプ。 数字や論理は当然見ますが、それだけではありません。 人財版を運営している立場として、志願者の「信念」や「覚悟」も深掘りします。 ただし、人情で甘くなることはありません。 その信念は本物か、心構えは本気か——そこを突いていきます。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/sakakibara-seiichi/"
+    },
+    {
+      "seat": 8,
+      "name": "関口 ケント",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ウェンズデイ代表取締役",
+      "business_summary": "• YouTube・SNS・地上波を横断したIP／番組プロデュース、 • 芸能人・クリエイター・企業公式チャンネルの企画運営・成長支援、 • テレビコンテンツのDX（デジタル展開・見逃し配信・SNS活用）支援、 • 怪談・ホラー領域に特化したメディア／イベント／コミュニティ開発、 • ファンコミュニティを基盤としたマーケティング設計・KGI達成支援、 • YouTubeコンサルティング・MCN／レーベル事業の構築・運営、 • 地上波×YouTube×リアルイベントのクロスメディア展開、 • 社会貢献型エンタメ（チャリティー配信・寄付企画）の企画運営、 • 新規メディア・新規IP・新規事業の立ち上げとプロデュース、 • 経営者向け顧問・事業伴走支援",
+      "business_domains": [
+        "マーケティング・メディア",
+        "エンタメ・クリエイター",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 32,
+      "investment_count": 10,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、理論の上でパッションと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/sekiguchi-kento/"
+    },
+    {
+      "seat": 9,
+      "name": "平出 心",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "プロ競馬予想屋「予想屋マスター」",
+      "business_summary": "知的財産権などの法律相談。競馬の予想コンサル。美容整体5店舗経営。",
+      "business_domains": [
+        "法務・会計・士業",
+        "美容・ウェルネス",
+        "経営支援・コンサルティング",
+        "教育・スクール"
+      ],
+      "appearances": 68,
+      "investment_count": 18,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、数字ゴリゴリタイプ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/hiraide-shin/"
+    },
+    {
+      "seat": 10,
+      "name": "島田 隆史",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社お客様みなさまおかげさま代表",
+      "business_summary": "飲食店経営",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "小売・通販・EC",
+        "フランチャイズ・多店舗展開",
+        "マーケティング・メディア"
+      ],
+      "appearances": 75,
+      "investment_count": 28,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、学歴は見ない。 数字も参考程度。 見るのは 「本気かどうか」だけ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/shimada-takashi/"
+    },
+    {
+      "seat": 11,
+      "name": "野口 功司",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社CBTソリューションズ代表",
+      "business_summary": "日商簿記や漢検、基本情報処理試験など資格検定を毎日コンピューターで全国320拠点で受験できる仕組みを構築。年間300万人以上が利用。年商100億超え達成。、 現在は100社100事業プロジェクトとして、100人の社長を育成中。経営者育成野口塾や、独自チャンネル「日本未来会議」などで日本の未来に情報を発信中。IT/AI事業を軸に新規ビジネスを立ち上げ。10以上の新規ビジネスに挑戦中。、 「令和の虎」だけでなく、「Nontitle」「就活NEO」など各種メディア出演中。",
+      "business_domains": [
+        "マーケティング・メディア",
+        "教育・スクール",
+        "人材・採用・組織",
+        "IT・SaaS・プラットフォーム"
+      ],
+      "appearances": 35,
+      "investment_count": 11,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、志願者ファースト。 人情派＋理論派の両方をバランス良く見るタイプ。 心技両面が揃っていなければ経営者としては成功しないと思っているので。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/noguchi-koji/"
+    },
+    {
+      "seat": 12,
+      "name": "迫 佑樹",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ブレイン代表",
+      "business_summary": "・知識共有プラットフォーム『Brain』開発、運営、 ・動画編集、ライティングなどのITスキルを学べるオンラインスクールの運営、 ・教育コンテンツの開発、販売、 ・Xポスト作成代行をはじめとしたtoB教育支援事業、 ・デジタル通貨SACOIN（サコイン）の発行、普及",
+      "business_domains": [
+        "教育・スクール",
+        "IT・SaaS・プラットフォーム",
+        "小売・通販・EC",
+        "マーケティング・メディア"
+      ],
+      "appearances": 6,
+      "investment_count": 1,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプだが、志願者のために厳しいことを発言することもある。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/sako-yuki/"
+    },
+    {
+      "seat": 13,
+      "name": "神田 みつき",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ルミナス代表取締役",
+      "business_summary": "飲食、芸能",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "エンタメ・クリエイター",
+        "人材・採用・組織",
+        "小売・通販・EC"
+      ],
+      "appearances": 39,
+      "investment_count": 12,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、本当にその人が成功できるためにはを第一に。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/kanda-mitsuki/"
+    },
+    {
+      "seat": 14,
+      "name": "田中 雄士",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ユージーエース代表",
+      "business_summary": "格闘技ジム、 不動産会社、 ヒップホップアーティスト活動、 アパレル、 安藤社長との共同事業冷感ポンチョなど",
+      "business_domains": [
+        "美容・ウェルネス",
+        "不動産・建設・住宅",
+        "エンタメ・クリエイター"
+      ],
+      "appearances": 81,
+      "investment_count": 20,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、今年は人情でいこかな。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/tanaka-yuji/"
+    },
+    {
+      "seat": 15,
+      "name": "桐原 隆",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "RAM Homes Allied Services Inc. 代表",
+      "business_summary": "フィリピン不動産販売、管理、運用",
+      "business_domains": [
+        "不動産・建設・住宅",
+        "営業・販売組織"
+      ],
+      "appearances": 63,
+      "investment_count": 17,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添いタイプです。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/kirihara-takashi/"
+    },
+    {
+      "seat": 16,
+      "name": "南 忠則",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社WOODBASE・F代表取締役",
+      "business_summary": "住宅・店舗・ハイブラ等のオーダーメイド家具の製作と、内装の設計・施工・建築工事。",
+      "business_domains": [
+        "不動産・建設・住宅",
+        "製造・エネルギー・環境",
+        "小売・通販・EC",
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 35,
+      "investment_count": 10,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、人情タイプ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/minami-tadanori/"
+    },
+    {
+      "seat": 17,
+      "name": "唐沢 菜々江",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "クラブNanae オーナーママ",
+      "business_summary": "銀座クラブ、飲食、美容、コンサル",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "美容・ウェルネス",
+        "経営支援・コンサルティング",
+        "医療・介護・福祉"
+      ],
+      "appearances": 150,
+      "investment_count": 50,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、人情タイプ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/karasawa-nanae/"
+    },
+    {
+      "seat": 18,
+      "name": "大石 純平",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "ファミリーオフィス・ジャパン株式会社代表",
+      "business_summary": "「日本にファミリーオフィス・サービスを」、 上場企業オーナー、M&Aイグジットオーナー、プロアスリート、ドクターなど、 富裕層ファミリーに対して、資本政策やM&A、事業継承、相続、財産保全、資産管理など、ファミリーにCFO的な立場で支援。完全紹介制を貫く。、 エンジェル投資家。名古屋エンジェル投資家コミュニティ運営。",
+      "business_domains": [
+        "金融・投資・資産管理",
+        "M&A・事業再生"
+      ],
+      "appearances": 50,
+      "investment_count": 15,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、原体験を元に頑張っている人を支援していくタイプ。伴走型。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/ohishi-junpei/"
+    },
+    {
+      "seat": 19,
+      "name": "竹内 亢一",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社Suneight代表取締役",
+      "business_summary": "・YouTube番組制作、 ・社長ブランディング、 ・ドキュメンタリー番組『野望家たち』、 ・PR・プロモーション支援 志願者との向き合い方 天邪鬼タイプ。 PV 紹介動画 Message 虎からのメッセージ",
+      "business_domains": [
+        "マーケティング・メディア"
+      ],
+      "appearances": 209,
+      "investment_count": 55,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディアの公開職歴と、番組集計上の出演209回・出資55回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://reiwanotora.jp/tiger/takeuchi-kouichi/"
+    },
+    {
+      "seat": 20,
+      "name": "田中 絢望",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社AMM代表",
+      "business_summary": "エステサロンへのマーケティングコンサル、化粧品卸、マシン卸",
+      "business_domains": [
+        "美容・ウェルネス",
+        "マーケティング・メディア",
+        "経営支援・コンサルティング",
+        "小売・通販・EC"
+      ],
+      "appearances": 12,
+      "investment_count": 2,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、数字で詰めて、そこが明らかになれば寄り添うタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/tanaka-ami/"
+    },
+    {
+      "seat": 21,
+      "name": "遠藤 悠記",
+      "roster_status": "current",
+      "birth_date": "1990-03-17",
+      "birth_date_source_url": "https://reiwanotora.jp/tiger/endo-yuki/",
+      "company_role": "株式会社えん代表",
+      "business_summary": "武田塾(学習塾)、インディバケアプラチナム(美容エステサロン)、遠藤顧問",
+      "business_domains": [
+        "美容・ウェルネス",
+        "教育・スクール",
+        "フランチャイズ・多店舗展開",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 64,
+      "investment_count": 17,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、冷静に判断するけど、最後は人情と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/endo-yuki/"
+    },
+    {
+      "seat": 22,
+      "name": "稲葉 信",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ネルプ代表取締役",
+      "business_summary": "現在はSaaS企業3社の代表を務め、SNS×IT領域に特化したプロダクトの開発・運営を行っている。、 主に、企業・店舗の集客、顧客コミュニケーション、業務効率化を支援するSaaSを展開。 / 主なプロダクトは以下の通り。 / ・Instagramチャットボット／自動返信システム「iステップ」、 ・X（旧Twitter）機能拡張ツール「XTEP」、 ・Threads自動運用・自動返信ツール「スレップ」、 ・TikTok機能拡張ツール「TTステップ」、 ・Facebook機能拡張ツール「Fステップ」、 ・MEO対策・口コミ管理ツール「口コミ365」 / SNS運用の自動化・効率化と、売上・集客への貢献を軸に、複数SNSを横断した支援を強みとしている。",
+      "business_domains": [
+        "IT・SaaS・プラットフォーム",
+        "マーケティング・メディア",
+        "営業・販売組織",
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 72,
+      "investment_count": 27,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、元志願者として、志願者の気持ちに一番寄り添える虎でありたいと考えています。 数字や理屈だけで判断するのではなく、覚悟や背景も含めて本気で向き合います。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/inaba-shin/"
+    },
+    {
+      "seat": 23,
+      "name": "寺田 高士",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社一会不動産代表",
+      "business_summary": "新築戸建の企画、建築、販売、、 中古マンション・戸建の買取、内装デザイン、リフォーム、販売、 賃貸物件の管理、 仲介",
+      "business_domains": [
+        "不動産・建設・住宅",
+        "営業・販売組織",
+        "小売・通販・EC"
+      ],
+      "appearances": 53,
+      "investment_count": 14,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、論理的な思考で数字や結果を見るタイプ、感情的ではなく冷静に本質を見抜くタイプ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/terada-takashi/"
+    },
+    {
+      "seat": 24,
+      "name": "孫 駿一郎",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "X CLINIC代表",
+      "business_summary": "●X CLINC、 全国に5院を展開する美容クリニック。美容外科・美容皮膚科を軸に、審美歯科、再生医療、アートメイクまで幅広く対応しています。各分野のスペシャリストが在籍し、一人ひとりの骨格や表情に合わせた“やりすぎない美しさ”を追求。ナチュラルな若返りや垢抜けを叶える、上質な美容医療を身近に感じられるクリニックです。 / ●カジュアルクリニック、 都心から離れた地域に暮らす主婦・学生など、「美容医療をもっと気軽に始めたい」方のためのクリニック。安全性を大切にしながら、通いやすい価格と分かりやすいメニューで、日常に美容医療を取り入れられる環境を提供します。 / ●Xology、 Xologyは、「美学を追求する」精神を形にし、日常で美を実感できる商品として届けるブランド。使う人の人生を前進させるために、美への信念をお客さまと共に探究していきます。",
+      "business_domains": [
+        "医療・介護・福祉",
+        "美容・ウェルネス",
+        "製造・エネルギー・環境",
+        "小売・通販・EC"
+      ],
+      "appearances": 43,
+      "investment_count": 11,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、人情タイプ。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/son-shunichirou/"
+    },
+    {
+      "seat": 25,
+      "name": "宮本 聖菜",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "ecxia株式会社代表",
+      "business_summary": "歯のホワイトニングサロンエクシアホワイトニング全国展開、FC事業",
+      "business_domains": [
+        "美容・ウェルネス",
+        "フランチャイズ・多店舗展開",
+        "小売・通販・EC"
+      ],
+      "appearances": 59,
+      "investment_count": 19,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、人としてどうか見る、言い訳には厳しめタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/miyamoto-sena/"
+    },
+    {
+      "seat": 26,
+      "name": "荒木 杏奈",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "アンナアドバイザーズ株式会社代表",
+      "business_summary": "不動産仲介業及び金融及び不動産投資に関するコンサルティング業務、 不動産及び事業投資、 マーケティングに関する企画、調査及びコンサルティング業、 投資に関するセミナーの企画及び運営、 不動産の売買、賃貸、管理、内装工事請負及内装クリニング業務その他、生活に関わる様々なサービスの提供、 様々なメディアにおけるコンテンツの企画、制作、 各種セミナー、研修の企画及行と並行して講師派遣、 整体サロン経営、 前部号に附帯関連する一切の事業 / 免許番号 宅地建物取引業 東京都知事免許（2）第99967号",
+      "business_domains": [
+        "不動産・建設・住宅",
+        "金融・投資・資産管理",
+        "経営支援・コンサルティング",
+        "マーケティング・メディア"
+      ],
+      "appearances": 71,
+      "investment_count": 31,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプですが数字もみます。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/araki-anna/"
+    },
+    {
+      "seat": 27,
+      "name": "竹長 篤史",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社電光石火代表",
+      "business_summary": "主に飲食業。お好み焼き店です。",
+      "business_domains": [
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 47,
+      "investment_count": 14,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプだと思います。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/takenaga-atsushi/"
+    },
+    {
+      "seat": 28,
+      "name": "東 将大",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ロレインブロウ代表",
+      "business_summary": "まつ毛眉毛サロン、ピラティススタジオのフランチャイズ本部",
+      "business_domains": [
+        "美容・ウェルネス",
+        "フランチャイズ・多店舗展開",
+        "小売・通販・EC",
+        "人材・採用・組織"
+      ],
+      "appearances": 53,
+      "investment_count": 22,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、経営は結局、人だと思っています。 だからこそ数字やノウハウだけではなく、「誰のためにやるのか」「どんな未来を作りたいのか」という想いを大切にしています。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/azuma-shota/"
+    },
+    {
+      "seat": 29,
+      "name": "河原 由次",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "ネクストレベルホールディングス株式会社 代表取締役会長",
+      "business_summary": "各種HRマッチングプラットフォームの運営",
+      "business_domains": [
+        "人材・採用・組織",
+        "IT・SaaS・プラットフォーム",
+        "飲食・宿泊・接客",
+        "マーケティング・メディア"
+      ],
+      "appearances": 7,
+      "investment_count": 3,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、挑戦する気持ちに寄り添い、本人にとってプラスとなるアドバイスを心がけていますと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/kawahara-yoshitsugu/"
+    },
+    {
+      "seat": 30,
+      "name": "小林 真之",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ProLogue代表",
+      "business_summary": "WEB広告代理店・ASP事業・WEB広告顧問",
+      "business_domains": [
+        "マーケティング・メディア",
+        "経営支援・コンサルティング",
+        "営業・販売組織",
+        "M&A・事業再生"
+      ],
+      "appearances": 57,
+      "investment_count": 9,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/kobayashi-masayuki/"
+    },
+    {
+      "seat": 31,
+      "name": "佐々木 貴史",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社りらいぶ 代表",
+      "business_summary": "リライブシャツの販売",
+      "business_domains": [
+        "IT・SaaS・プラットフォーム",
+        "営業・販売組織"
+      ],
+      "appearances": 54,
+      "investment_count": 25,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/sasaki-takashi/"
+    },
+    {
+      "seat": 32,
+      "name": "高澤 有紀",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ADOYOSU 代表",
+      "business_summary": "とくに海外企業のデジタル集客とオンライン活用を支えるWeb系サービス",
+      "business_domains": [
+        "マーケティング・メディア",
+        "金融・投資・資産管理",
+        "美容・ウェルネス",
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 117,
+      "investment_count": 43,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/takazawa-yuki/"
+    },
+    {
+      "seat": 33,
+      "name": "津田 篤志",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社AT 代表",
+      "business_summary": "“病気”ではなく、“人”と向き合うことを理念に掲げ、医療ケアを必要とする人々に寄り添い続ける。、 さらに、週20時間正社員制度や夜間専門サービス「24ナース」など独自の仕組みを導入し、医療・介護業界における深刻な人材不足という社会課題にも挑み続けている。 / 現場目線と異業種の発想を掛け合わせながら、訪問看護のインフラ化を推進。、 その信念は次々と新たなビジネスを生み出し、事業規模は年商200億円規模へ迫る勢いで成長を続ける。 / 医療・介護の未来を切り拓く経営者、津田篤志。",
+      "business_domains": [
+        "医療・介護・福祉",
+        "人材・採用・組織"
+      ],
+      "appearances": 4,
+      "investment_count": 2,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添い、情熱タイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/tsuda-atsushi/"
+    },
+    {
+      "seat": 34,
+      "name": "ど素人ホテル再建計画",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社再建コンサルティング 代表",
+      "business_summary": "SNSコンサルティング、 ドキュメンタリー制作",
+      "business_domains": [
+        "マーケティング・メディア",
+        "飲食・宿泊・接客",
+        "M&A・事業再生",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 4,
+      "investment_count": 1,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプ、SNSを起点に勝ち筋を見つけることが得意ですと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/doshirouto-hotel/"
+    },
+    {
+      "seat": 35,
+      "name": "土橋 和貴",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "ミダシー株式会社 代表取締役",
+      "business_summary": "「ミダシー」は、“月1回・1時間・1万円で、身だしなみを完壁に。“をコンセプトに、、 ヒゲ脱毛/セルフホワイトニング/眉毛スタイリング/鼻毛ワックス脱毛/手の甲・指脱毛/ネイルケア/フェイスパック/リップエステなど、男性の身だしなみケアを一度に受けられるサー、 ビスです。 / 現在は新宿本店を中心に、全国展開・フランチャイズ展開を進めており、、 2026年度中の全国40店舗体制、将来的には全国200店舗・年商100億円規模を目指してます。",
+      "business_domains": [
+        "美容・ウェルネス",
+        "フランチャイズ・多店舗展開",
+        "小売・通販・EC",
+        "IT・SaaS・プラットフォーム"
+      ],
+      "appearances": 6,
+      "investment_count": 2,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、ロジカル激詰めタイプ。 数字や事業計画、再現性はしっかり見つつ、志願者の想いや挑戦する覚悟が本気か見てます。 良い部分は伸ばし、甘い部分は激詰めします。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/dobashi-kazuki/"
+    },
+    {
+      "seat": 36,
+      "name": "中村 英俊",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社中村建設 代表取締役",
+      "business_summary": "仮設工事 仮設資材販売レンタル 店舗内装 大規模修繕工事 業務部空調設備室外機室内機電気代削減機器レボルト+レボルトOS 抗菌除菌防カビ消臭空間施工、 スーパースマイルコーティング、 （SSC） 精密水クエクト事業 食品販売事業 シェルターリフォーム、 シールドウォール工法 マイプロ事業※清掃事業の事",
+      "business_domains": [
+        "不動産・建設・住宅",
+        "営業・販売組織",
+        "人材・採用・組織",
+        "製造・エネルギー・環境"
+      ],
+      "appearances": 4,
+      "investment_count": 2,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、出来るだけ志願者さんの発したいことを引き出したい。 物やスキーム提案の場合、突っ込みところが無いか？ 深掘りし、無くしてあげたい。と説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/nakamura-hidetosih/"
+    },
+    {
+      "seat": 37,
+      "name": "西田 拳",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社テクニケーションシード代表取締役",
+      "business_summary": "ITコンサルティング システムインテグレーション ディストリビューション事業 QA事業 RPO事業",
+      "business_domains": [
+        "IT・SaaS・プラットフォーム",
+        "小売・通販・EC"
+      ],
+      "appearances": 7,
+      "investment_count": 1,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/nishida-ken/"
+    },
+    {
+      "seat": 38,
+      "name": "畠山 大輝",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社Green Energy Partners 代表",
+      "business_summary": "家庭用蓄電池の販売と施工 産業用、系統用蓄電池販売、施工",
+      "business_domains": [
+        "製造・エネルギー・環境",
+        "人材・採用・組織",
+        "営業・販売組織"
+      ],
+      "appearances": 3,
+      "investment_count": 0,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、人情タイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/hatakeyama-daiki/"
+    },
+    {
+      "seat": 39,
+      "name": "松下 直人",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "EC-Consulting Japan株式会社代表取締役",
+      "business_summary": "EC事業、コンサルティング事業、システム開発事業",
+      "business_domains": [
+        "小売・通販・EC",
+        "経営支援・コンサルティング",
+        "教育・スクール",
+        "IT・SaaS・プラットフォーム"
+      ],
+      "appearances": 3,
+      "investment_count": 0,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/matsushita-naoto/"
+    },
+    {
+      "seat": 40,
+      "name": "茂木 哲也",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ピナイ・インターナショナル代表",
+      "business_summary": "家事代行サービス・人材紹介サービス",
+      "business_domains": [
+        "専門サービス・生活支援",
+        "M&A・事業再生",
+        "教育・スクール",
+        "金融・投資・資産管理"
+      ],
+      "appearances": 83,
+      "investment_count": 19,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/moteki-tetsuya/"
+    },
+    {
+      "seat": 41,
+      "name": "山本 雅俊",
+      "roster_status": "current",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社やまもとくん 代表取締役",
+      "business_summary": "総合リフォーム事業、住宅総合施工事業、太陽光・蓄電池販売事業",
+      "business_domains": [
+        "不動産・建設・住宅",
+        "営業・販売組織",
+        "製造・エネルギー・環境",
+        "教育・スクール"
+      ],
+      "appearances": 3,
+      "investment_count": 1,
+      "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、人情・寄り添うタイプと説明している。",
+      "profile_url": "https://reiwanotora.jp/tiger/yamamoto-masatoshi/"
+    },
+    {
+      "seat": 42,
+      "name": "トモハッピー",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社晴れる屋 代表",
+      "business_summary": "小売・通販・EC、エンタメ・クリエイター、マーケティング・メディア",
+      "business_domains": [
+        "小売・通販・EC",
+        "エンタメ・クリエイター",
+        "マーケティング・メディア"
+      ],
+      "appearances": 340,
+      "investment_count": 110,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。小売・通販・EC、エンタメ・クリエイター、マーケティング・メディアの公開職歴と、番組集計上の出演340回・出資110回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 43,
+      "name": "井口智明",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ディアローグホールディングス 代表取締役",
+      "business_summary": "不動産・建設・住宅、美容・ウェルネス、医療・介護・福祉、マーケティング・メディア",
+      "business_domains": [
+        "不動産・建設・住宅",
+        "美容・ウェルネス",
+        "医療・介護・福祉",
+        "マーケティング・メディア"
+      ],
+      "appearances": 113,
+      "investment_count": 31,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。不動産・建設・住宅、美容・ウェルネス、医療・介護・福祉、マーケティング・メディアの公開職歴と、番組集計上の出演113回・出資31回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 44,
+      "name": "青笹寛史（あお）",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "アズール株式会社代表取締役",
+      "business_summary": "マーケティング・メディア",
+      "business_domains": [
+        "マーケティング・メディア"
+      ],
+      "appearances": 104,
+      "investment_count": 31,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディアの公開職歴と、番組集計上の出演104回・出資31回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 45,
+      "name": "竹之内教博",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社T’sインベストメント会長",
+      "business_summary": "飲食・宿泊・接客、IT・SaaS・プラットフォーム、小売・通販・EC",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "IT・SaaS・プラットフォーム",
+        "小売・通販・EC"
+      ],
+      "appearances": 99,
+      "investment_count": 39,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客、IT・SaaS・プラットフォーム、小売・通販・ECの公開職歴と、番組集計上の出演99回・出資39回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 46,
+      "name": "株本祐己",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "StockSun株式会社 代表取締役社長",
+      "business_summary": "マーケティング・メディア、経営支援・コンサルティング",
+      "business_domains": [
+        "マーケティング・メディア",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 70,
+      "investment_count": 6,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディア、経営支援・コンサルティングの公開職歴と、番組集計上の出演70回・出資6回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 47,
+      "name": "木下勇人",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "税理士法人レディング 代表税理士・公認会計士",
+      "business_summary": "法務・会計・士業",
+      "business_domains": [
+        "法務・会計・士業"
+      ],
+      "appearances": 60,
+      "investment_count": 26,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。法務・会計・士業の公開職歴と、番組集計上の出演60回・出資26回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 48,
+      "name": "條隼人",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社SGGKグループインターナショナル 代表取締役",
+      "business_summary": "飲食・宿泊・接客、経営支援・コンサルティング、小売・通販・EC",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "経営支援・コンサルティング",
+        "小売・通販・EC"
+      ],
+      "appearances": 45,
+      "investment_count": 9,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客、経営支援・コンサルティング、小売・通販・ECの公開職歴と、番組集計上の出演45回・出資9回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 49,
+      "name": "岩井良明",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "登場時の表示：株式会社MONOLITH Japan代表取締役社長",
+      "business_summary": "エンタメ・クリエイター、金融・投資・資産管理、医療・介護・福祉、IT・SaaS・プラットフォーム",
+      "business_domains": [
+        "エンタメ・クリエイター",
+        "金融・投資・資産管理",
+        "医療・介護・福祉",
+        "IT・SaaS・プラットフォーム"
+      ],
+      "appearances": 44,
+      "investment_count": 22,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。エンタメ・クリエイター、金融・投資・資産管理、医療・介護・福祉、IT・SaaS・プラットフォームの公開職歴と、番組集計上の出演44回・出資22回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 50,
+      "name": "岡田真弓",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社MR代表取締役 全国主要都市に総合探偵社MRを展開している。",
+      "business_summary": "専門サービス・生活支援",
+      "business_domains": [
+        "専門サービス・生活支援"
+      ],
+      "appearances": 40,
+      "investment_count": 23,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。専門サービス・生活支援の公開職歴と、番組集計上の出演40回・出資23回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 51,
+      "name": "北川哲平",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "Reクリエイト株式会社 代表取締役 本革に拘るレザー事業を展開",
+      "business_summary": "経営支援・コンサルティング、医療・介護・福祉、営業・販売組織",
+      "business_domains": [
+        "経営支援・コンサルティング",
+        "医療・介護・福祉",
+        "営業・販売組織"
+      ],
+      "appearances": 35,
+      "investment_count": 15,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティング、医療・介護・福祉、営業・販売組織の公開職歴と、番組集計上の出演35回・出資15回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 52,
+      "name": "森龍一",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社NEXTスタッフサービス 代表",
+      "business_summary": "人材・採用・組織",
+      "business_domains": [
+        "人材・採用・組織"
+      ],
+      "appearances": 31,
+      "investment_count": 9,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。人材・採用・組織の公開職歴と、番組集計上の出演31回・出資9回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 53,
+      "name": "渡邊正都",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "Fine Fast Foods（飲食店）",
+      "business_summary": "飲食・宿泊・接客",
+      "business_domains": [
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 30,
+      "investment_count": 4,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客の公開職歴と、番組集計上の出演30回・出資4回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 54,
+      "name": "Fumi Sugita",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "Terra Matcha Founder",
+      "business_summary": "マーケティング・メディア",
+      "business_domains": [
+        "マーケティング・メディア"
+      ],
+      "appearances": 29,
+      "investment_count": 12,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディアの公開職歴と、番組集計上の出演29回・出資12回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 55,
+      "name": "木下 博勝",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "さいたま新都心ジャガークリニック（理事長)（外科、内科、小児科）",
+      "business_summary": "医療・介護・福祉",
+      "business_domains": [
+        "医療・介護・福祉"
+      ],
+      "appearances": 24,
+      "investment_count": 4,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。医療・介護・福祉の公開職歴と、番組集計上の出演24回・出資4回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 56,
+      "name": "岩崎 健人",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社 喜創産業 代表",
+      "business_summary": "経営支援・コンサルティング",
+      "business_domains": [
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 23,
+      "investment_count": 5,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティングの公開職歴と、番組集計上の出演23回・出資5回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 57,
+      "name": "大迫源一",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ふじなコーポレーション 代表取締役",
+      "business_summary": "飲食・宿泊・接客",
+      "business_domains": [
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 20,
+      "investment_count": 6,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客の公開職歴と、番組集計上の出演20回・出資6回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 58,
+      "name": "高橋未樹",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "一般社団法人虹視力クリエイティブアソシエイト代表",
+      "business_summary": "医療・介護・福祉",
+      "business_domains": [
+        "医療・介護・福祉"
+      ],
+      "appearances": 20,
+      "investment_count": 5,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。医療・介護・福祉の公開職歴と、番組集計上の出演20回・出資5回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 59,
+      "name": "福田雅典",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社メモワールしおん 代表取締役",
+      "business_summary": "専門サービス・生活支援、教育・スクール、飲食・宿泊・接客",
+      "business_domains": [
+        "専門サービス・生活支援",
+        "教育・スクール",
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 18,
+      "investment_count": 4,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。専門サービス・生活支援、教育・スクール、飲食・宿泊・接客の公開職歴と、番組集計上の出演18回・出資4回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 60,
+      "name": "野田慎太郎",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社AEトランスポート代表取締役 物流を通じて社会変革に挑んでいる",
+      "business_summary": "物流・モビリティ、マーケティング・メディア",
+      "business_domains": [
+        "物流・モビリティ",
+        "マーケティング・メディア"
+      ],
+      "appearances": 15,
+      "investment_count": 7,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。物流・モビリティ、マーケティング・メディアの公開職歴と、番組集計上の出演15回・出資7回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 61,
+      "name": "南原竜樹",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社LUFTホールディングス 会長",
+      "business_summary": "物流・モビリティ、営業・販売組織",
+      "business_domains": [
+        "物流・モビリティ",
+        "営業・販売組織"
+      ],
+      "appearances": 14,
+      "investment_count": 4,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。物流・モビリティ、営業・販売組織の公開職歴と、番組集計上の出演14回・出資4回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 62,
+      "name": "黒川 たくや",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社セインムーCEO",
+      "business_summary": "経営支援・コンサルティング",
+      "business_domains": [
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 14,
+      "investment_count": 5,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティングの公開職歴と、番組集計上の出演14回・出資5回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 63,
+      "name": "矢神 サラ",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "社団法人アジア包括支援センター代表理事",
+      "business_summary": "エンタメ・クリエイター、飲食・宿泊・接客、マーケティング・メディア",
+      "business_domains": [
+        "エンタメ・クリエイター",
+        "飲食・宿泊・接客",
+        "マーケティング・メディア"
+      ],
+      "appearances": 13,
+      "investment_count": 6,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。エンタメ・クリエイター、飲食・宿泊・接客、マーケティング・メディアの公開職歴と、番組集計上の出演13回・出資6回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 64,
+      "name": "冬真怜",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "IT企業代表取締役社長",
+      "business_summary": "マーケティング・メディア、IT・SaaS・プラットフォーム、営業・販売組織",
+      "business_domains": [
+        "マーケティング・メディア",
+        "IT・SaaS・プラットフォーム",
+        "営業・販売組織"
+      ],
+      "appearances": 12,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディア、IT・SaaS・プラットフォーム、営業・販売組織の公開職歴と、番組集計上の出演12回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 65,
+      "name": "安達逸平",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社J-GATE代表取締役社長",
+      "business_summary": "教育・スクール、金融・投資・資産管理、経営支援・コンサルティング、営業・販売組織",
+      "business_domains": [
+        "教育・スクール",
+        "金融・投資・資産管理",
+        "経営支援・コンサルティング",
+        "営業・販売組織"
+      ],
+      "appearances": 12,
+      "investment_count": 4,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。教育・スクール、金融・投資・資産管理、経営支援・コンサルティング、営業・販売組織の公開職歴と、番組集計上の出演12回・出資4回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 66,
+      "name": "吉野繁",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社CREAM HONPO 代表取締役",
+      "business_summary": "飲食・宿泊・接客",
+      "business_domains": [
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 11,
+      "investment_count": 3,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客の公開職歴と、番組集計上の出演11回・出資3回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 67,
+      "name": "杉本幸倫（もとのり社長）",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社メルヴェイユ代表取締役。通信回線営業、組織育成、M&A、SNS発信を経験",
+      "business_summary": "営業・販売組織、人材・採用・組織、M&A・事業再生、マーケティング・メディア",
+      "business_domains": [
+        "営業・販売組織",
+        "人材・採用・組織",
+        "M&A・事業再生",
+        "マーケティング・メディア"
+      ],
+      "appearances": 11,
+      "investment_count": 5,
+      "public_viewpoint_summary": "信頼と誠実な行動、相手の期待を上回る実行、営業組織の再現性を重視すると本人プロフィールで説明している。",
+      "profile_url": "https://www.coffeehub.jp/y-sugimoto0226"
+    },
+    {
+      "seat": 68,
+      "name": "山澤 礼明",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社 FIT PLACE代表",
+      "business_summary": "IT・SaaS・プラットフォーム、人材・採用・組織",
+      "business_domains": [
+        "IT・SaaS・プラットフォーム",
+        "人材・採用・組織"
+      ],
+      "appearances": 11,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。IT・SaaS・プラットフォーム、人材・採用・組織の公開職歴と、番組集計上の出演11回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 69,
+      "name": "川中子 輝昂",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社LINGs 代表取締役",
+      "business_summary": "人材・採用・組織、マーケティング・メディア、物流・モビリティ",
+      "business_domains": [
+        "人材・採用・組織",
+        "マーケティング・メディア",
+        "物流・モビリティ"
+      ],
+      "appearances": 10,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。人材・採用・組織、マーケティング・メディア、物流・モビリティの公開職歴と、番組集計上の出演10回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 70,
+      "name": "磯遊晋介",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "ISOYU株式会社 代表取締役",
+      "business_summary": "フランチャイズ・多店舗展開、小売・通販・EC",
+      "business_domains": [
+        "フランチャイズ・多店舗展開",
+        "小売・通販・EC"
+      ],
+      "appearances": 9,
+      "investment_count": 4,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。フランチャイズ・多店舗展開、小売・通販・ECの公開職歴と、番組集計上の出演9回・出資4回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 71,
+      "name": "日熊秀貴",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "オルソ株式会社代表取締役",
+      "business_summary": "美容・ウェルネス、教育・スクール",
+      "business_domains": [
+        "美容・ウェルネス",
+        "教育・スクール"
+      ],
+      "appearances": 9,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。美容・ウェルネス、教育・スクールの公開職歴と、番組集計上の出演9回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 72,
+      "name": "井川 意高",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "大王製紙 株式会社 元会長",
+      "business_summary": "経営支援・コンサルティング",
+      "business_domains": [
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 9,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティングの公開職歴と、番組集計上の出演9回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 73,
+      "name": "沓名 裕城",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社非常電源メンテナンスサービス代表取締役社長",
+      "business_summary": "金融・投資・資産管理、マーケティング・メディア、製造・エネルギー・環境",
+      "business_domains": [
+        "金融・投資・資産管理",
+        "マーケティング・メディア",
+        "製造・エネルギー・環境"
+      ],
+      "appearances": 8,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。金融・投資・資産管理、マーケティング・メディア、製造・エネルギー・環境の公開職歴と、番組集計上の出演8回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 74,
+      "name": "山田久太郎",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "アロマプリエール代表",
+      "business_summary": "美容・ウェルネス",
+      "business_domains": [
+        "美容・ウェルネス"
+      ],
+      "appearances": 8,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。美容・ウェルネスの公開職歴と、番組集計上の出演8回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 75,
+      "name": "三崎優太（青汁王子）",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社みさきホールディングス 代表取締役社長",
+      "business_summary": "金融・投資・資産管理、マーケティング・メディア、小売・通販・EC",
+      "business_domains": [
+        "金融・投資・資産管理",
+        "マーケティング・メディア",
+        "小売・通販・EC"
+      ],
+      "appearances": 8,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。金融・投資・資産管理、マーケティング・メディア、小売・通販・ECの公開職歴と、番組集計上の出演8回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 76,
+      "name": "黒田 健太郎",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社リバネス 代表取締役",
+      "business_summary": "経営支援・コンサルティング",
+      "business_domains": [
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 7,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティングの公開職歴と、番組集計上の出演7回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 77,
+      "name": "カトリッセ・ヤン=ピートル",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社テンペスト 代表取締役CEO",
+      "business_summary": "飲食・宿泊・接客、営業・販売組織",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "営業・販売組織"
+      ],
+      "appearances": 7,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客、営業・販売組織の公開職歴と、番組集計上の出演7回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 78,
+      "name": "中川浩秀",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "弁護士法人東京スタートアップ法律事務所 代表弁護士",
+      "business_summary": "法務・会計・士業",
+      "business_domains": [
+        "法務・会計・士業"
+      ],
+      "appearances": 7,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。法務・会計・士業の公開職歴と、番組集計上の出演7回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 79,
+      "name": "奥谷敦子",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "代表 奥谷商売研究所",
+      "business_summary": "経営支援・コンサルティング、飲食・宿泊・接客",
+      "business_domains": [
+        "経営支援・コンサルティング",
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 6,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティング、飲食・宿泊・接客の公開職歴と、番組集計上の出演6回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 80,
+      "name": "西本誠（Tecco）",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "ラグナロク株式会社 代表",
+      "business_summary": "IT・SaaS・プラットフォーム",
+      "business_domains": [
+        "IT・SaaS・プラットフォーム"
+      ],
+      "appearances": 6,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。IT・SaaS・プラットフォームの公開職歴と、番組集計上の出演6回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 81,
+      "name": "重田裕輔",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "アーステックプレゼンツ株式会社代表",
+      "business_summary": "不動産・建設・住宅",
+      "business_domains": [
+        "不動産・建設・住宅"
+      ],
+      "appearances": 6,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。不動産・建設・住宅の公開職歴と、番組集計上の出演6回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 82,
+      "name": "前德政宗",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社エムグラント 鎌倉へやこまち 代表取締役",
+      "business_summary": "不動産・建設・住宅",
+      "business_domains": [
+        "不動産・建設・住宅"
+      ],
+      "appearances": 6,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。不動産・建設・住宅の公開職歴と、番組集計上の出演6回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 83,
+      "name": "升澤裕介",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社グッドフェイラーの代表",
+      "business_summary": "マーケティング・メディア、経営支援・コンサルティング、エンタメ・クリエイター、金融・投資・資産管理",
+      "business_domains": [
+        "マーケティング・メディア",
+        "経営支援・コンサルティング",
+        "エンタメ・クリエイター",
+        "金融・投資・資産管理"
+      ],
+      "appearances": 5,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディア、経営支援・コンサルティング、エンタメ・クリエイター、金融・投資・資産管理の公開職歴と、番組集計上の出演5回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 84,
+      "name": "島袋直樹",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "M＆A BANK株式会社 取締役会長",
+      "business_summary": "M&A・事業再生",
+      "business_domains": [
+        "M&A・事業再生"
+      ],
+      "appearances": 5,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。M&A・事業再生の公開職歴と、番組集計上の出演5回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 85,
+      "name": "京極琉",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社Kyogoku 代表",
+      "business_summary": "美容・ウェルネス",
+      "business_domains": [
+        "美容・ウェルネス"
+      ],
+      "appearances": 5,
+      "investment_count": 2,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。美容・ウェルネスの公開職歴と、番組集計上の出演5回・出資2回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 86,
+      "name": "小澤 辰矢",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "小澤総業株式会社 代表",
+      "business_summary": "経営支援・コンサルティング",
+      "business_domains": [
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 5,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティングの公開職歴と、番組集計上の出演5回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 87,
+      "name": "長谷部文康",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ROMANDO ROLL JAPAN 代表取締役会長",
+      "business_summary": "飲食・宿泊・接客、営業・販売組織",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "営業・販売組織"
+      ],
+      "appearances": 4,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客、営業・販売組織の公開職歴と、番組集計上の出演4回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 88,
+      "name": "池端美和",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社MIWAIKEHATA 代表取締役",
+      "business_summary": "美容・ウェルネス、IT・SaaS・プラットフォーム、マーケティング・メディア、不動産・建設・住宅",
+      "business_domains": [
+        "美容・ウェルネス",
+        "IT・SaaS・プラットフォーム",
+        "マーケティング・メディア",
+        "不動産・建設・住宅"
+      ],
+      "appearances": 4,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。美容・ウェルネス、IT・SaaS・プラットフォーム、マーケティング・メディア、不動産・建設・住宅の公開職歴と、番組集計上の出演4回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 89,
+      "name": "ヒカル",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "登場時の表示：株式会社シュプラスの代表取締役",
+      "business_summary": "マーケティング・メディア、エンタメ・クリエイター、美容・ウェルネス、金融・投資・資産管理",
+      "business_domains": [
+        "マーケティング・メディア",
+        "エンタメ・クリエイター",
+        "美容・ウェルネス",
+        "金融・投資・資産管理"
+      ],
+      "appearances": 4,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディア、エンタメ・クリエイター、美容・ウェルネス、金融・投資・資産管理の公開職歴と、番組集計上の出演4回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 90,
+      "name": "蓮井廉（ADHD社長）",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "ReBORN GROUP株式会社創業者・会長。営業、人材育成、住宅用エネルギー商材を展開",
+      "business_summary": "営業・販売組織、人材・採用・組織、製造・エネルギー・環境",
+      "business_domains": [
+        "営業・販売組織",
+        "人材・採用・組織",
+        "製造・エネルギー・環境"
+      ],
+      "appearances": 4,
+      "investment_count": 3,
+      "public_viewpoint_summary": "失敗を恐れず常識に縛られず挑戦すること、従業員の成長と再起の機会を重視すると本人サイトで述べている。",
+      "profile_url": "https://reborn.rend.jp/story"
+    },
+    {
+      "seat": 91,
+      "name": "カイ ユリコ",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社パスチャーの経営に携わり、デジタルマーケティング支援を経験",
+      "business_summary": "マーケティング・メディア、IT・SaaS・プラットフォーム",
+      "business_domains": [
+        "マーケティング・メディア",
+        "IT・SaaS・プラットフォーム"
+      ],
+      "appearances": 3,
+      "investment_count": 1,
+      "public_viewpoint_summary": "デジタル上の顧客理解、SNS運用、集客施策の実行可能性を優先して検討する。",
+      "profile_url": "https://ja.everybodywiki.com/%E4%BB%A4%E5%92%8C%E3%81%AE%E8%99%8E"
+    },
+    {
+      "seat": 92,
+      "name": "兼子ただし",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社SSS 代表取締役",
+      "business_summary": "金融・投資・資産管理",
+      "business_domains": [
+        "金融・投資・資産管理"
+      ],
+      "appearances": 3,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。金融・投資・資産管理の公開職歴と、番組集計上の出演3回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 93,
+      "name": "寺林良",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "就労継続支援Tetoriaグループ代表。福祉と複数のFC事業を展開",
+      "business_summary": "医療・介護・福祉、フランチャイズ・多店舗展開、人材・採用・組織",
+      "business_domains": [
+        "医療・介護・福祉",
+        "フランチャイズ・多店舗展開",
+        "人材・採用・組織"
+      ],
+      "appearances": 3,
+      "investment_count": 2,
+      "public_viewpoint_summary": "福祉的価値と継続可能な事業運営を両立できるか、現場の雇用機会につながるかを重視する。",
+      "profile_url": "https://prtimes.jp/main/html/rd/p/000000074.000162890.html"
+    },
+    {
+      "seat": 94,
+      "name": "戸村 光",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "HACK JPN, INC. CEO",
+      "business_summary": "専門サービス・生活支援",
+      "business_domains": [
+        "専門サービス・生活支援"
+      ],
+      "appearances": 3,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。専門サービス・生活支援の公開職歴と、番組集計上の出演3回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 95,
+      "name": "村川智博",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社ベクトル 代表取締役CEO",
+      "business_summary": "美容・ウェルネス、小売・通販・EC、営業・販売組織",
+      "business_domains": [
+        "美容・ウェルネス",
+        "小売・通販・EC",
+        "営業・販売組織"
+      ],
+      "appearances": 3,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。美容・ウェルネス、小売・通販・EC、営業・販売組織の公開職歴と、番組集計上の出演3回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 96,
+      "name": "牧田彰俊",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社すばる 代表",
+      "business_summary": "フランチャイズ・多店舗展開、小売・通販・EC、M&A・事業再生",
+      "business_domains": [
+        "フランチャイズ・多店舗展開",
+        "小売・通販・EC",
+        "M&A・事業再生"
+      ],
+      "appearances": 3,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。フランチャイズ・多店舗展開、小売・通販・EC、M&A・事業再生の公開職歴と、番組集計上の出演3回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 97,
+      "name": "足立暢",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社俺豚 代表",
+      "business_summary": "経営支援・コンサルティング",
+      "business_domains": [
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 3,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティングの公開職歴と、番組集計上の出演3回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 98,
+      "name": "ロイター豪",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "HAB株式会社代表取締役CEO",
+      "business_summary": "専門サービス・生活支援",
+      "business_domains": [
+        "専門サービス・生活支援"
+      ],
+      "appearances": 3,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。専門サービス・生活支援の公開職歴と、番組集計上の出演3回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 99,
+      "name": "愛沢 えみり",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社 voyage代表",
+      "business_summary": "人材・採用・組織",
+      "business_domains": [
+        "人材・採用・組織"
+      ],
+      "appearances": 3,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。人材・採用・組織の公開職歴と、番組集計上の出演3回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 100,
+      "name": "三原 拓大",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社シュビヒロ代表取締役。SNS運用代行、経営顧問、二軍版令和の虎主宰",
+      "business_summary": "マーケティング・メディア、経営支援・コンサルティング、人材・採用・組織",
+      "business_domains": [
+        "マーケティング・メディア",
+        "経営支援・コンサルティング",
+        "人材・採用・組織"
+      ],
+      "appearances": 3,
+      "investment_count": 1,
+      "public_viewpoint_summary": "SNS予算の費用対効果、数字管理、顧客同士の協業可能性を検討し、率直で実務的な改善案を出す。",
+      "profile_url": "https://reiwanotora.jp/komon/mihara-takuto/"
+    },
+    {
+      "seat": 101,
+      "name": "高野秀敏",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社キープレイヤーズ代表取締役。人材紹介、採用支援、エンジェル投資を経験",
+      "business_summary": "人材・採用・組織、金融・投資・資産管理、経営支援・コンサルティング",
+      "business_domains": [
+        "人材・採用・組織",
+        "金融・投資・資産管理",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "採用可能性、経営チーム、成長企業との適合、資金調達後に組織を作れるかを重視する。",
+      "profile_url": "https://www.nexstokyo.metro.tokyo.lg.jp/member/mentor/detail/keyplayers"
+    },
+    {
+      "seat": 102,
+      "name": "泉舞",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社アルドコーポレーション代表取締役",
+      "business_summary": "経営支援・コンサルティング",
+      "business_domains": [
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティングの公開職歴と、番組集計上の出演2回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 103,
+      "name": "尾崎友俐",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社オリエンタル代表取締役。飲食店の起業、店舗プロデュース、集客支援を経験",
+      "business_summary": "飲食・宿泊・接客、マーケティング・メディア、経営支援・コンサルティング",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "マーケティング・メディア",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "机上の計画より現場観察と顧客反応を重視し、低資本で売上を作る工夫と実行速度を見る。",
+      "profile_url": "https://www.oriental-japan.co.jp/pr/foodprod.html"
+    },
+    {
+      "seat": 104,
+      "name": "川原ひろし",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "なんでんかんでん創業者。ラーメン店の出店、ブランド再生、飲食FCを経験",
+      "business_summary": "飲食・宿泊・接客、フランチャイズ・多店舗展開、M&A・事業再生",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "フランチャイズ・多店舗展開",
+        "M&A・事業再生"
+      ],
+      "appearances": 2,
+      "investment_count": 0,
+      "public_viewpoint_summary": "商品力、立地、話題化、店舗採算と、失敗後も立て直せる経営者の粘りを重視する。",
+      "profile_url": "https://ja.everybodywiki.com/%E4%BB%A4%E5%92%8C%E3%81%AE%E8%99%8E"
+    },
+    {
+      "seat": 105,
+      "name": "安田久",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社外食虎塾代表。飲食店経営、業態開発、外食経営支援を経験",
+      "business_summary": "飲食・宿泊・接客、経営支援・コンサルティング、M&A・事業再生",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "経営支援・コンサルティング",
+        "M&A・事業再生"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "客単価、原価、人件費、回転率、立地、再来店理由が一つの店舗モデルとして成立するかを重視する。",
+      "profile_url": "https://ja.everybodywiki.com/%E4%BB%A4%E5%92%8C%E3%81%AE%E8%99%8E"
+    },
+    {
+      "seat": 106,
+      "name": "六川正男",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社MJS 代表",
+      "business_summary": "飲食・宿泊・接客",
+      "business_domains": [
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 2,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客の公開職歴と、番組集計上の出演2回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 107,
+      "name": "岡田修一",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "YAKINIKUEN忍鬨グループ代表",
+      "business_summary": "飲食・宿泊・接客",
+      "business_domains": [
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。飲食・宿泊・接客の公開職歴と、番組集計上の出演2回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 108,
+      "name": "西村博之（ひろゆき）",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "インターネット事業家。2ちゃんねる開設、4chan運営などを経験",
+      "business_summary": "IT・SaaS・プラットフォーム、マーケティング・メディア",
+      "business_domains": [
+        "IT・SaaS・プラットフォーム",
+        "マーケティング・メディア"
+      ],
+      "appearances": 2,
+      "investment_count": 0,
+      "public_viewpoint_summary": "前提の矛盾、反証可能性、代替手段、少ない資本で検証できるかを問い、感情より論理の整合性を優先する。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 109,
+      "name": "大濱裕貴",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社クルイト代表。学習塾、通信制高校支援、教育メディアを複数拠点で運営",
+      "business_summary": "教育・スクール、フランチャイズ・多店舗展開、人材・採用・組織",
+      "business_domains": [
+        "教育・スクール",
+        "フランチャイズ・多店舗展開",
+        "人材・採用・組織"
+      ],
+      "appearances": 2,
+      "investment_count": 2,
+      "public_viewpoint_summary": "校舎単位の採算、教育成果、採用と教室運営の標準化、地域展開の再現性を重視する。",
+      "profile_url": "https://www.youtube.com/watch?v=SVzp4FMAMDo"
+    },
+    {
+      "seat": 110,
+      "name": "後藤 和良",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "有限会社 カグヤマ商会 代表",
+      "business_summary": "M&A・事業再生、営業・販売組織",
+      "business_domains": [
+        "M&A・事業再生",
+        "営業・販売組織"
+      ],
+      "appearances": 2,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。M&A・事業再生、営業・販売組織の公開職歴と、番組集計上の出演2回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 111,
+      "name": "竹村 義宏",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "竹村義宏事務所代表。FC本部構築・加盟開発を30年以上支援",
+      "business_summary": "フランチャイズ・多店舗展開、経営支援・コンサルティング、営業・販売組織",
+      "business_domains": [
+        "フランチャイズ・多店舗展開",
+        "経営支援・コンサルティング",
+        "営業・販売組織"
+      ],
+      "appearances": 2,
+      "investment_count": 0,
+      "public_viewpoint_summary": "FCは急拡大を可能にする一方で副作用も大きいという立場から、直営採算、本部機能、加盟店適合、募集の誠実性を厳しく見る。",
+      "profile_url": "https://fc-media.tv/profile/"
+    },
+    {
+      "seat": 112,
+      "name": "荻原 空",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "エシカル・スカイジャパン株式会社代表取締役。ショート動画運用、台本制作、組織化支援を展開",
+      "business_summary": "マーケティング・メディア、人材・採用・組織、経営支援・コンサルティング",
+      "business_domains": [
+        "マーケティング・メディア",
+        "人材・採用・組織",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "再生数だけでなく売上貢献、企画から分析までの一貫性、代表が現場を離れても回る組織設計を重視する。",
+      "profile_url": "https://lp.ethicalskyjapan.com/"
+    },
+    {
+      "seat": 113,
+      "name": "奥山 幸生",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社エヌイチ代表取締役。生成AI教育、YouTube、BtoBマーケティングを展開",
+      "business_summary": "IT・SaaS・プラットフォーム、教育・スクール、マーケティング・メディア",
+      "business_domains": [
+        "IT・SaaS・プラットフォーム",
+        "教育・スクール",
+        "マーケティング・メディア"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "AIを実務成果へ接続できるか、顧客導線、販売後の教育成果、急成長を支える組織を重視する。",
+      "profile_url": "https://www.wantedly.com/projects/1843635"
+    },
+    {
+      "seat": 114,
+      "name": "松本 和博",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社REISIN NOVA代表取締役。アパレル販売、店舗運営、POP UP事業を展開",
+      "business_summary": "小売・通販・EC、マーケティング・メディア、飲食・宿泊・接客",
+      "business_domains": [
+        "小売・通販・EC",
+        "マーケティング・メディア",
+        "飲食・宿泊・接客"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "商品の見せ方、SNS広告から来店への転換、商業施設との交渉、出店判断の速度を重視する。",
+      "profile_url": "https://reisinnova-recruit.com/"
+    },
+    {
+      "seat": 115,
+      "name": "松尾 大史",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "経営者・人財版令和の虎出演者。人材と事業の価値提供を重視",
+      "business_summary": "人材・採用・組織、経営支援・コンサルティング",
+      "business_domains": [
+        "人材・採用・組織",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 2,
+      "investment_count": 1,
+      "public_viewpoint_summary": "自分の希望より先に顧客や相手企業へ何を提供できるかを明確にしなければ、望む未来は作れないという立場を示している。",
+      "profile_url": "https://www.wantedly.com/companies/company_7366022/post_articles/1057668"
+    },
+    {
+      "seat": 116,
+      "name": "渡正行",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "合同会社lifedesign CEO",
+      "business_summary": "不動産・建設・住宅",
+      "business_domains": [
+        "不動産・建設・住宅"
+      ],
+      "appearances": 1,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。不動産・建設・住宅の公開職歴と、番組集計上の出演1回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    },
+    {
+      "seat": 117,
+      "name": "鈴木智哉",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社トゥモロー代表。飲食・小売ブランド、地域SNS、FC事業を展開",
+      "business_summary": "飲食・宿泊・接客、フランチャイズ・多店舗展開、マーケティング・メディア",
+      "business_domains": [
+        "飲食・宿泊・接客",
+        "フランチャイズ・多店舗展開",
+        "マーケティング・メディア"
+      ],
+      "appearances": 1,
+      "investment_count": 0,
+      "public_viewpoint_summary": "一時的なバズより地域の信用を積み上げ、店舗売上と継続収入へつなげる再現性を重視する。",
+      "profile_url": "https://reiwanotoramatome.com/tomoya-suzuki/"
+    },
+    {
+      "seat": 118,
+      "name": "仙石実",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "南青山アドバイザリーグループ代表",
+      "business_summary": "経営支援・コンサルティング、M&A・事業再生",
+      "business_domains": [
+        "経営支援・コンサルティング",
+        "M&A・事業再生"
+      ],
+      "appearances": 1,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティング、M&A・事業再生の公開職歴と、番組集計上の出演1回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 119,
+      "name": "辰巳大地",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "Tiger Casino JAPAN株式会社 代表取締役",
+      "business_summary": "教育・スクール",
+      "business_domains": [
+        "教育・スクール"
+      ],
+      "appearances": 1,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。教育・スクールの公開職歴と、番組集計上の出演1回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 120,
+      "name": "犬飼 京",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "アパレルブランドADRERのプロデュース・運営を経験",
+      "business_summary": "小売・通販・EC、マーケティング・メディア、エンタメ・クリエイター",
+      "business_domains": [
+        "小売・通販・EC",
+        "マーケティング・メディア",
+        "エンタメ・クリエイター"
+      ],
+      "appearances": 1,
+      "investment_count": 1,
+      "public_viewpoint_summary": "ブランドの世界観、ファン需要、商品企画、SNSから購買へ転換する力を重視する。",
+      "profile_url": "https://ja.everybodywiki.com/%E4%BB%A4%E5%92%8C%E3%81%AE%E8%99%8E"
+    },
+    {
+      "seat": 121,
+      "name": "尾賀裕一",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "生ごみ処理機NAXLU事業の起業家。志願者から虎へ転じた経歴を持つ",
+      "business_summary": "製造・エネルギー・環境、小売・通販・EC、営業・販売組織",
+      "business_domains": [
+        "製造・エネルギー・環境",
+        "小売・通販・EC",
+        "営業・販売組織"
+      ],
+      "appearances": 1,
+      "investment_count": 1,
+      "public_viewpoint_summary": "会社を社会への価値提供と人の成長の器と捉え、単独企業より協業で提供価値を高めることを重視する。",
+      "profile_url": "https://matsugeblog.com/householdgoods/18905"
+    },
+    {
+      "seat": 122,
+      "name": "髙木 宏昌",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社J-PRoach代表。JPCスポーツ教室と子ども向けFC事業を展開",
+      "business_summary": "教育・スクール、フランチャイズ・多店舗展開、医療・介護・福祉",
+      "business_domains": [
+        "教育・スクール",
+        "フランチャイズ・多店舗展開",
+        "医療・介護・福祉"
+      ],
+      "appearances": 1,
+      "investment_count": 1,
+      "public_viewpoint_summary": "子どもの成長価値、教室単位の採算、指導品質の標準化、FC展開後も品質を保てるかを重視する。",
+      "profile_url": "https://jpcsports-fc.com/"
+    },
+    {
+      "seat": 123,
+      "name": "山本 優斗",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "OYFグループ株式会社代表。高専特化学習塾、FC店舗、結婚支援事業を展開",
+      "business_summary": "教育・スクール、フランチャイズ・多店舗展開、経営支援・コンサルティング",
+      "business_domains": [
+        "教育・スクール",
+        "フランチャイズ・多店舗展開",
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 1,
+      "investment_count": 1,
+      "public_viewpoint_summary": "対象顧客を狭く定義した専門性、教育成果、校舎展開の再現性、複数事業の相乗効果を重視する。",
+      "profile_url": "https://gamer-zylo.com/other/reiwa-tigers"
+    },
+    {
+      "seat": 124,
+      "name": "前迫 潤哉",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "合同会社MOVEMENT PRODUCTION 代表",
+      "business_summary": "マーケティング・メディア",
+      "business_domains": [
+        "マーケティング・メディア"
+      ],
+      "appearances": 1,
+      "investment_count": 0,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディアの公開職歴と、番組集計上の出演1回・出資0回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/"
+    },
+    {
+      "seat": 125,
+      "name": "ゆとりくん（片石貴展）",
+      "roster_status": "historical",
+      "birth_date": null,
+      "birth_date_source_url": null,
+      "company_role": "株式会社yutori 代表",
+      "business_summary": "経営支援・コンサルティング",
+      "business_domains": [
+        "経営支援・コンサルティング"
+      ],
+      "appearances": 1,
+      "investment_count": 1,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。経営支援・コンサルティングの公開職歴と、番組集計上の出演1回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/"
+    }
+  ]
+}

--- a/lib/models/tiger_reviewer_profile.dart
+++ b/lib/models/tiger_reviewer_profile.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+class TigerReviewerProfileCatalog {
+  const TigerReviewerProfileCatalog({
+    required this.schemaVersion,
+    required this.snapshotDate,
+    required this.profilesBySeat,
+    required this.disclaimer,
+  });
+
+  final int schemaVersion;
+  final DateTime? snapshotDate;
+  final Map<int, TigerReviewerProfile> profilesBySeat;
+  final String disclaimer;
+
+  factory TigerReviewerProfileCatalog.fromJsonString(String source) {
+    final decoded = jsonDecode(source);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException(
+        'Tiger reviewer profile catalog must be an object.',
+      );
+    }
+    return TigerReviewerProfileCatalog.fromJson(decoded);
+  }
+
+  factory TigerReviewerProfileCatalog.fromJson(Map<String, dynamic> json) {
+    final profiles = json['profiles'];
+    final parsed = profiles is List
+        ? profiles
+              .whereType<Map>()
+              .map(
+                (profile) => TigerReviewerProfile.fromJson(
+                  Map<String, dynamic>.from(profile),
+                ),
+              )
+              .toList(growable: false)
+        : const <TigerReviewerProfile>[];
+    return TigerReviewerProfileCatalog(
+      schemaVersion: json['schema_version'] is int
+          ? json['schema_version'] as int
+          : 0,
+      snapshotDate: DateTime.tryParse(json['snapshot_date']?.toString() ?? ''),
+      profilesBySeat: <int, TigerReviewerProfile>{
+        for (final profile in parsed) profile.seat: profile,
+      },
+      disclaimer: json['disclaimer']?.toString() ?? '',
+    );
+  }
+}
+
+class TigerReviewerProfile {
+  const TigerReviewerProfile({
+    required this.seat,
+    required this.name,
+    required this.rosterStatus,
+    required this.birthDate,
+    required this.companyRole,
+    required this.businessSummary,
+    required this.businessDomains,
+    required this.appearances,
+    required this.investmentCount,
+    required this.publicViewpointSummary,
+    required this.profileUrl,
+    required this.birthDateSourceUrl,
+  });
+
+  final int seat;
+  final String name;
+  final String rosterStatus;
+  final DateTime? birthDate;
+  final String companyRole;
+  final String businessSummary;
+  final List<String> businessDomains;
+  final int appearances;
+  final int investmentCount;
+  final String publicViewpointSummary;
+  final Uri? profileUrl;
+  final Uri? birthDateSourceUrl;
+
+  String ageLabel(DateTime? asOf) {
+    if (birthDate == null || asOf == null) return '公開情報未確認';
+    var age = asOf.year - birthDate!.year;
+    final birthdayPassed =
+        asOf.month > birthDate!.month ||
+        (asOf.month == birthDate!.month && asOf.day >= birthDate!.day);
+    if (!birthdayPassed) age -= 1;
+    return '$age歳（${asOf.year}年${asOf.month}月${asOf.day}日時点）';
+  }
+
+  factory TigerReviewerProfile.fromJson(Map<String, dynamic> json) {
+    final rawDomains = json['business_domains'];
+    return TigerReviewerProfile(
+      seat: json['seat'] is num ? (json['seat'] as num).toInt() : 0,
+      name: json['name']?.toString() ?? '',
+      rosterStatus: json['roster_status']?.toString() ?? '',
+      birthDate: DateTime.tryParse(json['birth_date']?.toString() ?? ''),
+      companyRole: json['company_role']?.toString() ?? '',
+      businessSummary: json['business_summary']?.toString() ?? '',
+      businessDomains: rawDomains is List
+          ? rawDomains.map((value) => value.toString()).toList(growable: false)
+          : const <String>[],
+      appearances: json['appearances'] is num
+          ? (json['appearances'] as num).toInt()
+          : 0,
+      investmentCount: json['investment_count'] is num
+          ? (json['investment_count'] as num).toInt()
+          : 0,
+      publicViewpointSummary:
+          json['public_viewpoint_summary']?.toString() ?? '',
+      profileUrl: Uri.tryParse(json['profile_url']?.toString() ?? ''),
+      birthDateSourceUrl: Uri.tryParse(
+        json['birth_date_source_url']?.toString() ?? '',
+      ),
+    );
+  }
+}

--- a/lib/models/tiger_reviewer_profile.dart
+++ b/lib/models/tiger_reviewer_profile.dart
@@ -36,9 +36,8 @@ class TigerReviewerProfileCatalog {
             .toList(growable: false)
         : const <TigerReviewerProfile>[];
     return TigerReviewerProfileCatalog(
-      schemaVersion: json['schema_version'] is int
-          ? json['schema_version'] as int
-          : 0,
+      schemaVersion:
+          json['schema_version'] is int ? json['schema_version'] as int : 0,
       snapshotDate: DateTime.tryParse(json['snapshot_date']?.toString() ?? ''),
       profilesBySeat: <int, TigerReviewerProfile>{
         for (final profile in parsed) profile.seat: profile,
@@ -80,8 +79,7 @@ class TigerReviewerProfile {
   String ageLabel(DateTime? asOf) {
     if (birthDate == null || asOf == null) return '公開情報未確認';
     var age = asOf.year - birthDate!.year;
-    final birthdayPassed =
-        asOf.month > birthDate!.month ||
+    final birthdayPassed = asOf.month > birthDate!.month ||
         (asOf.month == birthDate!.month && asOf.day >= birthDate!.day);
     if (!birthdayPassed) age -= 1;
     return '$age歳（${asOf.year}年${asOf.month}月${asOf.day}日時点）';
@@ -99,9 +97,8 @@ class TigerReviewerProfile {
       businessDomains: rawDomains is List
           ? rawDomains.map((value) => value.toString()).toList(growable: false)
           : const <String>[],
-      appearances: json['appearances'] is num
-          ? (json['appearances'] as num).toInt()
-          : 0,
+      appearances:
+          json['appearances'] is num ? (json['appearances'] as num).toInt() : 0,
       investmentCount: json['investment_count'] is num
           ? (json['investment_count'] as num).toInt()
           : 0,

--- a/lib/models/tiger_reviewer_profile.dart
+++ b/lib/models/tiger_reviewer_profile.dart
@@ -27,13 +27,13 @@ class TigerReviewerProfileCatalog {
     final profiles = json['profiles'];
     final parsed = profiles is List
         ? profiles
-              .whereType<Map>()
-              .map(
-                (profile) => TigerReviewerProfile.fromJson(
-                  Map<String, dynamic>.from(profile),
-                ),
-              )
-              .toList(growable: false)
+            .whereType<Map>()
+            .map(
+              (profile) => TigerReviewerProfile.fromJson(
+                Map<String, dynamic>.from(profile),
+              ),
+            )
+            .toList(growable: false)
         : const <TigerReviewerProfile>[];
     return TigerReviewerProfileCatalog(
       schemaVersion: json['schema_version'] is int

--- a/lib/pages/tiger_review_lane_status_page.dart
+++ b/lib/pages/tiger_review_lane_status_page.dart
@@ -4,8 +4,11 @@ import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../models/tiger_review_lane_status.dart';
+import '../models/tiger_reviewer_profile.dart';
 
 typedef TigerLaneStatusLoader = Future<TigerReviewLaneStatus> Function();
+typedef TigerReviewerProfileLoader = Future<TigerReviewerProfileCatalog>
+    Function();
 
 enum TigerReviewLane {
   reviewers(
@@ -97,10 +100,16 @@ class TigerReviewHubPage extends StatelessWidget {
 }
 
 class TigerReviewLaneStatusPage extends StatefulWidget {
-  const TigerReviewLaneStatusPage({super.key, required this.kind, this.loader});
+  const TigerReviewLaneStatusPage({
+    super.key,
+    required this.kind,
+    this.loader,
+    this.profileLoader,
+  });
 
   final TigerReviewLane kind;
   final TigerLaneStatusLoader? loader;
+  final TigerReviewerProfileLoader? profileLoader;
 
   @override
   State<TigerReviewLaneStatusPage> createState() =>
@@ -108,35 +117,44 @@ class TigerReviewLaneStatusPage extends StatefulWidget {
 }
 
 class _TigerReviewLaneStatusPageState extends State<TigerReviewLaneStatusPage> {
-  late Future<TigerReviewLaneStatus> _status;
+  late Future<_TigerLanePageData> _data;
 
   @override
   void initState() {
     super.initState();
-    _status = _load();
+    _data = _load();
   }
 
-  Future<TigerReviewLaneStatus> _load() {
-    if (widget.loader != null) return widget.loader!();
-    return _loadStatusAsset(
-      widget.kind.asset,
-    ).then(TigerReviewLaneStatus.fromJsonString);
+  Future<_TigerLanePageData> _load() async {
+    final status = widget.loader != null
+        ? await widget.loader!()
+        : TigerReviewLaneStatus.fromJsonString(
+            await _loadAsset(widget.kind.asset, schemaVersion: 3),
+          );
+    final profiles = widget.kind == TigerReviewLane.reviewers
+        ? await (widget.profileLoader?.call() ??
+            _loadAsset(
+              'assets/data/tiger_reviewer_profiles.json',
+              schemaVersion: 1,
+            ).then(TigerReviewerProfileCatalog.fromJsonString))
+        : null;
+    return _TigerLanePageData(status: status, profiles: profiles);
   }
 
-  Future<String> _loadStatusAsset(String asset) {
+  Future<String> _loadAsset(String asset, {required int schemaVersion}) {
     if (!kIsWeb) return rootBundle.loadString(asset);
 
     // These JSON snapshots are refreshed by independent review automations.
     // Do not reuse a browser's previous asset response after a new release.
     return NetworkAssetBundle(
       Uri.base.resolve('assets/'),
-    ).loadString('$asset?review_status_schema=3');
+    ).loadString('$asset?review_status_schema=$schemaVersion');
   }
 
   Future<void> _reload() async {
     final next = _load();
     setState(() {
-      _status = next;
+      _data = next;
     });
     await next;
   }
@@ -155,8 +173,8 @@ class _TigerReviewLaneStatusPageState extends State<TigerReviewLaneStatusPage> {
           ),
         ],
       ),
-      body: FutureBuilder<TigerReviewLaneStatus>(
-        future: _status,
+      body: FutureBuilder<_TigerLanePageData>(
+        future: _data,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
@@ -170,13 +188,15 @@ class _TigerReviewLaneStatusPageState extends State<TigerReviewLaneStatusPage> {
               ),
             );
           }
-          final status = snapshot.requireData;
+          final data = snapshot.requireData;
+          final status = data.status;
           if (status.lane != widget.kind.lane) {
             return const Center(child: Text('公開データの系統が一致しません。'));
           }
           return _LaneContent(
             kind: widget.kind,
             status: status,
+            profiles: data.profiles,
             onRefresh: _reload,
           );
         },
@@ -185,15 +205,24 @@ class _TigerReviewLaneStatusPageState extends State<TigerReviewLaneStatusPage> {
   }
 }
 
+class _TigerLanePageData {
+  const _TigerLanePageData({required this.status, required this.profiles});
+
+  final TigerReviewLaneStatus status;
+  final TigerReviewerProfileCatalog? profiles;
+}
+
 class _LaneContent extends StatelessWidget {
   const _LaneContent({
     required this.kind,
     required this.status,
+    required this.profiles,
     required this.onRefresh,
   });
 
   final TigerReviewLane kind;
   final TigerReviewLaneStatus status;
+  final TigerReviewerProfileCatalog? profiles;
   final Future<void> Function() onRefresh;
 
   @override
@@ -254,22 +283,47 @@ class _LaneContent extends StatelessWidget {
                           itemBuilder: (context, index) => _StandingTile(
                             kind: kind,
                             entry: status.entries[index],
+                            profile: profiles
+                                ?.profilesBySeat[status.entries[index]['seat']],
+                            profileSnapshotDate: profiles?.snapshotDate,
                           ),
                         ),
                       ),
                     SliverPadding(
                       padding: EdgeInsets.fromLTRB(
                         horizontalPadding,
-                        status.disclaimer.isEmpty ? 8 : 16,
+                        status.disclaimer.isEmpty &&
+                                (profiles?.disclaimer.isEmpty ?? true)
+                            ? 8
+                            : 16,
                         horizontalPadding,
                         24,
                       ),
                       sliver: SliverToBoxAdapter(
-                        child: status.disclaimer.isEmpty
+                        child: status.disclaimer.isEmpty &&
+                                (profiles?.disclaimer.isEmpty ?? true)
                             ? const SizedBox.shrink()
-                            : Text(
-                                status.disclaimer,
-                                style: Theme.of(context).textTheme.bodySmall,
+                            : Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: <Widget>[
+                                  if (status.disclaimer.isNotEmpty)
+                                    Text(
+                                      status.disclaimer,
+                                      style: Theme.of(
+                                        context,
+                                      ).textTheme.bodySmall,
+                                    ),
+                                  if (profiles?.disclaimer case final text?)
+                                    if (text.isNotEmpty) ...<Widget>[
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        text,
+                                        style: Theme.of(
+                                          context,
+                                        ).textTheme.bodySmall,
+                                      ),
+                                    ],
+                                ],
                               ),
                       ),
                     ),
@@ -633,22 +687,35 @@ class _LatestCard extends StatelessWidget {
 }
 
 class _StandingTile extends StatelessWidget {
-  const _StandingTile({required this.kind, required this.entry});
+  const _StandingTile({
+    required this.kind,
+    required this.entry,
+    required this.profile,
+    required this.profileSnapshotDate,
+  });
 
   final TigerReviewLane kind;
   final Map<String, dynamic> entry;
+  final TigerReviewerProfile? profile;
+  final DateTime? profileSnapshotDate;
 
   @override
   Widget build(BuildContext context) {
+    if (kind == TigerReviewLane.reviewers) {
+      return _ReviewerStandingTile(
+        entry: entry,
+        profile: profile,
+        profileSnapshotDate: profileSnapshotDate,
+      );
+    }
     final title = switch (kind) {
-      TigerReviewLane.reviewers => entry['name'],
+      TigerReviewLane.reviewers => '',
       TigerReviewLane.courses => entry['title'],
       TigerReviewLane.features => entry['title'],
       TigerReviewLane.site => '',
     };
     final detail = switch (kind) {
-      TigerReviewLane.reviewers =>
-        '席 ${entry['seat']}・担当 ${entry['completed_cycles']}回',
+      TigerReviewLane.reviewers => '',
       TigerReviewLane.courses =>
         '${entry['provider']}・レビュー ${entry['completed_cycles']}回',
       TigerReviewLane.features =>
@@ -668,6 +735,160 @@ class _StandingTile extends StatelessWidget {
               ? '選出外'
               : '${entry['utility_score'] ?? '暫定'}点',
         ),
+      ),
+    );
+  }
+}
+
+class _ReviewerStandingTile extends StatelessWidget {
+  const _ReviewerStandingTile({
+    required this.entry,
+    required this.profile,
+    required this.profileSnapshotDate,
+  });
+
+  final Map<String, dynamic> entry;
+  final TigerReviewerProfile? profile;
+  final DateTime? profileSnapshotDate;
+
+  @override
+  Widget build(BuildContext context) {
+    final seat = entry['seat'];
+    final score = entry['eligible'] == false
+        ? '選出外'
+        : '${entry['utility_score'] ?? '暫定'}点';
+    return Card(
+      child: ExpansionTile(
+        key: Key('tiger-reviewer_league-$seat'),
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+        childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 18),
+        leading: CircleAvatar(child: Text('${entry['division'] ?? 3}')),
+        title: Row(
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                entry['name']?.toString() ?? '',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(score, style: Theme.of(context).textTheme.bodySmall),
+          ],
+        ),
+        subtitle: Text('席 $seat・担当 ${entry['completed_cycles']}回'),
+        children: <Widget>[
+          if (profile == null)
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: Text('公開プロフィール情報を確認できません。'),
+            )
+          else
+            _ReviewerProfileDetails(
+              profile: profile!,
+              snapshotDate: profileSnapshotDate,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReviewerProfileDetails extends StatelessWidget {
+  const _ReviewerProfileDetails({
+    required this.profile,
+    required this.snapshotDate,
+  });
+
+  final TigerReviewerProfile profile;
+  final DateTime? snapshotDate;
+
+  @override
+  Widget build(BuildContext context) {
+    final profileUrl = profile.profileUrl;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Divider(),
+        _ProfileFact(label: '年齢', value: profile.ageLabel(snapshotDate)),
+        _ProfileFact(
+          label: '肩書き',
+          value: profile.companyRole.isEmpty ? '公開情報未確認' : profile.companyRole,
+        ),
+        _ProfileFact(
+          label: '事業内容',
+          value: profile.businessSummary.isEmpty
+              ? '公開情報未確認'
+              : profile.businessSummary,
+        ),
+        _ProfileFact(
+          label: '出演実績',
+          value: '出演 ${profile.appearances}回・出資 ${profile.investmentCount}回',
+        ),
+        _ProfileFact(
+          label: '在籍区分',
+          value: profile.rosterStatus == 'current' ? '現役虎' : '歴代虎',
+        ),
+        if (profile.businessDomains.isNotEmpty) ...<Widget>[
+          const SizedBox(height: 8),
+          Text('事業分野', style: Theme.of(context).textTheme.labelLarge),
+          const SizedBox(height: 4),
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: <Widget>[
+              for (final domain in profile.businessDomains)
+                Chip(
+                  visualDensity: VisualDensity.compact,
+                  label: Text(domain),
+                ),
+            ],
+          ),
+        ],
+        if (profile.publicViewpointSummary.isNotEmpty) ...<Widget>[
+          const SizedBox(height: 8),
+          _ProfileFact(
+            label: '審査姿勢',
+            value: profile.publicViewpointSummary,
+          ),
+        ],
+        if (profileUrl != null && profileUrl.hasScheme) ...<Widget>[
+          const SizedBox(height: 8),
+          TextButton.icon(
+            key: Key('tiger-profile-source-${profile.seat}'),
+            onPressed: () => launchUrl(
+              profileUrl,
+              mode: LaunchMode.externalApplication,
+            ),
+            icon: const Icon(Icons.open_in_new, size: 18),
+            label: const Text('公開プロフィールを開く'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _ProfileFact extends StatelessWidget {
+  const _ProfileFact({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(
+            width: 76,
+            child: Text(label, style: Theme.of(context).textTheme.labelLarge),
+          ),
+          const SizedBox(width: 8),
+          Expanded(child: Text(value)),
+        ],
       ),
     );
   }

--- a/test/models/tiger_reviewer_profile_test.dart
+++ b/test/models/tiger_reviewer_profile_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/tiger_review_lane_status.dart';
+import 'package:my_web_app/models/tiger_reviewer_profile.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'parses the complete evidence-labelled reviewer profile catalog',
+    () async {
+      final source = await rootBundle.loadString(
+        'assets/data/tiger_reviewer_profiles.json',
+      );
+      final catalog = TigerReviewerProfileCatalog.fromJsonString(source);
+
+      expect(catalog.schemaVersion, 1);
+      expect(catalog.profilesBySeat, hasLength(125));
+      expect(catalog.profilesBySeat.keys.toSet(), hasLength(125));
+      expect(
+        catalog.profilesBySeat.values.every(
+          (profile) =>
+              profile.name.isNotEmpty &&
+              profile.companyRole.isNotEmpty &&
+              profile.businessSummary.isNotEmpty &&
+              profile.businessDomains.isNotEmpty &&
+              profile.profileUrl?.hasScheme == true,
+        ),
+        isTrue,
+      );
+      expect(
+        catalog.profilesBySeat.values
+            .where((profile) => profile.birthDate != null)
+            .every((profile) => profile.birthDateSourceUrl?.hasScheme == true),
+        isTrue,
+      );
+
+      final standingsSource = await rootBundle.loadString(
+        'assets/data/tiger_reviewer_league_status.json',
+      );
+      final standings = TigerReviewLaneStatus.fromJsonString(standingsSource);
+      for (final standing in standings.entries) {
+        final seat = standing['seat'] as int;
+        expect(catalog.profilesBySeat[seat]?.name, standing['name']);
+      }
+    },
+  );
+
+  test('calculates age only from a verified birth date', () {
+    final verified = TigerReviewerProfile(
+      seat: 21,
+      name: '遠藤 悠記',
+      rosterStatus: 'current',
+      birthDate: DateTime(1990, 3, 17),
+      companyRole: '株式会社えん代表',
+      businessSummary: '学習塾、美容エステサロン、顧問事業',
+      businessDomains: const <String>['教育・スクール'],
+      appearances: 64,
+      investmentCount: 17,
+      publicViewpointSummary: '',
+      profileUrl: Uri.parse('https://reiwanotora.jp/tiger/endo-yuki/'),
+      birthDateSourceUrl: Uri.parse('https://reiwanotora.jp/tiger/endo-yuki/'),
+    );
+    final unverified = TigerReviewerProfile(
+      seat: 1,
+      name: 'ドラゴン細井',
+      rosterStatus: 'current',
+      birthDate: null,
+      companyRole: 'アマソラクリニック 院長',
+      businessSummary: '美容クリニック',
+      businessDomains: const <String>['美容・ウェルネス'],
+      appearances: 151,
+      investmentCount: 56,
+      publicViewpointSummary: '',
+      profileUrl: Uri.parse('https://reiwanotora.jp/tiger/hosoi-ryu/'),
+      birthDateSourceUrl: null,
+    );
+
+    expect(verified.ageLabel(DateTime(2026, 8, 23)), '36歳（2026年8月23日時点）');
+    expect(unverified.ageLabel(DateTime(2026, 8, 23)), '公開情報未確認');
+  });
+}

--- a/test/pages/tiger_review_lane_status_page_test.dart
+++ b/test/pages/tiger_review_lane_status_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/models/tiger_review_lane_status.dart';
+import 'package:my_web_app/models/tiger_reviewer_profile.dart';
 import 'package:my_web_app/pages/tiger_review_lane_status_page.dart';
 
 void main() {
@@ -87,6 +88,74 @@ void main() {
     expect(loadCount, 2);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'reviewer lane expands age, business, and title on narrow screens',
+    (tester) async {
+      tester.view.physicalSize = const Size(360, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TigerReviewLaneStatusPage(
+            kind: TigerReviewLane.reviewers,
+            loader: () async => _status(
+              lane: 'reviewer_league',
+              entries: const <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'seat': 21,
+                  'name': '遠藤 悠記',
+                  'division': 2,
+                  'eligible': true,
+                  'completed_cycles': 2,
+                  'utility_score': 78.5,
+                },
+              ],
+            ),
+            profileLoader: () async => TigerReviewerProfileCatalog(
+              schemaVersion: 1,
+              snapshotDate: DateTime(2026, 8, 23),
+              profilesBySeat: <int, TigerReviewerProfile>{
+                21: TigerReviewerProfile(
+                  seat: 21,
+                  name: '遠藤 悠記',
+                  rosterStatus: 'current',
+                  birthDate: DateTime(1990, 3, 17),
+                  companyRole: '株式会社えん代表',
+                  businessSummary: '学習塾、美容エステサロン、顧問事業',
+                  businessDomains: const <String>['教育・スクール'],
+                  appearances: 64,
+                  investmentCount: 17,
+                  publicViewpointSummary: '最後は人情を重視する。',
+                  profileUrl: Uri.parse(
+                    'https://reiwanotora.jp/tiger/endo-yuki/',
+                  ),
+                  birthDateSourceUrl: Uri.parse(
+                    'https://reiwanotora.jp/tiger/endo-yuki/',
+                  ),
+                ),
+              },
+              disclaimer: '公開情報から構成したプロフィールです。',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('tiger-reviewer_league-21')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('36歳（2026年8月23日時点）'), findsOneWidget);
+      expect(find.text('株式会社えん代表'), findsOneWidget);
+      expect(find.text('学習塾、美容エステサロン、顧問事業'), findsOneWidget);
+      expect(find.text('教育・スクール'), findsOneWidget);
+      expect(find.text('出演 64回・出資 17回'), findsOneWidget);
+      expect(find.byKey(const Key('tiger-profile-source-21')), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('history shows findings and countermeasure trace', (
     tester,


### PR DESCRIPTION
## 変更内容

- 虎レビュアー125名の公開プロフィール台帳を追加
- 一覧行を展開して年齢・肩書き・事業内容・出演実績・在籍区分・審査姿勢を表示
- 公開プロフィールへの外部リンクと、推測しない年齢表示を追加
- 狭幅360pxを含むモデル／Widgetテストを追加

## 検証

- `flutter analyze lib/models/tiger_reviewer_profile.dart lib/pages/tiger_review_lane_status_page.dart test/models/tiger_reviewer_profile_test.dart test/pages/tiger_review_lane_status_page_test.dart` — No issues found
- `flutter test test/models/tiger_reviewer_profile_test.dart test/models/tiger_review_lane_status_test.dart test/pages/tiger_review_lane_status_page_test.dart --concurrency=2` — 14 tests passed
- プロフィール125名と順位データ125名の席番号・氏名一致を確認

## QA / 制約

- 360x800のWidgetテストで展開表示とオーバーフローなしを確認
- ローカルのFlutter Webコンパイラが異常終了したため、ブラウザ目視は本番デプロイ後のスモークテストで実施
- 正確な年齢は一次公開情報で確認できた場合のみ表示し、未確認は「公開情報未確認」
- E2Eファイル追加なし: 既存の公開読み取り専用画面への展開表示で、モデル／Widgetテストと本番スモークで検証

## デプロイ

- DBマイグレーション、環境変数追加、外部サービス設定変更なし
- mainマージ後の `deploy-prod.yml` によりFirebase Hostingへ反映
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Read-only row expansion is covered by model and widget tests plus the authorized production smoke test; no separate routed user flow was added.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Production wording in the release note triggered this gate, but the change is a read-only public profile UI with no security, rollback, data migration, production configuration, or observability code changes.
