### PR TITLE
fix: bound local analyzer subprocesses

### DIFF
--- a/docs/automation/static-analysis-ci.md
+++ b/docs/automation/static-analysis-ci.md
@@ -35,6 +35,35 @@ The local hook flow is documented in
 runs the fuller local CI mirror. Browser smoke remains in GitHub Actions by
 default and can be included locally with `CODEX_INCLUDE_BROWSER_SMOKE=1`.
 
+## Bounded local analyzer runner
+
+Issue #4266 adds deterministic resource bounds to `scripts/quality_gate.py`.
+Every delegated command has an explicit timeout. Flutter analyzer commands also
+take one advisory lock stored under the repository's shared Git directory, so
+all local worktrees serialize analyzer startup instead of competing for Dart
+analysis-server processes.
+
+Automation that validates an explicit set of Dart files must use the shared
+entry point rather than invoking `flutter analyze` directly:
+
+```powershell
+py -3 scripts/quality_gate.py --analyze-files lib/pages/example_page.dart test/pages/example_page_test.dart
+```
+
+The runner emits one structured `quality_gate_command` JSON record with the
+command, elapsed time, timeout, exit code, lock result, child-process cleanup
+result, and recovery command. Exit code `124` means the owned command tree was
+terminated after its timeout. Exit code `75` means the shared analyzer lock was
+not acquired within its bounded wait; the analyzer was not started.
+
+Local defaults can be tuned without changing CI policy:
+
+- `QUALITY_GATE_ANALYZE_TIMEOUT_SECONDS` — analyzer runtime limit (default 180s)
+- `QUALITY_GATE_ANALYZER_LOCK_TIMEOUT_SECONDS` — cross-worktree lock wait (default 30s)
+
+Timeout cleanup targets only the process tree created by that command. It must
+never terminate unrelated Dart, Flutter, IDE, or user processes.
+
 ## Auto-Fix Path
 
 `ci-auto-fix.yml` listens to the `CI` workflow's failed PR runs. For PR branches,

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -4,12 +4,24 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import shlex
 import shutil
+import signal
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO
+
+
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 300.0
+DEFAULT_ANALYZE_TIMEOUT_SECONDS = 180.0
+DEFAULT_ANALYZER_LOCK_TIMEOUT_SECONDS = 30.0
+TIMEOUT_EXIT_CODE = 124
+LOCK_TIMEOUT_EXIT_CODE = 75
 
 
 @dataclass(frozen=True)
@@ -17,6 +29,20 @@ class GateCommand:
     name: str
     args: list[str]
     required_binary: str | None = None
+    timeout_seconds: float = DEFAULT_COMMAND_TIMEOUT_SECONDS
+    serialize_analyzer: bool = False
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    elapsed_seconds: float
+    timed_out: bool
+    cleanup_result: str
+
+
+class AnalyzerLockTimeout(RuntimeError):
+    pass
 
 
 def repo_root() -> Path:
@@ -41,6 +67,113 @@ def flutter_vm_test_concurrency(platform_name: str | None = None) -> int:
     """Keep the long Windows VM suite on one stable test worker."""
     resolved_platform = os.name if platform_name is None else platform_name
     return 1 if resolved_platform == "nt" else 2
+
+
+def env_seconds(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def shared_git_dir(root: Path) -> Path:
+    dot_git = root / ".git"
+    if dot_git.is_dir():
+        return dot_git
+    if dot_git.is_file():
+        first_line = dot_git.read_text(encoding="utf-8").splitlines()[0]
+        prefix = "gitdir:"
+        if first_line.lower().startswith(prefix):
+            git_dir = Path(first_line[len(prefix) :].strip())
+            if not git_dir.is_absolute():
+                git_dir = (root / git_dir).resolve()
+            if git_dir.parent.name == "worktrees":
+                return git_dir.parent.parent
+            return git_dir
+    return root / ".git"
+
+
+def analyzer_lock_path(root: Path) -> Path:
+    state_dir = shared_git_dir(root) / "codex-quality-gate"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / "analyzer.lock"
+
+
+def _try_lock(handle: BinaryIO, platform_name: str) -> bool:
+    handle.seek(0)
+    if platform_name == "nt":
+        import msvcrt
+
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError:
+            return False
+        return True
+
+    import fcntl
+
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        return False
+    return True
+
+
+def _unlock(handle: BinaryIO, platform_name: str) -> None:
+    handle.seek(0)
+    if platform_name == "nt":
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class AnalyzerLock:
+    def __init__(
+        self,
+        path: Path,
+        timeout_seconds: float,
+        *,
+        platform_name: str | None = None,
+    ) -> None:
+        self.path = path
+        self.timeout_seconds = timeout_seconds
+        self.platform_name = os.name if platform_name is None else platform_name
+        self.handle: BinaryIO | None = None
+
+    def __enter__(self) -> "AnalyzerLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self.path.open("a+b")
+        if self.path.stat().st_size == 0:
+            handle.write(b"\0")
+            handle.flush()
+        deadline = time.monotonic() + self.timeout_seconds
+        while not _try_lock(handle, self.platform_name):
+            if time.monotonic() >= deadline:
+                handle.close()
+                raise AnalyzerLockTimeout(
+                    f"analyzer lock unavailable after {self.timeout_seconds:.1f}s: {self.path}"
+                )
+            time.sleep(0.05)
+        self.handle = handle
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self.handle is None:
+            return
+        try:
+            _unlock(self.handle, self.platform_name)
+        finally:
+            self.handle.close()
+            self.handle = None
 
 
 def base_commands() -> list[GateCommand]:
@@ -120,7 +253,16 @@ def base_commands() -> list[GateCommand]:
 def fast_commands() -> list[GateCommand]:
     return [
         *base_commands(),
-        GateCommand("flutter analyze", ["flutter", "analyze"], "flutter"),
+        GateCommand(
+            "flutter analyze",
+            ["flutter", "analyze"],
+            "flutter",
+            timeout_seconds=env_seconds(
+                "QUALITY_GATE_ANALYZE_TIMEOUT_SECONDS",
+                DEFAULT_ANALYZE_TIMEOUT_SECONDS,
+            ),
+            serialize_analyzer=True,
+        ),
         GateCommand(
             "deno lint edge functions",
             [
@@ -152,6 +294,7 @@ def full_commands(root: Path) -> list[GateCommand]:
                 f"--concurrency={flutter_vm_test_concurrency()}",
             ],
             "flutter",
+            timeout_seconds=1800.0,
         ),
     ]
     if include_browser_smoke():
@@ -166,6 +309,7 @@ def full_commands(root: Path) -> list[GateCommand]:
                     "test/web_import_smoke_test.dart",
                 ],
                 "flutter",
+                timeout_seconds=900.0,
             )
         )
     if has_deno_tests(root):
@@ -213,16 +357,149 @@ def command_env() -> dict[str, str]:
     return env
 
 
+def terminate_owned_process_tree(
+    proc: subprocess.Popen[bytes],
+    *,
+    platform_name: str | None = None,
+) -> str:
+    resolved_platform = os.name if platform_name is None else platform_name
+    if proc.poll() is not None:
+        return "already_exited"
+    if resolved_platform == "nt":
+        cleanup = subprocess.run(
+            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+        )
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+            return f"taskkill_exit_{cleanup.returncode}_then_parent_kill"
+        return f"taskkill_exit_{cleanup.returncode}"
+
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return "process_group_already_exited"
+    try:
+        proc.wait(timeout=2)
+        return "process_group_terminated"
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
+        return "process_group_killed"
+
+
+def run_process(
+    args: list[str],
+    root: Path,
+    timeout_seconds: float,
+    *,
+    platform_name: str | None = None,
+) -> CommandResult:
+    resolved_platform = os.name if platform_name is None else platform_name
+    popen_kwargs: dict[str, object] = {
+        "cwd": root,
+        "env": command_env(),
+    }
+    if resolved_platform == "nt":
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_kwargs["start_new_session"] = True
+    started = time.monotonic()
+    proc = subprocess.Popen(args, **popen_kwargs)
+    try:
+        returncode = proc.wait(timeout=timeout_seconds)
+        return CommandResult(
+            returncode=returncode,
+            elapsed_seconds=time.monotonic() - started,
+            timed_out=False,
+            cleanup_result="not_needed",
+        )
+    except subprocess.TimeoutExpired:
+        cleanup_result = terminate_owned_process_tree(
+            proc,
+            platform_name=resolved_platform,
+        )
+        return CommandResult(
+            returncode=TIMEOUT_EXIT_CODE,
+            elapsed_seconds=time.monotonic() - started,
+            timed_out=True,
+            cleanup_result=cleanup_result,
+        )
+
+
+def emit_result(
+    command: GateCommand,
+    result: CommandResult,
+    *,
+    lock_status: str,
+) -> None:
+    print(
+        json.dumps(
+            {
+                "event": "quality_gate_command",
+                "name": command.name,
+                "command": shlex.join(command.args),
+                "elapsed_seconds": round(result.elapsed_seconds, 3),
+                "timeout_seconds": command.timeout_seconds,
+                "returncode": result.returncode,
+                "timed_out": result.timed_out,
+                "cleanup_result": result.cleanup_result,
+                "analyzer_lock": lock_status,
+                "recovery_command": shlex.join(command.args),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+
 def run_gate(command: GateCommand, root: Path) -> int:
     print(f"==> {command.name}", flush=True)
     resolved_args = resolve_args(command)
     if resolved_args is None:
         print(f"missing required command: {command.required_binary}", file=sys.stderr)
         return 127
-    proc = subprocess.run(resolved_args, cwd=root, env=command_env(), check=False)
-    if proc.returncode != 0:
-        print(f"gate failed: {command.name} (exit {proc.returncode})", file=sys.stderr)
-    return proc.returncode
+    lock_status = "not_required"
+    try:
+        if command.serialize_analyzer:
+            lock_timeout = env_seconds(
+                "QUALITY_GATE_ANALYZER_LOCK_TIMEOUT_SECONDS",
+                DEFAULT_ANALYZER_LOCK_TIMEOUT_SECONDS,
+            )
+            with AnalyzerLock(analyzer_lock_path(root), lock_timeout):
+                lock_status = "acquired"
+                result = run_process(
+                    resolved_args,
+                    root,
+                    command.timeout_seconds,
+                )
+        else:
+            result = run_process(
+                resolved_args,
+                root,
+                command.timeout_seconds,
+            )
+    except AnalyzerLockTimeout as error:
+        print(str(error), file=sys.stderr)
+        result = CommandResult(
+            returncode=LOCK_TIMEOUT_EXIT_CODE,
+            elapsed_seconds=lock_timeout,
+            timed_out=False,
+            cleanup_result="not_started",
+        )
+        lock_status = "timeout"
+    emit_result(command, result, lock_status=lock_status)
+    if result.returncode != 0:
+        print(
+            f"gate failed: {command.name} (exit {result.returncode})",
+            file=sys.stderr,
+        )
+    return result.returncode
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -231,13 +508,33 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     mode.add_argument("--fast", action="store_true", help="Run pre-commit quality gates.")
     mode.add_argument("--full", action="store_true", help="Run pre-push quality gates.")
     mode.add_argument("--list", action="store_true", help="Print the commands without running them.")
+    mode.add_argument(
+        "--analyze-files",
+        nargs="+",
+        metavar="PATH",
+        help="Run one bounded, serialized Flutter analysis over explicit paths.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     root = repo_root()
-    commands = full_commands(root) if args.full else fast_commands()
+    if args.analyze_files:
+        commands = [
+            GateCommand(
+                "flutter analyze targeted",
+                ["flutter", "analyze", "--no-pub", *args.analyze_files],
+                "flutter",
+                timeout_seconds=env_seconds(
+                    "QUALITY_GATE_ANALYZE_TIMEOUT_SECONDS",
+                    DEFAULT_ANALYZE_TIMEOUT_SECONDS,
+                ),
+                serialize_analyzer=True,
+            )
+        ]
+    else:
+        commands = full_commands(root) if args.full else fast_commands()
 
     if args.list:
         for command in commands:

--- a/scripts/quality_gate_test.py
+++ b/scripts/quality_gate_test.py
@@ -1,10 +1,51 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import ctypes
+import os
 from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from quality_gate import flutter_vm_test_concurrency, full_commands
+from quality_gate import (
+    AnalyzerLock,
+    AnalyzerLockTimeout,
+    LOCK_TIMEOUT_EXIT_CODE,
+    TIMEOUT_EXIT_CODE,
+    GateCommand,
+    analyzer_lock_path,
+    flutter_vm_test_concurrency,
+    full_commands,
+    main,
+    run_gate,
+    run_process,
+    shared_git_dir,
+    terminate_owned_process_tree,
+)
+
+
+def pid_is_running(pid: int) -> bool:
+    if os.name == "nt":
+        process_query_limited_information = 0x1000
+        handle = ctypes.windll.kernel32.OpenProcess(
+            process_query_limited_information,
+            False,
+            pid,
+        )
+        if not handle:
+            return False
+        ctypes.windll.kernel32.CloseHandle(handle)
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
 
 
 class QualityGateTest(unittest.TestCase):
@@ -40,6 +81,111 @@ class QualityGateTest(unittest.TestCase):
             "run: flutter test --coverage --concurrency=2",
             workflow,
         )
+
+    def test_analyzer_lock_is_shared_across_worktrees(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        common_dir = shared_git_dir(root)
+
+        self.assertEqual(analyzer_lock_path(root).parent.parent, common_dir)
+
+    def test_analyzer_lock_wait_is_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            lock_path = Path(temp_dir) / "analyzer.lock"
+            started = time.monotonic()
+            with AnalyzerLock(lock_path, 1.0):
+                with self.assertRaises(AnalyzerLockTimeout):
+                    with AnalyzerLock(lock_path, 0.1):
+                        pass
+            self.assertLess(time.monotonic() - started, 1.0)
+
+    def test_hanging_command_times_out_and_cleans_owned_descendants(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            child_pid_path = root / "child.pid"
+            unrelated = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                creationflags=(
+                    subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0
+                ),
+                start_new_session=os.name != "nt",
+            )
+            try:
+                script = (
+                    "import pathlib,subprocess,sys,time;"
+                    "child=subprocess.Popen([sys.executable,'-c','import time; time.sleep(60)']);"
+                    "pathlib.Path(sys.argv[1]).write_text(str(child.pid),encoding='utf-8');"
+                    "time.sleep(60)"
+                )
+                result = run_process(
+                    [sys.executable, "-c", script, str(child_pid_path)],
+                    root,
+                    1.0,
+                )
+
+                self.assertEqual(result.returncode, TIMEOUT_EXIT_CODE)
+                self.assertTrue(result.timed_out)
+                self.assertTrue(child_pid_path.is_file())
+                child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+                self.assertFalse(pid_is_running(child_pid))
+                self.assertIsNone(unrelated.poll())
+            finally:
+                unrelated.kill()
+                unrelated.wait(timeout=5)
+
+    def test_windows_cleanup_routes_through_taskkill_tree(self) -> None:
+        proc = SimpleNamespace(pid=1234, poll=lambda: None, wait=lambda timeout: 0)
+        completed = SimpleNamespace(returncode=0)
+        with patch("quality_gate.subprocess.run", return_value=completed) as run:
+            result = terminate_owned_process_tree(proc, platform_name="nt")
+
+        self.assertEqual(result, "taskkill_exit_0")
+        run.assert_called_once_with(
+            ["taskkill", "/PID", "1234", "/T", "/F"],
+            capture_output=True,
+            check=False,
+        )
+
+    def test_posix_cleanup_routes_through_owned_process_group(self) -> None:
+        proc = SimpleNamespace(pid=1234, poll=lambda: None, wait=lambda timeout: 0)
+        with patch("quality_gate.os.killpg", create=True) as killpg:
+            result = terminate_owned_process_tree(proc, platform_name="posix")
+
+        self.assertEqual(result, "process_group_terminated")
+        killpg.assert_called_once_with(1234, 15)
+
+    def test_run_gate_reports_timeout_as_failure(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        command = GateCommand(
+            "fake hang",
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            timeout_seconds=0.1,
+        )
+
+        self.assertEqual(run_gate(command, root), TIMEOUT_EXIT_CODE)
+
+    def test_lock_timeout_exit_code_is_distinct_from_command_timeout(self) -> None:
+        self.assertNotEqual(LOCK_TIMEOUT_EXIT_CODE, TIMEOUT_EXIT_CODE)
+
+    def test_analyze_files_cli_builds_bounded_serialized_command(self) -> None:
+        with patch("quality_gate.run_gate", return_value=0) as run:
+            self.assertEqual(
+                main(["--analyze-files", "lib/example.dart", "test/example_test.dart"]),
+                0,
+            )
+
+        command = run.call_args.args[0]
+        self.assertEqual(
+            command.args,
+            [
+                "flutter",
+                "analyze",
+                "--no-pub",
+                "lib/example.dart",
+                "test/example_test.dart",
+            ],
+        )
+        self.assertTrue(command.serialize_analyzer)
+        self.assertGreater(command.timeout_seconds, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add explicit per-command timeouts to local quality gates
- serialize analyzer startup across local worktrees with a bounded advisory lock
- terminate only the owned subprocess tree on timeout and emit structured recovery evidence
- add `--analyze-files` for Tiger review and other scoped automation

## Incident evidence
- Tiger `site_review` tokens 25 and 26 both stalled in targeted analyzer execution and exhausted the durable job retry budget
- a clean `origin/main` worktree reproduced the analyzer wait; interrupting the parent left two owned analysis-server process trees behind
- those exact owned trees were removed; unrelated processes were not touched

## Validation
- `py -3 -m py_compile scripts/quality_gate.py scripts/quality_gate_test.py`
- `py -3 scripts/quality_gate_test.py` (10 passed)
- `py -3 scripts/pre_commit_quality_gate_test.py` (4 passed)
- `py -3 scripts/cicd_efficiency_test.py` (8 passed)
- `py -3 scripts/pre_commit_quality_gate.py` (passed)
- live 1-second timeout probe: exit 124, analyzer lock acquired, no owned analysis-server remainder

Closes #4266