### PR TITLE
fix: AI大学で公開動画より下へ到達できるようにする

### DIFF
--- a/lib/widgets/ai_university_published_video_banner.dart
+++ b/lib/widgets/ai_university_published_video_banner.dart
@@ -47,7 +47,6 @@ class AiUniversityPublishedVideoBanner extends StatelessWidget {
           child: LayoutBuilder(
             builder: (context, constraints) {
               final compact = constraints.maxWidth < 620;
-              final itemWidth = (constraints.maxWidth - 12) / 2;
 
               return Column(
                 mainAxisSize: MainAxisSize.min,
@@ -78,24 +77,71 @@ class AiUniversityPublishedVideoBanner extends StatelessWidget {
                       ),
                     )
                   else
-                    Wrap(
-                      spacing: 12,
-                      runSpacing: 12,
-                      children: [
-                        for (var index = 0; index < videos.length; index++)
-                          SizedBox(
-                            width: itemWidth,
-                            child: _VideoLessonTile(
-                              index: index,
-                              video: videos[index],
-                            ),
-                          ),
-                      ],
-                    ),
+                    _DesktopVideoGrid(videos: videos),
                 ],
               );
             },
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DesktopVideoGrid extends StatefulWidget {
+  const _DesktopVideoGrid({required this.videos});
+
+  final List<AiUniversityPublishedVideoBannerItem> videos;
+
+  @override
+  State<_DesktopVideoGrid> createState() => _DesktopVideoGridState();
+}
+
+class _DesktopVideoGridState extends State<_DesktopVideoGrid> {
+  static const _itemHeight = 86.0;
+  static const _spacing = 12.0;
+  static const _maxVisibleRows = 2;
+
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rowCount = (widget.videos.length + 1) ~/ 2;
+    final contentHeight = rowCount * _itemHeight + (rowCount - 1) * _spacing;
+    const maxHeight =
+        _maxVisibleRows * _itemHeight + (_maxVisibleRows - 1) * _spacing;
+    final viewportHeight = contentHeight.clamp(0.0, maxHeight).toDouble();
+    final isScrollable = rowCount > _maxVisibleRows;
+
+    return SizedBox(
+      key: const Key('published-video-desktop-grid'),
+      height: viewportHeight,
+      child: Scrollbar(
+        controller: _scrollController,
+        thumbVisibility: isScrollable,
+        interactive: true,
+        thickness: 6,
+        radius: const Radius.circular(999),
+        child: GridView.builder(
+          key: const Key('published-video-desktop-scroll-view'),
+          controller: _scrollController,
+          primary: false,
+          padding: EdgeInsets.only(right: isScrollable ? 12 : 0),
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 2,
+            mainAxisExtent: _itemHeight,
+            crossAxisSpacing: _spacing,
+            mainAxisSpacing: _spacing,
+          ),
+          itemCount: widget.videos.length,
+          itemBuilder: (context, index) =>
+              _VideoLessonTile(index: index, video: widget.videos[index]),
         ),
       ),
     );

--- a/test/widgets/ai_university_published_video_banner_test.dart
+++ b/test/widgets/ai_university_published_video_banner_test.dart
@@ -58,6 +58,67 @@ void main() {
     expect(secondPlayCount, 1);
   });
 
+  testWidgets('PC幅では動画一覧の高さを制限し、最後の動画まで縦スクロールできる', (tester) async {
+    var lastPlayCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: Scaffold(
+          body: Column(
+            children: [
+              AiUniversityPublishedVideoBanner(
+                videos: [
+                  for (var index = 0; index < 16; index++)
+                    AiUniversityPublishedVideoBannerItem(
+                      title: '公開動画 ${index + 1}',
+                      providerLabel: 'OpenAI',
+                      onPlay: index == 15 ? () => lastPlayCount++ : () {},
+                    ),
+                ],
+              ),
+              const Expanded(
+                child: ColoredBox(
+                  key: Key('content-below-published-videos'),
+                  color: Colors.black,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final banner = tester.getRect(
+      find.byKey(const Key('published-video-banner')),
+    );
+    final contentBelow = tester.getRect(
+      find.byKey(const Key('content-below-published-videos')),
+    );
+
+    expect(
+      find.byKey(const Key('published-video-desktop-grid')),
+      findsOneWidget,
+    );
+    expect(banner.height, lessThan(310));
+    expect(contentBelow.height, greaterThan(0));
+    expect(contentBelow.top, banner.bottom);
+
+    await tester.drag(
+      find.byKey(const Key('published-video-desktop-scroll-view')),
+      const Offset(0, -1000),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('published-video-play-button-15')),
+      findsOneWidget,
+    );
+    await tester.tap(find.byKey(const Key('published-video-play-button-15')));
+    await tester.pump();
+    expect(lastPlayCount, 1);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('狭い幅では動画を固定高の横カルーセルにして本文を押し出さない', (tester) async {
     await tester.pumpWidget(
       subject(onFirstPlay: () {}, onSecondPlay: () {}, width: 320),


### PR DESCRIPTION
## 変更内容

- AI大学のPC表示で、公開動画16件が無制限に縦展開されて下部教材を押し出す問題を修正
- PC幅の公開動画一覧を2列×最大2行の縦スクロールグリッドに変更
- スクロールバーを表示し、全動画への到達性を維持
- 620px未満の既存モバイル横カルーセルは維持

## 検証

- `flutter analyze lib/widgets/ai_university_published_video_banner.dart test/widgets/ai_university_published_video_banner_test.dart` — pass
- AI大学関連のwidget/contractテスト6件 — pass
- 16件表示時にバナー高310px未満、下部コンテンツ表示、最終動画へのスクロールと再生操作をwidget testで確認
- ローカルWebを1900x900で表示し、公開動画欄の下に新ジャンルと教材本体が表示されることを確認
- `git diff --check` — pass

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: The responsive scroll change is isolated to one widget and its user-visible height, lower-content visibility, final-item scrolling, and tap behavior are covered deterministically by focused widget tests; production smoke verification follows deployment.

## 注意事項

- ローカルのリポジトリ全体 `flutter analyze` はコードエラーではなく、空きメモリ約1.5GBの環境でDart解析サーバーがOOM終了したため未完了
- GitHub Actionsを全体検証の権威とし、必須チェック成功後にのみマージ・本番確認する
- 永続化・API・DB変更なし
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Production smoke wording triggered the keyword gate; this PR only changes a local Flutter presentation widget and its focused widget test, with no security, data migration, deployment configuration, or observability path changes.
