### PR TITLE
feat: ライブ多言語字幕を追加 (#1278)

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -157,6 +157,7 @@ import '../pages/social_feed_page.dart';
 import '../pages/subscription_billing_page.dart';
 import '../pages/digital_product_store_pages.dart';
 import '../pages/viral_ad_generator_page.dart';
+import '../ui/features/live_captions/live_captions_feature.dart';
 import '../ui/features/video_studio/video_studio_feature.dart';
 import '../ui/features/notion_migration/notion_migration_feature.dart';
 import '../pages/youtube_stats_page.dart';
@@ -2265,6 +2266,23 @@ List<HomeToolEntry> buildHomeToolCatalog({
       color: const Color(0xFF283593),
       keywords: const <String>['ABテスト', 'ランディング', 'LP', 'CVR', 'コンバージョン'],
       onOpen: (context) => _pushPage(context, const LandingAbTestPage()),
+    ),
+    HomeToolEntry(
+      id: 'live-captions',
+      sectionId: 'growth',
+      title: 'ライブ多言語字幕',
+      subtitle: '配信音声をリアルタイム文字起こしし、視聴言語へ自動翻訳',
+      icon: Icons.closed_caption_outlined,
+      color: const Color(0xFF3949AB),
+      keywords: const <String>[
+        'ライブ配信',
+        '字幕',
+        '文字起こし',
+        '翻訳',
+        'caption',
+        'streaming',
+      ],
+      onOpen: (context) => _pushPage(context, const LiveCaptionsFeature()),
     ),
     HomeToolEntry(
       id: 'video-studio',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -219,6 +219,7 @@ import 'package:my_web_app/pages/loyalty_points_page.dart';
 import 'package:my_web_app/pages/viral_ad_generator_page.dart';
 import 'package:my_web_app/pages/growth_automation_controller_page.dart';
 import 'package:my_web_app/pages/landing_ab_test_page.dart';
+import 'package:my_web_app/ui/features/live_captions/live_captions_feature.dart';
 import 'package:my_web_app/ui/features/video_studio/video_studio_feature.dart';
 import 'package:my_web_app/ui/features/notion_migration/notion_migration_feature.dart';
 import 'package:my_web_app/ui/features/procrastination_reset/procrastination_reset_feature.dart';
@@ -1340,6 +1341,11 @@ Route<dynamic> generateAppRoute(
       );
     case '/landing-ab-test':
       return MaterialPageRoute(builder: (_) => const LandingAbTestPage());
+    case '/live-captions':
+      return MaterialPageRoute(
+        builder: (_) => const LiveCaptionsFeature(),
+        settings: RouteSettings(name: settings.name),
+      );
     case '/video-studio':
       return MaterialPageRoute(
         builder: (_) => VideoStudioFeature(initialUri: uri),

--- a/lib/ui/features/live_captions/data/live_caption_translation_gateway.dart
+++ b/lib/ui/features/live_captions/data/live_caption_translation_gateway.dart
@@ -11,7 +11,7 @@ abstract class LiveCaptionTranslationGateway {
 
 class AiLiveCaptionTranslationGateway implements LiveCaptionTranslationGateway {
   AiLiveCaptionTranslationGateway({AIService? aiService})
-    : _aiService = aiService ?? AIService();
+      : _aiService = aiService ?? AIService();
 
   final AIService _aiService;
 

--- a/lib/ui/features/live_captions/data/live_caption_translation_gateway.dart
+++ b/lib/ui/features/live_captions/data/live_caption_translation_gateway.dart
@@ -1,0 +1,50 @@
+import '../../../../services/ai_service.dart';
+import '../domain/live_caption_models.dart';
+
+abstract class LiveCaptionTranslationGateway {
+  Future<String> translate({
+    required String text,
+    required LiveCaptionLanguage sourceLanguage,
+    required LiveCaptionLanguage targetLanguage,
+  });
+}
+
+class AiLiveCaptionTranslationGateway implements LiveCaptionTranslationGateway {
+  AiLiveCaptionTranslationGateway({AIService? aiService})
+    : _aiService = aiService ?? AIService();
+
+  final AIService _aiService;
+
+  @override
+  Future<String> translate({
+    required String text,
+    required LiveCaptionLanguage sourceLanguage,
+    required LiveCaptionLanguage targetLanguage,
+  }) async {
+    if (sourceLanguage.tag == targetLanguage.tag) return text;
+
+    final translated = await _aiService.translateText(
+      text,
+      targetLanguage: targetLanguage.translationName,
+      styleName: 'live-caption',
+      styleInstruction:
+          'Translate spoken ${sourceLanguage.translationName} into concise '
+          '${targetLanguage.translationName} subtitles. Return only the '
+          'translation, without labels, commentary, or quotation marks.',
+    );
+    final normalized = translated.trim();
+    if (normalized.isEmpty) {
+      throw const LiveCaptionTranslationException('翻訳結果が空でした。');
+    }
+    return normalized;
+  }
+}
+
+class LiveCaptionTranslationException implements Exception {
+  const LiveCaptionTranslationException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/ui/features/live_captions/domain/live_caption_models.dart
+++ b/lib/ui/features/live_captions/domain/live_caption_models.dart
@@ -1,0 +1,74 @@
+class LiveCaptionLanguage {
+  const LiveCaptionLanguage({
+    required this.tag,
+    required this.label,
+    required this.translationName,
+  });
+
+  final String tag;
+  final String label;
+  final String translationName;
+}
+
+const List<LiveCaptionLanguage> kLiveCaptionLanguages = <LiveCaptionLanguage>[
+  LiveCaptionLanguage(tag: 'ja-JP', label: '日本語', translationName: 'Japanese'),
+  LiveCaptionLanguage(tag: 'en-US', label: '英語', translationName: 'English'),
+  LiveCaptionLanguage(
+    tag: 'zh-CN',
+    label: '中国語（簡体字）',
+    translationName: 'Simplified Chinese',
+  ),
+  LiveCaptionLanguage(tag: 'ko-KR', label: '韓国語', translationName: 'Korean'),
+  LiveCaptionLanguage(tag: 'es-ES', label: 'スペイン語', translationName: 'Spanish'),
+  LiveCaptionLanguage(tag: 'fr-FR', label: 'フランス語', translationName: 'French'),
+];
+
+LiveCaptionLanguage liveCaptionLanguageByTag(String tag) {
+  return kLiveCaptionLanguages.firstWhere(
+    (language) => language.tag == tag,
+    orElse: () => kLiveCaptionLanguages.first,
+  );
+}
+
+class LiveCaptionSegment {
+  LiveCaptionSegment({
+    required this.id,
+    required this.sourceLanguageTag,
+    required this.sourceText,
+    required this.receivedAt,
+    Map<String, String> translations = const <String, String>{},
+  }) : translations = Map<String, String>.unmodifiable(translations);
+
+  final int id;
+  final String sourceLanguageTag;
+  final String sourceText;
+  final DateTime receivedAt;
+  final Map<String, String> translations;
+
+  String textFor(String languageTag) {
+    if (languageTag == sourceLanguageTag) return sourceText;
+    return translations[languageTag] ?? sourceText;
+  }
+
+  bool hasTranslation(String languageTag) =>
+      languageTag == sourceLanguageTag || translations.containsKey(languageTag);
+
+  LiveCaptionSegment withTranslation(String languageTag, String text) {
+    return LiveCaptionSegment(
+      id: id,
+      sourceLanguageTag: sourceLanguageTag,
+      sourceText: sourceText,
+      receivedAt: receivedAt,
+      translations: <String, String>{...translations, languageTag: text},
+    );
+  }
+}
+
+enum LiveCaptionStatus {
+  idle,
+  listening,
+  translating,
+  stopped,
+  unsupported,
+  error,
+}

--- a/lib/ui/features/live_captions/live_captions_feature.dart
+++ b/lib/ui/features/live_captions/live_captions_feature.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import 'data/live_caption_translation_gateway.dart';
+import 'services/live_speech_recognizer.dart';
+import 'view_models/live_captions_view_model.dart';
+import 'views/live_captions_page.dart';
+
+class LiveCaptionsFeature extends StatelessWidget {
+  const LiveCaptionsFeature({
+    super.key,
+    this.translationGateway,
+    this.speechRecognizer,
+  });
+
+  final LiveCaptionTranslationGateway? translationGateway;
+  final LiveSpeechRecognizer? speechRecognizer;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<LiveCaptionsViewModel>(
+      create: (_) => LiveCaptionsViewModel(
+        translationGateway:
+            translationGateway ?? AiLiveCaptionTranslationGateway(),
+        speechRecognizer: speechRecognizer ?? createLiveSpeechRecognizer(),
+      ),
+      child: const LiveCaptionsPage(),
+    );
+  }
+}

--- a/lib/ui/features/live_captions/services/live_speech_recognizer.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer.dart
@@ -1,0 +1,9 @@
+import 'live_speech_recognizer_base.dart';
+import 'live_speech_recognizer_stub.dart'
+    if (dart.library.js_interop) 'live_speech_recognizer_web.dart'
+    as platform;
+
+export 'live_speech_recognizer_base.dart';
+
+LiveSpeechRecognizer createLiveSpeechRecognizer() =>
+    platform.createLiveSpeechRecognizer();

--- a/lib/ui/features/live_captions/services/live_speech_recognizer.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer.dart
@@ -1,7 +1,6 @@
 import 'live_speech_recognizer_base.dart';
 import 'live_speech_recognizer_stub.dart'
-    if (dart.library.js_interop) 'live_speech_recognizer_web.dart'
-    as platform;
+    if (dart.library.js_interop) 'live_speech_recognizer_web.dart' as platform;
 
 export 'live_speech_recognizer_base.dart';
 

--- a/lib/ui/features/live_captions/services/live_speech_recognizer_base.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer_base.dart
@@ -1,4 +1,7 @@
-typedef LiveSpeechResultCallback = void Function(String transcript, bool isFinal);
+typedef LiveSpeechResultCallback = void Function({
+  required String transcript,
+  required bool isFinal,
+});
 typedef LiveSpeechErrorCallback = void Function(String message);
 
 abstract class LiveSpeechRecognizer {

--- a/lib/ui/features/live_captions/services/live_speech_recognizer_base.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer_base.dart
@@ -1,5 +1,4 @@
-typedef LiveSpeechResultCallback = void Function(
-    String transcript, bool isFinal);
+typedef LiveSpeechResultCallback = void Function(String transcript, bool isFinal);
 typedef LiveSpeechErrorCallback = void Function(String message);
 
 abstract class LiveSpeechRecognizer {

--- a/lib/ui/features/live_captions/services/live_speech_recognizer_base.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer_base.dart
@@ -1,0 +1,26 @@
+typedef LiveSpeechResultCallback =
+    void Function(String transcript, bool isFinal);
+typedef LiveSpeechErrorCallback = void Function(String message);
+
+abstract class LiveSpeechRecognizer {
+  bool get isSupported;
+
+  Future<void> start({
+    required String languageTag,
+    required LiveSpeechResultCallback onResult,
+    required LiveSpeechErrorCallback onError,
+  });
+
+  Future<void> stop();
+
+  void dispose();
+}
+
+class LiveSpeechRecognitionException implements Exception {
+  const LiveSpeechRecognitionException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/ui/features/live_captions/services/live_speech_recognizer_base.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer_base.dart
@@ -1,5 +1,5 @@
-typedef LiveSpeechResultCallback =
-    void Function(String transcript, bool isFinal);
+typedef LiveSpeechResultCallback = void Function(
+    String transcript, bool isFinal);
 typedef LiveSpeechErrorCallback = void Function(String message);
 
 abstract class LiveSpeechRecognizer {

--- a/lib/ui/features/live_captions/services/live_speech_recognizer_stub.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer_stub.dart
@@ -1,0 +1,24 @@
+import 'live_speech_recognizer_base.dart';
+
+LiveSpeechRecognizer createLiveSpeechRecognizer() =>
+    _UnsupportedLiveSpeechRecognizer();
+
+class _UnsupportedLiveSpeechRecognizer implements LiveSpeechRecognizer {
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<void> start({
+    required String languageTag,
+    required LiveSpeechResultCallback onResult,
+    required LiveSpeechErrorCallback onError,
+  }) {
+    throw const LiveSpeechRecognitionException('この端末ではブラウザー音声認識を利用できません。');
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  void dispose() {}
+}

--- a/lib/ui/features/live_captions/services/live_speech_recognizer_web.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer_web.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+import 'live_speech_recognizer_base.dart';
+
+LiveSpeechRecognizer createLiveSpeechRecognizer() => _WebLiveSpeechRecognizer();
+
+class _WebLiveSpeechRecognizer implements LiveSpeechRecognizer {
+  _WebLiveSpeechRecognizer() {
+    try {
+      _recognition = web.SpeechRecognition();
+    } catch (_) {
+      _recognition = null;
+    }
+  }
+
+  web.SpeechRecognition? _recognition;
+  Timer? _restartTimer;
+  bool _shouldListen = false;
+  LiveSpeechResultCallback? _onResult;
+  LiveSpeechErrorCallback? _onError;
+
+  @override
+  bool get isSupported => _recognition != null;
+
+  @override
+  Future<void> start({
+    required String languageTag,
+    required LiveSpeechResultCallback onResult,
+    required LiveSpeechErrorCallback onError,
+  }) async {
+    final recognition = _recognition;
+    if (recognition == null) {
+      throw const LiveSpeechRecognitionException(
+        'このブラウザーはWeb Speech APIに対応していません。',
+      );
+    }
+
+    _restartTimer?.cancel();
+    _shouldListen = true;
+    _onResult = onResult;
+    _onError = onError;
+    recognition
+      ..lang = languageTag
+      ..continuous = true
+      ..interimResults = true
+      ..maxAlternatives = 1;
+
+    recognition.onresult = ((web.SpeechRecognitionEvent event) {
+      final results = event.results;
+      for (var index = event.resultIndex; index < results.length; index++) {
+        final result = results.item(index);
+        if (result.length == 0) continue;
+        final transcript = result.item(0).transcript.trim();
+        if (transcript.isNotEmpty) {
+          _onResult?.call(transcript, result.isFinal);
+        }
+      }
+    }).toJS;
+
+    recognition.onerror = ((web.SpeechRecognitionErrorEvent event) {
+      final code = event.error;
+      if (code == 'not-allowed' || code == 'service-not-allowed') {
+        _shouldListen = false;
+      }
+      _onError?.call(_friendlySpeechError(code));
+    }).toJS;
+
+    recognition.onend = (() {
+      if (!_shouldListen) return;
+      _restartTimer?.cancel();
+      _restartTimer = Timer(const Duration(milliseconds: 250), () {
+        if (!_shouldListen) return;
+        try {
+          _recognition?.start();
+        } catch (_) {
+          _onError?.call('音声認識の再開に失敗しました。もう一度開始してください。');
+        }
+      });
+    }).toJS;
+
+    try {
+      recognition.start();
+    } catch (_) {
+      _shouldListen = false;
+      throw const LiveSpeechRecognitionException(
+        '音声認識を開始できませんでした。マイク権限を確認してください。',
+      );
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    _shouldListen = false;
+    _restartTimer?.cancel();
+    _restartTimer = null;
+    try {
+      _recognition?.stop();
+    } catch (_) {
+      // The browser may already have ended the recognition session.
+    }
+  }
+
+  @override
+  void dispose() {
+    _shouldListen = false;
+    _restartTimer?.cancel();
+    try {
+      _recognition?.abort();
+    } catch (_) {
+      // Nothing remains to release when the browser already ended the session.
+    }
+    _recognition = null;
+  }
+}
+
+String _friendlySpeechError(String code) {
+  switch (code) {
+    case 'not-allowed':
+    case 'service-not-allowed':
+      return 'マイク権限がありません。ブラウザー設定から許可してください。';
+    case 'no-speech':
+      return '音声を検出できませんでした。マイクへ近づいて話してください。';
+    case 'audio-capture':
+      return '利用できるマイクが見つかりません。';
+    case 'network':
+      return '音声認識サービスへ接続できませんでした。';
+    default:
+      return '音声認識でエラーが発生しました（$code）。';
+  }
+}

--- a/lib/ui/features/live_captions/services/live_speech_recognizer_web.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer_web.dart
@@ -55,7 +55,10 @@ class _WebLiveSpeechRecognizer implements LiveSpeechRecognizer {
         if (result.length == 0) continue;
         final transcript = result.item(0).transcript.trim();
         if (transcript.isNotEmpty) {
-          _onResult?.call(transcript, result.isFinal);
+          _onResult?.call(
+            transcript: transcript,
+            isFinal: result.isFinal,
+          );
         }
       }
     }).toJS;

--- a/lib/ui/features/live_captions/services/live_speech_recognizer_web.dart
+++ b/lib/ui/features/live_captions/services/live_speech_recognizer_web.dart
@@ -49,6 +49,7 @@ class _WebLiveSpeechRecognizer implements LiveSpeechRecognizer {
       ..maxAlternatives = 1;
 
     recognition.onresult = ((web.SpeechRecognitionEvent event) {
+      if (!_shouldListen) return;
       final results = event.results;
       for (var index = event.resultIndex; index < results.length; index++) {
         final result = results.item(index);
@@ -65,9 +66,8 @@ class _WebLiveSpeechRecognizer implements LiveSpeechRecognizer {
 
     recognition.onerror = ((web.SpeechRecognitionErrorEvent event) {
       final code = event.error;
-      if (code == 'not-allowed' || code == 'service-not-allowed') {
-        _shouldListen = false;
-      }
+      _shouldListen = false;
+      _restartTimer?.cancel();
       _onError?.call(_friendlySpeechError(code));
     }).toJS;
 
@@ -79,6 +79,7 @@ class _WebLiveSpeechRecognizer implements LiveSpeechRecognizer {
         try {
           _recognition?.start();
         } catch (_) {
+          _shouldListen = false;
           _onError?.call('音声認識の再開に失敗しました。もう一度開始してください。');
         }
       });

--- a/lib/ui/features/live_captions/view_models/live_captions_view_model.dart
+++ b/lib/ui/features/live_captions/view_models/live_captions_view_model.dart
@@ -12,13 +12,13 @@ class LiveCaptionsViewModel extends ChangeNotifier {
     required LiveSpeechRecognizer speechRecognizer,
     DateTime Function()? now,
     int maxSegments = 30,
-  }) : _translationGateway = translationGateway,
-       _speechRecognizer = speechRecognizer,
-       _now = now ?? DateTime.now,
-       _maxSegments = maxSegments,
-       _status = speechRecognizer.isSupported
-           ? LiveCaptionStatus.idle
-           : LiveCaptionStatus.unsupported;
+  })  : _translationGateway = translationGateway,
+        _speechRecognizer = speechRecognizer,
+        _now = now ?? DateTime.now,
+        _maxSegments = maxSegments,
+        _status = speechRecognizer.isSupported
+            ? LiveCaptionStatus.idle
+            : LiveCaptionStatus.unsupported;
 
   final LiveCaptionTranslationGateway _translationGateway;
   final LiveSpeechRecognizer _speechRecognizer;
@@ -113,8 +113,7 @@ class LiveCaptionsViewModel extends ChangeNotifier {
   }
 
   void setViewerLanguage(String languageTag) {
-    final isAvailable =
-        languageTag == _sourceLanguageTag ||
+    final isAvailable = languageTag == _sourceLanguageTag ||
         _targetLanguageTags.contains(languageTag);
     if (!isAvailable || languageTag == _viewerLanguageTag) return;
     _viewerLanguageTag = languageTag;
@@ -195,8 +194,8 @@ class LiveCaptionsViewModel extends ChangeNotifier {
     _pendingTranslations += targets.length;
     _status = targets.isEmpty
         ? (_isListening
-              ? LiveCaptionStatus.listening
-              : LiveCaptionStatus.stopped)
+            ? LiveCaptionStatus.listening
+            : LiveCaptionStatus.stopped)
         : LiveCaptionStatus.translating;
     _notify();
 
@@ -215,8 +214,8 @@ class LiveCaptionsViewModel extends ChangeNotifier {
     _status = _pendingTranslations > 0
         ? LiveCaptionStatus.translating
         : (_isListening
-              ? LiveCaptionStatus.listening
-              : LiveCaptionStatus.stopped);
+            ? LiveCaptionStatus.listening
+            : LiveCaptionStatus.stopped);
     _notify();
   }
 

--- a/lib/ui/features/live_captions/view_models/live_captions_view_model.dart
+++ b/lib/ui/features/live_captions/view_models/live_captions_view_model.dart
@@ -133,7 +133,7 @@ class LiveCaptionsViewModel extends ChangeNotifier {
     try {
       await _speechRecognizer.start(
         languageTag: _sourceLanguageTag,
-        onResult: (transcript, isFinal) {
+        onResult: ({required transcript, required isFinal}) {
           unawaited(ingestTranscript(transcript, isFinal: isFinal));
         },
         onError: _handleSpeechError,

--- a/lib/ui/features/live_captions/view_models/live_captions_view_model.dart
+++ b/lib/ui/features/live_captions/view_models/live_captions_view_model.dart
@@ -34,9 +34,11 @@ class LiveCaptionsViewModel extends ChangeNotifier {
   String? _errorMessage;
   Duration? _lastTranslationLatency;
   bool _isListening = false;
+  bool _isStarting = false;
   bool _disposed = false;
   int _pendingTranslations = 0;
   int _nextSegmentId = 1;
+  int _recognitionSession = 0;
 
   LiveCaptionStatus get status => _status;
   LiveCaptionLanguage get sourceLanguage =>
@@ -108,6 +110,7 @@ class LiveCaptionsViewModel extends ChangeNotifier {
       }
     } else {
       _targetLanguageTags.add(languageTag);
+      unawaited(_backfillTargetLanguage(languageTag));
     }
     _notify();
   }
@@ -121,7 +124,7 @@ class LiveCaptionsViewModel extends ChangeNotifier {
   }
 
   Future<bool> start() async {
-    if (_isListening) return true;
+    if (_isListening || _isStarting) return true;
     if (!_speechRecognizer.isSupported) {
       _status = LiveCaptionStatus.unsupported;
       _errorMessage = 'ChromeまたはEdgeの最新版でマイクを許可してください。';
@@ -130,21 +133,36 @@ class LiveCaptionsViewModel extends ChangeNotifier {
     }
 
     _errorMessage = null;
+    _isStarting = true;
+    _isListening = true;
+    final session = ++_recognitionSession;
+    _status = _pendingTranslations > 0
+        ? LiveCaptionStatus.translating
+        : LiveCaptionStatus.listening;
+    _notify();
     try {
       await _speechRecognizer.start(
         languageTag: _sourceLanguageTag,
         onResult: ({required transcript, required isFinal}) {
+          if (_disposed || session != _recognitionSession || !_isListening) {
+            return;
+          }
           unawaited(ingestTranscript(transcript, isFinal: isFinal));
         },
-        onError: _handleSpeechError,
+        onError: (message) => _handleSpeechError(session, message),
       );
-      _isListening = true;
+      if (_disposed || session != _recognitionSession || !_isListening) {
+        return false;
+      }
+      _isStarting = false;
       _status = _pendingTranslations > 0
           ? LiveCaptionStatus.translating
           : LiveCaptionStatus.listening;
       _notify();
       return true;
     } catch (error) {
+      if (_disposed || session != _recognitionSession) return false;
+      _isStarting = false;
       _isListening = false;
       _status = LiveCaptionStatus.error;
       _errorMessage = error.toString();
@@ -154,13 +172,15 @@ class LiveCaptionsViewModel extends ChangeNotifier {
   }
 
   Future<void> stop() async {
+    ++_recognitionSession;
+    _isStarting = false;
     _isListening = false;
-    await _speechRecognizer.stop();
     _interimText = '';
     _status = _pendingTranslations > 0
         ? LiveCaptionStatus.translating
         : LiveCaptionStatus.stopped;
     _notify();
+    await _speechRecognizer.stop();
   }
 
   Future<void> ingestTranscript(
@@ -210,12 +230,15 @@ class LiveCaptionsViewModel extends ChangeNotifier {
       ),
     );
     _pendingTranslations -= targets.length;
+    if (_disposed) return;
     _lastTranslationLatency = _now().difference(segment.receivedAt);
-    _status = _pendingTranslations > 0
-        ? LiveCaptionStatus.translating
-        : (_isListening
-            ? LiveCaptionStatus.listening
-            : LiveCaptionStatus.stopped);
+    if (_status != LiveCaptionStatus.error) {
+      _status = _pendingTranslations > 0
+          ? LiveCaptionStatus.translating
+          : (_isListening
+              ? LiveCaptionStatus.listening
+              : LiveCaptionStatus.stopped);
+    }
     _notify();
   }
 
@@ -238,6 +261,7 @@ class LiveCaptionsViewModel extends ChangeNotifier {
         sourceLanguage: source,
         targetLanguage: target,
       );
+      if (_disposed) return;
       final index = _segments.indexWhere((item) => item.id == segmentId);
       if (index < 0) return;
       _segments[index] = _segments[index].withTranslation(
@@ -246,16 +270,59 @@ class LiveCaptionsViewModel extends ChangeNotifier {
       );
       _notify();
     } catch (error) {
-      _errorMessage = '${target.label}字幕を生成できませんでした: $error';
+      if (_disposed) return;
+      if (_status != LiveCaptionStatus.error) {
+        _errorMessage = '${target.label}字幕を生成できませんでした: $error';
+      }
       _notify();
     }
   }
 
-  void _handleSpeechError(String message) {
+  Future<void> _backfillTargetLanguage(String languageTag) async {
+    final target = liveCaptionLanguageByTag(languageTag);
+    final missingSegments = _segments
+        .where((segment) => !segment.hasTranslation(languageTag))
+        .toList(growable: false);
+    if (missingSegments.isEmpty || _disposed) return;
+
+    _pendingTranslations += missingSegments.length;
+    if (_status != LiveCaptionStatus.error) {
+      _status = LiveCaptionStatus.translating;
+    }
+    _notify();
+
+    await Future.wait<void>(
+      missingSegments.map(
+        (segment) => _translateSegment(
+          segmentId: segment.id,
+          text: segment.sourceText,
+          source: liveCaptionLanguageByTag(segment.sourceLanguageTag),
+          target: target,
+        ),
+      ),
+    );
+    _pendingTranslations -= missingSegments.length;
+    if (_disposed) return;
+    if (_status != LiveCaptionStatus.error) {
+      _status = _pendingTranslations > 0
+          ? LiveCaptionStatus.translating
+          : (_isListening
+              ? LiveCaptionStatus.listening
+              : LiveCaptionStatus.stopped);
+    }
+    _notify();
+  }
+
+  void _handleSpeechError(int session, String message) {
+    if (_disposed || session != _recognitionSession) return;
+    ++_recognitionSession;
+    _isStarting = false;
     _isListening = false;
+    _interimText = '';
     _status = LiveCaptionStatus.error;
     _errorMessage = message;
     _notify();
+    unawaited(_speechRecognizer.stop());
   }
 
   void _notify() {
@@ -264,6 +331,9 @@ class LiveCaptionsViewModel extends ChangeNotifier {
 
   @override
   void dispose() {
+    ++_recognitionSession;
+    _isStarting = false;
+    _isListening = false;
     _disposed = true;
     _speechRecognizer.dispose();
     super.dispose();

--- a/lib/ui/features/live_captions/view_models/live_captions_view_model.dart
+++ b/lib/ui/features/live_captions/view_models/live_captions_view_model.dart
@@ -1,0 +1,272 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../data/live_caption_translation_gateway.dart';
+import '../domain/live_caption_models.dart';
+import '../services/live_speech_recognizer.dart';
+
+class LiveCaptionsViewModel extends ChangeNotifier {
+  LiveCaptionsViewModel({
+    required LiveCaptionTranslationGateway translationGateway,
+    required LiveSpeechRecognizer speechRecognizer,
+    DateTime Function()? now,
+    int maxSegments = 30,
+  }) : _translationGateway = translationGateway,
+       _speechRecognizer = speechRecognizer,
+       _now = now ?? DateTime.now,
+       _maxSegments = maxSegments,
+       _status = speechRecognizer.isSupported
+           ? LiveCaptionStatus.idle
+           : LiveCaptionStatus.unsupported;
+
+  final LiveCaptionTranslationGateway _translationGateway;
+  final LiveSpeechRecognizer _speechRecognizer;
+  final DateTime Function() _now;
+  final int _maxSegments;
+
+  LiveCaptionStatus _status;
+  String _sourceLanguageTag = 'ja-JP';
+  final Set<String> _targetLanguageTags = <String>{'en-US'};
+  String _viewerLanguageTag = 'en-US';
+  final List<LiveCaptionSegment> _segments = <LiveCaptionSegment>[];
+  String _interimText = '';
+  String? _errorMessage;
+  Duration? _lastTranslationLatency;
+  bool _isListening = false;
+  bool _disposed = false;
+  int _pendingTranslations = 0;
+  int _nextSegmentId = 1;
+
+  LiveCaptionStatus get status => _status;
+  LiveCaptionLanguage get sourceLanguage =>
+      liveCaptionLanguageByTag(_sourceLanguageTag);
+  String get sourceLanguageTag => _sourceLanguageTag;
+  Set<String> get targetLanguageTags =>
+      Set<String>.unmodifiable(_targetLanguageTags);
+  String get viewerLanguageTag => _viewerLanguageTag;
+  List<LiveCaptionSegment> get segments =>
+      List<LiveCaptionSegment>.unmodifiable(_segments);
+  String get interimText => _interimText;
+  String? get errorMessage => _errorMessage;
+  Duration? get lastTranslationLatency => _lastTranslationLatency;
+  bool get isListening => _isListening;
+  bool get isSupported => _speechRecognizer.isSupported;
+
+  String get statusLabel {
+    switch (_status) {
+      case LiveCaptionStatus.idle:
+        return '待機中';
+      case LiveCaptionStatus.listening:
+        return '音声認識中';
+      case LiveCaptionStatus.translating:
+        return '翻訳中';
+      case LiveCaptionStatus.stopped:
+        return '停止中';
+      case LiveCaptionStatus.unsupported:
+        return '非対応ブラウザー';
+      case LiveCaptionStatus.error:
+        return 'エラー';
+    }
+  }
+
+  String get currentViewerText {
+    if (_viewerLanguageTag == _sourceLanguageTag && _interimText.isNotEmpty) {
+      return _interimText;
+    }
+    if (_segments.isEmpty) {
+      return _interimText.isEmpty ? '字幕はここに表示されます' : _interimText;
+    }
+    return _segments.last.textFor(_viewerLanguageTag);
+  }
+
+  void setSourceLanguage(String languageTag) {
+    if (_isListening || languageTag == _sourceLanguageTag) return;
+    _sourceLanguageTag = languageTag;
+    _targetLanguageTags.remove(languageTag);
+    if (_targetLanguageTags.isEmpty) {
+      _targetLanguageTags.add(
+        kLiveCaptionLanguages
+            .firstWhere((language) => language.tag != languageTag)
+            .tag,
+      );
+    }
+    if (_viewerLanguageTag == languageTag ||
+        !_targetLanguageTags.contains(_viewerLanguageTag)) {
+      _viewerLanguageTag = _targetLanguageTags.first;
+    }
+    _notify();
+  }
+
+  void toggleTargetLanguage(String languageTag) {
+    if (languageTag == _sourceLanguageTag) return;
+    if (_targetLanguageTags.contains(languageTag)) {
+      if (_targetLanguageTags.length == 1) return;
+      _targetLanguageTags.remove(languageTag);
+      if (_viewerLanguageTag == languageTag) {
+        _viewerLanguageTag = _targetLanguageTags.first;
+      }
+    } else {
+      _targetLanguageTags.add(languageTag);
+    }
+    _notify();
+  }
+
+  void setViewerLanguage(String languageTag) {
+    final isAvailable =
+        languageTag == _sourceLanguageTag ||
+        _targetLanguageTags.contains(languageTag);
+    if (!isAvailable || languageTag == _viewerLanguageTag) return;
+    _viewerLanguageTag = languageTag;
+    _notify();
+  }
+
+  Future<bool> start() async {
+    if (_isListening) return true;
+    if (!_speechRecognizer.isSupported) {
+      _status = LiveCaptionStatus.unsupported;
+      _errorMessage = 'ChromeまたはEdgeの最新版でマイクを許可してください。';
+      _notify();
+      return false;
+    }
+
+    _errorMessage = null;
+    try {
+      await _speechRecognizer.start(
+        languageTag: _sourceLanguageTag,
+        onResult: (transcript, isFinal) {
+          unawaited(ingestTranscript(transcript, isFinal: isFinal));
+        },
+        onError: _handleSpeechError,
+      );
+      _isListening = true;
+      _status = _pendingTranslations > 0
+          ? LiveCaptionStatus.translating
+          : LiveCaptionStatus.listening;
+      _notify();
+      return true;
+    } catch (error) {
+      _isListening = false;
+      _status = LiveCaptionStatus.error;
+      _errorMessage = error.toString();
+      _notify();
+      return false;
+    }
+  }
+
+  Future<void> stop() async {
+    _isListening = false;
+    await _speechRecognizer.stop();
+    _interimText = '';
+    _status = _pendingTranslations > 0
+        ? LiveCaptionStatus.translating
+        : LiveCaptionStatus.stopped;
+    _notify();
+  }
+
+  Future<void> ingestTranscript(
+    String transcript, {
+    required bool isFinal,
+  }) async {
+    final normalized = transcript.trim();
+    if (normalized.isEmpty) return;
+
+    if (!isFinal) {
+      _interimText = normalized;
+      _notify();
+      return;
+    }
+
+    _interimText = '';
+    final segment = LiveCaptionSegment(
+      id: _nextSegmentId++,
+      sourceLanguageTag: _sourceLanguageTag,
+      sourceText: normalized,
+      receivedAt: _now(),
+    );
+    _segments.add(segment);
+    if (_segments.length > _maxSegments) {
+      _segments.removeRange(0, _segments.length - _maxSegments);
+    }
+
+    final targets = _targetLanguageTags
+        .map(liveCaptionLanguageByTag)
+        .toList(growable: false);
+    _pendingTranslations += targets.length;
+    _status = targets.isEmpty
+        ? (_isListening
+              ? LiveCaptionStatus.listening
+              : LiveCaptionStatus.stopped)
+        : LiveCaptionStatus.translating;
+    _notify();
+
+    await Future.wait<void>(
+      targets.map(
+        (target) => _translateSegment(
+          segmentId: segment.id,
+          text: normalized,
+          source: sourceLanguage,
+          target: target,
+        ),
+      ),
+    );
+    _pendingTranslations -= targets.length;
+    _lastTranslationLatency = _now().difference(segment.receivedAt);
+    _status = _pendingTranslations > 0
+        ? LiveCaptionStatus.translating
+        : (_isListening
+              ? LiveCaptionStatus.listening
+              : LiveCaptionStatus.stopped);
+    _notify();
+  }
+
+  void clearSegments() {
+    _segments.clear();
+    _interimText = '';
+    _lastTranslationLatency = null;
+    _notify();
+  }
+
+  Future<void> _translateSegment({
+    required int segmentId,
+    required String text,
+    required LiveCaptionLanguage source,
+    required LiveCaptionLanguage target,
+  }) async {
+    try {
+      final translated = await _translationGateway.translate(
+        text: text,
+        sourceLanguage: source,
+        targetLanguage: target,
+      );
+      final index = _segments.indexWhere((item) => item.id == segmentId);
+      if (index < 0) return;
+      _segments[index] = _segments[index].withTranslation(
+        target.tag,
+        translated,
+      );
+      _notify();
+    } catch (error) {
+      _errorMessage = '${target.label}字幕を生成できませんでした: $error';
+      _notify();
+    }
+  }
+
+  void _handleSpeechError(String message) {
+    _isListening = false;
+    _status = LiveCaptionStatus.error;
+    _errorMessage = message;
+    _notify();
+  }
+
+  void _notify() {
+    if (!_disposed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _speechRecognizer.dispose();
+    super.dispose();
+  }
+}

--- a/lib/ui/features/live_captions/views/live_captions_page.dart
+++ b/lib/ui/features/live_captions/views/live_captions_page.dart
@@ -202,9 +202,8 @@ class _PreviewPanel extends StatelessWidget {
               ),
               TextButton.icon(
                 key: const Key('live-caption-clear'),
-                onPressed: viewModel.segments.isEmpty
-                    ? null
-                    : viewModel.clearSegments,
+                onPressed:
+                    viewModel.segments.isEmpty ? null : viewModel.clearSegments,
                 icon: const Icon(Icons.delete_sweep_outlined),
                 label: const Text('クリア'),
               ),

--- a/lib/ui/features/live_captions/views/live_captions_page.dart
+++ b/lib/ui/features/live_captions/views/live_captions_page.dart
@@ -1,0 +1,493 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../theme/design_tokens.dart';
+import '../domain/live_caption_models.dart';
+import '../view_models/live_captions_view_model.dart';
+
+class LiveCaptionsPage extends StatelessWidget {
+  const LiveCaptionsPage({super.key});
+
+  static const double _wideBreakpoint = 980;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: DesignTokens.background,
+      appBar: AppBar(
+        backgroundColor: DesignTokens.surface1,
+        foregroundColor: DesignTokens.textPrimary,
+        title: const Text('ライブ多言語字幕'),
+      ),
+      body: Consumer<LiveCaptionsViewModel>(
+        builder: (context, viewModel, _) {
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final content = constraints.maxWidth >= _wideBreakpoint
+                  ? Row(
+                      key: const Key('live-captions-wide'),
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Expanded(
+                          flex: 3,
+                          child: _PreviewPanel(viewModel: viewModel),
+                        ),
+                        const SizedBox(width: DesignTokens.space16),
+                        Expanded(
+                          flex: 2,
+                          child: _SettingsPanel(viewModel: viewModel),
+                        ),
+                      ],
+                    )
+                  : Column(
+                      key: const Key('live-captions-compact'),
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        _PreviewPanel(viewModel: viewModel),
+                        const SizedBox(height: DesignTokens.space16),
+                        _SettingsPanel(viewModel: viewModel),
+                      ],
+                    );
+
+              return SingleChildScrollView(
+                padding: const EdgeInsets.all(DesignTokens.space16),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 1320),
+                  child: Center(child: content),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PreviewPanel extends StatelessWidget {
+  const _PreviewPanel({required this.viewModel});
+
+  final LiveCaptionsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final viewerLanguages = <LiveCaptionLanguage>[
+      viewModel.sourceLanguage,
+      ...kLiveCaptionLanguages.where(
+        (language) => viewModel.targetLanguageTags.contains(language.tag),
+      ),
+    ];
+    final latestSegments = viewModel.segments.reversed.take(8).toList();
+
+    return _Panel(
+      title: '配信プレビュー',
+      trailing: _StatusBadge(viewModel: viewModel),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: Container(
+              key: const Key('live-caption-preview'),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(DesignTokens.radiusMedium),
+                gradient: const LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: <Color>[Color(0xFF10152F), Color(0xFF050505)],
+                ),
+                border: Border.all(color: DesignTokens.divider),
+              ),
+              child: Stack(
+                children: <Widget>[
+                  const Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Icon(
+                          Icons.live_tv_outlined,
+                          size: 56,
+                          color: DesignTokens.indigoLight,
+                        ),
+                        SizedBox(height: DesignTokens.space8),
+                        Text(
+                          'ライブ映像プレビュー',
+                          style: TextStyle(color: DesignTokens.textSecondary),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Semantics(
+                      liveRegion: true,
+                      label: '現在の字幕: ${viewModel.currentViewerText}',
+                      child: Container(
+                        key: const Key('live-caption-overlay'),
+                        width: double.infinity,
+                        margin: const EdgeInsets.all(DesignTokens.space16),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: DesignTokens.space16,
+                          vertical: DesignTokens.space12,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: .76),
+                          borderRadius: BorderRadius.circular(
+                            DesignTokens.radiusSmall,
+                          ),
+                        ),
+                        child: Text(
+                          viewModel.currentViewerText,
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            color: DesignTokens.textPrimary,
+                            fontSize: 20,
+                            height: 1.45,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: DesignTokens.space12),
+          Row(
+            children: <Widget>[
+              const Icon(
+                Icons.translate,
+                color: DesignTokens.indigoLight,
+                size: 20,
+              ),
+              const SizedBox(width: DesignTokens.space8),
+              const Text('視聴言語', style: _secondaryStyle),
+              const SizedBox(width: DesignTokens.space12),
+              Expanded(
+                child: DropdownButton<String>(
+                  key: const Key('live-caption-viewer-language'),
+                  isExpanded: true,
+                  value: viewModel.viewerLanguageTag,
+                  dropdownColor: DesignTokens.surface2,
+                  style: const TextStyle(color: DesignTokens.textPrimary),
+                  items: viewerLanguages
+                      .map(
+                        (language) => DropdownMenuItem<String>(
+                          value: language.tag,
+                          child: Text(language.label),
+                        ),
+                      )
+                      .toList(growable: false),
+                  onChanged: (value) {
+                    if (value != null) viewModel.setViewerLanguage(value);
+                  },
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: DesignTokens.space16),
+          Row(
+            children: <Widget>[
+              const Expanded(
+                child: Text(
+                  '字幕タイムライン',
+                  style: TextStyle(
+                    color: DesignTokens.textPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              TextButton.icon(
+                key: const Key('live-caption-clear'),
+                onPressed: viewModel.segments.isEmpty
+                    ? null
+                    : viewModel.clearSegments,
+                icon: const Icon(Icons.delete_sweep_outlined),
+                label: const Text('クリア'),
+              ),
+            ],
+          ),
+          if (latestSegments.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: DesignTokens.space20),
+              child: Text(
+                '配信を開始すると、確定した字幕が時系列で表示されます。',
+                textAlign: TextAlign.center,
+                style: _secondaryStyle,
+              ),
+            )
+          else
+            ...latestSegments.map(
+              (segment) => _TimelineItem(
+                segment: segment,
+                viewerLanguageTag: viewModel.viewerLanguageTag,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsPanel extends StatelessWidget {
+  const _SettingsPanel({required this.viewModel});
+
+  final LiveCaptionsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return _Panel(
+      title: '配信者・管理設定',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          const Text('音声のソース言語', style: _secondaryStyle),
+          const SizedBox(height: DesignTokens.space8),
+          DropdownButtonFormField<String>(
+            key: const Key('live-caption-source-language'),
+            initialValue: viewModel.sourceLanguageTag,
+            dropdownColor: DesignTokens.surface2,
+            style: const TextStyle(color: DesignTokens.textPrimary),
+            decoration: _inputDecoration(),
+            items: kLiveCaptionLanguages
+                .map(
+                  (language) => DropdownMenuItem<String>(
+                    value: language.tag,
+                    child: Text(language.label),
+                  ),
+                )
+                .toList(growable: false),
+            onChanged: viewModel.isListening
+                ? null
+                : (value) {
+                    if (value != null) viewModel.setSourceLanguage(value);
+                  },
+          ),
+          const SizedBox(height: DesignTokens.space20),
+          const Text('視聴者が選べる翻訳字幕', style: _secondaryStyle),
+          const SizedBox(height: DesignTokens.space8),
+          Wrap(
+            spacing: DesignTokens.space8,
+            runSpacing: DesignTokens.space8,
+            children: kLiveCaptionLanguages
+                .where(
+                  (language) => language.tag != viewModel.sourceLanguageTag,
+                )
+                .map(
+                  (language) => FilterChip(
+                    key: Key('live-caption-target-${language.tag}'),
+                    label: Text(language.label),
+                    selected: viewModel.targetLanguageTags.contains(
+                      language.tag,
+                    ),
+                    onSelected: (_) =>
+                        viewModel.toggleTargetLanguage(language.tag),
+                    selectedColor: DesignTokens.indigo,
+                    backgroundColor: DesignTokens.surface3,
+                    checkmarkColor: DesignTokens.textPrimary,
+                    labelStyle: const TextStyle(
+                      color: DesignTokens.textPrimary,
+                    ),
+                    side: BorderSide.none,
+                  ),
+                )
+                .toList(growable: false),
+          ),
+          const SizedBox(height: DesignTokens.space20),
+          if (!viewModel.isSupported)
+            const _MessageBox(
+              key: Key('live-caption-unsupported'),
+              color: DesignTokens.amber,
+              message: '音声認識はChrome / EdgeのWeb版で利用できます。対応ブラウザーでマイクを許可してください。',
+            ),
+          if (viewModel.errorMessage case final message?)
+            _MessageBox(
+              key: const Key('live-caption-error'),
+              color: DesignTokens.red,
+              message: message,
+            ),
+          if (viewModel.isListening)
+            OutlinedButton.icon(
+              key: const Key('live-caption-stop'),
+              onPressed: () => unawaited(viewModel.stop()),
+              icon: const Icon(Icons.stop_circle_outlined),
+              label: const Text('字幕配信を停止'),
+            )
+          else
+            FilledButton.icon(
+              key: const Key('live-caption-start'),
+              onPressed: viewModel.isSupported
+                  ? () => unawaited(viewModel.start())
+                  : null,
+              icon: const Icon(Icons.mic),
+              label: const Text('マイクで字幕配信を開始'),
+            ),
+          const SizedBox(height: DesignTokens.space12),
+          const Text(
+            '確定した音声だけを翻訳し、視聴者が選んだ言語へ順次反映します。APIキーはブラウザーへ公開せず、既存の認証済みAI Edge Functionを経由します。',
+            style: _secondaryStyle,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimelineItem extends StatelessWidget {
+  const _TimelineItem({required this.segment, required this.viewerLanguageTag});
+
+  final LiveCaptionSegment segment;
+  final String viewerLanguageTag;
+
+  @override
+  Widget build(BuildContext context) {
+    final translated = segment.hasTranslation(viewerLanguageTag);
+    return Container(
+      margin: const EdgeInsets.only(bottom: DesignTokens.space8),
+      padding: const EdgeInsets.all(DesignTokens.space12),
+      decoration: BoxDecoration(
+        color: DesignTokens.surface2,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            segment.sourceText,
+            style: const TextStyle(color: DesignTokens.textSecondary),
+          ),
+          const SizedBox(height: DesignTokens.space4),
+          Text(
+            segment.textFor(viewerLanguageTag),
+            style: const TextStyle(
+              color: DesignTokens.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          if (!translated) const Text('翻訳中…', style: _secondaryStyle),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.viewModel});
+
+  final LiveCaptionsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final latency = viewModel.lastTranslationLatency;
+    final isActive = viewModel.isListening;
+    return Container(
+      key: const Key('live-caption-status'),
+      padding: const EdgeInsets.symmetric(
+        horizontal: DesignTokens.space12,
+        vertical: DesignTokens.space8,
+      ),
+      decoration: BoxDecoration(
+        color: (isActive ? DesignTokens.green : DesignTokens.surface3)
+            .withValues(alpha: .22),
+        borderRadius: BorderRadius.circular(DesignTokens.radiusCircle),
+      ),
+      child: Text(
+        latency == null
+            ? viewModel.statusLabel
+            : '${viewModel.statusLabel} · ${latency.inMilliseconds}ms',
+        style: TextStyle(
+          color: isActive ? DesignTokens.green : DesignTokens.textSecondary,
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+class _Panel extends StatelessWidget {
+  const _Panel({required this.title, required this.child, this.trailing});
+
+  final String title;
+  final Widget child;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(DesignTokens.space16),
+      decoration: BoxDecoration(
+        color: DesignTokens.surface1,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusLarge),
+        border: Border.all(color: DesignTokens.divider),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  title,
+                  style: const TextStyle(
+                    color: DesignTokens.textPrimary,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+              if (trailing != null) trailing!,
+            ],
+          ),
+          const SizedBox(height: DesignTokens.space16),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _MessageBox extends StatelessWidget {
+  const _MessageBox({super.key, required this.color, required this.message});
+
+  final Color color;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: DesignTokens.space12),
+      padding: const EdgeInsets.all(DesignTokens.space12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: .12),
+        border: Border.all(color: color.withValues(alpha: .6)),
+        borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+      ),
+      child: Text(message, style: TextStyle(color: color, height: 1.45)),
+    );
+  }
+}
+
+const TextStyle _secondaryStyle = TextStyle(
+  color: DesignTokens.textSecondary,
+  fontSize: 13,
+  height: 1.5,
+);
+
+InputDecoration _inputDecoration() {
+  return InputDecoration(
+    filled: true,
+    fillColor: DesignTokens.surface3,
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+      borderSide: const BorderSide(color: DesignTokens.divider),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(DesignTokens.radiusSmall),
+      borderSide: const BorderSide(color: DesignTokens.indigoLight, width: 2),
+    ),
+  );
+}

--- a/lib/ui/features/live_captions/views/live_captions_page.dart
+++ b/lib/ui/features/live_captions/views/live_captions_page.dart
@@ -73,6 +73,9 @@ class _PreviewPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final viewerLanguage = liveCaptionLanguageByTag(
+      viewModel.viewerLanguageTag,
+    );
     final viewerLanguages = <LiveCaptionLanguage>[
       viewModel.sourceLanguage,
       ...kLiveCaptionLanguages.where(
@@ -123,7 +126,8 @@ class _PreviewPanel extends StatelessWidget {
                     alignment: Alignment.bottomCenter,
                     child: Semantics(
                       liveRegion: true,
-                      label: '現在の字幕: ${viewModel.currentViewerText}',
+                      label:
+                          '${viewerLanguage.label}、${viewModel.statusLabel}。現在の字幕: ${viewModel.currentViewerText}',
                       child: Container(
                         key: const Key('live-caption-overlay'),
                         width: double.infinity,
@@ -303,10 +307,13 @@ class _SettingsPanel extends StatelessWidget {
               message: '音声認識はChrome / EdgeのWeb版で利用できます。対応ブラウザーでマイクを許可してください。',
             ),
           if (viewModel.errorMessage case final message?)
-            _MessageBox(
-              key: const Key('live-caption-error'),
-              color: DesignTokens.red,
-              message: message,
+            Semantics(
+              liveRegion: true,
+              child: _MessageBox(
+                key: const Key('live-caption-error'),
+                color: DesignTokens.red,
+                message: message,
+              ),
             ),
           if (viewModel.isListening)
             OutlinedButton.icon(

--- a/lib/utils/feature_route_labels.dart
+++ b/lib/utils/feature_route_labels.dart
@@ -47,6 +47,7 @@ const Map<String, String> _consolidatedFeatureLabels = <String, String>{
   '/autonomous-ops-console': '自律オペレーションコンソール',
   '/focus-timer': '集中タイマー',
   '/life-goals': '人生目標管理',
+  '/live-captions': 'ライブ多言語字幕',
   '/local-election-700': '2027 統一地方選 700必達管理室',
   '/daily-habits': '毎日の習慣',
   '/mind-map': 'マインドマップ',

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -195,6 +195,7 @@ const List<String> kAllAppRoutes = <String>[
   '/legal-compliance',
   '/life-goals',
   '/life-goals-kpi',
+  '/live-captions',
   '/line-notifications',
   '/local-election-700',
   '/local-election-schedule',

--- a/test/ui/features/live_captions/live_captions_page_test.dart
+++ b/test/ui/features/live_captions/live_captions_page_test.dart
@@ -72,6 +72,28 @@ void main() {
     expect(find.byKey(const Key('live-captions-compact')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('supports the wide boundary with large text', (tester) async {
+    tester.view.physicalSize = const Size(980, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: LiveCaptionsFeature(
+            translationGateway: _FakeTranslationGateway(),
+            speechRecognizer: _FakeSpeechRecognizer(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('live-captions-wide')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _FakeTranslationGateway implements LiveCaptionTranslationGateway {

--- a/test/ui/features/live_captions/live_captions_page_test.dart
+++ b/test/ui/features/live_captions/live_captions_page_test.dart
@@ -43,7 +43,7 @@ void main() {
       ),
     );
     expect(
-      overlaySemantics.any((widget) => widget.properties.liveRegion),
+      overlaySemantics.any((widget) => widget.properties.liveRegion == true),
       isTrue,
     );
 

--- a/test/ui/features/live_captions/live_captions_page_test.dart
+++ b/test/ui/features/live_captions/live_captions_page_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/live_captions/data/live_caption_translation_gateway.dart';
+import 'package:my_web_app/ui/features/live_captions/domain/live_caption_models.dart';
+import 'package:my_web_app/ui/features/live_captions/live_captions_feature.dart';
+import 'package:my_web_app/ui/features/live_captions/services/live_speech_recognizer.dart';
+
+void main() {
+  testWidgets('starts recognition and renders translated captions', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final recognizer = _FakeSpeechRecognizer();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiveCaptionsFeature(
+          translationGateway: _FakeTranslationGateway(),
+          speechRecognizer: recognizer,
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('live-captions-wide')), findsOneWidget);
+    expect(find.byKey(const Key('live-caption-preview')), findsOneWidget);
+    expect(find.byKey(const Key('live-caption-start')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('live-caption-start')));
+    await tester.pump();
+    expect(find.byKey(const Key('live-caption-stop')), findsOneWidget);
+
+    recognizer.emit('みなさん、こんにちは', isFinal: true);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hello, everyone.'), findsWidgets);
+    final overlaySemantics = tester.widgetList<Semantics>(
+      find.ancestor(
+        of: find.byKey(const Key('live-caption-overlay')),
+        matching: find.byType(Semantics),
+      ),
+    );
+    expect(
+      overlaySemantics.any((widget) => widget.properties.liveRegion),
+      isTrue,
+    );
+
+    final koreanChip = find.byKey(const Key('live-caption-target-ko-KR'));
+    expect(tester.widget<FilterChip>(koreanChip).selected, isFalse);
+    await tester.tap(koreanChip);
+    await tester.pump();
+    expect(tester.widget<FilterChip>(koreanChip).selected, isTrue);
+  });
+
+  testWidgets('uses the compact layout on narrow screens', (tester) async {
+    tester.view.physicalSize = const Size(640, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiveCaptionsFeature(
+          translationGateway: _FakeTranslationGateway(),
+          speechRecognizer: _FakeSpeechRecognizer(),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('live-captions-compact')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class _FakeTranslationGateway implements LiveCaptionTranslationGateway {
+  @override
+  Future<String> translate({
+    required String text,
+    required LiveCaptionLanguage sourceLanguage,
+    required LiveCaptionLanguage targetLanguage,
+  }) async {
+    if (targetLanguage.tag == 'en-US') return 'Hello, everyone.';
+    return '$text (${targetLanguage.label})';
+  }
+}
+
+class _FakeSpeechRecognizer implements LiveSpeechRecognizer {
+  LiveSpeechResultCallback? _onResult;
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<void> start({
+    required String languageTag,
+    required LiveSpeechResultCallback onResult,
+    required LiveSpeechErrorCallback onError,
+  }) async {
+    _onResult = onResult;
+  }
+
+  void emit(String text, {required bool isFinal}) =>
+      _onResult?.call(text, isFinal);
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  void dispose() {}
+}

--- a/test/ui/features/live_captions/live_captions_page_test.dart
+++ b/test/ui/features/live_captions/live_captions_page_test.dart
@@ -46,6 +46,13 @@ void main() {
       overlaySemantics.any((widget) => widget.properties.liveRegion == true),
       isTrue,
     );
+    expect(
+      overlaySemantics.any((widget) {
+        final label = widget.properties.label ?? '';
+        return label.contains('英語') && label.contains('音声認識中');
+      }),
+      isTrue,
+    );
 
     final koreanChip = find.byKey(const Key('live-caption-target-ko-KR'));
     expect(tester.widget<FilterChip>(koreanChip).selected, isFalse);

--- a/test/ui/features/live_captions/live_captions_page_test.dart
+++ b/test/ui/features/live_captions/live_captions_page_test.dart
@@ -102,7 +102,7 @@ class _FakeSpeechRecognizer implements LiveSpeechRecognizer {
   }
 
   void emit(String text, {required bool isFinal}) =>
-      _onResult?.call(text, isFinal);
+      _onResult?.call(transcript: text, isFinal: isFinal);
 
   @override
   Future<void> stop() async {}

--- a/test/ui/features/live_captions/live_captions_view_model_test.dart
+++ b/test/ui/features/live_captions/live_captions_view_model_test.dart
@@ -137,7 +137,7 @@ class _FakeSpeechRecognizer implements LiveSpeechRecognizer {
   }
 
   void emit(String text, {required bool isFinal}) =>
-      _onResult?.call(text, isFinal);
+      _onResult?.call(transcript: text, isFinal: isFinal);
 
   void emitError(String message) => _onError?.call(message);
 

--- a/test/ui/features/live_captions/live_captions_view_model_test.dart
+++ b/test/ui/features/live_captions/live_captions_view_model_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/ui/features/live_captions/data/live_caption_translation_gateway.dart';
 import 'package:my_web_app/ui/features/live_captions/domain/live_caption_models.dart';
@@ -81,6 +83,71 @@ void main() {
       expect(viewModel.errorMessage, contains('英語字幕を生成できませんでした'));
     });
 
+    test('coalesces repeated starts while recognition is starting', () async {
+      speechRecognizer.startCompleter = Completer<void>();
+
+      final firstStart = viewModel.start();
+      final secondStart = viewModel.start();
+
+      expect(speechRecognizer.startCalls, 1);
+      expect(await secondStart, isTrue);
+      speechRecognizer.startCompleter!.complete();
+      expect(await firstStart, isTrue);
+      expect(viewModel.status, LiveCaptionStatus.listening);
+    });
+
+    test('stops recognition and preserves error status on speech error',
+        () async {
+      await viewModel.start();
+
+      speechRecognizer.emitError('マイク接続エラー');
+      await pumpEventQueue();
+
+      expect(speechRecognizer.stopCalls, 1);
+      expect(viewModel.isListening, isFalse);
+      expect(viewModel.status, LiveCaptionStatus.error);
+      expect(viewModel.errorMessage, 'マイク接続エラー');
+    });
+
+    test('ignores speech callbacks from a stopped session', () async {
+      await viewModel.start();
+      await viewModel.stop();
+
+      speechRecognizer.emit('停止後の字幕', isFinal: true);
+      await pumpEventQueue();
+
+      expect(viewModel.segments, isEmpty);
+      expect(viewModel.status, LiveCaptionStatus.stopped);
+    });
+
+    test('translation completion does not overwrite a speech error', () async {
+      translationGateway.completer = Completer<String>();
+      await viewModel.start();
+
+      speechRecognizer.emit('翻訳待機中', isFinal: true);
+      await pumpEventQueue();
+      speechRecognizer.emitError('音声認識エラー');
+      await pumpEventQueue();
+      translationGateway.completer!.complete('Translation completed');
+      await pumpEventQueue();
+
+      expect(viewModel.status, LiveCaptionStatus.error);
+      expect(viewModel.errorMessage, '音声認識エラー');
+    });
+
+    test('backfills existing captions when a target language is added',
+        () async {
+      translationGateway.responses['en-US'] = 'Existing English caption';
+      translationGateway.responses['ko-KR'] = '기존 한국어 자막';
+      await viewModel.ingestTranscript('既存の字幕', isFinal: true);
+
+      viewModel.toggleTargetLanguage('ko-KR');
+      await pumpEventQueue();
+
+      expect(viewModel.segments.single.textFor('ko-KR'), '기존 한국어 자막');
+      expect(viewModel.status, LiveCaptionStatus.stopped);
+    });
+
     test(
       'reports unsupported recognition without starting a session',
       () async {
@@ -102,6 +169,7 @@ void main() {
 class _FakeTranslationGateway implements LiveCaptionTranslationGateway {
   final Map<String, String> responses = <String, String>{};
   Exception? error;
+  Completer<String>? completer;
 
   @override
   Future<String> translate({
@@ -110,6 +178,7 @@ class _FakeTranslationGateway implements LiveCaptionTranslationGateway {
     required LiveCaptionLanguage targetLanguage,
   }) async {
     if (error case final error?) throw error;
+    if (completer case final completer?) return completer.future;
     return responses[targetLanguage.tag] ?? '$text (${targetLanguage.tag})';
   }
 }
@@ -121,6 +190,9 @@ class _FakeSpeechRecognizer implements LiveSpeechRecognizer {
   LiveSpeechResultCallback? _onResult;
   LiveSpeechErrorCallback? _onError;
   String? startedLanguageTag;
+  Completer<void>? startCompleter;
+  int startCalls = 0;
+  int stopCalls = 0;
 
   @override
   bool get isSupported => supported;
@@ -131,9 +203,11 @@ class _FakeSpeechRecognizer implements LiveSpeechRecognizer {
     required LiveSpeechResultCallback onResult,
     required LiveSpeechErrorCallback onError,
   }) async {
+    startCalls++;
     startedLanguageTag = languageTag;
     _onResult = onResult;
     _onError = onError;
+    await startCompleter?.future;
   }
 
   void emit(String text, {required bool isFinal}) =>
@@ -142,7 +216,9 @@ class _FakeSpeechRecognizer implements LiveSpeechRecognizer {
   void emitError(String message) => _onError?.call(message);
 
   @override
-  Future<void> stop() async {}
+  Future<void> stop() async {
+    stopCalls++;
+  }
 
   @override
   void dispose() {}

--- a/test/ui/features/live_captions/live_captions_view_model_test.dart
+++ b/test/ui/features/live_captions/live_captions_view_model_test.dart
@@ -101,7 +101,7 @@ void main() {
 
 class _FakeTranslationGateway implements LiveCaptionTranslationGateway {
   final Map<String, String> responses = <String, String>{};
-  Object? error;
+  Exception? error;
 
   @override
   Future<String> translate({

--- a/test/ui/features/live_captions/live_captions_view_model_test.dart
+++ b/test/ui/features/live_captions/live_captions_view_model_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/live_captions/data/live_caption_translation_gateway.dart';
+import 'package:my_web_app/ui/features/live_captions/domain/live_caption_models.dart';
+import 'package:my_web_app/ui/features/live_captions/services/live_speech_recognizer.dart';
+import 'package:my_web_app/ui/features/live_captions/view_models/live_captions_view_model.dart';
+
+void main() {
+  group('LiveCaptionsViewModel', () {
+    late _FakeTranslationGateway translationGateway;
+    late _FakeSpeechRecognizer speechRecognizer;
+    late LiveCaptionsViewModel viewModel;
+
+    setUp(() {
+      translationGateway = _FakeTranslationGateway();
+      speechRecognizer = _FakeSpeechRecognizer();
+      viewModel = LiveCaptionsViewModel(
+        translationGateway: translationGateway,
+        speechRecognizer: speechRecognizer,
+      );
+    });
+
+    tearDown(() => viewModel.dispose());
+
+    test('uses Japanese speech and English viewer captions by default', () {
+      expect(viewModel.sourceLanguageTag, 'ja-JP');
+      expect(viewModel.targetLanguageTags, <String>{'en-US'});
+      expect(viewModel.viewerLanguageTag, 'en-US');
+      expect(viewModel.status, LiveCaptionStatus.idle);
+    });
+
+    test(
+      'streams interim speech then stores translated final captions',
+      () async {
+        translationGateway.responses['en-US'] = 'Hello, everyone.';
+
+        expect(await viewModel.start(), isTrue);
+        expect(speechRecognizer.startedLanguageTag, 'ja-JP');
+        expect(viewModel.status, LiveCaptionStatus.listening);
+
+        speechRecognizer.emit('みなさん、こん', isFinal: false);
+        await pumpEventQueue();
+        expect(viewModel.interimText, 'みなさん、こん');
+
+        speechRecognizer.emit('みなさん、こんにちは', isFinal: true);
+        await pumpEventQueue();
+
+        expect(viewModel.segments, hasLength(1));
+        expect(viewModel.segments.single.sourceText, 'みなさん、こんにちは');
+        expect(viewModel.segments.single.textFor('en-US'), 'Hello, everyone.');
+        expect(viewModel.currentViewerText, 'Hello, everyone.');
+        expect(viewModel.lastTranslationLatency, isNotNull);
+        expect(viewModel.status, LiveCaptionStatus.listening);
+      },
+    );
+
+    test('administrator can change source and enabled viewer languages', () {
+      viewModel.setSourceLanguage('en-US');
+
+      expect(viewModel.sourceLanguageTag, 'en-US');
+      expect(viewModel.targetLanguageTags, contains('ja-JP'));
+      expect(viewModel.targetLanguageTags, isNot(contains('en-US')));
+
+      viewModel.toggleTargetLanguage('ko-KR');
+      viewModel.setViewerLanguage('ko-KR');
+      expect(viewModel.targetLanguageTags, contains('ko-KR'));
+      expect(viewModel.viewerLanguageTag, 'ko-KR');
+
+      viewModel.toggleTargetLanguage('ko-KR');
+      expect(viewModel.targetLanguageTags, isNot(contains('ko-KR')));
+      expect(viewModel.viewerLanguageTag, 'ja-JP');
+    });
+
+    test('keeps source text visible when one translation fails', () async {
+      translationGateway.error = const LiveCaptionTranslationException(
+        'temporary unavailable',
+      );
+
+      await viewModel.ingestTranscript('障害時も字幕を残す', isFinal: true);
+
+      expect(viewModel.segments.single.textFor('en-US'), '障害時も字幕を残す');
+      expect(viewModel.errorMessage, contains('英語字幕を生成できませんでした'));
+    });
+
+    test(
+      'reports unsupported recognition without starting a session',
+      () async {
+        viewModel.dispose();
+        speechRecognizer = _FakeSpeechRecognizer(supported: false);
+        viewModel = LiveCaptionsViewModel(
+          translationGateway: translationGateway,
+          speechRecognizer: speechRecognizer,
+        );
+
+        expect(await viewModel.start(), isFalse);
+        expect(viewModel.status, LiveCaptionStatus.unsupported);
+        expect(viewModel.errorMessage, contains('Chrome'));
+      },
+    );
+  });
+}
+
+class _FakeTranslationGateway implements LiveCaptionTranslationGateway {
+  final Map<String, String> responses = <String, String>{};
+  Object? error;
+
+  @override
+  Future<String> translate({
+    required String text,
+    required LiveCaptionLanguage sourceLanguage,
+    required LiveCaptionLanguage targetLanguage,
+  }) async {
+    if (error case final error?) throw error;
+    return responses[targetLanguage.tag] ?? '$text (${targetLanguage.tag})';
+  }
+}
+
+class _FakeSpeechRecognizer implements LiveSpeechRecognizer {
+  _FakeSpeechRecognizer({this.supported = true});
+
+  final bool supported;
+  LiveSpeechResultCallback? _onResult;
+  LiveSpeechErrorCallback? _onError;
+  String? startedLanguageTag;
+
+  @override
+  bool get isSupported => supported;
+
+  @override
+  Future<void> start({
+    required String languageTag,
+    required LiveSpeechResultCallback onResult,
+    required LiveSpeechErrorCallback onError,
+  }) async {
+    startedLanguageTag = languageTag;
+    _onResult = onResult;
+    _onError = onError;
+  }
+
+  void emit(String text, {required bool isFinal}) =>
+      _onResult?.call(text, isFinal);
+
+  void emitError(String message) => _onError?.call(message);
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  void dispose() {}
+}

--- a/test/utils/feature_route_labels_test.dart
+++ b/test/utils/feature_route_labels_test.dart
@@ -9,6 +9,7 @@ void main() {
       expect(featureLabelForRoute('/ai-university'), 'AI大学');
       expect(featureLabelForRoute('/release-notes'), 'Release Notes');
       expect(featureLabelForRoute('/procrastination-reset'), '先延ばしリセット');
+      expect(featureLabelForRoute('/live-captions'), 'ライブ多言語字幕');
     });
 
     test('未知ルートは slug を Title Case に整形してフォールバックする', () {


### PR DESCRIPTION
Closes #1278

## Summary

- add a `/live-captions` feature and home entry for browser microphone transcription
- translate finalized speech segments in parallel through the existing authenticated AI Edge Function
- let operators select the source language and enabled viewer languages, and backfill existing captions when a language is added
- let viewers switch subtitle language while preserving a readable source-text fallback
- add responsive preview, language/status-aware live-region semantics, caption history, and friendly permission/error states
- prevent concurrent starts, stale callbacks after stop, error-triggered recognition restarts, and stale translation status updates

## Acceptance mapping

1. Source-language transcription: Web Speech API recognition uses the operator-selected BCP-47 locale.
2. Real-time viewer subtitles: finalized speech segments are translated in parallel and rendered in the selected viewer language with latency feedback.
3. Language administration: the settings panel changes the source language and enables/disables supported target languages; newly enabled languages are backfilled for retained caption history.

## Validation

- GitHub Actions CI run 32860302626 passed: security, Flutter analyze, Dart format, full VM tests with coverage, Chrome web-import smoke, production web build, and build-output verification
- targeted `dart format` and `git diff --check` passed locally
- local Flutter analyze/tests were not duplicated because RAM had reached 96.2% with 0.59 GB free; the GitHub runner provided the authoritative Flutter 3.38.10 / Dart 3.10.9 result
- local Git hooks reported `lefthook` was not available in PATH; no local hook result is claimed

## Subagent evidence

- Lead: Codex #1
- `issue1278_logic_review`: read-only concurrency/lifecycle review; found recognition restart, concurrent start, stale callback, error-state overwrite, and dispose risks
- `issue1278_ux_review`: read-only acceptance/accessibility review; found missing language backfill, live-region context, and responsive boundary coverage
- Validation impact: lifecycle and P1/P2 findings were implemented with session-generation guards, error-stop behavior, backfill logic, dispose guards, and regression tests; deterministic CI passed
- Cleanup impact: subagents made no filesystem changes and ran no build, test, network, or browser process

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Browser microphone permission and Web Speech API input are not deterministic on the repository CI runner; VM/widget tests plus the Chrome import smoke cover the bounded flow for this Draft PR.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Keyword-only trigger from describing the existing authenticated AI gateway; no authentication, secret, data migration, or production configuration path changed.

## Remaining risk

- microphone transcription depends on browser Web Speech API support and permission
- translations depend on the existing authenticated AI provider quota and latency
- history clearing still has no confirmation/undo; this low-priority UX follow-up is outside the Issue acceptance criteria
- real microphone acceptance still requires manual Chrome/Edge QA, so this PR remains Draft