### PR TITLE
fix: bound Flutter analyzer quality gates

### DIFF
--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -4,12 +4,22 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO
+
+
+TIMEOUT_EXIT_CODE = 124
+LOCK_TIMEOUT_EXIT_CODE = 75
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 300.0
+DEFAULT_ANALYZER_LOCK_WAIT_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -17,6 +27,24 @@ class GateCommand:
     name: str
     args: list[str]
     required_binary: str | None = None
+    timeout_seconds: float = DEFAULT_COMMAND_TIMEOUT_SECONDS
+    resource_lock: str | None = None
+
+
+@dataclass(frozen=True)
+class GateResult:
+    name: str
+    command: list[str]
+    returncode: int
+    status: str
+    elapsed_seconds: float
+    timeout_seconds: float
+    cleanup: dict[str, object]
+    lock_path: str | None = None
+
+
+class ResourceLockTimeout(RuntimeError):
+    """Raised when a shared local resource cannot be leased in time."""
 
 
 def repo_root() -> Path:
@@ -120,7 +148,13 @@ def base_commands() -> list[GateCommand]:
 def fast_commands() -> list[GateCommand]:
     return [
         *base_commands(),
-        GateCommand("flutter analyze", ["flutter", "analyze"], "flutter"),
+        GateCommand(
+            "flutter analyze",
+            ["flutter", "analyze"],
+            "flutter",
+            timeout_seconds=300,
+            resource_lock="flutter-analyzer",
+        ),
         GateCommand(
             "deno lint edge functions",
             [
@@ -131,6 +165,7 @@ def fast_commands() -> list[GateCommand]:
                 "supabase/functions/",
             ],
             "deno",
+            timeout_seconds=300,
         ),
     ]
 
@@ -142,6 +177,7 @@ def full_commands(root: Path) -> list[GateCommand]:
             "dart format check",
             ["dart", "format", "--output=none", "--set-exit-if-changed", "."],
             "dart",
+            timeout_seconds=300,
         ),
         GateCommand(
             "flutter vm tests",
@@ -152,6 +188,7 @@ def full_commands(root: Path) -> list[GateCommand]:
                 f"--concurrency={flutter_vm_test_concurrency()}",
             ],
             "flutter",
+            timeout_seconds=3600,
         ),
     ]
     if include_browser_smoke():
@@ -166,6 +203,7 @@ def full_commands(root: Path) -> list[GateCommand]:
                     "test/web_import_smoke_test.dart",
                 ],
                 "flutter",
+                timeout_seconds=900,
             )
         )
     if has_deno_tests(root):
@@ -182,6 +220,7 @@ def full_commands(root: Path) -> list[GateCommand]:
                     "supabase/functions/",
                 ],
                 "deno",
+                timeout_seconds=1200,
             )
         )
     return commands
@@ -213,16 +252,252 @@ def command_env() -> dict[str, str]:
     return env
 
 
-def run_gate(command: GateCommand, root: Path) -> int:
-    print(f"==> {command.name}", flush=True)
+def _git_common_dir(root: Path) -> Path:
+    override = os.environ.get("QUALITY_GATE_LOCK_ROOT")
+    if override:
+        return Path(override).resolve()
+    result = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=10,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip()).resolve()
+    return (root / ".git").resolve()
+
+
+def resource_lock_path(root: Path, resource: str) -> Path:
+    path = _git_common_dir(root) / "codex-quality" / f"{resource}.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _try_lock_windows(handle: BinaryIO) -> None:
+    import msvcrt
+
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(b"\0")
+        handle.flush()
+    handle.seek(0)
+    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+
+
+def _unlock_windows(handle: BinaryIO) -> None:
+    import msvcrt
+
+    handle.seek(0)
+    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _try_lock_posix(handle: BinaryIO) -> None:
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_posix(handle: BinaryIO) -> None:
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class ResourceLock:
+    def __init__(
+        self,
+        path: Path,
+        wait_seconds: float,
+        *,
+        platform_name: str | None = None,
+    ) -> None:
+        self.path = path
+        self.wait_seconds = max(0.0, wait_seconds)
+        self.platform_name = os.name if platform_name is None else platform_name
+        self.handle: BinaryIO | None = None
+
+    def __enter__(self) -> "ResourceLock":
+        deadline = time.monotonic() + self.wait_seconds
+        handle = self.path.open("a+b")
+        while True:
+            try:
+                if self.platform_name == "nt":
+                    _try_lock_windows(handle)
+                else:
+                    _try_lock_posix(handle)
+                self.handle = handle
+                return self
+            except OSError as error:
+                if time.monotonic() >= deadline:
+                    handle.close()
+                    raise ResourceLockTimeout(
+                        f"resource lock unavailable after {self.wait_seconds:.1f}s: {self.path}"
+                    ) from error
+                time.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
+
+    def __exit__(self, *_args: object) -> None:
+        if self.handle is None:
+            return
+        try:
+            if self.platform_name == "nt":
+                _unlock_windows(self.handle)
+            else:
+                _unlock_posix(self.handle)
+        finally:
+            self.handle.close()
+            self.handle = None
+
+
+def terminate_owned_process_tree(
+    proc: subprocess.Popen[bytes],
+    *,
+    platform_name: str | None = None,
+) -> dict[str, object]:
+    resolved_platform = os.name if platform_name is None else platform_name
+    result: dict[str, object] = {
+        "attempted": True,
+        "method": "taskkill" if resolved_platform == "nt" else "process_group",
+        "root_pid": proc.pid,
+        "succeeded": False,
+    }
+    try:
+        if resolved_platform == "nt":
+            cleanup = subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                capture_output=True,
+                timeout=15,
+                check=False,
+            )
+            result["cleanup_returncode"] = cleanup.returncode
+        else:
+            os.killpg(proc.pid, signal.SIGTERM)
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
+        result["succeeded"] = proc.poll() is not None
+    except (OSError, subprocess.SubprocessError) as error:
+        result["error"] = str(error)
+    return result
+
+
+def execute_gate(
+    command: GateCommand,
+    root: Path,
+    *,
+    timeout_seconds: float | None = None,
+    lock_wait_seconds: float = DEFAULT_ANALYZER_LOCK_WAIT_SECONDS,
+) -> GateResult:
     resolved_args = resolve_args(command)
+    timeout = command.timeout_seconds if timeout_seconds is None else timeout_seconds
+    started = time.monotonic()
     if resolved_args is None:
-        print(f"missing required command: {command.required_binary}", file=sys.stderr)
-        return 127
-    proc = subprocess.run(resolved_args, cwd=root, env=command_env(), check=False)
-    if proc.returncode != 0:
-        print(f"gate failed: {command.name} (exit {proc.returncode})", file=sys.stderr)
-    return proc.returncode
+        return GateResult(
+            command.name,
+            command.args,
+            127,
+            "missing_command",
+            0.0,
+            timeout,
+            {"attempted": False},
+        )
+
+    lock_path = (
+        resource_lock_path(root, command.resource_lock)
+        if command.resource_lock
+        else None
+    )
+    lock = ResourceLock(lock_path, lock_wait_seconds) if lock_path else None
+    try:
+        if lock:
+            lock.__enter__()
+    except ResourceLockTimeout:
+        return GateResult(
+            command.name,
+            resolved_args,
+            LOCK_TIMEOUT_EXIT_CODE,
+            "lock_timeout",
+            round(time.monotonic() - started, 3),
+            timeout,
+            {"attempted": False},
+            str(lock_path),
+        )
+
+    creation: dict[str, object] = {}
+    if os.name == "nt":
+        creation["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        creation["start_new_session"] = True
+    cleanup: dict[str, object] = {"attempted": False}
+    try:
+        proc = subprocess.Popen(
+            resolved_args,
+            cwd=root,
+            env=command_env(),
+            **creation,
+        )
+        try:
+            returncode = proc.wait(timeout=timeout)
+            status = "passed" if returncode == 0 else "failed"
+        except subprocess.TimeoutExpired:
+            cleanup = terminate_owned_process_tree(proc)
+            returncode = TIMEOUT_EXIT_CODE
+            status = "timeout"
+        return GateResult(
+            command.name,
+            resolved_args,
+            returncode,
+            status,
+            round(time.monotonic() - started, 3),
+            timeout,
+            cleanup,
+            str(lock_path) if lock_path else None,
+        )
+    finally:
+        if lock:
+            lock.__exit__(None, None, None)
+
+
+def run_gate(
+    command: GateCommand,
+    root: Path,
+    *,
+    timeout_seconds: float | None = None,
+    lock_wait_seconds: float = DEFAULT_ANALYZER_LOCK_WAIT_SECONDS,
+    recovery_command: str,
+) -> int:
+    print(f"==> {command.name}", flush=True)
+    result = execute_gate(
+        command,
+        root,
+        timeout_seconds=timeout_seconds,
+        lock_wait_seconds=lock_wait_seconds,
+    )
+    payload = {
+        "event": "quality_gate_command",
+        "name": result.name,
+        "command": result.command,
+        "status": result.status,
+        "exit_code": result.returncode,
+        "elapsed_seconds": result.elapsed_seconds,
+        "timeout_seconds": result.timeout_seconds,
+        "cleanup": result.cleanup,
+        "lock_path": result.lock_path,
+        "recovery_command": recovery_command,
+    }
+    print(json.dumps(payload, ensure_ascii=False), flush=True)
+    if result.returncode != 0:
+        print(
+            f"gate failed: {command.name} ({result.status}, exit {result.returncode}); "
+            f"recovery: {recovery_command}",
+            file=sys.stderr,
+        )
+    return result.returncode
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -231,21 +506,69 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     mode.add_argument("--fast", action="store_true", help="Run pre-commit quality gates.")
     mode.add_argument("--full", action="store_true", help="Run pre-push quality gates.")
     mode.add_argument("--list", action="store_true", help="Print the commands without running them.")
+    mode.add_argument(
+        "--analyze-only",
+        action="store_true",
+        help="Run one supervised Flutter analysis, optionally scoped to paths.",
+    )
+    parser.add_argument("paths", nargs="*", help="Paths for --analyze-only.")
+    parser.add_argument(
+        "--command-timeout-seconds",
+        type=float,
+        help="Override each command timeout (must be positive).",
+    )
+    parser.add_argument(
+        "--lock-wait-seconds",
+        type=float,
+        default=DEFAULT_ANALYZER_LOCK_WAIT_SECONDS,
+        help="Bounded wait for the cross-worktree analyzer lock.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     root = repo_root()
-    commands = full_commands(root) if args.full else fast_commands()
+    if args.command_timeout_seconds is not None and args.command_timeout_seconds <= 0:
+        raise SystemExit("--command-timeout-seconds must be positive")
+    if args.lock_wait_seconds < 0:
+        raise SystemExit("--lock-wait-seconds must be non-negative")
+    if args.paths and not args.analyze_only:
+        raise SystemExit("paths are accepted only with --analyze-only")
+    if args.analyze_only:
+        commands = [
+            GateCommand(
+                "flutter analyze",
+                ["flutter", "analyze", "--no-pub", *args.paths],
+                "flutter",
+                timeout_seconds=300,
+                resource_lock="flutter-analyzer",
+            )
+        ]
+    else:
+        commands = full_commands(root) if args.full else fast_commands()
+
+    mode_args = "--full" if args.full else "--fast"
+    if args.analyze_only:
+        mode_args = "--analyze-only " + " ".join(args.paths)
+    recovery_command = f"{sys.executable} scripts/quality_gate.py {mode_args}".strip()
 
     if args.list:
         for command in commands:
-            print(f"{command.name}: {' '.join(command.args)}")
+            print(
+                f"{command.name}: {' '.join(command.args)} "
+                f"(timeout={command.timeout_seconds:g}s, lock={command.resource_lock or 'none'})"
+            )
         return 0
 
     for command in commands:
-        code = run_gate(command, root)
+        code = run_gate(
+            command,
+            root,
+            timeout_seconds=args.command_timeout_seconds,
+            lock_wait_seconds=args.lock_wait_seconds,
+            recovery_command=recovery_command,
+        )
         if code != 0:
             return code
     return 0

--- a/scripts/quality_gate_test.py
+++ b/scripts/quality_gate_test.py
@@ -1,13 +1,164 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import contextlib
+import io
+import os
 from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
 import unittest
+from unittest.mock import patch
 
-from quality_gate import flutter_vm_test_concurrency, full_commands
+from quality_gate import (
+    GateCommand,
+    ResourceLock,
+    ResourceLockTimeout,
+    TIMEOUT_EXIT_CODE,
+    execute_gate,
+    fast_commands,
+    flutter_vm_test_concurrency,
+    full_commands,
+    resource_lock_path,
+    run_gate,
+    terminate_owned_process_tree,
+)
+
+
+def process_is_running(pid: int) -> bool:
+    if os.name == "nt":
+        import ctypes
+
+        handle = ctypes.windll.kernel32.OpenProcess(0x1000, False, pid)
+        if not handle:
+            return False
+        ctypes.windll.kernel32.CloseHandle(handle)
+        return True
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
 
 
 class QualityGateTest(unittest.TestCase):
+    def test_flutter_analyzer_has_timeout_and_cross_worktree_lock(self) -> None:
+        command = next(item for item in fast_commands() if item.name == "flutter analyze")
+
+        self.assertEqual(command.timeout_seconds, 300)
+        self.assertEqual(command.resource_lock, "flutter-analyzer")
+
+    def test_resource_lock_fails_with_bounded_zero_wait(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "analyzer.lock"
+            with ResourceLock(path, 0):
+                with self.assertRaises(ResourceLockTimeout):
+                    with ResourceLock(path, 0):
+                        self.fail("second lock must not be acquired")
+
+    def test_analyzer_lock_path_is_shared_by_worktrees(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            common = Path(temp) / "common-git"
+            with patch.dict(os.environ, {"QUALITY_GATE_LOCK_ROOT": str(common)}):
+                first = resource_lock_path(Path(temp) / "worktree-a", "flutter-analyzer")
+                second = resource_lock_path(Path(temp) / "worktree-b", "flutter-analyzer")
+
+        self.assertEqual(first, second)
+
+    def test_hanging_command_kills_owned_descendant_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            child_pid_path = root / "child.pid"
+            code = (
+                "import pathlib, subprocess, sys, time; "
+                "child=subprocess.Popen([sys.executable, '-c', "
+                "'import time; time.sleep(60)']); "
+                f"pathlib.Path({str(child_pid_path)!r}).write_text(str(child.pid)); "
+                "time.sleep(60)"
+            )
+            unrelated = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(60)"]
+            )
+            child_pid = 0
+            try:
+                result = execute_gate(
+                    GateCommand(
+                        "fake hang",
+                        [sys.executable, "-c", code],
+                        timeout_seconds=0.5,
+                    ),
+                    root,
+                )
+                self.assertEqual(result.returncode, TIMEOUT_EXIT_CODE)
+                self.assertEqual(result.status, "timeout")
+                self.assertLess(result.elapsed_seconds, 10)
+                self.assertTrue(result.cleanup["attempted"])
+                self.assertTrue(result.cleanup["succeeded"])
+                self.assertIsNone(unrelated.poll())
+
+                child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+                deadline = time.monotonic() + 3
+                while process_is_running(child_pid) and time.monotonic() < deadline:
+                    time.sleep(0.05)
+                self.assertFalse(process_is_running(child_pid))
+            finally:
+                unrelated.terminate()
+                try:
+                    unrelated.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    unrelated.kill()
+                if child_pid and process_is_running(child_pid):
+                    if os.name == "nt":
+                        subprocess.run(
+                            ["taskkill", "/PID", str(child_pid), "/T", "/F"],
+                            capture_output=True,
+                            check=False,
+                        )
+                    else:
+                        os.kill(child_pid, signal.SIGKILL)
+
+    def test_cleanup_routes_to_windows_taskkill(self) -> None:
+        proc = unittest.mock.Mock(pid=1234)
+        proc.poll.return_value = 1
+        with patch("quality_gate.subprocess.run") as run:
+            run.return_value.returncode = 0
+            result = terminate_owned_process_tree(proc, platform_name="nt")
+
+        run.assert_called_once_with(
+            ["taskkill", "/PID", "1234", "/T", "/F"],
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        self.assertEqual(result["method"], "taskkill")
+
+    def test_cleanup_routes_to_posix_process_group(self) -> None:
+        proc = unittest.mock.Mock(pid=4321)
+        proc.poll.return_value = 1
+        with patch("quality_gate.os.killpg", create=True) as killpg:
+            result = terminate_owned_process_tree(proc, platform_name="posix")
+
+        killpg.assert_called_once_with(4321, signal.SIGTERM)
+        self.assertEqual(result["method"], "process_group")
+
+    def test_run_gate_emits_structured_recovery_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = run_gate(
+                    GateCommand("pass", [sys.executable, "-c", "pass"]),
+                    Path(temp),
+                    recovery_command="python scripts/quality_gate.py --fast",
+                )
+
+        self.assertEqual(code, 0)
+        self.assertIn('"event": "quality_gate_command"', stdout.getvalue())
+        self.assertIn('"recovery_command":', stdout.getvalue())
+
     def test_pre_push_does_not_repeat_the_full_ci_gate(self) -> None:
         root = Path(__file__).resolve().parents[1]
         lefthook = (root / "lefthook.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add explicit per-command timeouts and a supervised `--analyze-only` mode
- serialize Flutter analyzer use across worktrees with a shared Git-common-dir lock
- terminate only the owned process tree on timeout on Windows/POSIX
- emit structured elapsed/timeout/cleanup/lock/recovery evidence
- add deterministic fake-hang, descendant-cleanup, unrelated-process, lock, and platform-routing tests

## Reproduction evidence
The Tiger `site_review` analyzer stalled in fencing-token runs 25 and 26. With this wrapper, the same 10-file command terminated deterministically after 203.172 seconds when Flutter's analysis server exited with code 1, and emitted structured failure evidence instead of hanging indefinitely.

## Validation
- `py -3 scripts/quality_gate_test.py` (9 passed)
- `py -3 scripts/pre_commit_quality_gate_test.py` (4 passed)
- `py -3 scripts/cicd_efficiency_test.py` (8 passed)
- `py -3 -m py_compile scripts/quality_gate.py scripts/quality_gate_test.py`
- `git diff --check`

Progresses #4266. The separate Lefthook PATH/bootstrap acceptance item remains open and is intentionally not auto-closed by this PR.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: automation runner only; no security, data, deployment, or production path changes.