### PR TITLE
fix: 虎プロフィールschema 2でキャッシュを更新

### DIFF
--- a/lib/pages/tiger_review_lane_status_page.dart
+++ b/lib/pages/tiger_review_lane_status_page.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
@@ -12,6 +12,17 @@ import '../models/tiger_reviewer_profile.dart';
 typedef TigerLaneStatusLoader = Future<TigerReviewLaneStatus> Function();
 typedef TigerReviewerProfileLoader = Future<TigerReviewerProfileCatalog>
     Function();
+
+@visibleForTesting
+const int tigerReviewerProfileSchemaVersion = 2;
+
+@visibleForTesting
+Uri buildTigerReviewAssetUri(
+  Uri base,
+  String asset, {
+  required int schemaVersion,
+}) =>
+    base.resolve('assets/$asset?review_status_schema=$schemaVersion');
 
 enum TigerReviewLane {
   reviewers(
@@ -139,7 +150,7 @@ class _TigerReviewLaneStatusPageState extends State<TigerReviewLaneStatusPage> {
         ? (widget.profileLoader?.call() ??
             _loadAsset(
               'assets/data/tiger_reviewer_profiles.json',
-              schemaVersion: 1,
+              schemaVersion: tigerReviewerProfileSchemaVersion,
             ).then(TigerReviewerProfileCatalog.fromJsonString))
         : Future<TigerReviewerProfileCatalog?>.value();
     final status = await statusFuture;
@@ -152,8 +163,10 @@ class _TigerReviewLaneStatusPageState extends State<TigerReviewLaneStatusPage> {
 
     // These JSON snapshots are refreshed by independent review automations.
     // Do not reuse a browser's previous asset response after a new release.
-    final uri = Uri.base.resolve(
-      'assets/$asset?review_status_schema=$schemaVersion',
+    final uri = buildTigerReviewAssetUri(
+      Uri.base,
+      asset,
+      schemaVersion: schemaVersion,
     );
     final response = await http.get(uri);
     if (response.statusCode < 200 || response.statusCode >= 300) {

--- a/test/pages/tiger_review_lane_status_page_test.dart
+++ b/test/pages/tiger_review_lane_status_page_test.dart
@@ -5,6 +5,21 @@ import 'package:my_web_app/models/tiger_reviewer_profile.dart';
 import 'package:my_web_app/pages/tiger_review_lane_status_page.dart';
 
 void main() {
+  test('profile schema invalidates the browser asset cache', () {
+    final uri = buildTigerReviewAssetUri(
+      Uri.parse('https://example.com/tiger-reviewers'),
+      'assets/data/tiger_reviewer_profiles.json',
+      schemaVersion: tigerReviewerProfileSchemaVersion,
+    );
+
+    expect(tigerReviewerProfileSchemaVersion, 2);
+    expect(
+      uri.toString(),
+      'https://example.com/assets/assets/data/tiger_reviewer_profiles.json'
+      '?review_status_schema=2',
+    );
+  });
+
   testWidgets('hub exposes four independent review lanes', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: TigerReviewHubPage()));
 


### PR DESCRIPTION
## Summary
- 虎プロフィールカタログのWeb取得キャッシュキーをschema 1からschema 2へ更新
- asset URL生成をテスト可能な純粋関数に分離
- 既存ブラウザが旧カタログを再利用する回帰を防ぐテストを追加

## Validation
- Dart 3.10.9 `dart format --output=none --set-exit-if-changed` (0 changed)
- `flutter analyze --no-pub lib/pages/tiger_review_lane_status_page.dart test/pages/tiger_review_lane_status_page_test.dart` (0 issues)
- `flutter test --no-pub --concurrency=1 test/pages/tiger_review_lane_status_page_test.dart` (9 passed)

## Minimal E2E Gate
- Implementation-detail independent: 本番の虎レビュアー画面がschema 2のプロフィールカタログを取得し、第2回の拡充表示を利用者へ示す。
- Minimal scope: WebアセットURLのキャッシュキーと対応する回帰テストだけを変更。
- E2E: マージ後に本番URLで拡充カードと仙石実さんの詳細をデスクトップ・モバイル幅で確認する。
- E2E-Exception: URL生成の回帰テストと既存の狭幅Widgetテストが対象経路を覆い、マージ後に実ブラウザで本番確認するため。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: キャッシュキーだけの低リスク修正で個人データや採点ロジックは変更しないため、追加の高リスク例外なし。