### PR TITLE
ci: emit required checks for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,6 @@ on:
       - main
       - staging
       - develop
-    paths-ignore:
-      - 'docs/**'
-      - 'memory/**'
-      - '.claude/**'
-      - '.codex/**'
-      - '.agents/**'
-      - '*.md'
-      - '**/*.md'
-      - '.github/*.md'
-      - '.github/**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
   push:
     branches:
       - staging   # main は deploy-prod.yml が workflow_call で CI を呼ぶため除外 (二重起動防止)

--- a/scripts/cicd_efficiency_test.py
+++ b/scripts/cicd_efficiency_test.py
@@ -89,6 +89,30 @@ class CicdEfficiencyTest(unittest.TestCase):
         self.assertIn("if: steps.changes.outputs.caption == 'true'", workflow)
         self.assertIn("steps.changes.outputs.web == 'true'", workflow)
 
+    def test_required_ci_checks_are_emitted_for_docs_only_prs(self) -> None:
+        workflow = self.read(".github/workflows/ci.yml")
+        pull_request = workflow.split("  pull_request:", 1)[1].split(
+            "  push:", 1
+        )[0]
+        push = workflow.split("  push:", 1)[1].split("  workflow_call:", 1)[0]
+        lint_job = workflow.split("  lint-and-test:", 1)[1].split(
+            "  security-check:", 1
+        )[0]
+        security_job = workflow.split("  security-check:", 1)[1].split(
+            "  pr-comment:", 1
+        )[0]
+
+        self.assertNotIn("paths-ignore:", pull_request)
+        self.assertIn("paths-ignore:", push)
+        self.assertIn("  workflow_call:", workflow)
+        self.assertIn(
+            "FORCE_ALL: ${{ github.event_name != 'pull_request' }}", workflow
+        )
+        self.assertIn("name: Lint, Format, and Test", workflow)
+        self.assertIn("name: Security Check", workflow)
+        self.assertNotIn("\n    if:", lint_job)
+        self.assertNotIn("\n    if:", security_job)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- run the existing CI workflow for every pull request, including docs-only PRs
- retain docs-only `paths-ignore` on push events
- rely on the existing change classifier to skip Flutter, Deno, web, caption, and migration work when those scopes did not change
- add regression coverage for PR trigger availability, push filtering, workflow_call `FORCE_ALL`, stable required job names, and absence of job-level skip conditions

## Live reproduction
PR #4838 is docs-only. Before this fix it emits neither `Lint, Format, and Test` nor `Security Check`, so the required checks introduced for #1285 can never be satisfied.

After this PR merges, synchronizing #4838 will be the integration proof that both required checks are created and succeed while heavy path-scoped steps remain skipped.

## Validation
- `scripts/cicd_efficiency_test.py`: 9 passed
- `scripts/classify_ci_changes_test.py`: 6 passed
- `scripts/check_cicd_path_filters.py`: passed; push filters remain
- GitHub Actions node runtime check: 198 uses checked
- status-function / inline-Python / PowerShell-splatting checks: 120 workflows checked each
- `git diff --check`: passed

## Risk / rollback
- docs-only PRs now pay the lightweight checkout, classifier, contract-test, and security-scan cost required to emit stable required checks
- expensive Flutter/Deno/web/caption/migration steps remain conditionally path-scoped
- push and workflow_call behavior are preserved
- rollback is the single commit in this PR, but branch protection should first stop requiring contexts that would disappear

## Subagent evidence
- Role: bounded read-only CI follow-up reviewer
- Scope: PR/push/workflow_call events, required job names, classifier conditions, deadlock risk, heavy-step regression, and test robustness
- Result: P0/P1 none; docs-only PR jobs emitted, push filter preserved, heavy scopes remain conditional, workflow_call keeps FORCE_ALL
- P2 remediation: tests now also require workflow_call/FORCE_ALL and reject job-level skip conditions on both required jobs
- Validation impact: static review only; deterministic lead checks and live #4838 integration proof remain authoritative
- Cleanup impact: no edits, Git mutations, processes, generated artifacts, dependencies, browser, or media

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Deterministic required-check availability fix; no deploy, data migration, production runtime, or observability behavior changes.
- Ultrareview-Run: not run; this uses the documented narrow CI exception path with deterministic tests and live PR proof.

Closes #1285