### PR TITLE
docs(codex): adopt persisted goal workflow (#1860)

### DIFF
--- a/docs/AI_FALLBACK_RUNBOOK.md
+++ b/docs/AI_FALLBACK_RUNBOOK.md
@@ -32,8 +32,18 @@ Adoption notes for this cycle:
   long-session recovery, but they do not change the top-level two-instance cap.
 - Claude Code v2.1.122 Bedrock service-tier selection and v2.1.108 prompt-cache
   flags are provider-configuration candidates, not default environment changes.
-- OpenAI Codex CLI rust-v0.128.0 persisted `/goal` workflows are a future
-  Codex #1 planning aid; normal WBS work still uses scoped branches and PRs.
+- OpenAI Codex persisted goals are available to Codex #1 when the active app or
+  CLI runtime exposes the goal APIs. Use them to retain the objective and
+  continuation state, but keep the durable proof in the linked Issue, scoped
+  branch, PR, and validation result. A goal never grants extra authority to
+  merge, deploy, or change production data.
+- Do not pin a task class to the historical GPT-5.5 name. Apply the configured
+  adaptive model router to the models and effort levels exposed by the current
+  runtime, while preserving any explicit user selection.
+- Thread Automations (#1837) and persisted goals solve different problems:
+  automations provide an explicit schedule, while a goal preserves the state of
+  one approved body of work. Neither is a reason to create an unattended
+  dependency-update-to-merge pipeline.
 - Cursor context-usage breakdown, Gemini Code Assist release notes, and Devin
   CI-aware auto-fix are advisory signals unless a local verified workflow is
   explicitly routed.

--- a/docs/GOAL_WRAPUP_WORKFLOW.md
+++ b/docs/GOAL_WRAPUP_WORKFLOW.md
@@ -1,13 +1,32 @@
 # Goal And Wrap-Up Workflow
 
-Last updated: 2026-05-16
+Last updated: 2026-08-26
 
 ## Goal
 
 Keep long-running WBS work resumable across Codex sessions without relying on
-memory alone. Prefer `/goal` when the active Codex runtime exposes it. When it
-is not available in the non-interactive shell, mirror the same state through
-GitHub Issue, WBS task, branch, PR body, and this wrap-up template.
+memory alone. Prefer a persisted goal when the active Codex app or CLI runtime
+exposes it. The UI, model tools, or app-server API may expose that capability
+even when a non-interactive shell does not expose a literal `/goal` command.
+Always mirror the durable state through the GitHub Issue, WBS task, branch, PR
+body, and this wrap-up template.
+
+## Runtime Contract
+
+- A goal stores the objective and continuation status. It does not replace the
+  Issue acceptance criteria, branch/PR checkpoint, or deterministic validation.
+- Pause or clear a goal only after recording the next action and any recovery
+  state in GitHub or the wrap-up template.
+- Runtime continuation does not broaden the user's permissions. Production
+  writes, deploys, merges, messages, and other external changes retain their
+  normal approval and safety gates.
+- Use Thread Automations only when an explicit schedule is required. Do not
+  convert a goal into an unattended dependency-update-to-merge loop.
+- Select only a model and effort level that the current runtime exposes. Apply
+  the configured adaptive router instead of permanently assigning work to the
+  historical GPT-5.5 or Codex #2 labels.
+- Any subagent fan-out remains bounded by
+  `docs/SUBAGENT_ORCHESTRATION_POLICY.md`, including its resource-pressure gate.
 
 ## Session Start
 
@@ -115,5 +134,6 @@ Next actions:
 
 ## Linked Issue
 
-This workflow satisfies the docs portion of #2523. Future work can add a UI or
-CLI helper after the `/goal` command is proven interactively.
+This workflow satisfies #2523 and the persisted-goal adoption portion of #1860.
+The current Codex runtime has proven persisted objective/status recovery; no
+repository-specific UI or CLI wrapper is required.


### PR DESCRIPTION
## Summary
- mark persisted goals as an available Codex app/CLI runtime capability instead of a future-only experiment
- define the goal runtime safety contract and durable GitHub/WBS/PR checkpoints
- replace the historical GPT-5.5/Codex #2 assignment with adaptive routing over currently exposed models
- distinguish persisted continuation from scheduled Thread Automations and unattended merge/deploy pipelines

## Evidence
- the active Codex task exposes a persisted goal objective/status through the runtime goal API
- #1837 completed the separate Thread Automations review
- #2523 completed the goal-aware WBS/wrap-up template
- `docs/SUBAGENT_ORCHESTRATION_POLICY.md` already governs bounded fan-out

## Validation
- `git diff --check`
- `python scripts/config_size_monitor.py`

## Resource / subagent note
RAM remained above 91% with less than 1.4 GB free, so no subagent or build/test/browser process was started. This docs-only change used lightweight checks.

Closes #1860