### PR TITLE
feat: add chat highlight candidate workflow (#1279)

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -157,6 +157,7 @@ import '../pages/social_feed_page.dart';
 import '../pages/subscription_billing_page.dart';
 import '../pages/digital_product_store_pages.dart';
 import '../pages/viral_ad_generator_page.dart';
+import '../ui/features/chat_highlights/chat_highlights_feature.dart';
 import '../ui/features/video_studio/video_studio_feature.dart';
 import '../ui/features/notion_migration/notion_migration_feature.dart';
 import '../pages/youtube_stats_page.dart';
@@ -2265,6 +2266,23 @@ List<HomeToolEntry> buildHomeToolCatalog({
       color: const Color(0xFF283593),
       keywords: const <String>['ABテスト', 'ランディング', 'LP', 'CVR', 'コンバージョン'],
       onOpen: (context) => _pushPage(context, const LandingAbTestPage()),
+    ),
+    HomeToolEntry(
+      id: 'chat-highlights',
+      sectionId: 'growth',
+      title: 'チャットハイライト',
+      subtitle: 'コメントの熱量から動画編集候補の時間帯を自動抽出',
+      icon: Icons.auto_awesome_motion_outlined,
+      color: const Color(0xFF7E57C2),
+      keywords: const <String>[
+        'チャット',
+        'ライブ配信',
+        'ハイライト',
+        'コメント',
+        '動画編集',
+        'chat highlight',
+      ],
+      onOpen: (context) => _pushPage(context, const ChatHighlightsFeature()),
     ),
     HomeToolEntry(
       id: 'video-studio',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -219,6 +219,7 @@ import 'package:my_web_app/pages/loyalty_points_page.dart';
 import 'package:my_web_app/pages/viral_ad_generator_page.dart';
 import 'package:my_web_app/pages/growth_automation_controller_page.dart';
 import 'package:my_web_app/pages/landing_ab_test_page.dart';
+import 'package:my_web_app/ui/features/chat_highlights/chat_highlights_feature.dart';
 import 'package:my_web_app/ui/features/video_studio/video_studio_feature.dart';
 import 'package:my_web_app/ui/features/notion_migration/notion_migration_feature.dart';
 import 'package:my_web_app/ui/features/procrastination_reset/procrastination_reset_feature.dart';
@@ -1340,6 +1341,11 @@ Route<dynamic> generateAppRoute(
       );
     case '/landing-ab-test':
       return MaterialPageRoute(builder: (_) => const LandingAbTestPage());
+    case '/chat-highlights':
+      return MaterialPageRoute(
+        builder: (_) => const ChatHighlightsFeature(),
+        settings: RouteSettings(name: settings.name),
+      );
     case '/video-studio':
       return MaterialPageRoute(
         builder: (_) => VideoStudioFeature(initialUri: uri),

--- a/lib/ui/features/chat_highlights/chat_highlights_feature.dart
+++ b/lib/ui/features/chat_highlights/chat_highlights_feature.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import 'data/chat_highlight_export_gateway.dart';
+import 'data/chat_highlight_gateway.dart';
+import 'view_models/chat_highlights_view_model.dart';
+import 'views/chat_highlights_page.dart';
+
+class ChatHighlightsFeature extends StatelessWidget {
+  const ChatHighlightsFeature({
+    super.key,
+    this.gateway,
+    this.exportGateway,
+    this.now,
+  });
+
+  static const routeName = '/chat-highlights';
+
+  final ChatHighlightGateway? gateway;
+  final ChatHighlightExportGateway? exportGateway;
+  final DateTime Function()? now;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<ChatHighlightsViewModel>(
+      create: (_) => ChatHighlightsViewModel(
+        gateway: gateway ?? SharedPreferencesChatHighlightGateway(),
+        exportGateway:
+            exportGateway ?? const BrowserChatHighlightExportGateway(),
+        now: now,
+      )..load(),
+      child: const ChatHighlightsPage(),
+    );
+  }
+}

--- a/lib/ui/features/chat_highlights/data/chat_highlight_export_gateway.dart
+++ b/lib/ui/features/chat_highlights/data/chat_highlight_export_gateway.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import '../../../../utils/web_text_downloader.dart';
+import '../domain/chat_highlight_models.dart';
+
+typedef ChatHighlightTextDownloader = void Function(
+  String text,
+  String fileName,
+  String mimeType,
+);
+
+void _downloadManifest(String text, String fileName, String mimeType) {
+  downloadTextFile(text, fileName, mimeType: mimeType);
+}
+
+abstract class ChatHighlightExportGateway {
+  Future<void> export({
+    required ChatHighlightSnapshot snapshot,
+    required List<ChatHighlightCandidate> candidates,
+  });
+}
+
+class BrowserChatHighlightExportGateway implements ChatHighlightExportGateway {
+  const BrowserChatHighlightExportGateway({
+    this.downloader = _downloadManifest,
+    this.now = DateTime.now,
+  });
+
+  final ChatHighlightTextDownloader downloader;
+  final DateTime Function() now;
+
+  @override
+  Future<void> export({
+    required ChatHighlightSnapshot snapshot,
+    required List<ChatHighlightCandidate> candidates,
+  }) async {
+    final source = snapshot.sourceVideoUrl.trim();
+    final clips = <Map<String, dynamic>>[];
+    for (var index = 0; index < candidates.length; index++) {
+      final candidate = candidates[index];
+      final output = 'highlight_${(index + 1).toString().padLeft(2, '0')}.mp4';
+      clips.add(<String, dynamic>{
+        ...candidate.toJson(),
+        'outputFile': output,
+        'ffmpegArgs': <String>[
+          '-ss',
+          _seconds(candidate.start),
+          '-i',
+          source,
+          '-t',
+          _seconds(candidate.end - candidate.start),
+          '-c',
+          'copy',
+          output,
+        ],
+      });
+    }
+    final document = <String, dynamic>{
+      'schema': 'my-web-app/chat-highlight-manifest/v1',
+      'generatedAt': now().toUtc().toIso8601String(),
+      'source': <String, String>{
+        'title': snapshot.sourceTitle,
+        'videoUrl': source,
+      },
+      'settings': snapshot.settings.toJson(),
+      'clips': clips,
+      'notice': 'ffmpegArgs は編集環境で確認してから実行してください。',
+    };
+    downloader(
+      const JsonEncoder.withIndent('  ').convert(document),
+      'chat_highlight_manifest.json',
+      'application/json;charset=utf-8',
+    );
+  }
+
+  String _seconds(Duration value) =>
+      (value.inMilliseconds / 1000).toStringAsFixed(3);
+}

--- a/lib/ui/features/chat_highlights/data/chat_highlight_gateway.dart
+++ b/lib/ui/features/chat_highlights/data/chat_highlight_gateway.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../domain/chat_highlight_models.dart';
+
+abstract class ChatHighlightGateway {
+  Future<ChatHighlightSnapshot> load();
+
+  Future<void> save(ChatHighlightSnapshot snapshot);
+}
+
+class SharedPreferencesChatHighlightGateway implements ChatHighlightGateway {
+  SharedPreferencesChatHighlightGateway({SharedPreferences? preferences})
+      : _preferences = preferences;
+
+  static const storageKey = 'chat_highlight_snapshot_v1';
+  final SharedPreferences? _preferences;
+
+  @override
+  Future<ChatHighlightSnapshot> load() async {
+    final preferences = _preferences ?? await SharedPreferences.getInstance();
+    final raw = preferences.getString(storageKey);
+    if (raw == null || raw.isEmpty) return const ChatHighlightSnapshot();
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return const ChatHighlightSnapshot();
+      return ChatHighlightSnapshot.fromJson(Map<String, dynamic>.from(decoded));
+    } on Object {
+      return const ChatHighlightSnapshot();
+    }
+  }
+
+  @override
+  Future<void> save(ChatHighlightSnapshot snapshot) async {
+    final preferences = _preferences ?? await SharedPreferences.getInstance();
+    final saved = await preferences.setString(
+      storageKey,
+      jsonEncode(snapshot.toJson()),
+    );
+    if (!saved) throw StateError('チャットデータの端末内保存に失敗しました。');
+  }
+}

--- a/lib/ui/features/chat_highlights/domain/chat_highlight_models.dart
+++ b/lib/ui/features/chat_highlights/domain/chat_highlight_models.dart
@@ -1,0 +1,191 @@
+enum ChatHighlightTrigger { commentBurst, keywordBurst }
+
+class ChatHighlightEvent {
+  const ChatHighlightEvent({
+    required this.id,
+    required this.offset,
+    required this.author,
+    required this.message,
+  });
+
+  final String id;
+  final Duration offset;
+  final String author;
+  final String message;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'offsetMs': offset.inMilliseconds,
+        'author': author,
+        'message': message,
+      };
+
+  factory ChatHighlightEvent.fromJson(Map<String, dynamic> json) {
+    return ChatHighlightEvent(
+      id: json['id'] as String? ?? '',
+      offset: Duration(milliseconds: json['offsetMs'] as int? ?? 0),
+      author: json['author'] as String? ?? '',
+      message: json['message'] as String? ?? '',
+    );
+  }
+}
+
+class ChatHighlightSettings {
+  const ChatHighlightSettings({
+    this.windowSeconds = 30,
+    this.minimumComments = 4,
+    this.minimumKeywordEvents = 2,
+    this.preRollSeconds = 10,
+    this.postRollSeconds = 15,
+    this.keywords = const <String>['笑', '草', 'すごい', '神', 'wow', 'lol'],
+  });
+
+  final int windowSeconds;
+  final int minimumComments;
+  final int minimumKeywordEvents;
+  final int preRollSeconds;
+  final int postRollSeconds;
+  final List<String> keywords;
+
+  ChatHighlightSettings copyWith({
+    int? windowSeconds,
+    int? minimumComments,
+    int? minimumKeywordEvents,
+    int? preRollSeconds,
+    int? postRollSeconds,
+    List<String>? keywords,
+  }) {
+    return ChatHighlightSettings(
+      windowSeconds: windowSeconds ?? this.windowSeconds,
+      minimumComments: minimumComments ?? this.minimumComments,
+      minimumKeywordEvents: minimumKeywordEvents ?? this.minimumKeywordEvents,
+      preRollSeconds: preRollSeconds ?? this.preRollSeconds,
+      postRollSeconds: postRollSeconds ?? this.postRollSeconds,
+      keywords: keywords ?? this.keywords,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'windowSeconds': windowSeconds,
+        'minimumComments': minimumComments,
+        'minimumKeywordEvents': minimumKeywordEvents,
+        'preRollSeconds': preRollSeconds,
+        'postRollSeconds': postRollSeconds,
+        'keywords': keywords,
+      };
+
+  factory ChatHighlightSettings.fromJson(Map<String, dynamic> json) {
+    final rawKeywords = json['keywords'];
+    return ChatHighlightSettings(
+      windowSeconds: _positiveInt(json['windowSeconds'], 30),
+      minimumComments: _positiveInt(json['minimumComments'], 4),
+      minimumKeywordEvents: _positiveInt(json['minimumKeywordEvents'], 2),
+      preRollSeconds: _nonNegativeInt(json['preRollSeconds'], 10),
+      postRollSeconds: _nonNegativeInt(json['postRollSeconds'], 15),
+      keywords: rawKeywords is List
+          ? rawKeywords.whereType<String>().toList(growable: false)
+          : const <String>['笑', '草', 'すごい', '神', 'wow', 'lol'],
+    );
+  }
+
+  static int _positiveInt(Object? value, int fallback) =>
+      value is int && value > 0 ? value : fallback;
+
+  static int _nonNegativeInt(Object? value, int fallback) =>
+      value is int && value >= 0 ? value : fallback;
+}
+
+class ChatHighlightCandidate {
+  const ChatHighlightCandidate({
+    required this.start,
+    required this.end,
+    required this.peakCommentCount,
+    required this.peakKeywordEventCount,
+    required this.matchedKeywords,
+    required this.triggers,
+    required this.score,
+  });
+
+  final Duration start;
+  final Duration end;
+  final int peakCommentCount;
+  final int peakKeywordEventCount;
+  final Set<String> matchedKeywords;
+  final Set<ChatHighlightTrigger> triggers;
+  final double score;
+
+  String get id => '${start.inMilliseconds}-${end.inMilliseconds}';
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'startMs': start.inMilliseconds,
+        'endMs': end.inMilliseconds,
+        'peakCommentCount': peakCommentCount,
+        'peakKeywordEventCount': peakKeywordEventCount,
+        'matchedKeywords': matchedKeywords.toList()..sort(),
+        'triggers': triggers.map((trigger) => trigger.name).toList()..sort(),
+        'score': score,
+      };
+}
+
+class ChatHighlightSnapshot {
+  const ChatHighlightSnapshot({
+    this.sourceTitle = '',
+    this.sourceVideoUrl = '',
+    this.events = const <ChatHighlightEvent>[],
+    this.settings = const ChatHighlightSettings(),
+  });
+
+  final String sourceTitle;
+  final String sourceVideoUrl;
+  final List<ChatHighlightEvent> events;
+  final ChatHighlightSettings settings;
+
+  ChatHighlightSnapshot copyWith({
+    String? sourceTitle,
+    String? sourceVideoUrl,
+    List<ChatHighlightEvent>? events,
+    ChatHighlightSettings? settings,
+  }) {
+    return ChatHighlightSnapshot(
+      sourceTitle: sourceTitle ?? this.sourceTitle,
+      sourceVideoUrl: sourceVideoUrl ?? this.sourceVideoUrl,
+      events: events ?? this.events,
+      settings: settings ?? this.settings,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'version': 1,
+        'sourceTitle': sourceTitle,
+        'sourceVideoUrl': sourceVideoUrl,
+        'events': events.map((event) => event.toJson()).toList(),
+        'settings': settings.toJson(),
+      };
+
+  factory ChatHighlightSnapshot.fromJson(Map<String, dynamic> json) {
+    final rawEvents = json['events'];
+    final rawSettings = json['settings'];
+    return ChatHighlightSnapshot(
+      sourceTitle: json['sourceTitle'] as String? ?? '',
+      sourceVideoUrl: json['sourceVideoUrl'] as String? ?? '',
+      events: rawEvents is List
+          ? rawEvents
+              .whereType<Map>()
+              .map(
+                (event) => ChatHighlightEvent.fromJson(
+                  Map<String, dynamic>.from(event),
+                ),
+              )
+              .where((event) => event.id.isNotEmpty)
+              .take(500)
+              .toList(growable: false)
+          : const <ChatHighlightEvent>[],
+      settings: rawSettings is Map
+          ? ChatHighlightSettings.fromJson(
+              Map<String, dynamic>.from(rawSettings),
+            )
+          : const ChatHighlightSettings(),
+    );
+  }
+}

--- a/lib/ui/features/chat_highlights/domain/detect_chat_highlights.dart
+++ b/lib/ui/features/chat_highlights/domain/detect_chat_highlights.dart
@@ -1,0 +1,114 @@
+import 'dart:math' as math;
+
+import 'chat_highlight_models.dart';
+
+class DetectChatHighlights {
+  const DetectChatHighlights();
+
+  List<ChatHighlightCandidate> call(
+    List<ChatHighlightEvent> input,
+    ChatHighlightSettings settings, {
+    Duration? sourceDuration,
+  }) {
+    final keywords = settings.keywords
+        .map((keyword) => keyword.trim().toLowerCase())
+        .where((keyword) => keyword.isNotEmpty)
+        .toSet();
+    final byId = <String, ChatHighlightEvent>{};
+    for (final event in input) {
+      if (event.id.isNotEmpty && event.offset >= Duration.zero) {
+        byId.putIfAbsent(event.id, () => event);
+      }
+    }
+    final events = byId.values.toList()
+      ..sort((left, right) {
+        final offsetOrder = left.offset.compareTo(right.offset);
+        return offsetOrder != 0 ? offsetOrder : left.id.compareTo(right.id);
+      });
+    if (events.isEmpty) return const <ChatHighlightCandidate>[];
+
+    final raw = <ChatHighlightCandidate>[];
+    var left = 0;
+    for (var right = 0; right < events.length; right++) {
+      final windowStart =
+          events[right].offset - Duration(seconds: settings.windowSeconds);
+      while (left < right && events[left].offset < windowStart) {
+        left++;
+      }
+      final window = events.sublist(left, right + 1);
+      final matched = <String>{};
+      var keywordEvents = 0;
+      for (final event in window) {
+        final message = event.message.toLowerCase();
+        final eventMatches = keywords.where(message.contains).toSet();
+        if (eventMatches.isNotEmpty) keywordEvents++;
+        matched.addAll(eventMatches);
+      }
+      final triggers = <ChatHighlightTrigger>{};
+      if (window.length >= settings.minimumComments) {
+        triggers.add(ChatHighlightTrigger.commentBurst);
+      }
+      if (keywordEvents >= settings.minimumKeywordEvents) {
+        triggers.add(ChatHighlightTrigger.keywordBurst);
+      }
+      if (triggers.isEmpty) continue;
+
+      final startMs = math.max(
+        0,
+        window.first.offset.inMilliseconds - settings.preRollSeconds * 1000,
+      );
+      var endMs =
+          events[right].offset.inMilliseconds + settings.postRollSeconds * 1000;
+      if (sourceDuration != null) {
+        endMs = math.min(endMs, sourceDuration.inMilliseconds);
+      }
+      if (endMs <= startMs) continue;
+      final commentRatio = window.length / settings.minimumComments;
+      final keywordRatio = keywordEvents / settings.minimumKeywordEvents;
+      raw.add(
+        ChatHighlightCandidate(
+          start: Duration(milliseconds: startMs),
+          end: Duration(milliseconds: endMs),
+          peakCommentCount: window.length,
+          peakKeywordEventCount: keywordEvents,
+          matchedKeywords: matched,
+          triggers: triggers,
+          score: math.max(commentRatio, keywordRatio),
+        ),
+      );
+    }
+
+    final merged = <ChatHighlightCandidate>[];
+    for (final candidate in raw) {
+      if (merged.isEmpty || candidate.start > merged.last.end) {
+        merged.add(candidate);
+        continue;
+      }
+      final previous = merged.removeLast();
+      merged.add(
+        ChatHighlightCandidate(
+          start: previous.start,
+          end: candidate.end > previous.end ? candidate.end : previous.end,
+          peakCommentCount: math.max(
+            previous.peakCommentCount,
+            candidate.peakCommentCount,
+          ),
+          peakKeywordEventCount: math.max(
+            previous.peakKeywordEventCount,
+            candidate.peakKeywordEventCount,
+          ),
+          matchedKeywords: <String>{
+            ...previous.matchedKeywords,
+            ...candidate.matchedKeywords,
+          },
+          triggers: <ChatHighlightTrigger>{
+            ...previous.triggers,
+            ...candidate.triggers,
+          },
+          score: math.max(previous.score, candidate.score),
+        ),
+      );
+    }
+    return List<ChatHighlightCandidate>.unmodifiable(merged);
+  }
+}

--- a/lib/ui/features/chat_highlights/view_models/chat_highlights_view_model.dart
+++ b/lib/ui/features/chat_highlights/view_models/chat_highlights_view_model.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../data/chat_highlight_export_gateway.dart';
+import '../data/chat_highlight_gateway.dart';
+import '../domain/chat_highlight_models.dart';
+import '../domain/detect_chat_highlights.dart';
+
+enum ChatHighlightsLoadStatus { initial, loading, ready, failure }
+
+class ChatHighlightsViewModel extends ChangeNotifier {
+  ChatHighlightsViewModel({
+    required ChatHighlightGateway gateway,
+    required ChatHighlightExportGateway exportGateway,
+    DetectChatHighlights detector = const DetectChatHighlights(),
+    DateTime Function()? now,
+  })  : _gateway = gateway,
+        _exportGateway = exportGateway,
+        _detector = detector,
+        _now = now ?? DateTime.now;
+
+  static const maximumEvents = 500;
+
+  final ChatHighlightGateway _gateway;
+  final ChatHighlightExportGateway _exportGateway;
+  final DetectChatHighlights _detector;
+  final DateTime Function() _now;
+
+  ChatHighlightsLoadStatus loadStatus = ChatHighlightsLoadStatus.initial;
+  ChatHighlightSnapshot snapshot = const ChatHighlightSnapshot();
+  List<ChatHighlightCandidate> candidates = const <ChatHighlightCandidate>[];
+  String? errorMessage;
+  String? noticeMessage;
+  Future<void> _saveTail = Future<void>.value();
+  var _idSequence = 0;
+  var _disposed = false;
+
+  Future<void> load() async {
+    loadStatus = ChatHighlightsLoadStatus.loading;
+    _notify();
+    try {
+      snapshot = await _gateway.load();
+      _sortAndAnalyze();
+      loadStatus = ChatHighlightsLoadStatus.ready;
+    } catch (error) {
+      errorMessage = '保存済みチャットを読み込めませんでした: $error';
+      loadStatus = ChatHighlightsLoadStatus.failure;
+    }
+    _notify();
+  }
+
+  Future<bool> updateSource({
+    required String title,
+    required String url,
+  }) async {
+    final parsed = url.trim().isEmpty ? null : Uri.tryParse(url.trim());
+    if (parsed != null && parsed.scheme != 'https' && parsed.scheme != 'http') {
+      _setError('動画URLは http:// または https:// で入力してください。');
+      return false;
+    }
+    snapshot = snapshot.copyWith(
+      sourceTitle: title.trim(),
+      sourceVideoUrl: url.trim(),
+    );
+    return _persist('配信情報を保存しました。');
+  }
+
+  Future<bool> updateSettings(ChatHighlightSettings settings) async {
+    if (settings.windowSeconds <= 0 ||
+        settings.minimumComments <= 0 ||
+        settings.minimumKeywordEvents <= 0 ||
+        settings.preRollSeconds < 0 ||
+        settings.postRollSeconds < 0) {
+      _setError('集計窓と閾値は1以上、前後余白は0以上で指定してください。');
+      return false;
+    }
+    final keywords = settings.keywords
+        .map((keyword) => keyword.trim())
+        .where((keyword) => keyword.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    snapshot = snapshot.copyWith(
+      settings: settings.copyWith(keywords: keywords),
+    );
+    _sortAndAnalyze();
+    return _persist('判定条件を更新し、候補を再計算しました。');
+  }
+
+  Future<bool> addEvent({
+    required Duration offset,
+    required String author,
+    required String message,
+  }) async {
+    if (offset < Duration.zero) {
+      _setError('時刻は0秒以上で入力してください。');
+      return false;
+    }
+    if (message.trim().isEmpty) {
+      _setError('コメント本文を入力してください。');
+      return false;
+    }
+    final event = ChatHighlightEvent(
+      id: '${_now().microsecondsSinceEpoch}-${_idSequence++}',
+      offset: offset,
+      author: author.trim().isEmpty ? '匿名' : author.trim(),
+      message: message.trim(),
+    );
+    final events = <ChatHighlightEvent>[...snapshot.events, event]
+      ..sort((left, right) {
+        final order = left.offset.compareTo(right.offset);
+        return order != 0 ? order : left.id.compareTo(right.id);
+      });
+    if (events.length > maximumEvents) {
+      events.removeRange(0, events.length - maximumEvents);
+    }
+    snapshot = snapshot.copyWith(events: events);
+    _sortAndAnalyze();
+    return _persist('コメントを時系列へ追加しました。');
+  }
+
+  Future<void> addDemoEvents() async {
+    final base = _now().microsecondsSinceEpoch;
+    final sequence = _idSequence++;
+    final demo = <ChatHighlightEvent>[
+      ChatHighlightEvent(
+        id: '$base-$sequence-demo-1',
+        offset: const Duration(minutes: 1, seconds: 2),
+        author: 'viewer_a',
+        message: 'ここすごい！',
+      ),
+      ChatHighlightEvent(
+        id: '$base-$sequence-demo-2',
+        offset: const Duration(minutes: 1, seconds: 8),
+        author: 'viewer_b',
+        message: '神展開',
+      ),
+      ChatHighlightEvent(
+        id: '$base-$sequence-demo-3',
+        offset: const Duration(minutes: 1, seconds: 13),
+        author: 'viewer_c',
+        message: '笑笑',
+      ),
+      ChatHighlightEvent(
+        id: '$base-$sequence-demo-4',
+        offset: const Duration(minutes: 1, seconds: 17),
+        author: 'viewer_d',
+        message: 'もう一回見たい',
+      ),
+    ];
+    snapshot = snapshot.copyWith(
+      events: <ChatHighlightEvent>[...snapshot.events, ...demo],
+    );
+    _sortAndAnalyze();
+    await _persist('デモコメント4件を追加しました。');
+  }
+
+  Future<void> removeEvent(String id) async {
+    snapshot = snapshot.copyWith(
+      events: snapshot.events.where((event) => event.id != id).toList(),
+    );
+    _sortAndAnalyze();
+    await _persist('コメントを削除しました。');
+  }
+
+  Future<void> clearEvents() async {
+    snapshot = snapshot.copyWith(events: const <ChatHighlightEvent>[]);
+    _sortAndAnalyze();
+    await _persist('チャット履歴を消去しました。');
+  }
+
+  Future<bool> exportManifest() async {
+    if (candidates.isEmpty) {
+      _setError('出力できるハイライト候補がありません。');
+      return false;
+    }
+    final uri = Uri.tryParse(snapshot.sourceVideoUrl);
+    if (uri == null ||
+        (uri.scheme != 'https' && uri.scheme != 'http') ||
+        uri.host.isEmpty) {
+      _setError('編集元となる有効な動画URLを保存してください。');
+      return false;
+    }
+    try {
+      await _exportGateway.export(snapshot: snapshot, candidates: candidates);
+      errorMessage = null;
+      noticeMessage = '編集用クリップ指示書（JSON）を出力しました。';
+      _notify();
+      return true;
+    } catch (error) {
+      _setError('クリップ指示書を出力できませんでした: $error');
+      return false;
+    }
+  }
+
+  void _sortAndAnalyze() {
+    final sorted = snapshot.events.toList()
+      ..sort((left, right) {
+        final order = left.offset.compareTo(right.offset);
+        return order != 0 ? order : left.id.compareTo(right.id);
+      });
+    snapshot = snapshot.copyWith(events: sorted);
+    candidates = _detector(sorted, snapshot.settings);
+  }
+
+  Future<bool> _persist(String notice) async {
+    errorMessage = null;
+    noticeMessage = notice;
+    final value = snapshot;
+    _saveTail =
+        _saveTail.catchError((Object _) {}).then((_) => _gateway.save(value));
+    try {
+      await _saveTail;
+      _notify();
+      return true;
+    } catch (error) {
+      _setError('変更を端末へ保存できませんでした: $error');
+      return false;
+    }
+  }
+
+  void _setError(String message) {
+    errorMessage = message;
+    noticeMessage = null;
+    _notify();
+  }
+
+  void _notify() {
+    if (!_disposed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+}

--- a/lib/ui/features/chat_highlights/views/chat_highlights_page.dart
+++ b/lib/ui/features/chat_highlights/views/chat_highlights_page.dart
@@ -1,0 +1,780 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../domain/chat_highlight_models.dart';
+import '../view_models/chat_highlights_view_model.dart';
+
+class ChatHighlightsPage extends StatefulWidget {
+  const ChatHighlightsPage({super.key});
+
+  @override
+  State<ChatHighlightsPage> createState() => _ChatHighlightsPageState();
+}
+
+class _ChatHighlightsPageState extends State<ChatHighlightsPage> {
+  static const _wideBreakpoint = 980.0;
+
+  final _sourceTitle = TextEditingController();
+  final _sourceUrl = TextEditingController();
+  final _window = TextEditingController(text: '30');
+  final _minimumComments = TextEditingController(text: '4');
+  final _minimumKeywordEvents = TextEditingController(text: '2');
+  final _preRoll = TextEditingController(text: '10');
+  final _postRoll = TextEditingController(text: '15');
+  final _keywords = TextEditingController(text: '笑, 草, すごい, 神, wow, lol');
+  final _eventTime = TextEditingController();
+  final _eventAuthor = TextEditingController();
+  final _eventMessage = TextEditingController();
+  var _didHydrateControllers = false;
+
+  @override
+  void dispose() {
+    for (final controller in <TextEditingController>[
+      _sourceTitle,
+      _sourceUrl,
+      _window,
+      _minimumComments,
+      _minimumKeywordEvents,
+      _preRoll,
+      _postRoll,
+      _keywords,
+      _eventTime,
+      _eventAuthor,
+      _eventMessage,
+    ]) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.read<ChatHighlightsViewModel>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('チャットハイライト')),
+      body: SafeArea(
+        child: ListenableBuilder(
+          listenable: viewModel,
+          builder: (context, _) {
+            if (viewModel.loadStatus == ChatHighlightsLoadStatus.initial ||
+                viewModel.loadStatus == ChatHighlightsLoadStatus.loading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (viewModel.loadStatus == ChatHighlightsLoadStatus.failure) {
+              return _LoadFailure(
+                message: viewModel.errorMessage,
+                onRetry: viewModel.load,
+              );
+            }
+            _hydrateControllers(viewModel.snapshot);
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                final wide = constraints.maxWidth >= _wideBreakpoint;
+                final setup = _buildSetup(context, viewModel);
+                final results = _buildResults(context, viewModel);
+                return SingleChildScrollView(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: wide ? 32 : 16,
+                    vertical: 24,
+                  ),
+                  child: Center(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 1280),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: <Widget>[
+                          _buildHero(context),
+                          if (viewModel.errorMessage != null ||
+                              viewModel.noticeMessage != null) ...<Widget>[
+                            const SizedBox(height: 16),
+                            _StatusBanner(
+                              message: viewModel.errorMessage ??
+                                  viewModel.noticeMessage!,
+                              error: viewModel.errorMessage != null,
+                            ),
+                          ],
+                          const SizedBox(height: 20),
+                          wide
+                              ? Row(
+                                  key: const Key('chat-highlights-wide'),
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: <Widget>[
+                                    SizedBox(width: 430, child: setup),
+                                    const SizedBox(width: 24),
+                                    Expanded(child: results),
+                                  ],
+                                )
+                              : Column(
+                                  key: const Key('chat-highlights-narrow'),
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: <Widget>[
+                                    setup,
+                                    const SizedBox(height: 20),
+                                    results,
+                                  ],
+                                ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHero(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: <Color>[colors.primaryContainer, colors.tertiaryContainer],
+        ),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'チャットの熱量を、編集できる時間帯へ。',
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: colors.onPrimaryContainer,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'コメント頻度とキーワード反応を端末内で集計し、候補区間と根拠を自動表示します。'
+            '動画そのものではなく、安全に確認できる編集用JSON指示書を出力します。',
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: colors.onPrimaryContainer,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSetup(BuildContext context, ChatHighlightsViewModel viewModel) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _SectionCard(
+          title: '1. 配信情報',
+          subtitle: '元動画のURLは指示書に記録され、外部へ送信されません。',
+          child: Column(
+            children: <Widget>[
+              TextField(
+                key: const Key('chat-highlight-source-title'),
+                controller: _sourceTitle,
+                decoration: const InputDecoration(
+                  labelText: '配信タイトル',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('chat-highlight-source-url'),
+                controller: _sourceUrl,
+                keyboardType: TextInputType.url,
+                decoration: const InputDecoration(
+                  labelText: '元動画URL',
+                  hintText: 'https://example.com/stream.mp4',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: FilledButton.icon(
+                  key: const Key('chat-highlight-save-source'),
+                  onPressed: () => unawaited(
+                    viewModel.updateSource(
+                      title: _sourceTitle.text,
+                      url: _sourceUrl.text,
+                    ),
+                  ),
+                  icon: const Icon(Icons.save_outlined),
+                  label: const Text('配信情報を保存'),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        _SectionCard(
+          title: '2. 自動判定条件',
+          subtitle: '集計窓内で、コメント数またはキーワード反応数が閾値以上になると候補化します。',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Wrap(
+                spacing: 10,
+                runSpacing: 12,
+                children: <Widget>[
+                  _NumberField(
+                    key: const Key('chat-highlight-window'),
+                    controller: _window,
+                    label: '集計窓（秒）',
+                  ),
+                  _NumberField(
+                    key: const Key('chat-highlight-min-comments'),
+                    controller: _minimumComments,
+                    label: 'コメント閾値',
+                  ),
+                  _NumberField(
+                    key: const Key('chat-highlight-min-keywords'),
+                    controller: _minimumKeywordEvents,
+                    label: '反応閾値',
+                  ),
+                  _NumberField(
+                    key: const Key('chat-highlight-pre-roll'),
+                    controller: _preRoll,
+                    label: '前余白（秒）',
+                  ),
+                  _NumberField(
+                    key: const Key('chat-highlight-post-roll'),
+                    controller: _postRoll,
+                    label: '後余白（秒）',
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('chat-highlight-keywords'),
+                controller: _keywords,
+                decoration: const InputDecoration(
+                  labelText: '反応キーワード（カンマ区切り）',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              FilledButton.tonalIcon(
+                key: const Key('chat-highlight-apply-settings'),
+                onPressed: () => _applySettings(viewModel),
+                icon: const Icon(Icons.auto_graph_outlined),
+                label: const Text('条件を保存して再計算'),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        _SectionCard(
+          title: '3. チャットを追加',
+          subtitle: '時刻順が前後しても、自動で並べ直して端末内に保存します（最大500件）。',
+          child: Column(
+            children: <Widget>[
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  SizedBox(
+                    width: 110,
+                    child: TextField(
+                      key: const Key('chat-highlight-event-time'),
+                      controller: _eventTime,
+                      decoration: const InputDecoration(
+                        labelText: '時刻',
+                        hintText: '1:23',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: TextField(
+                      key: const Key('chat-highlight-event-author'),
+                      controller: _eventAuthor,
+                      decoration: const InputDecoration(
+                        labelText: '投稿者（任意）',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('chat-highlight-event-message'),
+                controller: _eventMessage,
+                maxLength: 280,
+                onSubmitted: (_) => _addEvent(viewModel),
+                decoration: const InputDecoration(
+                  labelText: 'コメント',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      key: const Key('chat-highlight-demo'),
+                      onPressed: () => unawaited(viewModel.addDemoEvents()),
+                      icon: const Icon(Icons.science_outlined),
+                      label: const Text('デモ4件'),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: FilledButton.icon(
+                      key: const Key('chat-highlight-add-event'),
+                      onPressed: () => _addEvent(viewModel),
+                      icon: const Icon(Icons.add_comment_outlined),
+                      label: const Text('追加'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildResults(
+    BuildContext context,
+    ChatHighlightsViewModel viewModel,
+  ) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _SectionCard(
+          title: 'ハイライト候補 ${viewModel.candidates.length}件',
+          subtitle: viewModel.candidates.isEmpty
+              ? '閾値を超える区間はまだありません。チャットを追加してください。'
+              : '候補は時系列順です。ピーク値と検出理由を確認してから編集へ渡せます。',
+          trailing: FilledButton.icon(
+            key: const Key('chat-highlight-export'),
+            onPressed: viewModel.candidates.isEmpty
+                ? null
+                : () => unawaited(viewModel.exportManifest()),
+            icon: const Icon(Icons.download_outlined),
+            label: const Text('JSON指示書'),
+          ),
+          child: viewModel.candidates.isEmpty
+              ? const _EmptyState(
+                  icon: Icons.auto_awesome_outlined,
+                  message: 'コメントの盛り上がりを検出すると、ここに候補区間が表示されます。',
+                )
+              : Column(
+                  children: <Widget>[
+                    for (var index = 0;
+                        index < viewModel.candidates.length;
+                        index++)
+                      _CandidateTile(
+                        index: index,
+                        candidate: viewModel.candidates[index],
+                      ),
+                  ],
+                ),
+        ),
+        const SizedBox(height: 16),
+        _SectionCard(
+          title: '保存済みチャット ${viewModel.snapshot.events.length}件',
+          subtitle: '同じIDの重複を除外し、配信開始からの時刻で集計します。',
+          trailing: TextButton.icon(
+            onPressed: viewModel.snapshot.events.isEmpty
+                ? null
+                : () => _confirmClear(context, viewModel),
+            icon: const Icon(Icons.delete_sweep_outlined),
+            label: const Text('全消去'),
+          ),
+          child: viewModel.snapshot.events.isEmpty
+              ? const _EmptyState(
+                  icon: Icons.forum_outlined,
+                  message: 'チャットはまだ保存されていません。',
+                )
+              : Column(
+                  children: <Widget>[
+                    for (final event in viewModel.snapshot.events)
+                      ListTile(
+                        dense: true,
+                        leading: SizedBox(
+                          width: 52,
+                          child: Text(
+                            _formatDuration(event.offset),
+                            style: theme.textTheme.labelLarge?.copyWith(
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        title: Text(event.message),
+                        subtitle: Text(event.author),
+                        trailing: IconButton(
+                          tooltip: 'このコメントを削除',
+                          onPressed: () =>
+                              unawaited(viewModel.removeEvent(event.id)),
+                          icon: const Icon(Icons.close),
+                        ),
+                      ),
+                  ],
+                ),
+        ),
+      ],
+    );
+  }
+
+  void _hydrateControllers(ChatHighlightSnapshot snapshot) {
+    if (_didHydrateControllers) return;
+    _didHydrateControllers = true;
+    _sourceTitle.text = snapshot.sourceTitle;
+    _sourceUrl.text = snapshot.sourceVideoUrl;
+    _window.text = '${snapshot.settings.windowSeconds}';
+    _minimumComments.text = '${snapshot.settings.minimumComments}';
+    _minimumKeywordEvents.text = '${snapshot.settings.minimumKeywordEvents}';
+    _preRoll.text = '${snapshot.settings.preRollSeconds}';
+    _postRoll.text = '${snapshot.settings.postRollSeconds}';
+    _keywords.text = snapshot.settings.keywords.join(', ');
+  }
+
+  void _applySettings(ChatHighlightsViewModel viewModel) {
+    unawaited(
+      viewModel.updateSettings(
+        ChatHighlightSettings(
+          windowSeconds: int.tryParse(_window.text) ?? 0,
+          minimumComments: int.tryParse(_minimumComments.text) ?? 0,
+          minimumKeywordEvents: int.tryParse(_minimumKeywordEvents.text) ?? 0,
+          preRollSeconds: int.tryParse(_preRoll.text) ?? -1,
+          postRollSeconds: int.tryParse(_postRoll.text) ?? -1,
+          keywords: _keywords.text.split(','),
+        ),
+      ),
+    );
+  }
+
+  void _addEvent(ChatHighlightsViewModel viewModel) {
+    final offset = _parseOffset(_eventTime.text);
+    if (offset == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('時刻は「1:23」または秒数で入力してください。')));
+      return;
+    }
+    unawaited(
+      viewModel
+          .addEvent(
+        offset: offset,
+        author: _eventAuthor.text,
+        message: _eventMessage.text,
+      )
+          .then((added) {
+        if (!added || !mounted) return;
+        _eventTime.clear();
+        _eventMessage.clear();
+      }),
+    );
+  }
+
+  Future<void> _confirmClear(
+    BuildContext context,
+    ChatHighlightsViewModel viewModel,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('チャット履歴を全消去しますか？'),
+        content: const Text('配信情報と判定条件は残ります。この操作は取り消せません。'),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('全消去'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) await viewModel.clearEvents();
+  }
+
+  Duration? _parseOffset(String raw) {
+    final parts = raw.trim().split(':');
+    if (parts.length == 1) {
+      final seconds = int.tryParse(parts.single);
+      return seconds == null || seconds < 0 ? null : Duration(seconds: seconds);
+    }
+    if (parts.length == 2 || parts.length == 3) {
+      final values = parts.map(int.tryParse).toList();
+      if (values.any((value) => value == null || value < 0)) return null;
+      final hours = parts.length == 3 ? values[0]! : 0;
+      final minutes = parts.length == 3 ? values[1]! : values[0]!;
+      final seconds = parts.length == 3 ? values[2]! : values[1]!;
+      if ((minutes >= 60 && parts.length == 3) || seconds >= 60) return null;
+      return Duration(hours: hours, minutes: minutes, seconds: seconds);
+    }
+    return null;
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({
+    required this.title,
+    required this.subtitle,
+    required this.child,
+    this.trailing,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget child;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final heading = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          title,
+          style: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          subtitle,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+            height: 1.45,
+          ),
+        ),
+      ],
+    );
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final action = trailing;
+                if (action == null) return heading;
+                if (constraints.maxWidth < 520) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      heading,
+                      const SizedBox(height: 12),
+                      Align(alignment: Alignment.centerRight, child: action),
+                    ],
+                  );
+                }
+                return Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Expanded(child: heading),
+                    const SizedBox(width: 12),
+                    action,
+                  ],
+                );
+              },
+            ),
+            const SizedBox(height: 18),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NumberField extends StatelessWidget {
+  const _NumberField({
+    super.key,
+    required this.controller,
+    required this.label,
+  });
+
+  final TextEditingController controller;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 120,
+      child: TextField(
+        controller: controller,
+        keyboardType: TextInputType.number,
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+        ),
+      ),
+    );
+  }
+}
+
+class _CandidateTile extends StatelessWidget {
+  const _CandidateTile({required this.index, required this.candidate});
+
+  final int index;
+  final ChatHighlightCandidate candidate;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final reason = <String>[
+      if (candidate.triggers.contains(ChatHighlightTrigger.commentBurst))
+        'コメント急増',
+      if (candidate.triggers.contains(ChatHighlightTrigger.keywordBurst))
+        'キーワード反応',
+    ].join(' + ');
+    return Semantics(
+      label: 'ハイライト候補${index + 1}、$reason',
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 10),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                CircleAvatar(child: Text('${index + 1}')),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    '${_formatDuration(candidate.start)} – '
+                    '${_formatDuration(candidate.end)}',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+                Chip(label: Text('熱量 ${candidate.score.toStringAsFixed(1)}x')),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              '$reason ・ ピーク${candidate.peakCommentCount}件'
+              ' ・ キーワード反応${candidate.peakKeywordEventCount}件',
+            ),
+            if (candidate.matchedKeywords.isNotEmpty) ...<Widget>[
+              const SizedBox(height: 6),
+              Text('一致: ${candidate.matchedKeywords.join(', ')}'),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusBanner extends StatelessWidget {
+  const _StatusBanner({required this.message, required this.error});
+
+  final String message;
+  final bool error;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final background =
+        error ? colors.errorContainer : colors.secondaryContainer;
+    final foreground =
+        error ? colors.onErrorContainer : colors.onSecondaryContainer;
+    return Material(
+      color: background,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Row(
+          children: <Widget>[
+            Icon(
+              error ? Icons.error_outline : Icons.check_circle_outline,
+              color: foreground,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(message, style: TextStyle(color: foreground)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.icon, required this.message});
+
+  final IconData icon;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Column(
+        children: <Widget>[
+          Icon(icon, size: 42, color: colors.onSurfaceVariant),
+          const SizedBox(height: 10),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: colors.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadFailure extends StatelessWidget {
+  const _LoadFailure({required this.message, required this.onRetry});
+
+  final String? message;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(Icons.error_outline, size: 48),
+            const SizedBox(height: 12),
+            Text(message ?? '読み込みに失敗しました。'),
+            const SizedBox(height: 12),
+            FilledButton(
+              onPressed: () => unawaited(onRetry()),
+              child: const Text('再試行'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _formatDuration(Duration duration) {
+  final hours = duration.inHours;
+  final minutes = duration.inMinutes.remainder(60);
+  final seconds = duration.inSeconds.remainder(60);
+  if (hours > 0) {
+    return '$hours:${minutes.toString().padLeft(2, '0')}:'
+        '${seconds.toString().padLeft(2, '0')}';
+  }
+  return '$minutes:${seconds.toString().padLeft(2, '0')}';
+}

--- a/lib/utils/feature_route_labels.dart
+++ b/lib/utils/feature_route_labels.dart
@@ -45,6 +45,7 @@ const Map<String, String> _consolidatedFeatureLabels = <String, String>{
   '/ai-writing-assistant': 'AI文章・要約アシスタント',
   '/asset-management': '資産・家計管理',
   '/autonomous-ops-console': '自律オペレーションコンソール',
+  '/chat-highlights': 'チャットハイライト',
   '/focus-timer': '集中タイマー',
   '/life-goals': '人生目標管理',
   '/local-election-700': '2027 統一地方選 700必達管理室',

--- a/test/routes/app_route_names.dart
+++ b/test/routes/app_route_names.dart
@@ -75,6 +75,7 @@ const List<String> kAllAppRoutes = <String>[
   '/business-card-manager',
   '/calendar-events',
   '/carbon-footprint',
+  '/chat-highlights',
   '/career-monthly-kpi',
   '/categories',
   '/cfo-cost-ledger',

--- a/test/ui/features/chat_highlights/data/chat_highlight_export_gateway_test.dart
+++ b/test/ui/features/chat_highlights/data/chat_highlight_export_gateway_test.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/chat_highlights/data/chat_highlight_export_gateway.dart';
+import 'package:my_web_app/ui/features/chat_highlights/domain/chat_highlight_models.dart';
+
+void main() {
+  test('実行文字列ではなく安全なFFmpeg引数配列をJSON出力する', () async {
+    String? content;
+    String? fileName;
+    String? mimeType;
+    final gateway = BrowserChatHighlightExportGateway(
+      now: () => DateTime.utc(2026, 8, 26),
+      downloader: (text, name, mime) {
+        content = text;
+        fileName = name;
+        mimeType = mime;
+      },
+    );
+    const snapshot = ChatHighlightSnapshot(
+      sourceTitle: '配信',
+      sourceVideoUrl: 'https://example.com/video.mp4?x=1&y=2',
+    );
+    const candidate = ChatHighlightCandidate(
+      start: Duration(seconds: 10),
+      end: Duration(seconds: 25),
+      peakCommentCount: 4,
+      peakKeywordEventCount: 2,
+      matchedKeywords: <String>{'神'},
+      triggers: <ChatHighlightTrigger>{ChatHighlightTrigger.commentBurst},
+      score: 1.5,
+    );
+
+    await gateway.export(
+      snapshot: snapshot,
+      candidates: const <ChatHighlightCandidate>[candidate],
+    );
+
+    final document = jsonDecode(content!) as Map<String, dynamic>;
+    final clips = document['clips'] as List<dynamic>;
+    final clip = clips.single as Map<String, dynamic>;
+    expect(fileName, 'chat_highlight_manifest.json');
+    expect(mimeType, 'application/json;charset=utf-8');
+    expect(clip.containsKey('ffmpegCommand'), isFalse);
+    expect(
+      clip['ffmpegArgs'],
+      contains('https://example.com/video.mp4?x=1&y=2'),
+    );
+  });
+}

--- a/test/ui/features/chat_highlights/data/chat_highlight_gateway_test.dart
+++ b/test/ui/features/chat_highlights/data/chat_highlight_gateway_test.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/chat_highlights/data/chat_highlight_gateway.dart';
+import 'package:my_web_app/ui/features/chat_highlights/domain/chat_highlight_models.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  test('時系列チャットと設定をversion付きJSONで復元する', () async {
+    final preferences = await SharedPreferences.getInstance();
+    final gateway = SharedPreferencesChatHighlightGateway(
+      preferences: preferences,
+    );
+    const snapshot = ChatHighlightSnapshot(
+      sourceTitle: '配信',
+      sourceVideoUrl: 'https://example.com/video.mp4',
+      events: <ChatHighlightEvent>[
+        ChatHighlightEvent(
+          id: 'event-1',
+          offset: Duration(seconds: 12),
+          author: 'viewer',
+          message: '神展開',
+        ),
+      ],
+      settings: ChatHighlightSettings(minimumComments: 3),
+    );
+
+    await gateway.save(snapshot);
+    final restored = await gateway.load();
+
+    expect(restored.sourceTitle, '配信');
+    expect(restored.events.single.offset, const Duration(seconds: 12));
+    expect(restored.events.single.message, '神展開');
+    expect(restored.settings.minimumComments, 3);
+    final stored = jsonDecode(
+      preferences.getString(
+        SharedPreferencesChatHighlightGateway.storageKey,
+      )!,
+    ) as Map<String, dynamic>;
+    expect(stored['version'], 1);
+  });
+
+  test('壊れたJSONは空スナップショットへ安全に復旧する', () async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.setString(
+      SharedPreferencesChatHighlightGateway.storageKey,
+      '{broken',
+    );
+
+    final restored = await SharedPreferencesChatHighlightGateway(
+      preferences: preferences,
+    ).load();
+
+    expect(restored.events, isEmpty);
+    expect(restored.sourceVideoUrl, isEmpty);
+  });
+}

--- a/test/ui/features/chat_highlights/domain/detect_chat_highlights_test.dart
+++ b/test/ui/features/chat_highlights/domain/detect_chat_highlights_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/chat_highlights/domain/chat_highlight_models.dart';
+import 'package:my_web_app/ui/features/chat_highlights/domain/detect_chat_highlights.dart';
+
+void main() {
+  const detector = DetectChatHighlights();
+
+  ChatHighlightEvent event(String id, int seconds, String message) {
+    return ChatHighlightEvent(
+      id: id,
+      offset: Duration(seconds: seconds),
+      author: 'viewer',
+      message: message,
+    );
+  }
+
+  test('コメント閾値は集計窓の境界を含めて候補化する', () {
+    final candidates = detector(
+      <ChatHighlightEvent>[
+        event('a', 10, 'a'),
+        event('b', 20, 'b'),
+        event('c', 30, 'c'),
+        event('d', 40, 'd'),
+      ],
+      const ChatHighlightSettings(
+        windowSeconds: 30,
+        minimumComments: 4,
+        minimumKeywordEvents: 9,
+        preRollSeconds: 5,
+        postRollSeconds: 10,
+        keywords: <String>[],
+      ),
+    );
+
+    expect(candidates, hasLength(1));
+    expect(candidates.single.start, const Duration(seconds: 5));
+    expect(candidates.single.end, const Duration(seconds: 50));
+    expect(candidates.single.peakCommentCount, 4);
+    expect(
+      candidates.single.triggers,
+      contains(ChatHighlightTrigger.commentBurst),
+    );
+  });
+
+  test('キーワード反応だけでも大文字小文字を無視して候補化する', () {
+    final candidates = detector(
+      <ChatHighlightEvent>[event('a', 60, 'WOW!'), event('b', 65, 'wow すごい')],
+      const ChatHighlightSettings(
+        minimumComments: 99,
+        minimumKeywordEvents: 2,
+        preRollSeconds: 0,
+        postRollSeconds: 5,
+        keywords: <String>['wow'],
+      ),
+    );
+
+    expect(candidates, hasLength(1));
+    expect(candidates.single.peakKeywordEventCount, 2);
+    expect(candidates.single.matchedKeywords, <String>{'wow'});
+    expect(
+      candidates.single.triggers,
+      contains(ChatHighlightTrigger.keywordBurst),
+    );
+  });
+
+  test('入力順と重複IDに依存せず、重なる候補を1区間へ統合する', () {
+    final candidates = detector(
+      <ChatHighlightEvent>[
+        event('c', 20, 'c'),
+        event('a', 10, 'a'),
+        event('b', 15, 'b'),
+        event('b', 16, '重複ID'),
+        event('d', 24, 'd'),
+      ],
+      const ChatHighlightSettings(
+        windowSeconds: 10,
+        minimumComments: 3,
+        minimumKeywordEvents: 99,
+        preRollSeconds: 2,
+        postRollSeconds: 5,
+        keywords: <String>[],
+      ),
+    );
+
+    expect(candidates, hasLength(1));
+    expect(candidates.single.start, const Duration(seconds: 8));
+    expect(candidates.single.end, const Duration(seconds: 29));
+  });
+
+  test('空入力と閾値未満は候補を返さない', () {
+    expect(
+      detector(const <ChatHighlightEvent>[], const ChatHighlightSettings()),
+      isEmpty,
+    );
+    expect(
+      detector(
+        <ChatHighlightEvent>[
+          event('a', 1, '通常コメント'),
+        ],
+        const ChatHighlightSettings(),
+      ),
+      isEmpty,
+    );
+  });
+}

--- a/test/ui/features/chat_highlights/view_models/chat_highlights_view_model_test.dart
+++ b/test/ui/features/chat_highlights/view_models/chat_highlights_view_model_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/chat_highlights/data/chat_highlight_export_gateway.dart';
+import 'package:my_web_app/ui/features/chat_highlights/data/chat_highlight_gateway.dart';
+import 'package:my_web_app/ui/features/chat_highlights/domain/chat_highlight_models.dart';
+import 'package:my_web_app/ui/features/chat_highlights/view_models/chat_highlights_view_model.dart';
+
+void main() {
+  test('追加時に時系列へ整列・保存し、候補を自動再計算する', () async {
+    final gateway = _MemoryGateway();
+    final exporter = _MemoryExporter();
+    var tick = 0;
+    final viewModel = ChatHighlightsViewModel(
+      gateway: gateway,
+      exportGateway: exporter,
+      now: () => DateTime.fromMicrosecondsSinceEpoch(++tick),
+    );
+    await viewModel.load();
+    await viewModel.updateSettings(
+      const ChatHighlightSettings(
+        minimumComments: 2,
+        minimumKeywordEvents: 99,
+        keywords: <String>[],
+      ),
+    );
+
+    await viewModel.addEvent(
+      offset: const Duration(seconds: 20),
+      author: 'b',
+      message: 'second',
+    );
+    await viewModel.addEvent(
+      offset: const Duration(seconds: 10),
+      author: 'a',
+      message: 'first',
+    );
+
+    expect(viewModel.snapshot.events.map((event) => event.message), <String>[
+      'first',
+      'second',
+    ]);
+    expect(viewModel.candidates, hasLength(1));
+    expect(gateway.saved.events, hasLength(2));
+  });
+
+  test('有効な動画URLと候補がある場合だけ指示書を出力する', () async {
+    final gateway = _MemoryGateway();
+    final exporter = _MemoryExporter();
+    final viewModel = ChatHighlightsViewModel(
+      gateway: gateway,
+      exportGateway: exporter,
+    );
+    await viewModel.load();
+
+    expect(await viewModel.exportManifest(), isFalse);
+    await viewModel.updateSource(
+      title: '配信',
+      url: 'https://example.com/video.mp4',
+    );
+    await viewModel.updateSettings(
+      const ChatHighlightSettings(
+        minimumComments: 1,
+        minimumKeywordEvents: 99,
+        keywords: <String>[],
+      ),
+    );
+    await viewModel.addEvent(
+      offset: const Duration(seconds: 10),
+      author: 'viewer',
+      message: '盛り上がり',
+    );
+
+    expect(await viewModel.exportManifest(), isTrue);
+    expect(exporter.exports, 1);
+  });
+}
+
+class _MemoryGateway implements ChatHighlightGateway {
+  ChatHighlightSnapshot saved = const ChatHighlightSnapshot();
+
+  @override
+  Future<ChatHighlightSnapshot> load() async => saved;
+
+  @override
+  Future<void> save(ChatHighlightSnapshot snapshot) async {
+    saved = snapshot;
+  }
+}
+
+class _MemoryExporter implements ChatHighlightExportGateway {
+  int exports = 0;
+
+  @override
+  Future<void> export({
+    required ChatHighlightSnapshot snapshot,
+    required List<ChatHighlightCandidate> candidates,
+  }) async {
+    exports++;
+  }
+}

--- a/test/ui/features/chat_highlights/views/chat_highlights_page_test.dart
+++ b/test/ui/features/chat_highlights/views/chat_highlights_page_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/chat_highlights/chat_highlights_feature.dart';
+import 'package:my_web_app/ui/features/chat_highlights/data/chat_highlight_export_gateway.dart';
+import 'package:my_web_app/ui/features/chat_highlights/data/chat_highlight_gateway.dart';
+import 'package:my_web_app/ui/features/chat_highlights/domain/chat_highlight_models.dart';
+
+void main() {
+  testWidgets('狭い画面でデモチャットから候補を作り指示書を出力できる', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final gateway = _MemoryGateway();
+    final exporter = _MemoryExporter();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChatHighlightsFeature(
+          gateway: gateway,
+          exportGateway: exporter,
+          now: () => DateTime.utc(2026, 8, 26),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('chat-highlights-narrow')), findsOneWidget);
+    await tester.enterText(
+      find.byKey(const Key('chat-highlight-source-url')),
+      'https://example.com/video.mp4',
+    );
+    await tester.ensureVisible(
+      find.byKey(const Key('chat-highlight-save-source')),
+    );
+    await tester.tap(find.byKey(const Key('chat-highlight-save-source')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const Key('chat-highlight-demo')));
+    await tester.tap(find.byKey(const Key('chat-highlight-demo')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('ハイライト候補 1件'), findsOneWidget);
+    await tester.ensureVisible(find.byKey(const Key('chat-highlight-export')));
+    await tester.tap(find.byKey(const Key('chat-highlight-export')));
+    await tester.pumpAndSettle();
+    expect(exporter.exports, 1);
+  });
+
+  testWidgets('広い画面では設定と結果を2カラム表示する', (tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChatHighlightsFeature(
+          gateway: _MemoryGateway(),
+          exportGateway: _MemoryExporter(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('chat-highlights-wide')), findsOneWidget);
+  });
+}
+
+class _MemoryGateway implements ChatHighlightGateway {
+  ChatHighlightSnapshot snapshot = const ChatHighlightSnapshot();
+
+  @override
+  Future<ChatHighlightSnapshot> load() async => snapshot;
+
+  @override
+  Future<void> save(ChatHighlightSnapshot value) async {
+    snapshot = value;
+  }
+}
+
+class _MemoryExporter implements ChatHighlightExportGateway {
+  int exports = 0;
+
+  @override
+  Future<void> export({
+    required ChatHighlightSnapshot snapshot,
+    required List<ChatHighlightCandidate> candidates,
+  }) async {
+    exports++;
+  }
+}

--- a/test/utils/feature_route_labels_test.dart
+++ b/test/utils/feature_route_labels_test.dart
@@ -8,6 +8,7 @@ void main() {
       expect(featureLabelForRoute('/site-guide-ai'), 'サイト案内AI');
       expect(featureLabelForRoute('/ai-university'), 'AI大学');
       expect(featureLabelForRoute('/release-notes'), 'Release Notes');
+      expect(featureLabelForRoute('/chat-highlights'), 'チャットハイライト');
       expect(featureLabelForRoute('/procrastination-reset'), '先延ばしリセット');
     });
 


### PR DESCRIPTION
## 概要

Issue #1279 の最初の実装スライスとして、ライブ配信チャットの時系列保存、盛り上がり候補の決定的抽出、動画編集用クリップ指示書の出力を追加します。

Refs #1279

## 実装内容

- チャットイベントを端末内へ最大500件、version付きJSONで時系列保存
- 固定集計窓でコメント数またはキーワード反応数の閾値を判定
- 重複IDの排除、境界値を含む判定、重複・接触区間の統合
- 前後余白、集計窓、各閾値、キーワードを画面から設定
- 候補区間、検出理由、ピーク件数、熱量スコアを一覧表示
- 390px / 1280pxのレスポンシブUIとホーム・直接URL導線
- 元動画URLと安全なFFmpeg引数配列を含む編集用JSONマニフェスト出力

## Issue受入条件との対応

- [x] チャットデータを時系列で集計・保存（現段階は手動/デモ入力、端末内保存）
- [x] コメント頻度またはキーワード閾値を超えた区間を自動一覧化
- [x] 候補を短尺動画編集へ渡せるJSON/FFmpeg引数配列としてエクスポート
- [ ] 配信サービスからのリアルタイム自動取り込み
- [ ] 認可・権利確認を伴うサーバー側の実動画レンダリング
- [ ] 実ブラウザーでのダウンロードと外部FFmpeg実行の手動QA

実動画が生成済みと誤認されないよう、画面とファイルは「編集用クリップ指示書」と明記しています。そのためPRはDraft、Issueはopenのままにします。

## 検証

- dart analyze lib/ui/features/chat_highlights test/ui/features/chat_highlights: No issues found
- flutter test --no-pub --concurrency=1 test/ui/features/chat_highlights: 11 passed
- feature_route_labels_test.dart + route_url_sync_test.dart: 19 passed
- home_tool_catalog_consolidation_test.dart + direct_path_routes_test.dart: 5 passed
- git diff --check: passed

全体flutter analyzeは巨大なmain.dartを含めてRAM使用率が上昇し3分超になったため、そのプロセスのみ停止しました。機能限定解析と対象テストは上記の通り完了しています。コミット時のlefthookはローカルPATHに無いという警告がありました。

## サブエージェント記録

- Carson / アルゴリズムレビュー / 読み取り専用: 決定的ソート、重複排除、閾値境界、区間統合、純粋検出器と出力境界の分離を提案。実装とユニットテストへ反映。成果物・残存プロセスなし。
- Leibniz / 統合レビュー / 読み取り専用: version付きSharedPreferences、壊れたJSON復旧、保存件数上限、conditional web exportの既存パターンを確認。データ層と復旧テストへ反映。成果物・残存プロセスなし。
- Popper / UX・出力レビュー / 読み取り専用: 既存Video Studioを実クリップ処理と誤認させない独立導線、候補根拠表示、レスポンシブ・アクセシビリティ、権利境界を提案。画面文言とDraft範囲へ反映。成果物・残存プロセスなし。

サブエージェント所見は決定的検証の代替にはせず、上記解析・テストで検証しました。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Draft scope defers browser download and external FFmpeg execution until the renderer and rights flow are decided; widget tests cover the current visible input/output flow.
