### PR TITLE
chore(vscode): standardize cross-platform terminal profiles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,61 @@
+{
+  "cSpell.words": [
+    "Cupertino",
+    "supabase"
+  ],
+  "cmake.ignoreCMakeListsMissing": true,
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": [],
+  "files.encoding": "utf8",
+  "terminal.integrated.cwd": "${workspaceFolder}",
+  "terminal.integrated.defaultProfile.windows": "my_web_app PowerShell",
+  "terminal.integrated.profiles.windows": {
+    "my_web_app PowerShell": {
+      "source": "PowerShell",
+      "args": [
+        "-NoLogo"
+      ]
+    }
+  },
+  "terminal.integrated.defaultProfile.osx": "my_web_app zsh",
+  "terminal.integrated.profiles.osx": {
+    "my_web_app zsh": {
+      "path": "/bin/zsh",
+      "args": [
+        "-l"
+      ]
+    }
+  },
+  "terminal.integrated.defaultProfile.linux": "my_web_app bash",
+  "terminal.integrated.profiles.linux": {
+    "my_web_app bash": {
+      "path": "/bin/bash",
+      "args": [
+        "-l"
+      ]
+    }
+  },
+  "terminal.integrated.env.windows": {
+    "PYTHONUTF8": "1",
+    "PYTHONIOENCODING": "utf-8"
+  },
+  "terminal.integrated.env.osx": {
+    "PYTHONUTF8": "1",
+    "PYTHONIOENCODING": "utf-8"
+  },
+  "terminal.integrated.env.linux": {
+    "PYTHONUTF8": "1",
+    "PYTHONIOENCODING": "utf-8"
+  },
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-action.json": [
+      ".github/actions/**/action.yml",
+      ".github/actions/**/action.yaml"
+    ],
+    "https://json.schemastore.org/github-workflow.json": [
+      ".github/workflows/*.yml",
+      ".github/workflows/*.yaml"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a tracked workspace `.vscode/settings.json`
- define portable project terminal profiles for Windows PowerShell, macOS zsh, and Linux bash
- start terminals at `${workspaceFolder}` and set non-secret UTF-8 Python environment values on every OS
- preserve the existing non-secret Deno, YAML, encoding, CMake, and spell-check workspace settings

## Why
Issue #1293 requires shared OS-specific terminal defaults and startup environment settings. The profiles use VS Code-supported `source`/`path` declarations and contain no user-specific absolute paths or credentials.

Official references:
- https://code.visualstudio.com/docs/terminal/profiles
- https://code.visualstudio.com/docs/reference/variables-reference
- https://code.visualstudio.com/docs/configure/settings

## Validation
- `python -c ...`: valid JSON; every default profile resolves to a profile defined for that OS; all three env maps and workspace cwd verified
- `git diff --cached --check`: passed
- VS Code CLI `1.129.1` detected locally
- Windows `powershell.exe` and `pwsh.exe` detected locally

No Flutter/Dart build is needed for this IDE-only JSON change.

## Risk / rollback
- The workspace default affects only newly opened VS Code terminals; it does not change the OS login shell, CI, or production runtime.
- `/bin/zsh` and `/bin/bash` assume standard macOS/Linux installations; unusual minimal environments can select a different terminal profile in VS Code.
- Rollback is the single commit in this PR.

## Subagent evidence
- Role: bounded read-only VS Code workspace settings reviewer
- Scope: staged `.vscode/settings.json`; OS profile/default/env consistency, portability, secret leakage, existing environment impact, and missing-profile behavior
- Result: P0/P1/P2 none; references resolve, no secrets or user-specific paths; P3 notes are limited to workspace-default behavior and nonstandard Unix images
- Validation impact: static diff review only; deterministic lead-session checks remain authoritative
- Cleanup impact: no edits, processes, generated artifacts, dependencies, browser state, or Git mutations

Closes #1293

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: IDE-only workspace JSON change; no security, data migration, production, or observability paths are touched.
- Ultrareview-Run: not run; this uses the deterministic false-positive exception path.
