### PR TITLE
feat(notes): add Evernote-compatible tag workflows

### DIFF
--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -1,3 +1,5 @@
+import '../services/note_tag_service.dart';
+
 class Note {
   final int id;
   final String userId;
@@ -14,6 +16,7 @@ class Note {
   final String captureStatus;
   final String captureSource;
   final DateTime? inboxSavedAt;
+  final List<String> tags;
 
   Note({
     required this.id,
@@ -31,6 +34,7 @@ class Note {
     this.captureStatus = 'organized',
     this.captureSource = 'editor',
     this.inboxSavedAt,
+    this.tags = const <String>[],
   });
 
   factory Note.fromJson(Map<String, dynamic> json) {
@@ -56,6 +60,7 @@ class Note {
       inboxSavedAt: json['inbox_saved_at'] != null
           ? DateTime.parse(json['inbox_saved_at'] as String)
           : null,
+      tags: NoteTagService.normalize(json['tags']),
     );
   }
 
@@ -76,6 +81,7 @@ class Note {
       'capture_status': captureStatus,
       'capture_source': captureSource,
       'inbox_saved_at': inboxSavedAt?.toIso8601String(),
+      'tags': tags,
     };
   }
 

--- a/lib/pages/note_editor_page.dart
+++ b/lib/pages/note_editor_page.dart
@@ -15,6 +15,7 @@ import '../services/auto_save_service.dart';
 import '../services/note_comments_service.dart';
 import '../services/note_prompt_library_service.dart';
 import '../services/note_semantic_search_service.dart';
+import '../services/note_tag_service.dart';
 import '../services/public_memo_service.dart';
 import '../services/undo_redo_service.dart';
 import '../utils/note_image_clipboard.dart';
@@ -25,6 +26,7 @@ import '../widgets/markdown_preview.dart';
 import '../widgets/note_comments_panel.dart';
 import '../widgets/note_editor/ai_assistant_menu.dart';
 import '../widgets/note_editor/editor_dialogs.dart';
+import '../widgets/note_tags_field.dart';
 import '../widgets/related_notes_strip.dart';
 
 class NoteEditorPage extends StatefulWidget {
@@ -153,6 +155,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
   String? _currentNoteId;
   DateTime? _reminderDate;
   bool _isFavorite = false;
+  List<String> _tags = const <String>[];
   bool _isLoading = false;
   bool _isLoadingAttachments = false;
   bool _isUploadingAttachment = false;
@@ -164,6 +167,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
   String? _persistedContent;
   String? _persistedReminderIso;
   bool? _persistedIsFavorite;
+  List<String>? _persistedTags;
   DateTime? _serverUpdatedAt;
   bool _showMarkdownPreview = false;
   bool? _isSlashCommandBarExpanded;
@@ -285,7 +289,8 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
       _titleController.text.trim().isNotEmpty ||
       _contentController.text.trim().isNotEmpty ||
       _reminderDate != null ||
-      _isFavorite;
+      _isFavorite ||
+      _tags.isNotEmpty;
 
   bool _boolFromValue(dynamic value) => value == true;
 
@@ -302,6 +307,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
       'content': content,
       'reminder_date': _reminderDate?.toIso8601String(),
       'is_favorite': _isFavorite,
+      'tags': _tags,
       // サーバーの updated_at と比較するため UTC で保存する。
       'saved_at': DateTime.now().toUtc().toIso8601String(),
     };
@@ -317,6 +323,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     String content;
     DateTime? reminderDate;
     bool isFavorite;
+    List<String> tags;
     DateTime? draftSavedAt;
     try {
       final decoded = jsonDecode(raw);
@@ -327,6 +334,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
           ? null
           : DateTime.tryParse(decoded['reminder_date'].toString())?.toLocal();
       isFavorite = _boolFromValue(decoded['is_favorite']);
+      tags = NoteTagService.normalize(decoded['tags']);
       draftSavedAt = decoded['saved_at'] == null
           ? null
           : DateTime.tryParse(decoded['saved_at'].toString())?.toUtc();
@@ -336,14 +344,16 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     if (title.isEmpty &&
         content.isEmpty &&
         reminderDate == null &&
-        !isFavorite) {
+        !isFavorite &&
+        tags.isEmpty) {
       return;
     }
 
     final hasChanges = _titleController.text != title ||
         _contentController.text != content ||
         _reminderDate?.toIso8601String() != reminderDate?.toIso8601String() ||
-        _isFavorite != isFavorite;
+        _isFavorite != isFavorite ||
+        !NoteTagService.equals(_tags, tags);
     if (!hasChanges) return;
 
     // 下書きより後にサーバー側が更新されている場合 (= 別端末での編集) は
@@ -388,6 +398,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     _contentController.text = content;
     _reminderDate = reminderDate;
     _isFavorite = isFavorite;
+    _tags = tags;
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -421,11 +432,13 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     required String content,
     required String? reminderIso,
     required bool isFavorite,
+    required List<String> tags,
   }) {
     _persistedTitle = title;
     _persistedContent = content;
     _persistedReminderIso = reminderIso;
     _persistedIsFavorite = isFavorite;
+    _persistedTags = NoteTagService.normalize(tags);
   }
 
   /// サーバー側の内容を一度でも取得できているか。取得できていない状態で
@@ -439,11 +452,13 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     required String content,
     required String? reminderIso,
     required bool isFavorite,
+    required List<String> tags,
   }) {
     return _persistedTitle == title &&
         _persistedContent == content &&
         _persistedReminderIso == reminderIso &&
-        _persistedIsFavorite == isFavorite;
+        _persistedIsFavorite == isFavorite &&
+        NoteTagService.equals(_persistedTags, tags);
   }
 
   void _detachTextListeners() {
@@ -467,7 +482,8 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     final hasAnyInput = _titleController.text.trim().isNotEmpty ||
         _contentController.text.trim().isNotEmpty ||
         _reminderDate != null ||
-        _isFavorite;
+        _isFavorite ||
+        _tags.isNotEmpty;
     // ローカル下書きを復元した直後は、画面上の内容がサーバーより新しい。
     // 従来はここで無条件に markAsSaved していたため「保存済み」と表示され
     // つつサーバーには届かず、次に何か入力するまで反映されなかった。
@@ -477,6 +493,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
           content: _contentController.text.trim(),
           reminderIso: _reminderDate?.toUtc().toIso8601String(),
           isFavorite: _isFavorite,
+          tags: _tags,
         );
 
     if (matchesServer || (_currentNoteId == null && !hasAnyInput)) {
@@ -517,6 +534,61 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     _autoSaveService.markAsModified();
     _autoSaveService.triggerAutoSave(_saveNoteWithoutClosing);
     _persistDraftToLocal();
+  }
+
+  void _handleTagsChanged(List<String> tags) {
+    final normalized = NoteTagService.normalize(tags);
+    if (NoteTagService.equals(_tags, normalized)) return;
+    setState(() {
+      _tags = normalized;
+    });
+    _autoSaveService.markAsModified();
+    _autoSaveService.triggerAutoSave(_saveNoteWithoutClosing);
+    _persistDraftToLocal();
+  }
+
+  Future<void> _showTagsEditor() async {
+    var workingTags = List<String>.from(_tags);
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (context, setSheetState) {
+            return SafeArea(
+              child: SingleChildScrollView(
+                padding: EdgeInsets.fromLTRB(
+                  20,
+                  20,
+                  20,
+                  20 + MediaQuery.viewInsetsOf(context).bottom,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'タグを編集',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 16),
+                    NoteTagsField(
+                      tags: workingTags,
+                      onChanged: (tags) {
+                        setSheetState(() {
+                          workingTags = tags;
+                        });
+                        _handleTagsChanged(tags);
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
   }
 
   void _showMessage(String message) {
@@ -1347,7 +1419,9 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     try {
       final data = await _supabase
           .from('notes')
-          .select('title, content, reminder_date, is_favorite, updated_at')
+          .select(
+            'title, content, reminder_date, is_favorite, tags, updated_at',
+          )
           .eq('id', id)
           .single();
       _serverUpdatedAt = data['updated_at'] == null
@@ -1364,12 +1438,14 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
                   data['reminder_date'].toString(),
                 )?.toLocal();
           _isFavorite = _boolFromValue(data['is_favorite']);
+          _tags = NoteTagService.normalize(data['tags']);
         });
         _markStatePersisted(
           title: _titleController.text.trim(),
           content: _contentController.text.trim(),
           reminderIso: _reminderDate?.toUtc().toIso8601String(),
           isFavorite: _isFavorite,
+          tags: _tags,
         );
         _syncObservedText();
       }
@@ -1456,6 +1532,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     final content = _contentController.text.trim();
     final reminderIso = _reminderDate?.toUtc().toIso8601String();
     final isFavorite = _isFavorite;
+    final tags = NoteTagService.normalize(_tags);
 
     if (!_hasPersistableState && _currentNoteId == null) {
       return;
@@ -1475,6 +1552,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
         content: content,
         reminderIso: reminderIso,
         isFavorite: isFavorite,
+        tags: tags,
       )) {
         _autoSaveService.markAsSaved();
         return;
@@ -1484,6 +1562,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
         'content': content,
         'reminder_date': reminderIso,
         'is_favorite': isFavorite,
+        'tags': tags,
         // timestamptz 列にはオフセット付きで渡す。ローカル時刻のまま送ると
         // サーバー側で UTC と解釈され JST 環境では 9 時間ずれる。
         'updated_at': DateTime.now().toUtc().toIso8601String(),
@@ -1497,6 +1576,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
             'content': content,
             'reminder_date': reminderIso,
             'is_favorite': isFavorite,
+            'tags': tags,
             'is_archived': false,
             'is_pinned': false,
           })
@@ -1517,6 +1597,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
       content: content,
       reminderIso: reminderIso,
       isFavorite: isFavorite,
+      tags: tags,
     );
 
     final currentMatchesSavedRequest = _matchesPersistedState(
@@ -1524,6 +1605,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
       content: _contentController.text.trim(),
       reminderIso: _reminderDate?.toUtc().toIso8601String(),
       isFavorite: _isFavorite,
+      tags: _tags,
     );
     if (currentMatchesSavedRequest) {
       _autoSaveService.markAsSaved();
@@ -2353,6 +2435,12 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
                     ),
                     label: Text(previewLabel),
                   ),
+                  OutlinedButton.icon(
+                    key: const Key('note_editor_tags_button'),
+                    onPressed: _showTagsEditor,
+                    icon: const Icon(Icons.sell_outlined),
+                    label: Text(isNarrow ? 'タグ' : 'タグ (${_tags.length})'),
+                  ),
                 ],
               ),
               if (!isNarrow) ...[
@@ -2471,11 +2559,13 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     final content = _contentController.text.trim();
     final reminderIso = _reminderDate?.toUtc().toIso8601String();
     final isFavorite = _isFavorite;
+    final tags = NoteTagService.normalize(_tags);
     if (_matchesPersistedState(
       title: title,
       content: content,
       reminderIso: reminderIso,
       isFavorite: isFavorite,
+      tags: tags,
     )) {
       return;
     }
@@ -2488,6 +2578,7 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
             'content': content,
             'reminder_date': reminderIso,
             'is_favorite': isFavorite,
+            'tags': tags,
             'updated_at': DateTime.now().toUtc().toIso8601String(),
           })
           .eq('id', noteId)

--- a/lib/pages/note_list_page.dart
+++ b/lib/pages/note_list_page.dart
@@ -210,19 +210,18 @@ class _NoteListPageState extends State<NoteListPage> {
     };
     final semanticMatches = _semanticSearchResults
         .map(
-          (result) => result.toNoteRow(localNote: notesById[result.id]),
-        )
+      (result) => result.toNoteRow(localNote: notesById[result.id]),
+    )
         .where(
-          (note) {
-            final matchesView = _showInboxOnly
-                ? _isInbox(note)
-                : (!_showFavoritesOnly || _isFavorite(note));
-            return matchesView &&
-                (selectedTag == null ||
-                    NoteTagService.containsTag(note['tags'], selectedTag));
-          },
-        )
-        .toList(growable: false);
+      (note) {
+        final matchesView = _showInboxOnly
+            ? _isInbox(note)
+            : (!_showFavoritesOnly || _isFavorite(note));
+        return matchesView &&
+            (selectedTag == null ||
+                NoteTagService.containsTag(note['tags'], selectedTag));
+      },
+    ).toList(growable: false);
     final semanticIds = semanticMatches.map(_noteId).toSet();
     final localMatches = locallyFiltered
         .where(_matchesSearch)
@@ -1393,12 +1392,11 @@ class _NoteListPageState extends State<NoteListPage> {
             .where((note) => !shareCandidateIds.contains(_noteId(note)))
             .toList()
         : reminderExcludedNotes;
-    final hasAnyEntries =
-        (!_showInboxOnly &&
-                _searchQuery.isEmpty &&
-                _selectedTag == null &&
-                _draftEntries.isNotEmpty) ||
-            visibleNotes.isNotEmpty;
+    final hasAnyEntries = (!_showInboxOnly &&
+            _searchQuery.isEmpty &&
+            _selectedTag == null &&
+            _draftEntries.isNotEmpty) ||
+        visibleNotes.isNotEmpty;
     final pageTitle = _showInboxOnly
         ? 'CKO OFFICE (Inbox)'
         : (_showFavoritesOnly ? 'CKO OFFICE (お気に入り)' : 'CKO OFFICE (メモ一覧)');
@@ -1630,10 +1628,10 @@ class _NoteListPageState extends State<NoteListPage> {
                               _selectedTag != null
                                   ? '「$_selectedTag」のメモはありません'
                                   : _showInboxOnly
-                                  ? 'Inboxは空です'
-                                  : (_showFavoritesOnly
-                                      ? 'お気に入りのメモはまだありません'
-                                      : 'まだメモがありません'),
+                                      ? 'Inboxは空です'
+                                      : (_showFavoritesOnly
+                                          ? 'お気に入りのメモはまだありません'
+                                          : 'まだメモがありません'),
                               style: const TextStyle(
                                 fontSize: 18,
                                 color: Color(0xFFB0B0B0),
@@ -1651,7 +1649,8 @@ class _NoteListPageState extends State<NoteListPage> {
                                 icon: const Icon(Icons.clear),
                                 label: const Text('タグ絞り込みを解除'),
                               ),
-                            ] else if (_showFavoritesOnly || _showInboxOnly) ...[
+                            ] else if (_showFavoritesOnly ||
+                                _showInboxOnly) ...[
                               const SizedBox(height: 12),
                               TextButton.icon(
                                 onPressed: _showInboxOnly

--- a/lib/pages/note_list_page.dart
+++ b/lib/pages/note_list_page.dart
@@ -8,6 +8,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../services/inbox_capture_service.dart';
 import '../services/note_semantic_search_service.dart';
+import '../services/note_tag_service.dart';
 import '../services/public_memo_service.dart';
 import 'note_editor_page.dart';
 
@@ -73,6 +74,7 @@ class _NoteListPageState extends State<NoteListPage> {
   // Win版#108: メモ検索 (title + content 部分一致・case insensitive)
   final TextEditingController _searchController = TextEditingController();
   String _searchQuery = '';
+  String? _selectedTag;
   Timer? _searchDebounce;
   List<NoteSearchResult> _semanticSearchResults = const <NoteSearchResult>[];
   String _semanticSearchMode = 'text_fallback';
@@ -104,13 +106,15 @@ class _NoteListPageState extends State<NoteListPage> {
     _fetchNotes();
   }
 
-  /// 検索クエリで note を絞り込み (title + content 部分一致・case insensitive)
+  /// 検索クエリで note を絞り込み (title + content + tags 部分一致)。
   bool _matchesSearch(Map<String, dynamic> note) {
     if (_searchQuery.isEmpty) return true;
     final q = _searchQuery.toLowerCase();
     final title = (note['title'] as String? ?? '').toLowerCase();
     final content = (note['content'] as String? ?? '').toLowerCase();
-    return title.contains(q) || content.contains(q);
+    return title.contains(q) ||
+        content.contains(q) ||
+        NoteTagService.containsSearch(note['tags'], q);
   }
 
   void _handleSearchChanged(String value) {
@@ -183,11 +187,19 @@ class _NoteListPageState extends State<NoteListPage> {
   List<Map<String, dynamic>> _visibleNotesForSearch(
     List<Map<String, dynamic>> notes,
   ) {
-    final locallyFiltered = _showInboxOnly
+    final viewFiltered = _showInboxOnly
         ? notes.where(_isInbox).toList(growable: false)
         : (_showFavoritesOnly
             ? notes.where(_isFavorite).toList(growable: false)
             : notes);
+    final selectedTag = _selectedTag;
+    final locallyFiltered = selectedTag == null
+        ? viewFiltered
+        : viewFiltered
+            .where(
+              (note) => NoteTagService.containsTag(note['tags'], selectedTag),
+            )
+            .toList(growable: false);
     if (_searchQuery.isEmpty) return locallyFiltered;
     if (!_semanticSearchCompleted || _semanticSearchError != null) {
       return locallyFiltered.where(_matchesSearch).toList();
@@ -196,16 +208,29 @@ class _NoteListPageState extends State<NoteListPage> {
     final notesById = <String, Map<String, dynamic>>{
       for (final note in notes) _noteId(note): note,
     };
-    return _semanticSearchResults
+    final semanticMatches = _semanticSearchResults
         .map(
           (result) => result.toNoteRow(localNote: notesById[result.id]),
         )
         .where(
-          (note) => _showInboxOnly
-              ? _isInbox(note)
-              : (!_showFavoritesOnly || _isFavorite(note)),
+          (note) {
+            final matchesView = _showInboxOnly
+                ? _isInbox(note)
+                : (!_showFavoritesOnly || _isFavorite(note));
+            return matchesView &&
+                (selectedTag == null ||
+                    NoteTagService.containsTag(note['tags'], selectedTag));
+          },
         )
         .toList(growable: false);
+    final semanticIds = semanticMatches.map(_noteId).toSet();
+    final localMatches = locallyFiltered
+        .where(_matchesSearch)
+        .where((note) => !semanticIds.contains(_noteId(note)));
+    return <Map<String, dynamic>>[
+      ...semanticMatches,
+      ...localMatches,
+    ];
   }
 
   String _searchStatusText(int resultCount) {
@@ -316,9 +341,7 @@ class _NoteListPageState extends State<NoteListPage> {
       note['capture_status'] == inboxCaptureStatus;
 
   List<String> _noteTags(Map<String, dynamic> note) {
-    final raw = note['tags'];
-    if (raw is! List) return const <String>[];
-    return raw.map((tag) => tag.toString()).toList(growable: false);
+    return NoteTagService.normalize(note['tags']);
   }
 
   bool _isPublished(Map<String, dynamic> note) =>
@@ -1012,6 +1035,7 @@ class _NoteListPageState extends State<NoteListPage> {
     final isInbox = _isInbox(note);
     final title = _noteTitle(note);
     final content = _noteContent(note);
+    final tags = _noteTags(note);
     final reminderDate = _reminderDateOf(note);
     final accentColor = highlightShareCandidate
         ? const Color(0xFF6366F1)
@@ -1174,6 +1198,46 @@ class _NoteListPageState extends State<NoteListPage> {
                 ),
               ),
             ],
+            if (tags.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                key: ValueKey<String>('note_tags_${_noteId(note)}'),
+                spacing: 6,
+                runSpacing: 6,
+                children: [
+                  for (final tag in tags.take(6))
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 180),
+                      child: ActionChip(
+                        key: ValueKey<String>(
+                          'note_list_tag_${_noteId(note)}_$tag',
+                        ),
+                        avatar: const Icon(Icons.sell_outlined, size: 14),
+                        label: Text(
+                          tag,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        onPressed: () {
+                          setState(() {
+                            _selectedTag = tag;
+                          });
+                        },
+                        visualDensity: VisualDensity.compact,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                    ),
+                  if (tags.length > 6)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: Text(
+                        '+${tags.length - 6}',
+                        style: Theme.of(context).textTheme.labelSmall,
+                      ),
+                    ),
+                ],
+              ),
+            ],
             if (content.isNotEmpty) ...[
               const SizedBox(height: 8),
               Text(
@@ -1299,6 +1363,11 @@ class _NoteListPageState extends State<NoteListPage> {
   @override
   Widget build(BuildContext context) {
     // 表示モード → 意味検索（失敗時は端末内検索）の順で絞り込む。
+    final availableTags = NoteTagService.collectFromRows(_notes);
+    final tagOptions = <String>[...availableTags];
+    if (_selectedTag != null && !tagOptions.contains(_selectedTag)) {
+      tagOptions.add(_selectedTag!);
+    }
     final visibleNotes = _visibleNotesForSearch(_notes);
     final inboxEntries = visibleNotes.where(_isInbox).toList();
     final inboxIds =
@@ -1325,7 +1394,10 @@ class _NoteListPageState extends State<NoteListPage> {
             .toList()
         : reminderExcludedNotes;
     final hasAnyEntries =
-        (!_showInboxOnly && _searchQuery.isEmpty && _draftEntries.isNotEmpty) ||
+        (!_showInboxOnly &&
+                _searchQuery.isEmpty &&
+                _selectedTag == null &&
+                _draftEntries.isNotEmpty) ||
             visibleNotes.isNotEmpty;
     final pageTitle = _showInboxOnly
         ? 'CKO OFFICE (Inbox)'
@@ -1460,6 +1532,58 @@ class _NoteListPageState extends State<NoteListPage> {
               ),
             ),
           ),
+          if (tagOptions.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Wrap(
+                spacing: 12,
+                runSpacing: 8,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  const Text('タグで絞り込み'),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      minWidth: 180,
+                      maxWidth: 320,
+                    ),
+                    child: DropdownButton<String>(
+                      key: const Key('note_list_tag_filter'),
+                      value: _selectedTag,
+                      isExpanded: true,
+                      hint: const Text('すべてのタグ'),
+                      items: tagOptions
+                          .map(
+                            (tag) => DropdownMenuItem<String>(
+                              value: tag,
+                              child: Text(
+                                tag,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          )
+                          .toList(growable: false),
+                      onChanged: (tag) {
+                        setState(() {
+                          _selectedTag = tag;
+                        });
+                      },
+                    ),
+                  ),
+                  if (_selectedTag != null)
+                    TextButton.icon(
+                      key: const Key('note_list_tag_filter_clear'),
+                      onPressed: () {
+                        setState(() {
+                          _selectedTag = null;
+                        });
+                      },
+                      icon: const Icon(Icons.clear, size: 18),
+                      label: const Text('解除'),
+                    ),
+                ],
+              ),
+            ),
           if (_searchQuery.isNotEmpty)
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
@@ -1503,7 +1627,9 @@ class _NoteListPageState extends State<NoteListPage> {
                             ),
                             const SizedBox(height: 16),
                             Text(
-                              _showInboxOnly
+                              _selectedTag != null
+                                  ? '「$_selectedTag」のメモはありません'
+                                  : _showInboxOnly
                                   ? 'Inboxは空です'
                                   : (_showFavoritesOnly
                                       ? 'お気に入りのメモはまだありません'
@@ -1514,7 +1640,18 @@ class _NoteListPageState extends State<NoteListPage> {
                                 height: 1.5,
                               ),
                             ),
-                            if (_showFavoritesOnly || _showInboxOnly) ...[
+                            if (_selectedTag != null) ...[
+                              const SizedBox(height: 12),
+                              TextButton.icon(
+                                onPressed: () {
+                                  setState(() {
+                                    _selectedTag = null;
+                                  });
+                                },
+                                icon: const Icon(Icons.clear),
+                                label: const Text('タグ絞り込みを解除'),
+                              ),
+                            ] else if (_showFavoritesOnly || _showInboxOnly) ...[
                               const SizedBox(height: 12),
                               TextButton.icon(
                                 onPressed: _showInboxOnly
@@ -1559,6 +1696,7 @@ class _NoteListPageState extends State<NoteListPage> {
                           ],
                           if (!_showInboxOnly &&
                               _searchQuery.isEmpty &&
+                              _selectedTag == null &&
                               _draftEntries.isNotEmpty) ...[
                             _buildSectionHeader(
                               '下書き',

--- a/lib/services/note_tag_service.dart
+++ b/lib/services/note_tag_service.dart
@@ -1,0 +1,64 @@
+class NoteTagService {
+  const NoteTagService._();
+
+  /// Supabase の text[]、ローカル下書き、UI 入力を同じ形にそろえる。
+  ///
+  /// Evernote 由来の表記を失わないよう、大文字小文字やタグ内の空白は変更せず、
+  /// 前後空白の除去と大文字小文字を無視した重複排除だけを行う。
+  static List<String> normalize(dynamic rawTags) {
+    final Iterable<dynamic> candidates;
+    if (rawTags == null) {
+      return const <String>[];
+    } else if (rawTags is Iterable) {
+      candidates = rawTags;
+    } else {
+      candidates = <dynamic>[rawTags];
+    }
+
+    final normalized = <String>[];
+    final seen = <String>{};
+    for (final candidate in candidates) {
+      if (candidate == null) continue;
+      final tag = candidate.toString().trim();
+      if (tag.isEmpty) continue;
+      if (seen.add(tag.toLowerCase())) {
+        normalized.add(tag);
+      }
+    }
+    return List<String>.unmodifiable(normalized);
+  }
+
+  static bool equals(dynamic left, dynamic right) {
+    final a = normalize(left);
+    final b = normalize(right);
+    if (a.length != b.length) return false;
+    for (var index = 0; index < a.length; index++) {
+      if (a[index] != b[index]) return false;
+    }
+    return true;
+  }
+
+  static bool containsTag(dynamic rawTags, String selectedTag) {
+    final target = selectedTag.trim().toLowerCase();
+    if (target.isEmpty) return true;
+    return normalize(rawTags).any((tag) => tag.toLowerCase() == target);
+  }
+
+  static bool containsSearch(dynamic rawTags, String query) {
+    final target = query.trim().toLowerCase();
+    if (target.isEmpty) return true;
+    return normalize(rawTags).any((tag) => tag.toLowerCase().contains(target));
+  }
+
+  static List<String> collectFromRows(Iterable<Map<String, dynamic>> rows) {
+    final byFoldedName = <String, String>{};
+    for (final row in rows) {
+      for (final tag in normalize(row['tags'])) {
+        byFoldedName.putIfAbsent(tag.toLowerCase(), () => tag);
+      }
+    }
+    final tags = byFoldedName.values.toList()
+      ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+    return List<String>.unmodifiable(tags);
+  }
+}

--- a/lib/widgets/note_tags_field.dart
+++ b/lib/widgets/note_tags_field.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import '../services/note_tag_service.dart';
+
+class NoteTagsField extends StatefulWidget {
+  const NoteTagsField({
+    super.key,
+    required this.tags,
+    required this.onChanged,
+    this.enabled = true,
+  });
+
+  final List<String> tags;
+  final ValueChanged<List<String>> onChanged;
+  final bool enabled;
+
+  @override
+  State<NoteTagsField> createState() => _NoteTagsFieldState();
+}
+
+class _NoteTagsFieldState extends State<NoteTagsField> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _addTag([String? rawValue]) {
+    if (!widget.enabled) return;
+    final value = rawValue ?? _controller.text;
+    final nextTags = NoteTagService.normalize(<String>[...widget.tags, value]);
+    _controller.clear();
+    if (!NoteTagService.equals(nextTags, widget.tags)) {
+      widget.onChanged(nextTags);
+    }
+  }
+
+  void _removeTag(String tag) {
+    if (!widget.enabled) return;
+    widget.onChanged(
+      widget.tags
+          .where((candidate) => candidate != tag)
+          .toList(growable: false),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      container: true,
+      label: 'タグ編集',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.sell_outlined,
+                size: 18,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 8),
+              Text('タグ', style: theme.textTheme.labelLarge),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            key: const Key('note_tags_wrap'),
+            spacing: 8,
+            runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              for (final tag in widget.tags)
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 240),
+                  child: InputChip(
+                    key: ValueKey<String>('note_tag_chip_$tag'),
+                    label: Text(
+                      tag,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    deleteIcon: const Icon(
+                      Icons.close,
+                      key: Key('note_tag_delete_icon'),
+                    ),
+                    onDeleted: widget.enabled ? () => _removeTag(tag) : null,
+                  ),
+                ),
+              ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 160, maxWidth: 260),
+                child: TextField(
+                  key: const Key('note_tags_input'),
+                  controller: _controller,
+                  enabled: widget.enabled,
+                  textInputAction: TextInputAction.done,
+                  onSubmitted: _addTag,
+                  decoration: InputDecoration(
+                    isDense: true,
+                    hintText: 'タグを追加',
+                    suffixIcon: IconButton(
+                      key: const Key('note_tags_add_button'),
+                      tooltip: 'タグを追加',
+                      onPressed: widget.enabled ? _addTag : null,
+                      icon: const Icon(Icons.add),
+                    ),
+                    border: const OutlineInputBorder(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/models/note_test.dart
+++ b/test/models/note_test.dart
@@ -20,6 +20,7 @@ void main() {
       'capture_status': 'inbox',
       'capture_source': 'quick_inbox',
       'inbox_saved_at': now.toIso8601String(),
+      'tags': <String>['Evernote', '移行済み'],
     };
 
     test('Note can be created from JSON', () {
@@ -36,6 +37,7 @@ void main() {
       expect(note.isInbox, isTrue);
       expect(note.captureSource, 'quick_inbox');
       expect(note.inboxSavedAt, isNotNull);
+      expect(note.tags, <String>['Evernote', '移行済み']);
     });
 
     test('Note can be converted to JSON', () {
@@ -51,6 +53,7 @@ void main() {
       expect(json['capture_status'], sampleJson['capture_status']);
       expect(json['capture_source'], sampleJson['capture_source']);
       expect(json['inbox_saved_at'], sampleJson['inbox_saved_at']);
+      expect(json['tags'], sampleJson['tags']);
     });
 
     test('isOverdue getter works correctly', () {
@@ -183,6 +186,7 @@ void main() {
       expect(note.captureSource, 'editor');
       expect(note.inboxSavedAt, isNull);
       expect(note.isInbox, isFalse);
+      expect(note.tags, isEmpty);
     });
   });
 }

--- a/test/pages/note_editor_page_test.dart
+++ b/test/pages/note_editor_page_test.dart
@@ -322,6 +322,7 @@ Map<String, dynamic> _noteRow({
     'content': content,
     'reminder_date': null,
     'is_favorite': false,
+    'tags': <String>['Evernote'],
     'created_at': '2026-07-19T09:00:00.000Z',
     'updated_at': '2026-07-19T09:00:00.000Z',
   };
@@ -403,6 +404,24 @@ void main() {
 
       expect(client.updates, hasLength(1));
       expect(client.updates.single['content'], '編集後の本文');
+    });
+
+    testWidgets('読み込んだタグを追加して自動保存できる', (tester) async {
+      final client = await _pumpEditor(tester);
+
+      await tester.tap(find.byKey(const Key('note_editor_tags_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('Evernote'), findsOneWidget);
+      await tester.enterText(
+        find.byKey(const Key('note_tags_input')),
+        '移行済み',
+      );
+      await tester.tap(find.byKey(const Key('note_tags_add_button')));
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
+
+      expect(client.updates, hasLength(1));
+      expect(client.updates.single['tags'], <String>['Evernote', '移行済み']);
     });
 
     testWidgets('autosave does not embed while manual save indexes once', (

--- a/test/pages/note_list_page_test.dart
+++ b/test/pages/note_list_page_test.dart
@@ -228,6 +228,7 @@ Map<String, dynamic> _noteRow({
   required bool isFavorite,
   String captureStatus = 'organized',
   String userId = 'test-user-id',
+  List<String> tags = const <String>[],
 }) {
   return <String, dynamic>{
     'id': id,
@@ -239,7 +240,10 @@ Map<String, dynamic> _noteRow({
     'is_favorite': isFavorite,
     'is_archived': false,
     'reminder_date': null,
-    'tags': captureStatus == 'inbox' ? <String>['inbox'] : <String>[],
+    'tags': <String>[
+      if (captureStatus == 'inbox') 'inbox',
+      ...tags,
+    ],
     'capture_status': captureStatus,
     'capture_source': captureStatus == 'inbox' ? 'quick_inbox' : 'editor',
     'inbox_saved_at':
@@ -529,5 +533,86 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(client.noteRanges, <(int, int)>[(0, 499), (500, 999)]);
+  });
+
+  testWidgets('カードのタグで一覧を絞り込み、解除できる', (tester) async {
+    final client = _FakeSupabaseClient(
+      noteRows: <Map<String, dynamic>>[
+        _noteRow(
+          id: 'work-note',
+          title: 'Work note',
+          isFavorite: false,
+          tags: const <String>['Work'],
+        ),
+        _noteRow(
+          id: 'private-note',
+          title: 'Private note',
+          isFavorite: false,
+          tags: const <String>['Private'],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: NoteListPage(supabaseClient: client)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('note_list_tag_work-note_Work')),
+    );
+    await tester.pump();
+
+    expect(find.text('Work note'), findsOneWidget);
+    expect(find.text('Private note'), findsNothing);
+
+    await tester.tap(find.byKey(const Key('note_list_tag_filter_clear')));
+    await tester.pump();
+
+    expect(find.text('Work note'), findsOneWidget);
+    expect(find.text('Private note'), findsOneWidget);
+  });
+
+  testWidgets('タグ名もローカル検索の対象になる', (tester) async {
+    final client = _FakeSupabaseClient(
+      noteRows: <Map<String, dynamic>>[
+        _noteRow(
+          id: 'migration-note',
+          title: 'Untitled record',
+          isFavorite: false,
+          tags: const <String>['Evernote移行'],
+        ),
+        _noteRow(
+          id: 'other-note',
+          title: 'Another record',
+          isFavorite: false,
+        ),
+      ],
+    );
+    final semanticSearch = _FakeSemanticSearchService(
+      const NoteSemanticSearchResponse(
+        searchMode: 'text_fallback',
+        results: <NoteSearchResult>[],
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NoteListPage(
+          supabaseClient: client,
+          semanticSearchService: semanticSearch,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('note_list_page_search_field')),
+      'Evernote移行',
+    );
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Untitled record'), findsOneWidget);
+    expect(find.text('Another record'), findsNothing);
   });
 }

--- a/test/services/note_tag_service_test.dart
+++ b/test/services/note_tag_service_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/note_tag_service.dart';
+
+void main() {
+  group('NoteTagService', () {
+    test('表記を保持しつつ空タグと大文字小文字違いの重複を除く', () {
+      expect(
+        NoteTagService.normalize(<Object?>[
+          '  Project Alpha  ',
+          '',
+          'project alpha',
+          '日本語 タグ',
+          null,
+        ]),
+        <String>['Project Alpha', '日本語 タグ'],
+      );
+    });
+
+    test('null は空配列として扱う', () {
+      expect(NoteTagService.normalize(null), isEmpty);
+    });
+
+    test('完全一致のタグ絞り込みと部分一致検索を区別する', () {
+      const tags = <String>['Client/Acme', '重要'];
+
+      expect(NoteTagService.containsTag(tags, 'client/acme'), isTrue);
+      expect(NoteTagService.containsTag(tags, 'client'), isFalse);
+      expect(NoteTagService.containsSearch(tags, 'acm'), isTrue);
+    });
+
+    test('複数行からタグを大文字小文字無視で収集して並べる', () {
+      final rows = <Map<String, dynamic>>[
+        <String, dynamic>{
+          'tags': <String>['Work', '重要'],
+        },
+        <String, dynamic>{
+          'tags': <String>['work', 'Archive'],
+        },
+      ];
+
+      expect(NoteTagService.collectFromRows(rows), <String>[
+        'Archive',
+        'Work',
+        '重要',
+      ]);
+    });
+  });
+}

--- a/test/widgets/note_tags_field_test.dart
+++ b/test/widgets/note_tags_field_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/note_tags_field.dart';
+
+void main() {
+  testWidgets('タグを追加・削除できる', (tester) async {
+    var tags = <String>['既存'];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) => Scaffold(
+            body: NoteTagsField(
+              tags: tags,
+              onChanged: (nextTags) {
+                setState(() {
+                  tags = nextTags;
+                });
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byKey(const Key('note_tags_input')), '  新規  ');
+    await tester.tap(find.byKey(const Key('note_tags_add_button')));
+    await tester.pump();
+
+    expect(tags, <String>['既存', '新規']);
+    expect(find.text('新規'), findsOneWidget);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('note_tag_chip_既存')),
+        matching: find.byKey(const Key('note_tag_delete_icon')),
+      ),
+    );
+    await tester.pump();
+
+    expect(tags, <String>['新規']);
+  });
+
+  testWidgets('大文字小文字だけが違う重複タグは追加しない', (tester) async {
+    var tags = <String>['Evernote'];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: NoteTagsField(
+            tags: tags,
+            onChanged: (nextTags) => tags = nextTags,
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('note_tags_input')),
+      'evernote',
+    );
+    await tester.tap(find.byKey(const Key('note_tags_add_button')));
+    await tester.pump();
+
+    expect(tags, <String>['Evernote']);
+  });
+}


### PR DESCRIPTION
## Summary
- preserve and normalize note tags across the model, local drafts, inserts, updates, and exit flushes
- add responsive tag editing from the note editor toolbar
- display tags on note cards and add exact-tag filtering plus tag-aware local search
- keep semantic search results while appending matching local tag results

## Validation
- `flutter analyze --no-pub` on all 10 changed Dart files: no issues
- model/service/widget/editor suites: 25 tests passed
- note list suite: 10 tests passed on Flutter VM
- the local Chrome test runner stalled before executing tests; its task-owned Dart/Chrome processes were stopped and the identical widget suite passed on VM

## Minimal E2E Gate
- Implementation-detail independent: the tests assert user-visible tag input, removal, display, filtering, search, and empty recovery rather than private internals.
- Minimal scope: about 3 cases cover the happy path, duplicate or empty input, and filter recovery.
- E2E: a Flutter `integration_test/` or Playwright `test/e2e/` route would be the production mechanism.
- E2E-Exception: This scoped UI workflow is covered by implementation-detail-independent Flutter widget tests; it adds no new route or external service contract.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Keyword-only migration context triggered this gate; no auth, secrets, payments, production data, schema, deployment, or destructive path changed.

## Safety
- no database migration or RLS change
- no Evernote upload, source deletion, or subscription action