### PR TITLE
feat: 先延ばしリセット機能を追加

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -1816,6 +1816,25 @@ List<HomeToolEntry> buildHomeToolCatalog({
       onOpen: (context) => _pushPage(context, const VirtualPetPage()),
     ),
     HomeToolEntry(
+      id: 'procrastination-reset',
+      sectionId: 'personal',
+      title: '先延ばしリセット',
+      subtitle: '大きなタスクを5分の行動と最初の一手に変える',
+      icon: Icons.bolt_outlined,
+      color: const Color(0xFF7C3AED),
+      keywords: const <String>[
+        '先延ばし',
+        '行動',
+        '5分',
+        'タスク分解',
+        '集中',
+        'スマホ',
+        'procrastination',
+      ],
+      onOpen: (context) =>
+          Navigator.of(context).pushNamed('/procrastination-reset'),
+    ),
+    HomeToolEntry(
       id: 'focus-capture',
       sectionId: 'personal',
       title: 'フォーカス捕獲ゲーム',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -221,6 +221,7 @@ import 'package:my_web_app/pages/growth_automation_controller_page.dart';
 import 'package:my_web_app/pages/landing_ab_test_page.dart';
 import 'package:my_web_app/ui/features/video_studio/video_studio_feature.dart';
 import 'package:my_web_app/ui/features/notion_migration/notion_migration_feature.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/procrastination_reset_feature.dart';
 import 'package:my_web_app/pages/youtube_stats_page.dart';
 import 'package:my_web_app/pages/audio_effects_processor_page.dart';
 import 'package:my_web_app/pages/fitness_health_tracker_page.dart';
@@ -1547,6 +1548,13 @@ Route<dynamic> generateAppRoute(
     case '/personal-dashboard':
       return MaterialPageRoute(
         builder: (_) => const PersonalDashboardPage(),
+      );
+    case '/procrastination-reset':
+      return MaterialPageRoute(
+        builder: (_) => const ProcrastinationResetFeature(),
+        settings: const RouteSettings(
+          name: ProcrastinationResetFeature.routeName,
+        ),
       );
     case '/my-skills':
       return MaterialPageRoute(builder: (_) => const MySkillsPage());

--- a/lib/ui/features/procrastination_reset/data/procrastination_reset_gateway.dart
+++ b/lib/ui/features/procrastination_reset/data/procrastination_reset_gateway.dart
@@ -13,7 +13,7 @@ abstract class ProcrastinationResetGateway {
 class SharedPreferencesProcrastinationResetGateway
     implements ProcrastinationResetGateway {
   SharedPreferencesProcrastinationResetGateway({SharedPreferences? preferences})
-    : _preferences = preferences;
+      : _preferences = preferences;
 
   static const storageKey = 'procrastination_reset_snapshot_v1';
 

--- a/lib/ui/features/procrastination_reset/data/procrastination_reset_gateway.dart
+++ b/lib/ui/features/procrastination_reset/data/procrastination_reset_gateway.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../domain/procrastination_reset_models.dart';
+
+abstract class ProcrastinationResetGateway {
+  Future<ProcrastinationResetSnapshot> load();
+
+  Future<void> save(ProcrastinationResetSnapshot snapshot);
+}
+
+class SharedPreferencesProcrastinationResetGateway
+    implements ProcrastinationResetGateway {
+  SharedPreferencesProcrastinationResetGateway({SharedPreferences? preferences})
+    : _preferences = preferences;
+
+  static const storageKey = 'procrastination_reset_snapshot_v1';
+
+  final SharedPreferences? _preferences;
+
+  @override
+  Future<ProcrastinationResetSnapshot> load() async {
+    final preferences = _preferences ?? await SharedPreferences.getInstance();
+    final raw = preferences.getString(storageKey);
+    if (raw == null || raw.isEmpty) {
+      return const ProcrastinationResetSnapshot();
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return const ProcrastinationResetSnapshot();
+      return ProcrastinationResetSnapshot.fromJson(
+        Map<String, dynamic>.from(decoded),
+      );
+    } on FormatException {
+      return const ProcrastinationResetSnapshot();
+    }
+  }
+
+  @override
+  Future<void> save(ProcrastinationResetSnapshot snapshot) async {
+    final preferences = _preferences ?? await SharedPreferences.getInstance();
+    final saved = await preferences.setString(
+      storageKey,
+      jsonEncode(snapshot.toJson()),
+    );
+    if (!saved) {
+      throw StateError('先延ばしリセットの端末内保存に失敗しました。');
+    }
+  }
+}

--- a/lib/ui/features/procrastination_reset/domain/procrastination_reset_models.dart
+++ b/lib/ui/features/procrastination_reset/domain/procrastination_reset_models.dart
@@ -1,0 +1,148 @@
+enum DistractionBarrier {
+  anotherRoom,
+  outOfSight,
+  notificationsOff;
+
+  static DistractionBarrier fromStorage(String? value) {
+    return DistractionBarrier.values.firstWhere(
+      (barrier) => barrier.name == value,
+      orElse: () => DistractionBarrier.anotherRoom,
+    );
+  }
+}
+
+class ProcrastinationResetSession {
+  const ProcrastinationResetSession({
+    required this.task,
+    required this.fiveMinuteAction,
+    required this.firstMove,
+    required this.barrier,
+    required this.createdAt,
+    this.startedAt,
+  });
+
+  factory ProcrastinationResetSession.fromJson(Map<String, dynamic> json) {
+    return ProcrastinationResetSession(
+      task: json['task']?.toString() ?? '',
+      fiveMinuteAction: json['five_minute_action']?.toString() ?? '',
+      firstMove: json['first_move']?.toString() ?? '',
+      barrier: DistractionBarrier.fromStorage(json['barrier']?.toString()),
+      createdAt:
+          DateTime.tryParse(json['created_at']?.toString() ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      startedAt: DateTime.tryParse(json['started_at']?.toString() ?? ''),
+    );
+  }
+
+  final String task;
+  final String fiveMinuteAction;
+  final String firstMove;
+  final DistractionBarrier barrier;
+  final DateTime createdAt;
+  final DateTime? startedAt;
+
+  bool get hasStarted => startedAt != null;
+
+  ProcrastinationResetSession start(DateTime at) {
+    return ProcrastinationResetSession(
+      task: task,
+      fiveMinuteAction: fiveMinuteAction,
+      firstMove: firstMove,
+      barrier: barrier,
+      createdAt: createdAt,
+      startedAt: at,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'task': task,
+    'five_minute_action': fiveMinuteAction,
+    'first_move': firstMove,
+    'barrier': barrier.name,
+    'created_at': createdAt.toIso8601String(),
+    if (startedAt != null) 'started_at': startedAt!.toIso8601String(),
+  };
+}
+
+class ProcrastinationResetSnapshot {
+  const ProcrastinationResetSnapshot({
+    this.session,
+    this.completedCount = 0,
+    this.lastCompletedAt,
+  });
+
+  factory ProcrastinationResetSnapshot.fromJson(Map<String, dynamic> json) {
+    final rawSession = json['session'];
+    return ProcrastinationResetSnapshot(
+      session: rawSession is Map
+          ? ProcrastinationResetSession.fromJson(
+              Map<String, dynamic>.from(rawSession),
+            )
+          : null,
+      completedCount: (json['completed_count'] as num?)?.toInt() ?? 0,
+      lastCompletedAt: DateTime.tryParse(
+        json['last_completed_at']?.toString() ?? '',
+      ),
+    );
+  }
+
+  final ProcrastinationResetSession? session;
+  final int completedCount;
+  final DateTime? lastCompletedAt;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    if (session != null) 'session': session!.toJson(),
+    'completed_count': completedCount,
+    if (lastCompletedAt != null)
+      'last_completed_at': lastCompletedAt!.toIso8601String(),
+  };
+}
+
+class ProcrastinationPlanValidationException implements Exception {
+  const ProcrastinationPlanValidationException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class BuildProcrastinationPlan {
+  const BuildProcrastinationPlan();
+
+  ProcrastinationResetSession call({
+    required String task,
+    required String fiveMinuteAction,
+    required String firstMove,
+    required DistractionBarrier barrier,
+    required DateTime createdAt,
+  }) {
+    final normalizedTask = _normalize(task);
+    final normalizedAction = _normalize(fiveMinuteAction);
+    final normalizedFirstMove = _normalize(firstMove);
+
+    if (normalizedTask.isEmpty) {
+      throw const ProcrastinationPlanValidationException(
+        '先延ばししていることを入力してください。',
+      );
+    }
+    if (normalizedAction.isEmpty) {
+      throw const ProcrastinationPlanValidationException('5分で終わる行動を入力してください。');
+    }
+    if (normalizedFirstMove.isEmpty) {
+      throw const ProcrastinationPlanValidationException('最初の一動作を入力してください。');
+    }
+
+    return ProcrastinationResetSession(
+      task: normalizedTask,
+      fiveMinuteAction: normalizedAction,
+      firstMove: normalizedFirstMove,
+      barrier: barrier,
+      createdAt: createdAt,
+    );
+  }
+
+  String _normalize(String value) {
+    return value.trim().replaceAll(RegExp(r'\s+'), ' ');
+  }
+}

--- a/lib/ui/features/procrastination_reset/domain/procrastination_reset_models.dart
+++ b/lib/ui/features/procrastination_reset/domain/procrastination_reset_models.dart
@@ -27,8 +27,7 @@ class ProcrastinationResetSession {
       fiveMinuteAction: json['five_minute_action']?.toString() ?? '',
       firstMove: json['first_move']?.toString() ?? '',
       barrier: DistractionBarrier.fromStorage(json['barrier']?.toString()),
-      createdAt:
-          DateTime.tryParse(json['created_at']?.toString() ?? '') ??
+      createdAt: DateTime.tryParse(json['created_at']?.toString() ?? '') ??
           DateTime.fromMillisecondsSinceEpoch(0),
       startedAt: DateTime.tryParse(json['started_at']?.toString() ?? ''),
     );
@@ -55,13 +54,13 @@ class ProcrastinationResetSession {
   }
 
   Map<String, dynamic> toJson() => <String, dynamic>{
-    'task': task,
-    'five_minute_action': fiveMinuteAction,
-    'first_move': firstMove,
-    'barrier': barrier.name,
-    'created_at': createdAt.toIso8601String(),
-    if (startedAt != null) 'started_at': startedAt!.toIso8601String(),
-  };
+        'task': task,
+        'five_minute_action': fiveMinuteAction,
+        'first_move': firstMove,
+        'barrier': barrier.name,
+        'created_at': createdAt.toIso8601String(),
+        if (startedAt != null) 'started_at': startedAt!.toIso8601String(),
+      };
 }
 
 class ProcrastinationResetSnapshot {
@@ -91,11 +90,11 @@ class ProcrastinationResetSnapshot {
   final DateTime? lastCompletedAt;
 
   Map<String, dynamic> toJson() => <String, dynamic>{
-    if (session != null) 'session': session!.toJson(),
-    'completed_count': completedCount,
-    if (lastCompletedAt != null)
-      'last_completed_at': lastCompletedAt!.toIso8601String(),
-  };
+        if (session != null) 'session': session!.toJson(),
+        'completed_count': completedCount,
+        if (lastCompletedAt != null)
+          'last_completed_at': lastCompletedAt!.toIso8601String(),
+      };
 }
 
 class ProcrastinationPlanValidationException implements Exception {

--- a/lib/ui/features/procrastination_reset/procrastination_reset_feature.dart
+++ b/lib/ui/features/procrastination_reset/procrastination_reset_feature.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import 'data/procrastination_reset_gateway.dart';
+import 'view_models/procrastination_reset_view_model.dart';
+import 'views/procrastination_reset_page.dart';
+
+class ProcrastinationResetFeature extends StatelessWidget {
+  const ProcrastinationResetFeature({super.key, this.gateway, this.now});
+
+  static const routeName = '/procrastination-reset';
+
+  final ProcrastinationResetGateway? gateway;
+  final DateTime Function()? now;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<ProcrastinationResetViewModel>(
+      create: (_) => ProcrastinationResetViewModel(
+        gateway: gateway ?? SharedPreferencesProcrastinationResetGateway(),
+        now: now,
+      )..load(),
+      child: const ProcrastinationResetPage(),
+    );
+  }
+}

--- a/lib/ui/features/procrastination_reset/view_models/procrastination_reset_view_model.dart
+++ b/lib/ui/features/procrastination_reset/view_models/procrastination_reset_view_model.dart
@@ -1,0 +1,186 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../data/procrastination_reset_gateway.dart';
+import '../domain/procrastination_reset_models.dart';
+
+enum ProcrastinationResetLoadStatus { initial, loading, ready, failure }
+
+class ProcrastinationResetViewModel extends ChangeNotifier {
+  ProcrastinationResetViewModel({
+    required ProcrastinationResetGateway gateway,
+    BuildProcrastinationPlan planBuilder = const BuildProcrastinationPlan(),
+    DateTime Function()? now,
+  }) : _gateway = gateway,
+       _planBuilder = planBuilder,
+       _now = now ?? DateTime.now;
+
+  static const sessionDurationSeconds = 5 * 60;
+
+  final ProcrastinationResetGateway _gateway;
+  final BuildProcrastinationPlan _planBuilder;
+  final DateTime Function() _now;
+
+  ProcrastinationResetLoadStatus _loadStatus =
+      ProcrastinationResetLoadStatus.initial;
+  ProcrastinationResetSnapshot _snapshot = const ProcrastinationResetSnapshot();
+  Timer? _timer;
+  int _remainingSeconds = sessionDurationSeconds;
+  bool _isSaving = false;
+  String? _errorMessage;
+  String? _lastCompletedAction;
+
+  ProcrastinationResetLoadStatus get loadStatus => _loadStatus;
+  ProcrastinationResetSession? get session => _snapshot.session;
+  int get completedCount => _snapshot.completedCount;
+  int get remainingSeconds => _remainingSeconds;
+  bool get isSaving => _isSaving;
+  bool get isTimerComplete =>
+      session?.hasStarted == true && _remainingSeconds == 0;
+  String? get errorMessage => _errorMessage;
+  String? get lastCompletedAction => _lastCompletedAction;
+
+  Future<void> load() async {
+    _loadStatus = ProcrastinationResetLoadStatus.loading;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      _snapshot = await _gateway.load();
+      _loadStatus = ProcrastinationResetLoadStatus.ready;
+      _syncTimer();
+    } catch (_) {
+      _loadStatus = ProcrastinationResetLoadStatus.failure;
+      _errorMessage = '保存したプランを読み込めませんでした。もう一度お試しください。';
+    }
+    notifyListeners();
+  }
+
+  Future<bool> createPlan({
+    required String task,
+    required String fiveMinuteAction,
+    required String firstMove,
+    required DistractionBarrier barrier,
+  }) async {
+    if (_isSaving) return false;
+    _errorMessage = null;
+    ProcrastinationResetSession plan;
+    try {
+      plan = _planBuilder(
+        task: task,
+        fiveMinuteAction: fiveMinuteAction,
+        firstMove: firstMove,
+        barrier: barrier,
+        createdAt: _now(),
+      );
+    } on ProcrastinationPlanValidationException catch (error) {
+      _errorMessage = error.message;
+      notifyListeners();
+      return false;
+    }
+
+    final next = ProcrastinationResetSnapshot(
+      session: plan,
+      completedCount: _snapshot.completedCount,
+      lastCompletedAt: _snapshot.lastCompletedAt,
+    );
+    return _save(next);
+  }
+
+  Future<bool> startSession() async {
+    final current = session;
+    if (current == null || current.hasStarted || _isSaving) return false;
+    final next = ProcrastinationResetSnapshot(
+      session: current.start(_now()),
+      completedCount: _snapshot.completedCount,
+      lastCompletedAt: _snapshot.lastCompletedAt,
+    );
+    final saved = await _save(next);
+    if (saved) _syncTimer();
+    return saved;
+  }
+
+  Future<bool> completeSession() async {
+    final current = session;
+    if (current == null || _isSaving) return false;
+    final completedAt = _now();
+    final next = ProcrastinationResetSnapshot(
+      completedCount: _snapshot.completedCount + 1,
+      lastCompletedAt: completedAt,
+    );
+    final saved = await _save(next);
+    if (saved) {
+      _timer?.cancel();
+      _remainingSeconds = sessionDurationSeconds;
+      _lastCompletedAction = current.fiveMinuteAction;
+      notifyListeners();
+    }
+    return saved;
+  }
+
+  Future<bool> resetSession() async {
+    if (session == null || _isSaving) return false;
+    final next = ProcrastinationResetSnapshot(
+      completedCount: _snapshot.completedCount,
+      lastCompletedAt: _snapshot.lastCompletedAt,
+    );
+    final saved = await _save(next);
+    if (saved) {
+      _timer?.cancel();
+      _remainingSeconds = sessionDurationSeconds;
+      notifyListeners();
+    }
+    return saved;
+  }
+
+  void clearCompletionNotice() {
+    if (_lastCompletedAction == null) return;
+    _lastCompletedAction = null;
+    notifyListeners();
+  }
+
+  Future<bool> _save(ProcrastinationResetSnapshot next) async {
+    _isSaving = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      await _gateway.save(next);
+      _snapshot = next;
+      return true;
+    } catch (_) {
+      _errorMessage = '端末内に保存できませんでした。空き容量やブラウザ設定をご確認ください。';
+      return false;
+    } finally {
+      _isSaving = false;
+      notifyListeners();
+    }
+  }
+
+  void _syncTimer() {
+    _timer?.cancel();
+    final startedAt = session?.startedAt;
+    if (startedAt == null) {
+      _remainingSeconds = sessionDurationSeconds;
+      return;
+    }
+    _updateRemaining(startedAt);
+    if (_remainingSeconds == 0) return;
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      _updateRemaining(startedAt);
+      notifyListeners();
+      if (_remainingSeconds == 0) _timer?.cancel();
+    });
+  }
+
+  void _updateRemaining(DateTime startedAt) {
+    final elapsed = _now().difference(startedAt).inSeconds;
+    final next = sessionDurationSeconds - elapsed;
+    _remainingSeconds = next.clamp(0, sessionDurationSeconds);
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/ui/features/procrastination_reset/view_models/procrastination_reset_view_model.dart
+++ b/lib/ui/features/procrastination_reset/view_models/procrastination_reset_view_model.dart
@@ -12,9 +12,9 @@ class ProcrastinationResetViewModel extends ChangeNotifier {
     required ProcrastinationResetGateway gateway,
     BuildProcrastinationPlan planBuilder = const BuildProcrastinationPlan(),
     DateTime Function()? now,
-  }) : _gateway = gateway,
-       _planBuilder = planBuilder,
-       _now = now ?? DateTime.now;
+  })  : _gateway = gateway,
+        _planBuilder = planBuilder,
+        _now = now ?? DateTime.now;
 
   static const sessionDurationSeconds = 5 * 60;
 

--- a/lib/ui/features/procrastination_reset/views/procrastination_reset_page.dart
+++ b/lib/ui/features/procrastination_reset/views/procrastination_reset_page.dart
@@ -1,0 +1,743 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../domain/procrastination_reset_models.dart';
+import '../view_models/procrastination_reset_view_model.dart';
+
+class ProcrastinationResetPage extends StatefulWidget {
+  const ProcrastinationResetPage({super.key});
+
+  @override
+  State<ProcrastinationResetPage> createState() =>
+      _ProcrastinationResetPageState();
+}
+
+class _ProcrastinationResetPageState extends State<ProcrastinationResetPage> {
+  static const _wideBreakpoint = 900.0;
+
+  final _formKey = GlobalKey<FormState>();
+  final _taskController = TextEditingController();
+  final _actionController = TextEditingController();
+  final _firstMoveController = TextEditingController();
+  DistractionBarrier _barrier = DistractionBarrier.anotherRoom;
+
+  @override
+  void dispose() {
+    _taskController.dispose();
+    _actionController.dispose();
+    _firstMoveController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.read<ProcrastinationResetViewModel>();
+    final colors = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(title: const Text('先延ばしリセット')),
+      body: SafeArea(
+        child: ListenableBuilder(
+          listenable: viewModel,
+          builder: (context, _) {
+            return switch (viewModel.loadStatus) {
+              ProcrastinationResetLoadStatus.initial ||
+              ProcrastinationResetLoadStatus.loading => const Center(
+                child: CircularProgressIndicator(),
+              ),
+              ProcrastinationResetLoadStatus.failure => _LoadFailure(
+                message: viewModel.errorMessage,
+                onRetry: viewModel.load,
+              ),
+              ProcrastinationResetLoadStatus.ready => Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: <Color>[
+                      colors.primaryContainer.withValues(alpha: 0.32),
+                      colors.surface,
+                      colors.tertiaryContainer.withValues(alpha: 0.24),
+                    ],
+                  ),
+                ),
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    final wide = constraints.maxWidth >= _wideBreakpoint;
+                    final intro = _buildIntro(context, viewModel);
+                    final action = viewModel.session == null
+                        ? _buildPlanner(context, viewModel)
+                        : _buildActiveSession(context, viewModel);
+                    return SingleChildScrollView(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: wide ? 32 : 16,
+                        vertical: 24,
+                      ),
+                      child: Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 1180),
+                          child: wide
+                              ? Row(
+                                  key: const Key('procrastination-reset-wide'),
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: <Widget>[
+                                    SizedBox(width: 360, child: intro),
+                                    const SizedBox(width: 28),
+                                    Expanded(child: action),
+                                  ],
+                                )
+                              : Column(
+                                  key: const Key(
+                                    'procrastination-reset-narrow',
+                                  ),
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: <Widget>[
+                                    intro,
+                                    const SizedBox(height: 20),
+                                    action,
+                                  ],
+                                ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            };
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIntro(
+    BuildContext context,
+    ProcrastinationResetViewModel viewModel,
+  ) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+          decoration: BoxDecoration(
+            color: colors.primaryContainer,
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Text(
+            '意志力を使わず、着手を軽くする',
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: colors.onPrimaryContainer,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        const SizedBox(height: 18),
+        Text(
+          '大きなタスクを、\n5分の行動に変える。',
+          style: theme.textTheme.headlineMedium?.copyWith(
+            fontWeight: FontWeight.w800,
+            height: 1.25,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          '先延ばしを性格のせいにせず、始める直前の摩擦を3つの構造で小さくします。',
+          style: theme.textTheme.bodyLarge?.copyWith(
+            color: colors.onSurfaceVariant,
+            height: 1.6,
+          ),
+        ),
+        const SizedBox(height: 24),
+        const _PrincipleTile(
+          number: '1',
+          title: '5分で終わる数字へ',
+          description: '「記事を書く」ではなく「タイトル案を3つ書く」まで小さくします。',
+          icon: Icons.timer_outlined,
+        ),
+        const SizedBox(height: 12),
+        const _PrincipleTile(
+          number: '2',
+          title: '最初の一手は一動作',
+          description: '「ファイルを開く」のように、迷わず実行できる動詞1つへ固定します。',
+          icon: Icons.touch_app_outlined,
+        ),
+        const SizedBox(height: 12),
+        const _PrincipleTile(
+          number: '3',
+          title: '誘惑は環境から遠ざける',
+          description: 'スマホや通知を視界と手の届く範囲から外して、判断回数を減らします。',
+          icon: Icons.phonelink_erase_outlined,
+        ),
+        if (viewModel.completedCount > 0) ...<Widget>[
+          const SizedBox(height: 20),
+          Card(
+            color: colors.secondaryContainer,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: <Widget>[
+                  Icon(Icons.local_fire_department, color: colors.secondary),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      'これまで ${viewModel.completedCount} 回、最初の一歩を完了しました。',
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: colors.onSecondaryContainer,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildPlanner(
+    BuildContext context,
+    ProcrastinationResetViewModel viewModel,
+  ) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Text(
+                '今日の5分プラン',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                '完璧な計画ではなく、今すぐ始められる大きさを作ります。',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 24),
+              TextFormField(
+                key: const Key('procrastination-task-field'),
+                controller: _taskController,
+                maxLength: 120,
+                textInputAction: TextInputAction.next,
+                decoration: const InputDecoration(
+                  labelText: '先延ばししていること',
+                  hintText: '例：記事を書く',
+                  prefixIcon: Icon(Icons.inventory_2_outlined),
+                  border: OutlineInputBorder(),
+                ),
+                validator: _requiredValidator,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const Key('procrastination-action-field'),
+                controller: _actionController,
+                maxLength: 80,
+                textInputAction: TextInputAction.next,
+                decoration: const InputDecoration(
+                  labelText: '5分で終わる行動',
+                  hintText: '例：タイトル案を3つ書く',
+                  prefixIcon: Icon(Icons.timer_outlined),
+                  border: OutlineInputBorder(),
+                ),
+                validator: _requiredValidator,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const Key('procrastination-first-move-field'),
+                controller: _firstMoveController,
+                maxLength: 40,
+                textInputAction: TextInputAction.done,
+                onFieldSubmitted: (_) => _createPlan(viewModel),
+                decoration: const InputDecoration(
+                  labelText: '最初の一動作',
+                  hintText: '例：メモを開く',
+                  prefixIcon: Icon(Icons.play_arrow_outlined),
+                  border: OutlineInputBorder(),
+                ),
+                validator: _requiredValidator,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                '誘惑を遠ざける方法',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: DistractionBarrier.values
+                    .map((barrier) {
+                      return ChoiceChip(
+                        key: Key('barrier-${barrier.name}'),
+                        label: Text(_barrierLabel(barrier)),
+                        selected: _barrier == barrier,
+                        onSelected: (_) => setState(() => _barrier = barrier),
+                      );
+                    })
+                    .toList(growable: false),
+              ),
+              if (viewModel.errorMessage != null) ...<Widget>[
+                const SizedBox(height: 16),
+                _ErrorBanner(message: viewModel.errorMessage!),
+              ],
+              if (viewModel.lastCompletedAction != null) ...<Widget>[
+                const SizedBox(height: 16),
+                _CompletionBanner(
+                  action: viewModel.lastCompletedAction!,
+                  onDismiss: viewModel.clearCompletionNotice,
+                ),
+              ],
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                key: const Key('create-procrastination-plan'),
+                onPressed: viewModel.isSaving
+                    ? null
+                    : () => _createPlan(viewModel),
+                icon: const Icon(Icons.bolt),
+                label: Text(viewModel.isSaving ? '保存中…' : '実行プランを作る'),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'プランと完了回数はこの端末内だけに保存されます。',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActiveSession(
+    BuildContext context,
+    ProcrastinationResetViewModel viewModel,
+  ) {
+    final session = viewModel.session!;
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final progress =
+        1 -
+        (viewModel.remainingSeconds /
+            ProcrastinationResetViewModel.sessionDurationSeconds);
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        'いまやること',
+                        style: theme.textTheme.labelLarge?.copyWith(
+                          color: colors.primary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        session.task,
+                        key: const Key('active-procrastination-task'),
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'プランを作り直す',
+                  onPressed: viewModel.isSaving
+                      ? null
+                      : () => _resetPlan(viewModel),
+                  icon: const Icon(Icons.edit_outlined),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            _ActionStep(
+              number: '1',
+              label: '最初の一動作',
+              value: session.firstMove,
+              emphasized: !session.hasStarted,
+            ),
+            const SizedBox(height: 12),
+            _ActionStep(
+              number: '2',
+              label: '5分だけやる',
+              value: session.fiveMinuteAction,
+              emphasized: session.hasStarted,
+            ),
+            const SizedBox(height: 12),
+            _ActionStep(
+              number: '3',
+              label: '環境を先に変える',
+              value: _barrierLabel(session.barrier),
+              emphasized: false,
+            ),
+            const SizedBox(height: 28),
+            Center(
+              child: SizedBox(
+                width: 176,
+                height: 176,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: <Widget>[
+                    SizedBox.expand(
+                      child: CircularProgressIndicator(
+                        strokeWidth: 10,
+                        value: progress,
+                        backgroundColor: colors.surfaceContainerHighest,
+                        strokeCap: StrokeCap.round,
+                      ),
+                    ),
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Text(
+                          _formatDuration(viewModel.remainingSeconds),
+                          key: const Key('procrastination-timer'),
+                          style: theme.textTheme.displaySmall?.copyWith(
+                            fontWeight: FontWeight.w800,
+                            fontFeatures: const <FontFeature>[
+                              FontFeature.tabularFigures(),
+                            ],
+                          ),
+                        ),
+                        Text(
+                          session.hasStarted ? '5分だけ続ける' : '最初の一手から',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colors.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            if (!session.hasStarted)
+              FilledButton.icon(
+                key: const Key('start-procrastination-session'),
+                onPressed: viewModel.isSaving
+                    ? null
+                    : () => viewModel.startSession(),
+                icon: const Icon(Icons.play_arrow),
+                label: Text('「${session.firstMove}」をやる'),
+              )
+            else ...<Widget>[
+              if (viewModel.isTimerComplete)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Text(
+                    '5分経過しました。続けても、ここで終えても大丈夫です。',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: colors.primary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              FilledButton.icon(
+                key: const Key('complete-procrastination-session'),
+                onPressed: viewModel.isSaving
+                    ? null
+                    : () => _completePlan(viewModel),
+                icon: const Icon(Icons.check_circle_outline),
+                label: const Text('できた'),
+              ),
+            ],
+            const SizedBox(height: 10),
+            Text(
+              '一手だけでやめてもOK。始めた事実を成功として記録します。',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colors.onSurfaceVariant,
+              ),
+            ),
+            if (viewModel.errorMessage != null) ...<Widget>[
+              const SizedBox(height: 16),
+              _ErrorBanner(message: viewModel.errorMessage!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  String? _requiredValidator(String? value) {
+    return value == null || value.trim().isEmpty ? '入力してください' : null;
+  }
+
+  Future<void> _createPlan(ProcrastinationResetViewModel viewModel) async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    FocusScope.of(context).unfocus();
+    await viewModel.createPlan(
+      task: _taskController.text,
+      fiveMinuteAction: _actionController.text,
+      firstMove: _firstMoveController.text,
+      barrier: _barrier,
+    );
+  }
+
+  Future<void> _completePlan(ProcrastinationResetViewModel viewModel) async {
+    final completed = await viewModel.completeSession();
+    if (!mounted || !completed) return;
+    _taskController.clear();
+    _actionController.clear();
+    _firstMoveController.clear();
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('最初の一歩を完了として記録しました。')));
+  }
+
+  Future<void> _resetPlan(ProcrastinationResetViewModel viewModel) async {
+    final reset = await viewModel.resetSession();
+    if (!mounted || !reset) return;
+    _taskController.clear();
+    _actionController.clear();
+    _firstMoveController.clear();
+  }
+}
+
+class _PrincipleTile extends StatelessWidget {
+  const _PrincipleTile({
+    required this.number,
+    required this.title,
+    required this.description,
+    required this.icon,
+  });
+
+  final String number;
+  final String title;
+  final String description;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colors.surface.withValues(alpha: 0.78),
+        border: Border.all(color: colors.outlineVariant),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          CircleAvatar(
+            backgroundColor: colors.primaryContainer,
+            foregroundColor: colors.onPrimaryContainer,
+            child: Icon(icon, size: 20),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  '$number. $title',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 5),
+                Text(
+                  description,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colors.onSurfaceVariant,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionStep extends StatelessWidget {
+  const _ActionStep({
+    required this.number,
+    required this.label,
+    required this.value,
+    required this.emphasized,
+  });
+
+  final String number;
+  final String label;
+  final String value;
+  final bool emphasized;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 180),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: emphasized ? colors.primaryContainer : colors.surfaceContainer,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: emphasized ? colors.primary : colors.outlineVariant,
+          width: emphasized ? 1.5 : 1,
+        ),
+      ),
+      child: Row(
+        children: <Widget>[
+          CircleAvatar(
+            radius: 16,
+            backgroundColor: emphasized ? colors.primary : colors.surface,
+            foregroundColor: emphasized ? colors.onPrimary : colors.onSurface,
+            child: Text(number),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(label, style: theme.textTheme.labelMedium),
+                const SizedBox(height: 3),
+                Text(
+                  value,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadFailure extends StatelessWidget {
+  const _LoadFailure({required this.message, required this.onRetry});
+
+  final String? message;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(Icons.sync_problem, size: 48),
+            const SizedBox(height: 16),
+            Text(message ?? '読み込めませんでした。'),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('再試行'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.errorContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(message, style: TextStyle(color: colors.onErrorContainer)),
+    );
+  }
+}
+
+class _CompletionBanner extends StatelessWidget {
+  const _CompletionBanner({required this.action, required this.onDismiss});
+
+  final String action;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.tertiaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(Icons.check_circle, color: colors.tertiary),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              '「$action」を完了。達成感を次の行動につなげましょう。',
+              style: TextStyle(color: colors.onTertiaryContainer),
+            ),
+          ),
+          IconButton(
+            tooltip: '閉じる',
+            onPressed: onDismiss,
+            icon: const Icon(Icons.close),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _barrierLabel(DistractionBarrier barrier) {
+  return switch (barrier) {
+    DistractionBarrier.anotherRoom => 'スマホを別の部屋へ置く',
+    DistractionBarrier.outOfSight => 'スマホを引き出しへしまう',
+    DistractionBarrier.notificationsOff => '通知と不要なタブを閉じる',
+  };
+}
+
+String _formatDuration(int seconds) {
+  final minutes = seconds ~/ 60;
+  final remaining = seconds % 60;
+  return '${minutes.toString().padLeft(2, '0')}:'
+      '${remaining.toString().padLeft(2, '0')}';
+}

--- a/lib/ui/features/procrastination_reset/views/procrastination_reset_page.dart
+++ b/lib/ui/features/procrastination_reset/views/procrastination_reset_page.dart
@@ -41,68 +41,71 @@ class _ProcrastinationResetPageState extends State<ProcrastinationResetPage> {
           builder: (context, _) {
             return switch (viewModel.loadStatus) {
               ProcrastinationResetLoadStatus.initial ||
-              ProcrastinationResetLoadStatus.loading => const Center(
-                child: CircularProgressIndicator(),
-              ),
+              ProcrastinationResetLoadStatus.loading =>
+                const Center(
+                  child: CircularProgressIndicator(),
+                ),
               ProcrastinationResetLoadStatus.failure => _LoadFailure(
-                message: viewModel.errorMessage,
-                onRetry: viewModel.load,
-              ),
+                  message: viewModel.errorMessage,
+                  onRetry: viewModel.load,
+                ),
               ProcrastinationResetLoadStatus.ready => Container(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: <Color>[
-                      colors.primaryContainer.withValues(alpha: 0.32),
-                      colors.surface,
-                      colors.tertiaryContainer.withValues(alpha: 0.24),
-                    ],
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: <Color>[
+                        colors.primaryContainer.withValues(alpha: 0.32),
+                        colors.surface,
+                        colors.tertiaryContainer.withValues(alpha: 0.24),
+                      ],
+                    ),
+                  ),
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      final wide = constraints.maxWidth >= _wideBreakpoint;
+                      final intro = _buildIntro(context, viewModel);
+                      final action = viewModel.session == null
+                          ? _buildPlanner(context, viewModel)
+                          : _buildActiveSession(context, viewModel);
+                      return SingleChildScrollView(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: wide ? 32 : 16,
+                          vertical: 24,
+                        ),
+                        child: Center(
+                          child: ConstrainedBox(
+                            constraints: const BoxConstraints(maxWidth: 1180),
+                            child: wide
+                                ? Row(
+                                    key:
+                                        const Key('procrastination-reset-wide'),
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: <Widget>[
+                                      SizedBox(width: 360, child: intro),
+                                      const SizedBox(width: 28),
+                                      Expanded(child: action),
+                                    ],
+                                  )
+                                : Column(
+                                    key: const Key(
+                                      'procrastination-reset-narrow',
+                                    ),
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.stretch,
+                                    children: <Widget>[
+                                      intro,
+                                      const SizedBox(height: 20),
+                                      action,
+                                    ],
+                                  ),
+                          ),
+                        ),
+                      );
+                    },
                   ),
                 ),
-                child: LayoutBuilder(
-                  builder: (context, constraints) {
-                    final wide = constraints.maxWidth >= _wideBreakpoint;
-                    final intro = _buildIntro(context, viewModel);
-                    final action = viewModel.session == null
-                        ? _buildPlanner(context, viewModel)
-                        : _buildActiveSession(context, viewModel);
-                    return SingleChildScrollView(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: wide ? 32 : 16,
-                        vertical: 24,
-                      ),
-                      child: Center(
-                        child: ConstrainedBox(
-                          constraints: const BoxConstraints(maxWidth: 1180),
-                          child: wide
-                              ? Row(
-                                  key: const Key('procrastination-reset-wide'),
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: <Widget>[
-                                    SizedBox(width: 360, child: intro),
-                                    const SizedBox(width: 28),
-                                    Expanded(child: action),
-                                  ],
-                                )
-                              : Column(
-                                  key: const Key(
-                                    'procrastination-reset-narrow',
-                                  ),
-                                  crossAxisAlignment:
-                                      CrossAxisAlignment.stretch,
-                                  children: <Widget>[
-                                    intro,
-                                    const SizedBox(height: 20),
-                                    action,
-                                  ],
-                                ),
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              ),
             };
           },
         ),
@@ -279,16 +282,14 @@ class _ProcrastinationResetPageState extends State<ProcrastinationResetPage> {
               Wrap(
                 spacing: 8,
                 runSpacing: 8,
-                children: DistractionBarrier.values
-                    .map((barrier) {
-                      return ChoiceChip(
-                        key: Key('barrier-${barrier.name}'),
-                        label: Text(_barrierLabel(barrier)),
-                        selected: _barrier == barrier,
-                        onSelected: (_) => setState(() => _barrier = barrier),
-                      );
-                    })
-                    .toList(growable: false),
+                children: DistractionBarrier.values.map((barrier) {
+                  return ChoiceChip(
+                    key: Key('barrier-${barrier.name}'),
+                    label: Text(_barrierLabel(barrier)),
+                    selected: _barrier == barrier,
+                    onSelected: (_) => setState(() => _barrier = barrier),
+                  );
+                }).toList(growable: false),
               ),
               if (viewModel.errorMessage != null) ...<Widget>[
                 const SizedBox(height: 16),
@@ -304,9 +305,8 @@ class _ProcrastinationResetPageState extends State<ProcrastinationResetPage> {
               const SizedBox(height: 24),
               FilledButton.icon(
                 key: const Key('create-procrastination-plan'),
-                onPressed: viewModel.isSaving
-                    ? null
-                    : () => _createPlan(viewModel),
+                onPressed:
+                    viewModel.isSaving ? null : () => _createPlan(viewModel),
                 icon: const Icon(Icons.bolt),
                 label: Text(viewModel.isSaving ? '保存中…' : '実行プランを作る'),
               ),
@@ -332,8 +332,7 @@ class _ProcrastinationResetPageState extends State<ProcrastinationResetPage> {
     final session = viewModel.session!;
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final progress =
-        1 -
+    final progress = 1 -
         (viewModel.remainingSeconds /
             ProcrastinationResetViewModel.sessionDurationSeconds);
     return Card(
@@ -370,9 +369,8 @@ class _ProcrastinationResetPageState extends State<ProcrastinationResetPage> {
                 ),
                 IconButton(
                   tooltip: 'プランを作り直す',
-                  onPressed: viewModel.isSaving
-                      ? null
-                      : () => _resetPlan(viewModel),
+                  onPressed:
+                      viewModel.isSaving ? null : () => _resetPlan(viewModel),
                   icon: const Icon(Icons.edit_outlined),
                 ),
               ],
@@ -443,9 +441,8 @@ class _ProcrastinationResetPageState extends State<ProcrastinationResetPage> {
             if (!session.hasStarted)
               FilledButton.icon(
                 key: const Key('start-procrastination-session'),
-                onPressed: viewModel.isSaving
-                    ? null
-                    : () => viewModel.startSession(),
+                onPressed:
+                    viewModel.isSaving ? null : () => viewModel.startSession(),
                 icon: const Icon(Icons.play_arrow),
                 label: Text('「${session.firstMove}」をやる'),
               )
@@ -464,9 +461,8 @@ class _ProcrastinationResetPageState extends State<ProcrastinationResetPage> {
                 ),
               FilledButton.icon(
                 key: const Key('complete-procrastination-session'),
-                onPressed: viewModel.isSaving
-                    ? null
-                    : () => _completePlan(viewModel),
+                onPressed:
+                    viewModel.isSaving ? null : () => _completePlan(viewModel),
                 icon: const Icon(Icons.check_circle_outline),
                 label: const Text('できた'),
               ),

--- a/lib/utils/feature_route_labels.dart
+++ b/lib/utils/feature_route_labels.dart
@@ -51,6 +51,7 @@ const Map<String, String> _consolidatedFeatureLabels = <String, String>{
   '/daily-habits': '毎日の習慣',
   '/mind-map': 'マインドマップ',
   '/one-in-two-out-assist': '1 In 2 Out UI整理アシスト',
+  '/procrastination-reset': '先延ばしリセット',
   '/referral': '友達招待・紹介プログラム',
   '/rewards': '実績・リワード',
   '/social-feed': 'MUSUBI ソーシャル',

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -253,6 +253,7 @@ const List<String> kAllAppRoutes = <String>[
   '/price-tracker',
   '/prison-mode',
   '/privacy',
+  '/procrastination-reset',
   '/profile-settings',
   '/project-gantt',
   '/public-guitar-gallery',

--- a/test/ui/features/procrastination_reset/procrastination_reset_gateway_test.dart
+++ b/test/ui/features/procrastination_reset/procrastination_reset_gateway_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/data/procrastination_reset_gateway.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/domain/procrastination_reset_models.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('端末内に実行中プランと完了回数を保存して復元する', () async {
+    final preferences = await SharedPreferences.getInstance();
+    final gateway = SharedPreferencesProcrastinationResetGateway(
+      preferences: preferences,
+    );
+    final createdAt = DateTime(2026, 8, 24, 12);
+    final startedAt = DateTime(2026, 8, 24, 12, 1);
+    final snapshot = ProcrastinationResetSnapshot(
+      session: ProcrastinationResetSession(
+        task: '記事を書く',
+        fiveMinuteAction: 'タイトル案を3つ書く',
+        firstMove: 'メモを開く',
+        barrier: DistractionBarrier.anotherRoom,
+        createdAt: createdAt,
+        startedAt: startedAt,
+      ),
+      completedCount: 4,
+      lastCompletedAt: DateTime(2026, 8, 23, 9),
+    );
+
+    await gateway.save(snapshot);
+    final restored = await gateway.load();
+
+    expect(restored.completedCount, 4);
+    expect(restored.session?.task, '記事を書く');
+    expect(restored.session?.fiveMinuteAction, 'タイトル案を3つ書く');
+    expect(restored.session?.firstMove, 'メモを開く');
+    expect(restored.session?.barrier, DistractionBarrier.anotherRoom);
+    expect(restored.session?.createdAt, createdAt);
+    expect(restored.session?.startedAt, startedAt);
+  });
+
+  test('壊れた保存値は空の状態として安全に扱う', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      SharedPreferencesProcrastinationResetGateway.storageKey: '{broken',
+    });
+    final gateway = SharedPreferencesProcrastinationResetGateway(
+      preferences: await SharedPreferences.getInstance(),
+    );
+
+    final restored = await gateway.load();
+
+    expect(restored.session, isNull);
+    expect(restored.completedCount, 0);
+  });
+}

--- a/test/ui/features/procrastination_reset/procrastination_reset_page_test.dart
+++ b/test/ui/features/procrastination_reset/procrastination_reset_page_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/data/procrastination_reset_gateway.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/domain/procrastination_reset_models.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/procrastination_reset_feature.dart';
+
+void main() {
+  testWidgets('3つの入力から5分プランを作り、開始と完了を記録できる', (tester) async {
+    final gateway = _MemoryGateway();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ProcrastinationResetFeature(
+          gateway: gateway,
+          now: () => DateTime(2026, 8, 24, 12),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('大きなタスクを、\n5分の行動に変える。'), findsOneWidget);
+    expect(find.text('今日の5分プラン'), findsOneWidget);
+
+    await tester.enterText(
+      find.byKey(const Key('procrastination-task-field')),
+      '記事を書く',
+    );
+    await tester.enterText(
+      find.byKey(const Key('procrastination-action-field')),
+      'タイトル案を3つ書く',
+    );
+    await tester.enterText(
+      find.byKey(const Key('procrastination-first-move-field')),
+      'メモを開く',
+    );
+    final createButton = find.byKey(const Key('create-procrastination-plan'));
+    await tester.ensureVisible(createButton);
+    await tester.tap(createButton);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('active-procrastination-task')),
+      findsOneWidget,
+    );
+    expect(find.text('記事を書く'), findsWidgets);
+    expect(find.text('タイトル案を3つ書く'), findsOneWidget);
+    expect(find.text('メモを開く'), findsWidgets);
+
+    final startButton = find.byKey(const Key('start-procrastination-session'));
+    await tester.ensureVisible(startButton);
+    await tester.tap(startButton);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('procrastination-timer')), findsOneWidget);
+    expect(find.text('05:00'), findsOneWidget);
+    final completeButton = find.byKey(
+      const Key('complete-procrastination-session'),
+    );
+    expect(completeButton, findsOneWidget);
+
+    await tester.tap(completeButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('今日の5分プラン'), findsOneWidget);
+    expect(find.textContaining('これまで 1 回'), findsOneWidget);
+    expect(find.textContaining('タイトル案を3つ書く」を完了'), findsOneWidget);
+  });
+
+  testWidgets('画面幅に応じて1列と2列を切り替える', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    final gateway = _MemoryGateway();
+
+    tester.view.physicalSize = const Size(390, 900);
+    await tester.pumpWidget(
+      MaterialApp(home: ProcrastinationResetFeature(gateway: gateway)),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('procrastination-reset-narrow')),
+      findsOneWidget,
+    );
+
+    tester.view.physicalSize = const Size(1200, 900);
+    await tester.pump();
+    expect(find.byKey(const Key('procrastination-reset-wide')), findsOneWidget);
+  });
+}
+
+class _MemoryGateway implements ProcrastinationResetGateway {
+  ProcrastinationResetSnapshot snapshot = const ProcrastinationResetSnapshot();
+
+  @override
+  Future<ProcrastinationResetSnapshot> load() async => snapshot;
+
+  @override
+  Future<void> save(ProcrastinationResetSnapshot snapshot) async {
+    this.snapshot = snapshot;
+  }
+}

--- a/test/ui/features/procrastination_reset/procrastination_reset_view_model_test.dart
+++ b/test/ui/features/procrastination_reset/procrastination_reset_view_model_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/data/procrastination_reset_gateway.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/domain/procrastination_reset_models.dart';
+import 'package:my_web_app/ui/features/procrastination_reset/view_models/procrastination_reset_view_model.dart';
+
+void main() {
+  group('ProcrastinationResetViewModel', () {
+    test('入力を整えて5分プランを保存する', () async {
+      final gateway = _MemoryGateway();
+      final now = DateTime(2026, 8, 24, 12);
+      final viewModel = ProcrastinationResetViewModel(
+        gateway: gateway,
+        now: () => now,
+      );
+      addTearDown(viewModel.dispose);
+      await viewModel.load();
+
+      final created = await viewModel.createPlan(
+        task: '  記事を   書く  ',
+        fiveMinuteAction: ' タイトル案を3つ書く ',
+        firstMove: ' メモを開く ',
+        barrier: DistractionBarrier.notificationsOff,
+      );
+
+      expect(created, isTrue);
+      expect(viewModel.session?.task, '記事を 書く');
+      expect(viewModel.session?.fiveMinuteAction, 'タイトル案を3つ書く');
+      expect(viewModel.session?.firstMove, 'メモを開く');
+      expect(viewModel.session?.barrier, DistractionBarrier.notificationsOff);
+      expect(gateway.snapshot.session?.createdAt, now);
+    });
+
+    test('最初の一手を開始し、完了すると回数を加算してプランを空にする', () async {
+      final gateway = _MemoryGateway();
+      final now = DateTime(2026, 8, 24, 12);
+      final viewModel = ProcrastinationResetViewModel(
+        gateway: gateway,
+        now: () => now,
+      );
+      addTearDown(viewModel.dispose);
+      await viewModel.load();
+      await viewModel.createPlan(
+        task: '確定申告をする',
+        fiveMinuteAction: '領収書を1枚記録する',
+        firstMove: '会計画面を開く',
+        barrier: DistractionBarrier.outOfSight,
+      );
+
+      expect(await viewModel.startSession(), isTrue);
+      expect(viewModel.session?.startedAt, now);
+      expect(viewModel.remainingSeconds, 300);
+
+      expect(await viewModel.completeSession(), isTrue);
+      expect(viewModel.session, isNull);
+      expect(viewModel.completedCount, 1);
+      expect(viewModel.lastCompletedAction, '領収書を1枚記録する');
+      expect(gateway.snapshot.lastCompletedAt, now);
+    });
+
+    test('開始済みプランは経過時間を差し引いて復元する', () async {
+      final now = DateTime(2026, 8, 24, 12, 5);
+      final gateway = _MemoryGateway(
+        ProcrastinationResetSnapshot(
+          session: ProcrastinationResetSession(
+            task: '営業する',
+            fiveMinuteAction: '送付先を1件調べる',
+            firstMove: '顧客リストを開く',
+            barrier: DistractionBarrier.anotherRoom,
+            createdAt: DateTime(2026, 8, 24, 12),
+            startedAt: DateTime(2026, 8, 24, 12, 3),
+          ),
+        ),
+      );
+      final viewModel = ProcrastinationResetViewModel(
+        gateway: gateway,
+        now: () => now,
+      );
+      addTearDown(viewModel.dispose);
+
+      await viewModel.load();
+
+      expect(viewModel.remainingSeconds, 180);
+    });
+
+    test('空の入力は保存せず、具体的なエラーを返す', () async {
+      final gateway = _MemoryGateway();
+      final viewModel = ProcrastinationResetViewModel(gateway: gateway);
+      addTearDown(viewModel.dispose);
+      await viewModel.load();
+
+      final created = await viewModel.createPlan(
+        task: '',
+        fiveMinuteAction: '1件調べる',
+        firstMove: '一覧を開く',
+        barrier: DistractionBarrier.anotherRoom,
+      );
+
+      expect(created, isFalse);
+      expect(viewModel.errorMessage, contains('先延ばししていること'));
+      expect(gateway.saveCount, 0);
+    });
+  });
+}
+
+class _MemoryGateway implements ProcrastinationResetGateway {
+  _MemoryGateway([this.snapshot = const ProcrastinationResetSnapshot()]);
+
+  ProcrastinationResetSnapshot snapshot;
+  int saveCount = 0;
+
+  @override
+  Future<ProcrastinationResetSnapshot> load() async => snapshot;
+
+  @override
+  Future<void> save(ProcrastinationResetSnapshot snapshot) async {
+    saveCount += 1;
+    this.snapshot = snapshot;
+  }
+}

--- a/test/utils/feature_route_labels_test.dart
+++ b/test/utils/feature_route_labels_test.dart
@@ -8,6 +8,7 @@ void main() {
       expect(featureLabelForRoute('/site-guide-ai'), 'サイト案内AI');
       expect(featureLabelForRoute('/ai-university'), 'AI大学');
       expect(featureLabelForRoute('/release-notes'), 'Release Notes');
+      expect(featureLabelForRoute('/procrastination-reset'), '先延ばしリセット');
     });
 
     test('未知ルートは slug を Title Case に整形してフォールバックする', () {


### PR DESCRIPTION
## Summary
- add a "先延ばしリセット" flow that turns a large task into a five-minute action, one first move, and a distraction barrier
- persist the active session, timer start, completion count, and restoration state in SharedPreferences
- expose the feature from the personal home catalog and `/procrastination-reset`

## Architecture
- layered Flutter feature with domain models, local gateway, ChangeNotifier view model, and responsive view
- no external transmission; plans remain on the current device

## Validation
- `flutter analyze --no-pub` — no issues
- focused feature/catalog/route tests — 30 passed
- final route/label regression rerun — 19 passed
- browser QA at 1280x900 and 390x844
- verified create, reload restoration, timer start, completion, and completion count
- mobile horizontal metrics: innerWidth=390, documentScrollWidth=390
- no application console errors

## Minimal E2E Gate
- Implementation-detail independent: the tests assert user-visible input/output, not private internals.
- Minimal scope: about 3 cases (create/start/complete happy path, empty-input error path, reload recovery).
- E2E: Playwright exercised the local Flutter Web route at desktop and mobile widths.
- E2E-Exception: a permanent integration_test file is omitted because focused widget tests pin the same visible I/O and Playwright live QA already verified route restoration.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: The high-risk keyword is release prose only; this PR changes local-device UI and SharedPreferences, not auth, payments, migrations, external data, or deployment infrastructure.

## Release
- production deployment is requested; merge will trigger `deploy-prod.yml`