### PR TITLE
fix(ci): standardize untrusted workflow inputs

### DIFF
--- a/.github/workflows/ai-university-reminder.yml
+++ b/.github/workflows/ai-university-reminder.yml
@@ -76,10 +76,11 @@ jobs:
         env:
           SENT_COUNT: ${{ steps.remind.outputs.sent }}
           ELIGIBLE_COUNT: ${{ steps.remind.outputs.eligible }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           STATUS="${{ job.status }}"
           [ "$STATUS" = "success" ] && STATUS_KEY="success" || STATUS_KEY="error"
-          SUMMARY="ai-university-reminder: eligible=$ELIGIBLE_COUNT sent=$SENT_COUNT dry_run=${{ github.event.inputs.dry_run || 'false' }}"
+          SUMMARY="ai-university-reminder: eligible=$ELIGIBLE_COUNT sent=$SENT_COUNT dry_run=$DRY_RUN"
           curl -s -o /dev/null \
             -X POST \
             -H "apikey: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
@@ -96,8 +97,8 @@ jobs:
           SENT_COUNT: ${{ steps.remind.outputs.sent }}
           ELIGIBLE_COUNT: ${{ steps.remind.outputs.eligible }}
           SKIPPED_COUNT: ${{ steps.remind.outputs.skipped }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
-          DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
           STATUS="${{ job.status }}"
           ICON=$([ "$STATUS" = "success" ] && echo "✅" || echo "❌")
           {

--- a/.github/workflows/blog-backfill-from-apis.yml
+++ b/.github/workflows/blog-backfill-from-apis.yml
@@ -28,8 +28,9 @@ jobs:
 
     steps:
       - name: Call schedule-hub blog.backfill_from_apis
+        env:
+          DAYS: ${{ inputs.days }}
         run: |
-          DAYS="${{ inputs.days }}"
           PAYLOAD=$(jq -n --arg action "blog.backfill_from_apis" --argjson days "${DAYS:-60}" \
             '{action: $action, days: $days}')
           echo "Payload: $PAYLOAD"

--- a/.github/workflows/blog-batch-publish.yml
+++ b/.github/workflows/blog-batch-publish.yml
@@ -119,9 +119,13 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+          PLATFORMS_INPUT: ${{ github.event.inputs.platforms }}
+          DELAY_INPUT: ${{ github.event.inputs.delay_seconds }}
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## 実行結果" >> $GITHUB_STEP_SUMMARY
-          echo "- dry_run: ${{ github.event.inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
-          echo "- platforms: ${{ github.event.inputs.platforms }}" >> $GITHUB_STEP_SUMMARY
-          echo "- delay: ${{ github.event.inputs.delay_seconds }}s" >> $GITHUB_STEP_SUMMARY
+          echo "- dry_run: $DRY_RUN_INPUT" >> $GITHUB_STEP_SUMMARY
+          echo "- platforms: $PLATFORMS_INPUT" >> $GITHUB_STEP_SUMMARY
+          echo "- delay: ${DELAY_INPUT}s" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -77,12 +77,15 @@ jobs:
 
       - name: Determine target date and period
         id: period
+        env:
+          TARGET_DATE_INPUT: ${{ github.event.inputs.target_date }}
+          DAYS_INPUT: ${{ github.event.inputs.days || '1' }}
         run: |
-          TARGET_DATE="${{ github.event.inputs.target_date }}"
+          TARGET_DATE="$TARGET_DATE_INPUT"
           if [ -z "$TARGET_DATE" ]; then
             TARGET_DATE=$(TZ=Asia/Tokyo date +%Y-%m-%d)
           fi
-          DAYS="${{ github.event.inputs.days || '1' }}"
+          DAYS="$DAYS_INPUT"
           SINCE=$(date -d "$TARGET_DATE -$DAYS days" +%Y-%m-%d 2>/dev/null || date -v-${DAYS}d -j -f %Y-%m-%d "$TARGET_DATE" +%Y-%m-%d 2>/dev/null || echo "$TARGET_DATE")
           echo "target_date=$TARGET_DATE" >> $GITHUB_OUTPUT
           echo "since=$SINCE" >> $GITHUB_OUTPUT

--- a/.github/workflows/blog-engagement.yml
+++ b/.github/workflows/blog-engagement.yml
@@ -73,11 +73,14 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run || 'false' }}
+          DEVTO_KEY_STATUS: ${{ secrets.DEVTO_API_KEY != '' && 'set' || '⚠️ not set' }}
         run: |
           echo "## Blog Engagement $(TZ=Asia/Tokyo date +'%Y-%m-%d %H:%M JST')" >> $GITHUB_STEP_SUMMARY
           echo "| 項目 | 値 |" >> $GITHUB_STEP_SUMMARY
           echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
           echo "| mode | read-only analytics (auto-reply/follow 恒久廃止 2026-07-13) |" >> $GITHUB_STEP_SUMMARY
-          echo "| dry_run | ${{ github.event.inputs.dry_run || 'false' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| dry_run | $DRY_RUN_INPUT |" >> $GITHUB_STEP_SUMMARY
           echo "| Qiita | ⛔ 停止中 (2026-07-12 アカウント利用停止 → 接触停止) |" >> $GITHUB_STEP_SUMMARY
-          echo "| dev.to key | ${{ secrets.DEVTO_API_KEY != '' && 'set' || '⚠️ not set' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| dev.to key | $DEVTO_KEY_STATUS |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -52,13 +52,15 @@ jobs:
       # ── Step 1.5: 自動スケジュール実行時 — 未投稿ドラフト自動選択 ──────
       - name: Resolve publish draft
         id: auto_select
+        env:
+          DRAFT_PATH_INPUT: ${{ github.event.inputs.draft_path }}
         run: |
           # docs/blog-drafts/ から未投稿ドラフトを日付順(古い順)で探す
           # YYYY-MM-DD.md 形式の日次自動レポートはスキップ
           # frontmatter なし (# 見出しのみ) のファイルも対象
           REQUESTED_DRAFT=""
           if [ "${{ github.event_name }}" != "schedule" ]; then
-            REQUESTED_DRAFT="${{ github.event.inputs.draft_path }}"
+            REQUESTED_DRAFT="$DRAFT_PATH_INPUT"
           fi
 
           if [ -n "$REQUESTED_DRAFT" ] && [ -f "$REQUESTED_DRAFT" ]; then
@@ -276,6 +278,8 @@ jobs:
         env:
           ARTICLE_TITLE: ${{ steps.meta.outputs.title }}
           DRAFT_PATH_VAR: ${{ steps.meta.outputs.draft_path }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+          PLATFORMS_INPUT: ${{ github.event.inputs.platforms }}
         run: |
           DRAFT_PATH="$DRAFT_PATH_VAR"
           TITLE="$ARTICLE_TITLE"
@@ -285,8 +289,8 @@ jobs:
             DRY_RUN="false"
             PLATFORMS="devto"
           else
-            DRY_RUN="${{ github.event.inputs.dry_run }}"
-            PLATFORMS="${{ github.event.inputs.platforms }}"
+            DRY_RUN="$DRY_RUN_INPUT"
+            PLATFORMS="$PLATFORMS_INPUT"
           fi
 
           if [ "$DRY_RUN" = "true" ]; then
@@ -331,6 +335,8 @@ jobs:
           DRAFT_PATH_VAR: ${{ steps.meta.outputs.draft_path }}
           TAGS_VAR: ${{ steps.meta.outputs.tags }}
           DRAFT_PATH_EN: ${{ github.event.inputs.draft_path_en }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+          PLATFORMS_INPUT: ${{ github.event.inputs.platforms }}
         run: |
           DRAFT_PATH="$DRAFT_PATH_VAR"
           TITLE="$ARTICLE_TITLE"
@@ -341,8 +347,8 @@ jobs:
             DRY_RUN="false"
             PLATFORMS="devto"
           else
-            DRY_RUN="${{ github.event.inputs.dry_run }}"
-            PLATFORMS="${{ github.event.inputs.platforms }}"
+            DRY_RUN="$DRY_RUN_INPUT"
+            PLATFORMS="$PLATFORMS_INPUT"
           fi
           
           CONTENT_JP=$(cat "$DRAFT_PATH")
@@ -491,8 +497,9 @@ jobs:
           ARTICLE_TITLE: ${{ steps.meta.outputs.title }}
           QIITA_URL: ${{ steps.publish.outputs.qiita_url }}
           DEVTO_URL: ${{ steps.publish.outputs.devto_url }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
         run: |
-          DRY_RUN="${{ github.event.inputs.dry_run }}"
+          DRY_RUN="$DRY_RUN_INPUT"
           STATUS="success"
           if [ "${{ steps.auto_select.outputs.has_draft }}" = "true" ] && \
              [ "$DRY_RUN" != "true" ] && \
@@ -515,10 +522,13 @@ jobs:
         env:
           ARTICLE_TITLE: ${{ steps.meta.outputs.title }}
           DRAFT_PATH_OUT: ${{ steps.meta.outputs.draft_path }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+          QIITA_URL: ${{ steps.publish.outputs.qiita_url }}
+          DEVTO_URL: ${{ steps.publish.outputs.devto_url }}
         run: |
-          DRY_RUN="${{ github.event.inputs.dry_run }}"
-          QIITA="${{ steps.publish.outputs.qiita_url }}"
-          DEVTO="${{ steps.publish.outputs.devto_url }}"
+          DRY_RUN="$DRY_RUN_INPUT"
+          QIITA="$QIITA_URL"
+          DEVTO="$DEVTO_URL"
           {
             echo "## Blog Publish $(TZ=Asia/Tokyo date +'%Y-%m-%d %H:%M JST')"
             echo ""
@@ -548,6 +558,9 @@ jobs:
           ARTICLE_TITLE: ${{ steps.meta.outputs.title }}
           GH_TOKEN: ${{ secrets.BYPASS_RULES || secrets.GITHUB_TOKEN }}
           BYPASS_TOKEN: ${{ secrets.BYPASS_RULES }}
+          PLATFORMS_INPUT: ${{ github.event.inputs.platforms }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           TODAY=$(date -u +%Y-%m-%d)
           mkdir -p docs/incident-reports
@@ -562,9 +575,9 @@ jobs:
               "${{ github.run_id }}" "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}"
             printf -- "- **draft**: \`%s\`\n" "${DRAFT_PATH_OUT:-unknown}"
             printf -- "- **title**: %s\n" "${ARTICLE_TITLE:-unknown}"
-            printf -- "- **platforms**: %s\n" "${{ github.event.inputs.platforms }}"
-            printf -- "- **event**: %s\n" "${{ github.event_name }}"
-            printf -- "- **actor**: %s\n" "${{ github.triggering_actor }}"
+            printf -- "- **platforms**: %s\n" "$PLATFORMS_INPUT"
+            printf -- "- **event**: %s\n" "$EVENT_NAME"
+            printf -- "- **actor**: %s\n" "$TRIGGERING_ACTOR"
           } >> "$FILE"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build-in-public-extract.yml
+++ b/.github/workflows/build-in-public-extract.yml
@@ -40,8 +40,9 @@ jobs:
           python-version: '3.12'
 
       - name: Run extract
+        env:
+          DAYS: ${{ github.event.inputs.days || '7' }}
         run: |
-          DAYS="${{ github.event.inputs.days || '7' }}"
           python scripts/build_in_public_extract.py --days "$DAYS"
 
       - name: Commit drafts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,10 @@ jobs:
         run: python scripts/check_github_actions_powershell_splatting.py
         continue-on-error: false
 
+      - name: Check GitHub Actions script injection safety
+        run: python scripts/check_github_actions_script_injection.py
+        continue-on-error: false
+
       - name: Test tools-hub MCP smoke response compatibility
         shell: pwsh
         run: ./test/scripts/tools_hub_mcp_smoke_response_test.ps1
@@ -382,7 +386,7 @@ jobs:
           FLUTTER_WEB_TEST="${{ steps.flutter_web_test.outcome }}"
           DENO_TEST="${{ steps.deno_test.outcome }}"
           {
-            echo "## CI Results — \`${{ github.ref_name }}\` @ \`${GITHUB_SHA:0:7}\`"
+            echo "## CI Results — \`${GITHUB_REF_NAME}\` @ \`${GITHUB_SHA:0:7}\`"
             echo ""
             echo "| Scope | Required | Outcome |"
             echo "| --- | --- | --- |"

--- a/.github/workflows/claude-session-hygiene-cron.yml
+++ b/.github/workflows/claude-session-hygiene-cron.yml
@@ -48,10 +48,12 @@ jobs:
       - name: Run session hygiene check
         id: hygiene
         shell: pwsh
+        env:
+          APPLY_INPUT: ${{ inputs.apply }}
         run: |
           New-Item -ItemType Directory -Force -Path memory | Out-Null
           $applyArg = @()
-          if ("${{ github.event_name }}" -eq "schedule" -or "${{ inputs.apply }}" -eq "true") {
+          if ($env:GITHUB_EVENT_NAME -eq "schedule" -or $env:APPLY_INPUT -eq "true") {
             $applyArg = @("--apply")
           }
 

--- a/.github/workflows/competitor-discovery.yml
+++ b/.github/workflows/competitor-discovery.yml
@@ -59,11 +59,14 @@ jobs:
       # ── Step 2: カテゴリ別 Gemini 調査 ───────────────────────────────────
       - name: Step 2 - カテゴリ別 trending 競合発掘 (Gemini Flash)
         id: discover
+        env:
+          CATEGORIES_INPUT: ${{ github.event.inputs.categories || 'productivity,ai-coding,fintech,ai-platform,e-commerce,health,collaboration,hr-tech,legal-tech,data' }}
+          MAX_PER_CATEGORY_INPUT: ${{ github.event.inputs.max_per_category || '5' }}
         run: |
           WEEK=$(date +'%Y-%V')
           echo "discovery_week=$WEEK" >> $GITHUB_OUTPUT
-          CATEGORIES="${{ github.event.inputs.categories || 'productivity,ai-coding,fintech,ai-platform,e-commerce,health,collaboration,hr-tech,legal-tech,data' }}"
-          MAX_PER_CAT="${{ github.event.inputs.max_per_category || '5' }}"
+          CATEGORIES="$CATEGORIES_INPUT"
+          MAX_PER_CAT="$MAX_PER_CATEGORY_INPUT"
           python3 .github/scripts/competitor_discover.py \
             --categories="$CATEGORIES" \
             --max-per-cat="$MAX_PER_CAT" \

--- a/.github/workflows/competitor-monitoring.yml
+++ b/.github/workflows/competitor-monitoring.yml
@@ -48,6 +48,9 @@ jobs:
       # ── Step 1: 日付・イベントカレンダー判定 ─────────────────────────────
       - name: Step 1 - 日付 + 特記イベント検出
         id: calendar
+        env:
+          EVENT_OVERRIDE_INPUT: ${{ github.event.inputs.event_override || '' }}
+          FOCUS_COMPETITOR_INPUT: ${{ github.event.inputs.focus_competitor || '' }}
         run: |
           TODAY=$(TZ=Asia/Tokyo date +'%Y-%m-%d')
           MONTH=$(TZ=Asia/Tokyo date +'%m')
@@ -78,14 +81,14 @@ jobs:
           esac
 
           # 手動 override
-          if [ -n "${{ github.event.inputs.event_override }}" ]; then
-            SPECIAL_EVENT="${{ github.event.inputs.event_override }}"
+          if [ -n "$EVENT_OVERRIDE_INPUT" ]; then
+            SPECIAL_EVENT="$EVENT_OVERRIDE_INPUT"
             EVENT_DESC="手動指定イベント: $SPECIAL_EVENT"
           fi
 
           echo "special_event=$SPECIAL_EVENT" >> $GITHUB_OUTPUT
           echo "event_desc=$EVENT_DESC" >> $GITHUB_OUTPUT
-          echo "focus=${{ github.event.inputs.focus_competitor || '' }}" >> $GITHUB_OUTPUT
+          echo "focus=$FOCUS_COMPETITOR_INPUT" >> $GITHUB_OUTPUT
 
           echo "📅 Today: $TODAY"
           echo "🎯 Special event: ${SPECIAL_EVENT:-なし}"

--- a/.github/workflows/daily-report-freshness-monitor.yml
+++ b/.github/workflows/daily-report-freshness-monitor.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Resolve target date
         id: target
+        env:
+          DATE_INPUT: ${{ inputs.date || '' }}
         run: |
-          DATE="${{ inputs.date }}"
+          DATE="$DATE_INPUT"
           if [ -z "$DATE" ]; then
             DATE=$(TZ=Asia/Tokyo date +%Y-%m-%d)
           fi

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -185,7 +185,7 @@ jobs:
             echo "| Firebase channel | dev |"
             echo "| URL | https://my-web-app-b67f4--dev.web.app |"
             echo ""
-            echo "**Actor**: ${{ github.actor }} | **Branch**: \`${{ github.ref_name }}\`"
+            echo "**Actor**: $GITHUB_ACTOR | **Branch**: \`$GITHUB_REF_NAME\`"
           } >> $GITHUB_STEP_SUMMARY
 
   notify:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -985,77 +985,55 @@ jobs:
     steps:
       - name: Notify Slack on Success
         if: needs.deploy.result == 'success' && needs.deploy.outputs.deployable == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: |
-          cat <<EOF > payload.json
-          {
-            "text": "✅ Production Deployment Successful!",
-            "blocks": [
-              {
-                "type": "header",
-                "text": { "type": "plain_text", "text": "✅ Production Deployment Successful!" }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  { "type": "mrkdwn", "text": "*Environment:*\nProduction" },
-                  { "type": "mrkdwn", "text": "*Branch:*\n\`${{ github.ref_name }}\`" },
-                  { "type": "mrkdwn", "text": "*Commit:*\n\`${{ github.sha }}\`" },
-                  { "type": "mrkdwn", "text": "*Author:*\n${{ github.actor }}" }
-                ]
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": { "type": "plain_text", "text": "View Workflow" },
-                    "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  },
-                  {
-                    "type": "button",
-                    "text": { "type": "plain_text", "text": "View Site" },
-                    "url": "https://${{ secrets.FIREBASE_PROJECT_ID }}.web.app"
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
-          curl -X POST -H 'Content-type: application/json' --data @payload.json ${{ secrets.SLACK_WEBHOOK_URL }} --max-time 10 || true
+          jq -n \
+            --arg branch "$GITHUB_REF_NAME" \
+            --arg commit "$GITHUB_SHA" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg workflow_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --arg site_url "https://$FIREBASE_PROJECT_ID.web.app" \
+            '{
+              text: "✅ Production Deployment Successful!",
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: "✅ Production Deployment Successful!"}},
+                {type: "section", fields: [
+                  {type: "mrkdwn", text: "*Environment:*\nProduction"},
+                  {type: "mrkdwn", text: ("*Branch:*\n`" + $branch + "`")},
+                  {type: "mrkdwn", text: ("*Commit:*\n`" + $commit + "`")},
+                  {type: "mrkdwn", text: ("*Author:*\n" + $actor)}
+                ]},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "View Workflow"}, url: $workflow_url},
+                  {type: "button", text: {type: "plain_text", text: "View Site"}, url: $site_url}
+                ]}
+              ]
+            }' > payload.json
+          curl -X POST -H 'Content-type: application/json' --data @payload.json "$SLACK_WEBHOOK_URL" --max-time 10 || true
 
       - name: Notify Slack on Failure
         if: needs.deploy.result == 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
         run: |
-          cat <<EOF > payload.json
-          {
-            "text": "❌ Production Deployment Failed!",
-            "blocks": [
-              {
-                "type": "header",
-                "text": { "type": "plain_text", "text": "❌ Production Deployment Failed!" }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Deploy Status:* \`${{ needs.deploy.result }}\`\n*Author:* ${{ github.actor }}"
-                }
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": { "type": "plain_text", "text": "View Logs" },
-                    "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                    "style": "danger"
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
-          curl -X POST -H 'Content-type: application/json' --data @payload.json ${{ secrets.SLACK_WEBHOOK_URL }} --max-time 10 || true
+          jq -n \
+            --arg result "$DEPLOY_RESULT" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg workflow_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            '{
+              text: "❌ Production Deployment Failed!",
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: "❌ Production Deployment Failed!"}},
+                {type: "section", text: {type: "mrkdwn", text: ("*Deploy Status:* `" + $result + "`\n*Author:* " + $actor)}},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "View Logs"}, url: $workflow_url, style: "danger"}
+                ]}
+              ]
+            }' > payload.json
+          curl -X POST -H 'Content-type: application/json' --data @payload.json "$SLACK_WEBHOOK_URL" --max-time 10 || true
 
       - name: Comment on commit
         if: needs.deploy.result == 'success' && needs.deploy.outputs.deployable == 'true'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -215,7 +215,7 @@ jobs:
             echo "| Firebase channel | staging |"
             echo "| URL | https://my-web-app-b67f4--staging.web.app |"
             echo ""
-            echo "**Actor**: ${{ github.actor }} | **Branch**: \`${{ github.ref_name }}\`"
+            echo "**Actor**: $GITHUB_ACTOR | **Branch**: \`$GITHUB_REF_NAME\`"
           } >> $GITHUB_STEP_SUMMARY
 
   notify:

--- a/.github/workflows/fix-supabase-network.yml
+++ b/.github/workflows/fix-supabase-network.yml
@@ -33,14 +33,16 @@ jobs:
     steps:
       - name: Determine action
         id: action
+        env:
+          ACTION_INPUT: ${{ github.event.inputs.action || 'check' }}
         run: |
           # push トリガー時は allow-all をデフォルト
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "action=allow-all" >> $GITHUB_OUTPUT
             echo "🔧 push トリガー検出 — allow-all で実行"
           else
-            echo "action=${{ github.event.inputs.action }}" >> $GITHUB_OUTPUT
-            echo "🔧 workflow_dispatch — action=${{ github.event.inputs.action }}"
+            echo "action=$ACTION_INPUT" >> $GITHUB_OUTPUT
+            echo "🔧 workflow_dispatch — action=$ACTION_INPUT"
           fi
 
       - name: Check current Network Restrictions

--- a/.github/workflows/horse-racing-update.yml
+++ b/.github/workflows/horse-racing-update.yml
@@ -46,20 +46,22 @@ jobs:
 
       - name: 対象日付を設定
         id: date
+        env:
+          INPUT_DATE: ${{ inputs.date }}
         run: |
-          if [ -n "${{ inputs.date }}" ]; then
-            echo "TARGET_DATE=${{ inputs.date }}" >> "$GITHUB_ENV"
+          if [ -n "$INPUT_DATE" ]; then
+            echo "TARGET_DATE=$INPUT_DATE" >> "$GITHUB_ENV"
           else
             echo "TARGET_DATE=$(TZ=Asia/Tokyo date +%Y-%m-%d)" >> "$GITHUB_ENV"
           fi
 
       - name: 競馬情報更新 (all mode)
         env:
+          MODE: ${{ inputs.mode || 'all' }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           TOOLS_HUB_URL: ${{ secrets.SUPABASE_URL_PROD }}/functions/v1/tools-hub
         run: |
-          MODE="${{ inputs.mode }}"
           # 専用ステップがある mode は skip (二重実行 + 504 timeout 防止)
           # history/evaluate/backfill/stats/dqs_recalc は各専用ステップで処理
           SKIP_MODES="history evaluate backfill stats dqs_recalc"
@@ -73,10 +75,10 @@ jobs:
 
       - name: 前走情報取得 (JST 9時台 or history/all モード時のみ)
         env:
+          MODE: ${{ inputs.mode || 'all' }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          MODE="${{ inputs.mode }}"
           HOUR=$(TZ=Asia/Tokyo date +%H)
           if [ "$HOUR" = "09" ] || [ "$MODE" = "history" ] || [ "$MODE" = "all" ]; then
             echo "前走情報取得を実行 (時刻: ${HOUR}時, モード: ${MODE:-all})"
@@ -87,11 +89,11 @@ jobs:
 
       - name: 精度再評価バッチ (JST 17〜23時台 or evaluate/all モード時のみ)
         env:
+          MODE: ${{ inputs.mode || 'all' }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           TOOLS_HUB_URL: ${{ secrets.SUPABASE_URL_PROD }}/functions/v1/tools-hub
         run: |
-          MODE="${{ inputs.mode }}"
           HOUR=$(TZ=Asia/Tokyo date +%H)
           # JST 17:00〜23:00 に実行 — 結果は通常17時以降に確定するため即時評価
           # evaluate は冪等なので同一レースの二重実行はスキップされる
@@ -104,15 +106,15 @@ jobs:
 
       - name: 過去学習データbackfill (日曜JST 23時台 or backfill モード時のみ)
         env:
+          MODE: ${{ inputs.mode || 'all' }}
+          DAYS: ${{ inputs.days || '21' }}
+          FORCE: ${{ inputs.force || 'false' }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           TOOLS_HUB_URL: ${{ secrets.SUPABASE_URL_PROD }}/functions/v1/tools-hub
         run: |
-          MODE="${{ inputs.mode }}"
           HOUR=$(TZ=Asia/Tokyo date +%H)
           DOW=$(TZ=Asia/Tokyo date +%u)
-          DAYS="${{ inputs.days || '21' }}"
-          FORCE="${{ inputs.force || 'false' }}"
           if [ "$MODE" = "backfill" ] || ([ "$DOW" = "7" ] && [ "$HOUR" = "23" ]); then
             echo "過去学習データbackfillを実行 (DOW=${DOW}, 時刻=${HOUR}時, days=${DAYS}, force=${FORCE})"
             FORCE_FLAG=""
@@ -124,12 +126,12 @@ jobs:
 
       - name: 学習統計レポート (JST 0時台 or stats/all モード時のみ)
         env:
+          MODE: ${{ inputs.mode || 'all' }}
+          STAT_DAYS: ${{ inputs.days || '7' }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          MODE="${{ inputs.mode }}"
           HOUR=$(TZ=Asia/Tokyo date +%H)
-          STAT_DAYS="${{ inputs.days || '7' }}"
           if [ "$MODE" = "stats" ] || [ "$MODE" = "all" ] || [ "${MODE}" = "" ] && [ "$HOUR" = "00" ]; then
             echo "学習統計レポートを出力 (時刻: ${HOUR}時, モード: ${MODE:-all}, days=${STAT_DAYS})"
             python scripts/fetch_horse_racing.py --mode stats --days "$STAT_DAYS"
@@ -139,10 +141,10 @@ jobs:
 
       - name: データ品質スコア再計算 (日曜JST 1時台 or dqs_recalc モード時のみ)
         env:
+          MODE: ${{ inputs.mode || 'all' }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          MODE="${{ inputs.mode }}"
           HOUR=$(TZ=Asia/Tokyo date +%H)
           DOW=$(TZ=Asia/Tokyo date +%u)
           if [ "$MODE" = "dqs_recalc" ] || ([ "$DOW" = "7" ] && [ "$HOUR" = "01" ]); then
@@ -153,8 +155,10 @@ jobs:
           fi
 
       - name: 完了サマリー
+        env:
+          SUMMARY_MODE: ${{ inputs.mode || 'all' }}
         run: |
           echo "### 競馬情報更新完了" >> "$GITHUB_STEP_SUMMARY"
           echo "- 対象日: $TARGET_DATE" >> "$GITHUB_STEP_SUMMARY"
-          echo "- モード: ${{ inputs.mode || 'all' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- モード: $SUMMARY_MODE" >> "$GITHUB_STEP_SUMMARY"
           echo "- 実行時刻: $(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M JST')" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/kg-indexer-nightly.yml
+++ b/.github/workflows/kg-indexer-nightly.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Resolve apply mode
         id: mode
         shell: bash
+        env:
+          APPLY_INPUT: ${{ inputs.apply }}
         run: |
-          APPLY_INPUT="${{ inputs.apply }}"
           if [ -z "$APPLY_INPUT" ]; then
             APPLY_INPUT="true"
           fi

--- a/.github/workflows/kokumin-election-intelligence-update.yml
+++ b/.github/workflows/kokumin-election-intelligence-update.yml
@@ -48,10 +48,12 @@ jobs:
 
       - name: Refresh official snapshot
         shell: bash
+        env:
+          ALLOW_LARGE_DROP_INPUT: ${{ inputs.allow_large_drop || false }}
         run: |
           set -euo pipefail
           args=()
-          if [[ "${{ inputs.allow_large_drop || false }}" == "true" ]]; then
+          if [[ "$ALLOW_LARGE_DROP_INPUT" == "true" ]]; then
             args+=(--allow-large-drop)
           fi
           python scripts/update_kokumin_local_endorsements.py "${args[@]}"

--- a/.github/workflows/mobile-release-build.yml
+++ b/.github/workflows/mobile-release-build.yml
@@ -101,9 +101,12 @@ jobs:
 
       - name: Resolve build version
         shell: bash
+        env:
+          BUILD_NAME_INPUT: ${{ inputs.build_name || '' }}
+          BUILD_NUMBER_INPUT: ${{ inputs.build_number || '' }}
         run: |
-          build_name="${{ inputs.build_name }}"
-          build_number="${{ inputs.build_number }}"
+          build_name="$BUILD_NAME_INPUT"
+          build_number="$BUILD_NUMBER_INPUT"
           if [ -z "$build_name" ]; then
             build_name="$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d '+' -f 1)"
           fi
@@ -183,9 +186,12 @@ jobs:
 
       - name: Resolve build version
         shell: bash
+        env:
+          BUILD_NAME_INPUT: ${{ inputs.build_name || '' }}
+          BUILD_NUMBER_INPUT: ${{ inputs.build_number || '' }}
         run: |
-          build_name="${{ inputs.build_name }}"
-          build_number="${{ inputs.build_number }}"
+          build_name="$BUILD_NAME_INPUT"
+          build_number="$BUILD_NUMBER_INPUT"
           if [ -z "$build_name" ]; then
             build_name="$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d '+' -f 1)"
           fi

--- a/.github/workflows/notebooklm-issue-crosscheck.yml
+++ b/.github/workflows/notebooklm-issue-crosscheck.yml
@@ -80,10 +80,13 @@ jobs:
       - name: Run cross-check
         id: run
         continue-on-error: true
+        env:
+          LIMIT: ${{ inputs.limit || '200' }}
+          COMMENT_TARGET: ${{ inputs.comment_target || '1647' }}
         run: |
           PYTHONUTF8=1 python scripts/notebooklm_issue_crosscheck.py \
-            --limit "${{ inputs.limit || '200' }}" \
-            --comment-on-issue "${{ inputs.comment_target || '1647' }}" \
+            --limit "$LIMIT" \
+            --comment-on-issue "$COMMENT_TARGET" \
             --json-out crosscheck_report.json \
             > crosscheck_report.txt 2>crosscheck_err.txt || true
           echo "--- stdout ---"

--- a/.github/workflows/notebooklm-requirements-to-issues.yml
+++ b/.github/workflows/notebooklm-requirements-to-issues.yml
@@ -128,15 +128,21 @@ jobs:
       - name: Extract requirements and create Issues
         if: steps.restore_auth.outputs.auth_ready == 'true' && steps.capture_notebooklm_list.outputs.list_ready == 'true'
         shell: bash
+        env:
+          START_INDEX_INPUT: ${{ inputs.start_index || '1' }}
+          LIMIT_INPUT: ${{ inputs.limit || '0' }}
+          MAX_CREATED_ISSUES_INPUT: ${{ inputs.max_created_issues || '9' }}
+          REQUIREMENTS_PER_NOTEBOOK_INPUT: ${{ inputs.requirements_per_notebook || '3' }}
+          CREATE_ISSUES_INPUT: ${{ inputs.create_issues }}
         run: |
           set -euo pipefail
           CREATE_ISSUES="true"
-          START_INDEX="${{ inputs.start_index || '1' }}"
-          LIMIT="${{ inputs.limit || '0' }}"
-          MAX_CREATED_ISSUES="${{ inputs.max_created_issues || '9' }}"
-          REQUIREMENTS_PER_NOTEBOOK="${{ inputs.requirements_per_notebook || '3' }}"
+          START_INDEX="$START_INDEX_INPUT"
+          LIMIT="$LIMIT_INPUT"
+          MAX_CREATED_ISSUES="$MAX_CREATED_ISSUES_INPUT"
+          REQUIREMENTS_PER_NOTEBOOK="$REQUIREMENTS_PER_NOTEBOOK_INPUT"
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            CREATE_ISSUES="${{ inputs.create_issues }}"
+            CREATE_ISSUES="$CREATE_ISSUES_INPUT"
           fi
           CREATE_ARGS=()
           if [ "${CREATE_ISSUES}" = "true" ]; then

--- a/.github/workflows/notebooklm-video-pipeline.yml
+++ b/.github/workflows/notebooklm-video-pipeline.yml
@@ -75,6 +75,11 @@ jobs:
       HAS_ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY != '' }}
       HAS_YOUTUBE_CLIENT_SECRET_JSON: ${{ secrets.YOUTUBE_CLIENT_SECRET_JSON != '' }}
       HAS_YOUTUBE_TOKEN_JSON: ${{ secrets.YOUTUBE_TOKEN_JSON != '' }}
+      PIPELINE_NOTEBOOK_ID: ${{ inputs.notebook_id }}
+      PIPELINE_ARTIFACT_ID: ${{ inputs.artifact_id }}
+      PIPELINE_TITLE: ${{ inputs.title }}
+      PIPELINE_SERIES_NUMBER: ${{ inputs.series_number }}
+      PIPELINE_SLUG: ${{ inputs.slug }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -175,34 +180,34 @@ jobs:
 
       - name: Step 1 — Download video from NotebookLM
         run: |
-          notebooklm use ${{ inputs.notebook_id }}
-          notebooklm download video -a ${{ inputs.artifact_id }} \
-            videos/${{ inputs.slug }}.mp4
-          ls -lh videos/${{ inputs.slug }}.mp4
+          notebooklm use "$PIPELINE_NOTEBOOK_ID"
+          notebooklm download video -a "$PIPELINE_ARTIFACT_ID" \
+            "videos/$PIPELINE_SLUG.mp4"
+          ls -lh "videos/$PIPELINE_SLUG.mp4"
           ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1 \
-            videos/${{ inputs.slug }}.mp4 | tee /tmp/duration.txt
+            "videos/$PIPELINE_SLUG.mp4" | tee /tmp/duration.txt
 
       - name: Step 2 — Transcribe via ElevenLabs Scribe
         run: |
           python scripts/video/transcribe.py \
-            videos/${{ inputs.slug }}.mp4
+            "videos/$PIPELINE_SLUG.mp4"
 
       - name: Step 3 — Build SRT (custom splitter)
         env:
           ASR_CORRECTIONS: ${{ inputs.asr_corrections_json }}
         run: |
           python scripts/video/build_srt.py \
-            videos/edit/transcripts/${{ inputs.slug }}.json \
+            "videos/edit/transcripts/$PIPELINE_SLUG.json" \
             videos/master.srt
 
       - name: Step 3b - Build Shorts package manifest (optional)
         if: ${{ inputs.generate_shorts_package }}
         run: |
           python scripts/video/build_shorts_package.py \
-            videos/edit/transcripts/${{ inputs.slug }}.json \
-            --source-video videos/${{ inputs.slug }}.mp4 \
-            --source-url "notebooklm://${{ inputs.notebook_id }}/${{ inputs.artifact_id }}" \
-            --title "${{ inputs.title }}" \
+            "videos/edit/transcripts/$PIPELINE_SLUG.json" \
+            --source-video "videos/$PIPELINE_SLUG.mp4" \
+            --source-url "notebooklm://$PIPELINE_NOTEBOOK_ID/$PIPELINE_ARTIFACT_ID" \
+            --title "$PIPELINE_TITLE" \
             --output-dir videos/shorts \
             --count 3
 
@@ -232,7 +237,7 @@ jobs:
           FADE_OUT=$(python -c "print(round(${MAIN_DUR} - 0.05, 2))")
           ffmpeg -y \
             -i videos/intro.mp4 \
-            -i videos/${{ inputs.slug }}.mp4 \
+            -i "videos/$PIPELINE_SLUG.mp4" \
             -i videos/outro.mp4 \
             -filter_complex "[1:a]aresample=44100,afade=t=in:st=0:d=0.05,afade=t=out:st=${FADE_OUT}:d=0.05[a1];[0:v:0][0:a:0][1:v:0][a1][2:v:0][2:a:0]concat=n=3:v=1:a=1[v][a];[v]eq=saturation=1.15:contrast=1.05:gamma=0.95[vout]" \
             -map "[vout]" -map "[a]" -c:v libx264 -preset fast -crf 22 \
@@ -255,8 +260,8 @@ jobs:
           python scripts/video/add_provenance.py \
             --input videos/output_D.mp4 \
             --output videos/output_D_provenanced.mp4 \
-            --title "${{ inputs.title }}" \
-            --series-number "${{ inputs.series_number }}" \
+            --title "$PIPELINE_TITLE" \
+            --series-number "$PIPELINE_SERIES_NUMBER" \
             --source-file videos/master.srt \
             --model "NotebookLM Deep Research + Claude Code Win版"
 
@@ -265,7 +270,7 @@ jobs:
         run: |
           OUT=$(python scripts/upload_youtube.py upload \
             --file videos/output_D_provenanced.mp4 \
-            --title "${{ inputs.title }} — 自分株式会社 AI大学解説 #${{ inputs.series_number }}" \
+            --title "$PIPELINE_TITLE — 自分株式会社 AI大学解説 #$PIPELINE_SERIES_NUMBER" \
             --description "NotebookLM Deep Research + 自分株式会社 AI大学 編集スタジオで生成。詳細は https://my-web-app-b67f4.web.app/ai-university" \
             --privacy unlisted)
           echo "$OUT"
@@ -286,8 +291,8 @@ jobs:
             exit 1
           fi
 
-          LABEL="番外: ${{ inputs.title }} (D variant)"
-          DESCRIPTION="NotebookLM Deep Research + intro/outro + カラーグレード + 字幕焼き込み。AI大学シリーズ #${{ inputs.series_number }}。"
+          LABEL="番外: $PIPELINE_TITLE (D variant)"
+          DESCRIPTION="NotebookLM Deep Research + intro/outro + カラーグレード + 字幕焼き込み。AI大学シリーズ #$PIPELINE_SERIES_NUMBER。"
 
           python scripts/embed_video_in_philosophy.py \
             --video-id "$VIDEO_ID" \
@@ -299,8 +304,8 @@ jobs:
           git config user.email 'notebooklm-video-pipeline[bot]@users.noreply.github.com'
           git add lib/pages/philosophy_page.dart
           git commit \
-            -m "feat(philosophy): embed video #${{ inputs.series_number }} (NotebookLM auto pipeline)" \
-            -m "VIDEO_ID=$VIDEO_ID  DURATION=$VIDEO_DURATION  TITLE=${{ inputs.title }}"
+            -m "feat(philosophy): embed video #$PIPELINE_SERIES_NUMBER (NotebookLM auto pipeline)" \
+            -m "VIDEO_ID=$VIDEO_ID  DURATION=$VIDEO_DURATION  TITLE=$PIPELINE_TITLE"
           git push origin HEAD:main
 
       - name: Notify Slack on success
@@ -315,32 +320,27 @@ jobs:
             echo "::warning::SLACK_WEBHOOK_URL not set — skipping Slack notify"
             exit 0
           fi
-          cat <<EOF > payload.json
-          {
-            "text": "🎬 NotebookLM video pipeline complete: ${{ inputs.title }}",
-            "blocks": [
-              {
-                "type": "header",
-                "text": { "type": "plain_text", "text": "🎬 動画パイプライン完了 #${{ inputs.series_number }}", "emoji": true }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  { "type": "mrkdwn", "text": "*Title:*\n${{ inputs.title }}" },
-                  { "type": "mrkdwn", "text": "*Duration:*\n$VIDEO_DURATION" },
-                  { "type": "mrkdwn", "text": "*Video:*\nhttps://youtu.be/$VIDEO_ID" },
-                  { "type": "mrkdwn", "text": "*Series:*\n#${{ inputs.series_number }}" }
-                ]
-              },
-              {
-                "type": "context",
-                "elements": [
-                  { "type": "mrkdwn", "text": "🤖 Auto-pipeline run: <$RUN_URL|view logs>  /  Step 8 embedded into philosophy_page.dart on main" }
-                ]
-              }
-            ]
-          }
-          EOF
+          jq -n \
+            --arg title "$PIPELINE_TITLE" \
+            --arg series "$PIPELINE_SERIES_NUMBER" \
+            --arg duration "$VIDEO_DURATION" \
+            --arg video_id "$VIDEO_ID" \
+            --arg run_url "$RUN_URL" \
+            '{
+              text: ("🎬 NotebookLM video pipeline complete: " + $title),
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: ("🎬 動画パイプライン完了 #" + $series), emoji: true}},
+                {type: "section", fields: [
+                  {type: "mrkdwn", text: ("*Title:*\n" + $title)},
+                  {type: "mrkdwn", text: ("*Duration:*\n" + $duration)},
+                  {type: "mrkdwn", text: ("*Video:*\nhttps://youtu.be/" + $video_id)},
+                  {type: "mrkdwn", text: ("*Series:*\n#" + $series)}
+                ]},
+                {type: "context", elements: [
+                  {type: "mrkdwn", text: ("🤖 Auto-pipeline run: <" + $run_url + "|view logs>  /  Step 8 embedded into philosophy_page.dart on main")}
+                ]}
+              ]
+            }' > payload.json
           curl -X POST -H 'Content-type: application/json' --data @payload.json "$SLACK_WEBHOOK_URL" --max-time 10 || true
 
       - name: Notify Slack on failure
@@ -353,32 +353,28 @@ jobs:
             echo "::warning::SLACK_WEBHOOK_URL not set — skipping Slack notify"
             exit 0
           fi
-          cat <<EOF > payload.json
-          {
-            "text": "❌ NotebookLM video pipeline FAILED: ${{ inputs.title }}",
-            "blocks": [
-              {
-                "type": "header",
-                "text": { "type": "plain_text", "text": "❌ 動画パイプライン失敗 #${{ inputs.series_number }}", "emoji": true }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  { "type": "mrkdwn", "text": "*Title:*\n${{ inputs.title }}" },
-                  { "type": "mrkdwn", "text": "*Slug:*\n${{ inputs.slug }}" },
-                  { "type": "mrkdwn", "text": "*Notebook:*\n${{ inputs.notebook_id }}" },
-                  { "type": "mrkdwn", "text": "*Artifact:*\n${{ inputs.artifact_id }}" }
-                ]
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  { "type": "button", "text": { "type": "plain_text", "text": "View failed run" }, "url": "$RUN_URL", "style": "danger" }
-                ]
-              }
-            ]
-          }
-          EOF
+          jq -n \
+            --arg title "$PIPELINE_TITLE" \
+            --arg series "$PIPELINE_SERIES_NUMBER" \
+            --arg slug "$PIPELINE_SLUG" \
+            --arg notebook_id "$PIPELINE_NOTEBOOK_ID" \
+            --arg artifact_id "$PIPELINE_ARTIFACT_ID" \
+            --arg run_url "$RUN_URL" \
+            '{
+              text: ("❌ NotebookLM video pipeline FAILED: " + $title),
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: ("❌ 動画パイプライン失敗 #" + $series), emoji: true}},
+                {type: "section", fields: [
+                  {type: "mrkdwn", text: ("*Title:*\n" + $title)},
+                  {type: "mrkdwn", text: ("*Slug:*\n" + $slug)},
+                  {type: "mrkdwn", text: ("*Notebook:*\n" + $notebook_id)},
+                  {type: "mrkdwn", text: ("*Artifact:*\n" + $artifact_id)}
+                ]},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "View failed run"}, url: $run_url, style: "danger"}
+                ]}
+              ]
+            }' > payload.json
           curl -X POST -H 'Content-type: application/json' --data @payload.json "$SLACK_WEBHOOK_URL" --max-time 10 || true
 
 # 残スコープ (Win版#132 part 38+ / cross-instance-pr 検討):

--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -51,12 +51,19 @@ jobs:
 
       - name: Call schedule-hub:notion.sync_wbs
         id: sync
+        env:
+          LIMIT_INPUT: ${{ github.event.inputs.limit || '30' }}
+          OFFSET_INPUT: ${{ github.event.inputs.offset || '0' }}
         run: |
+          PAYLOAD=$(jq -n \
+            --arg limit "$LIMIT_INPUT" \
+            --arg offset "$OFFSET_INPUT" \
+            '{action: "notion.sync_wbs", limit: ($limit | tonumber), offset: ($offset | tonumber)}')
           RESP=$(curl -sS -X POST \
             "https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/schedule-hub" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"action\":\"notion.sync_wbs\",\"limit\":${{ github.event.inputs.limit || '30' }},\"offset\":${{ github.event.inputs.offset || '0' }}}" \
+            -d "$PAYLOAD" \
             --max-time 600)
 
           echo "Response: $RESP"

--- a/.github/workflows/post-x-with-media.yml
+++ b/.github/workflows/post-x-with-media.yml
@@ -26,8 +26,10 @@ jobs:
     steps:
       - name: Build tweet text
         id: tweet
+        env:
+          CUSTOM_TEXT_INPUT: ${{ github.event.inputs.text || '' }}
         run: |
-          CUSTOM_TEXT="${{ github.event.inputs.text }}"
+          CUSTOM_TEXT="$CUSTOM_TEXT_INPUT"
           if [ -n "$CUSTOM_TEXT" ]; then
             TEXT="$CUSTOM_TEXT"
           else
@@ -45,8 +47,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post to X with OGP image
+        env:
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
-          DRY_RUN="${{ github.event.inputs.dry_run }}"
+          DRY_RUN="$DRY_RUN_INPUT"
           # Default to false for scheduled runs
           if [ -z "$DRY_RUN" ]; then
             DRY_RUN="false"

--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -30,9 +30,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Smoke memo.public.view / memo.public.list (no auth headers)
+        env:
+          MEMO_ID_INPUT: ${{ github.event.inputs.memo_id || '44' }}
         run: |
           BASE="https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/core-hub"
-          MEMO_ID="${{ github.event.inputs.memo_id || '44' }}"
+          MEMO_ID="$MEMO_ID_INPUT"
           FAIL=0
 
           check() {
@@ -112,9 +114,11 @@ jobs:
       # どの形が 401 になるか特定する診断ステップ (失敗しても job は落とさない)。
       - name: Diagnose external-AI request variants (informational)
         if: always()
+        env:
+          MEMO_ID_INPUT: ${{ github.event.inputs.memo_id || '44' }}
         run: |
           BASE="https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/core-hub"
-          MEMO_ID="${{ github.event.inputs.memo_id || '44' }}"
+          MEMO_ID="$MEMO_ID_INPUT"
           URL="$BASE?action=memo.public.view&id=$MEMO_ID"
 
           probe() {

--- a/.github/workflows/schedule-resilience-watch.yml
+++ b/.github/workflows/schedule-resilience-watch.yml
@@ -32,10 +32,11 @@ jobs:
       - name: Watch scheduled workflows
         env:
           GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
           mkdir -p tmp/schedule-resilience
           DRY_RUN_ARG=""
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             DRY_RUN_ARG="--dry-run"
           fi
           python scripts/schedule_resilience_watch.py \

--- a/.github/workflows/session-residuals-sync.yml
+++ b/.github/workflows/session-residuals-sync.yml
@@ -65,10 +65,18 @@ jobs:
 
       - name: Resolve params
         id: params
+        env:
+          DAYS_INPUT: ${{ inputs.days || '1' }}
+          APPLY_INPUT: ${{ inputs.apply }}
+          LIMIT_INPUT: ${{ inputs.limit || '5' }}
         run: |
-          DAYS="${{ inputs.days || '1' }}"
-          APPLY="${{ inputs.apply || 'true' }}"   # cron run = true (= dispatch defaults to false for safety)
-          LIMIT="${{ inputs.limit || '5' }}"
+          DAYS="$DAYS_INPUT"
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            APPLY="true"
+          else
+            APPLY="$APPLY_INPUT"
+          fi
+          LIMIT="$LIMIT_INPUT"
           echo "days=$DAYS"   >> $GITHUB_OUTPUT
           echo "apply=$APPLY" >> $GITHUB_OUTPUT
           echo "limit=$LIMIT" >> $GITHUB_OUTPUT

--- a/.github/workflows/tools-hub-mcp-smoke.yml
+++ b/.github/workflows/tools-hub-mcp-smoke.yml
@@ -35,6 +35,8 @@ jobs:
       DEFAULT_SUPABASE_URL: https://smmkxxavexumewbfaqpy.supabase.co
       MCP_BEARER_TOKEN: ${{ secrets.TOOLS_HUB_MCP_BEARER_TOKEN }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_URL_PROD: ${{ secrets.SUPABASE_URL_PROD || '' }}
+      BASE_URL_INPUT: ${{ inputs.base_url || '' }}
       REGISTRATION_REDIRECT_URI: ${{ inputs.registration_redirect_uri || '' }}
       ENABLE_WRITE_CONFIRMATION_PROBE: ${{ inputs.enable_write_confirmation_probe || false }}
 
@@ -58,9 +60,9 @@ jobs:
         if: steps.preflight.outputs.skip != 'true'
         shell: pwsh
         run: |
-          $baseUrl = "${{ inputs.base_url || '' }}"
+          $baseUrl = $env:BASE_URL_INPUT
           if ([string]::IsNullOrWhiteSpace($baseUrl)) {
-            $supabaseUrl = "${{ secrets.SUPABASE_URL_PROD || '' }}"
+            $supabaseUrl = $env:SUPABASE_URL_PROD
             if ([string]::IsNullOrWhiteSpace($supabaseUrl)) {
               $supabaseUrl = $env:DEFAULT_SUPABASE_URL
             }
@@ -71,10 +73,10 @@ jobs:
               if ($uri.Host.EndsWith(".supabase.co", [StringComparison]::OrdinalIgnoreCase)) {
                 $supabaseUrl = "$($uri.Scheme)://$($uri.Host)"
               } else {
-                $supabaseUrl = "${{ secrets.SUPABASE_URL_PROD || '' }}"
+                $supabaseUrl = $env:SUPABASE_URL_PROD
               }
             } catch {
-              $supabaseUrl = "${{ secrets.SUPABASE_URL_PROD || '' }}"
+              $supabaseUrl = $env:SUPABASE_URL_PROD
             }
           }
 
@@ -107,6 +109,8 @@ jobs:
       - name: Job summary
         if: always()
         shell: bash
+        env:
+          DCR_REDIRECT_CONFIGURED: ${{ inputs.registration_redirect_uri != '' }}
         run: |
           {
             echo "## tools-hub MCP Smoke"
@@ -117,7 +121,7 @@ jobs:
             echo "| Skipped | \`${{ steps.preflight.outputs.skip }}\` |"
             echo "| Outcome | \`${{ steps.smoke.outcome }}\` |"
             echo "| Auth token configured | \`${{ secrets.TOOLS_HUB_MCP_BEARER_TOKEN != '' }}\` |"
-            echo "| DCR redirect URI configured | \`${{ inputs.registration_redirect_uri != '' }}\` |"
+            echo "| DCR redirect URI configured | \`${DCR_REDIRECT_CONFIGURED}\` |"
             echo "| Write confirmation probe | \`${ENABLE_WRITE_CONFIRMATION_PROBE}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/weekly-sns-draft.yml
+++ b/.github/workflows/weekly-sns-draft.yml
@@ -47,9 +47,11 @@ jobs:
 
       - name: Determine target week
         id: period
+        env:
+          TARGET_DATE_INPUT: ${{ github.event.inputs.target_date }}
         run: |
           # target_date = 週末 (日曜) の日付 (空の場合は直近日曜)
-          TARGET_DATE="${{ github.event.inputs.target_date }}"
+          TARGET_DATE="$TARGET_DATE_INPUT"
           if [ -z "$TARGET_DATE" ]; then
             # 直近の日曜日を計算
             DOW=$(date -u +%u)  # 1=Mon ... 7=Sun

--- a/.github/workflows/wiki-compile-cron.yml
+++ b/.github/workflows/wiki-compile-cron.yml
@@ -68,11 +68,20 @@ jobs:
 
       - name: Resolve params
         id: params
+        env:
+          DAYS_INPUT: ${{ inputs.days || '30' }}
+          MIN_SOURCES_INPUT: ${{ inputs.min_sources || '5' }}
+          LIMIT_INPUT: ${{ inputs.limit || '50' }}
+          APPLY_INPUT: ${{ inputs.apply }}
         run: |
-          DAYS="${{ inputs.days || '30' }}"
-          MIN_SRC="${{ inputs.min_sources || '5' }}"
-          LIMIT="${{ inputs.limit || '50' }}"
-          APPLY="${{ inputs.apply || 'true' }}"
+          DAYS="$DAYS_INPUT"
+          MIN_SRC="$MIN_SOURCES_INPUT"
+          LIMIT="$LIMIT_INPUT"
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            APPLY="true"
+          else
+            APPLY="$APPLY_INPUT"
+          fi
           echo "days=$DAYS"     >> $GITHUB_OUTPUT
           echo "min_src=$MIN_SRC" >> $GITHUB_OUTPUT
           echo "limit=$LIMIT"   >> $GITHUB_OUTPUT

--- a/.github/workflows/x-ai-tool-tracker-queue.yml
+++ b/.github/workflows/x-ai-tool-tracker-queue.yml
@@ -40,6 +40,8 @@ jobs:
       EXPERIMENT_KEY: x_first_user_growth_10k
       VARIANT: ai_tool_tracker
       TARGET_URL: https://my-web-app-b67f4.web.app/?utm_source=x&utm_medium=data_report&utm_campaign=first_user_growth&utm_content=ai_tool_tracker
+      DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+      FORCE_INPUT: ${{ github.event.inputs.force }}
     steps:
       - name: Validate secrets
         shell: bash
@@ -53,8 +55,8 @@ jobs:
         id: mode
         shell: bash
         run: |
-          dry_run="${{ github.event.inputs.dry_run }}"
-          force="${{ github.event.inputs.force }}"
+          dry_run="$DRY_RUN_INPUT"
+          force="$FORCE_INPUT"
           if [ -z "${dry_run}" ]; then
             dry_run="false"
           fi

--- a/.github/workflows/x-growth-data-report-post.yml
+++ b/.github/workflows/x-growth-data-report-post.yml
@@ -40,6 +40,8 @@ jobs:
       EXPERIMENT_KEY: x_first_user_growth_10k
       VARIANT: weekly_data_report
       TARGET_URL: https://my-web-app-b67f4.web.app/?utm_source=x&utm_medium=data_report&utm_campaign=first_user_growth&utm_content=weekly_data_report
+      DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+      FORCE_INPUT: ${{ github.event.inputs.force }}
     steps:
       - name: Validate secrets
         shell: bash
@@ -53,8 +55,8 @@ jobs:
         id: mode
         shell: bash
         run: |
-          dry_run="${{ github.event.inputs.dry_run }}"
-          force="${{ github.event.inputs.force }}"
+          dry_run="$DRY_RUN_INPUT"
+          force="$FORCE_INPUT"
           if [ -z "${dry_run}" ]; then
             dry_run="false"
           fi

--- a/.github/workflows/x-household-tracker-post.yml
+++ b/.github/workflows/x-household-tracker-post.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       SUPABASE_URL: https://smmkxxavexumewbfaqpy.supabase.co
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
     steps:
       - name: Validate secrets
         shell: bash
@@ -43,7 +44,7 @@ jobs:
         id: mode
         shell: bash
         run: |
-          dry_run="${{ github.event.inputs.dry_run }}"
+          dry_run="$DRY_RUN_INPUT"
           if [ -z "${dry_run}" ]; then dry_run="false"; fi
           echo "dry_run=${dry_run}" >> "${GITHUB_OUTPUT}"
 

--- a/scripts/check_github_actions_script_injection.py
+++ b/scripts/check_github_actions_script_injection.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Reject untrusted GitHub expressions interpolated directly into `run` scripts."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_ROOT = Path(".github/workflows")
+RUN_KEY = re.compile(
+    r"^(?P<indent>\s*)(?:-\s+)?run\s*:\s*(?P<value>.*)$",
+)
+BLOCK_SCALAR = re.compile(r"^[|>][0-9+-]*(?:\s+#.*)?$")
+EXPRESSION = re.compile(r"\$\{\{(?P<body>.*?)\}\}")
+REFERENCE = re.compile(r"\b(?:github|inputs|steps)\.[A-Za-z0-9_.-]+")
+
+# GitHub documents these terminal property names as potentially attacker-controlled.
+# `ref_name` is included because branch names can contain shell metacharacters.
+UNTRUSTED_TERMINALS = {
+    "body",
+    "default_branch",
+    "email",
+    "head_ref",
+    "label",
+    "message",
+    "name",
+    "page_name",
+    "ref",
+    "ref_name",
+    "title",
+}
+
+
+def workflow_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted([*root.glob("*.yml"), *root.glob("*.yaml")])
+
+
+def _is_untrusted_reference(reference: str) -> bool:
+    if reference.startswith("inputs.") or reference.startswith("github.event.inputs."):
+        return True
+    return reference.rsplit(".", maxsplit=1)[-1] in UNTRUSTED_TERMINALS
+
+
+def _line_has_untrusted_expression(line: str) -> bool:
+    for expression in EXPRESSION.finditer(line):
+        references = REFERENCE.findall(expression.group("body"))
+        if any(_is_untrusted_reference(reference) for reference in references):
+            return True
+    return False
+
+
+def _run_script_lines(lines: list[str]) -> list[tuple[int, str]]:
+    scripts: list[tuple[int, str]] = []
+    index = 0
+    while index < len(lines):
+        match = RUN_KEY.match(lines[index])
+        if not match:
+            index += 1
+            continue
+
+        value = match.group("value").strip()
+        if value and not BLOCK_SCALAR.match(value):
+            scripts.append((index + 1, lines[index]))
+            index += 1
+            continue
+
+        run_indent = len(match.group("indent"))
+        index += 1
+        while index < len(lines):
+            line = lines[index]
+            if line.strip() and len(line) - len(line.lstrip()) <= run_indent:
+                break
+            scripts.append((index + 1, line))
+            index += 1
+    return scripts
+
+
+def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
+    violations: list[tuple[Path, int, str]] = []
+    for path in paths:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for line_number, line in _run_script_lines(lines):
+            if _line_has_untrusted_expression(line):
+                violations.append((path, line_number, line.strip()))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(errors="backslashreplace")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    args = parser.parse_args(argv)
+
+    if not args.root.exists():
+        print(f"workflow directory not found: {args.root}", file=sys.stderr)
+        return 1
+
+    files = workflow_files(args.root)
+    violations = find_violations(files)
+    if violations:
+        print("Pass untrusted GitHub values through `env:` before using them in `run:`.")
+        for path, line_number, line in violations:
+            print(f"{path}:{line_number}: {line}")
+        return 1
+
+    print(f"OK: checked {len(files)} workflow files for script-injection risks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_check_github_actions_script_injection.py
+++ b/test/scripts/test_check_github_actions_script_injection.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_github_actions_script_injection import (
+    find_violations,
+    workflow_files,
+)
+
+
+class CheckGithubActionsScriptInjectionTest(unittest.TestCase):
+    def _violations(self, workflow: str) -> list[tuple[Path, int, str]]:
+        with tempfile.TemporaryDirectory() as tmp:
+            workflows = Path(tmp) / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            path = workflows / "ci.yml"
+            path.write_text(workflow, encoding="utf-8")
+            violations = find_violations(workflow_files(workflows))
+            return [(Path(item[0].name), item[1], item[2]) for item in violations]
+
+    def test_rejects_untrusted_values_in_block_run(self) -> None:
+        workflow = (
+            "jobs:\n"
+            "  test:\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          echo '${{ github.event.pull_request.title }}'\n"
+            "          echo '${{ inputs.title }}'\n"
+            "          echo '${{ steps.meta.outputs.title }}'\n"
+            "          echo '${{ github.ref_name }}'\n"
+        )
+
+        self.assertEqual(
+            self._violations(workflow),
+            [
+                (Path("ci.yml"), 5, "echo '${{ github.event.pull_request.title }}'"),
+                (Path("ci.yml"), 6, "echo '${{ inputs.title }}'"),
+                (Path("ci.yml"), 7, "echo '${{ steps.meta.outputs.title }}'"),
+                (Path("ci.yml"), 8, "echo '${{ github.ref_name }}'"),
+            ],
+        )
+
+    def test_rejects_workflow_input_in_inline_run(self) -> None:
+        workflow = "jobs:\n  test:\n    steps:\n      - run: echo '${{ inputs.slug }}'\n"
+
+        self.assertEqual(
+            self._violations(workflow),
+            [(Path("ci.yml"), 4, "- run: echo '${{ inputs.slug }}'")],
+        )
+
+    def test_allows_quote_safe_env_handoff_and_non_string_runtime_values(self) -> None:
+        workflow = (
+            "jobs:\n"
+            "  test:\n"
+            "    steps:\n"
+            "      - if: ${{ github.event.pull_request.title != '' }}\n"
+            "        env:\n"
+            "          TITLE: ${{ github.event.pull_request.title }}\n"
+            "        run: |\n"
+            "          printf '%s\\n' \"$TITLE\"\n"
+            "          echo '${{ github.sha }}'\n"
+            "          echo '${{ steps.test.outcome }}'\n"
+        )
+
+        self.assertEqual(self._violations(workflow), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a CI guard that rejects workflow inputs and GitHub-documented untrusted string properties interpolated directly into `run:` scripts
- route existing workflow-dispatch inputs and risky title/ref values through `env:` across the workflow fleet
- serialize NotebookLM and production Slack payloads with `jq --arg`, so single/double quotes remain data rather than shell/JSON syntax
- preserve `blog-publish.yml` frontmatter title/path/tag handling through environment variables
- preserve schedule-versus-manual apply semantics for hygiene, indexing, residual, and wiki jobs

## Validation
- `python scripts/check_github_actions_script_injection.py` (120 workflows, zero violations)
- `python scripts/check_github_actions_node_runtime.py`
- `python scripts/check_github_actions_python_inline.py`
- `python scripts/check_github_actions_status_functions.py`
- `python scripts/check_github_actions_powershell_splatting.py`
- `python -m unittest discover -s test/scripts -p "test_check_github_actions_*.py"` (12 tests)
- PyYAML parse of all 120 workflow files
- `git diff --check origin/main...HEAD`

## Subagent record
- commerce review lane: migrated the blog/reminder workflow batch; no build or commit
- realtime review lane: migrated hygiene/competitor/mobile and related automation inputs; no build or commit
- UX review lane: migrated horse-racing/NotebookLM/public-memo/schedule workflow inputs and stopped when RAM pressure increased; no build or commit
- lead lane: completed remaining workflows, reviewed all shared edits, corrected boolean schedule/manual semantics, added the guard/tests, and ran deterministic validation
- cleanup impact: all subagents completed; no generated artifacts or background build/test/browser processes were created

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Scoped GitHub Actions quoting-only refactor; deploy workflow changes affect notification JSON and summaries only, with no deployment logic, infrastructure, schema, data migration, or production-state mutation.
- Security: untrusted values move from generated scripts into environment variables; JSON strings use `jq --arg`.
- Rollback: revert this single commit to restore the prior workflow text.
- Data migration: none.
- Prod smoke: not required for notification/summary-only changes; workflow syntax and existing smoke gates validate the affected files.
- Observability: existing Slack notifications and GitHub job summaries remain the output channels.
- Unresolved ultrareview findings: none.

Closes #1303