### PR TITLE
fix(comparison): require evidence for public claims (closes #4726)

### DIFF
--- a/lib/models/competitor_claim_evidence.dart
+++ b/lib/models/competitor_claim_evidence.dart
@@ -1,0 +1,71 @@
+enum CompetitorClaimType {
+  summary('summary'),
+  pricing('pricing'),
+  feature('feature'),
+  japanPresence('japan_presence'),
+  other('other');
+
+  const CompetitorClaimType(this.databaseValue);
+
+  final String databaseValue;
+
+  static CompetitorClaimType? tryParse(Object? value) {
+    final normalized = value?.toString().trim();
+    for (final type in values) {
+      if (type.databaseValue == normalized) {
+        return type;
+      }
+    }
+    return null;
+  }
+}
+
+class CompetitorClaimEvidence {
+  const CompetitorClaimEvidence({
+    required this.competitorId,
+    required this.claimKey,
+    required this.claimType,
+    required this.claimText,
+    required this.sourceUri,
+    required this.verifiedAt,
+  });
+
+  final String competitorId;
+  final String claimKey;
+  final CompetitorClaimType claimType;
+  final String claimText;
+  final Uri sourceUri;
+  final DateTime verifiedAt;
+
+  static CompetitorClaimEvidence? tryFromJson(Map<String, dynamic> json) {
+    final competitorId = json['competitor_id']?.toString().trim() ?? '';
+    final claimKey = json['claim_key']?.toString().trim() ?? '';
+    final claimType = CompetitorClaimType.tryParse(json['claim_type']);
+    final claimText = json['claim_text']?.toString().trim() ?? '';
+    final sourceUri = Uri.tryParse(json['source_url']?.toString().trim() ?? '');
+    final verifiedAt = DateTime.tryParse(
+      json['verified_at']?.toString().trim() ?? '',
+    );
+    final validSource = sourceUri != null &&
+        (sourceUri.scheme == 'https' || sourceUri.scheme == 'http') &&
+        sourceUri.host.isNotEmpty;
+
+    if (competitorId.isEmpty ||
+        claimKey.isEmpty ||
+        claimType == null ||
+        claimText.isEmpty ||
+        !validSource ||
+        verifiedAt == null) {
+      return null;
+    }
+
+    return CompetitorClaimEvidence(
+      competitorId: competitorId,
+      claimKey: claimKey,
+      claimType: claimType,
+      claimText: claimText,
+      sourceUri: sourceUri,
+      verifiedAt: verifiedAt.toUtc(),
+    );
+  }
+}

--- a/lib/pages/comparison_page.dart
+++ b/lib/pages/comparison_page.dart
@@ -1,7 +1,11 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:my_web_app/models/competitor_claim_evidence.dart';
+import 'package:my_web_app/services/competitor_claim_evidence_repository.dart';
+import 'package:my_web_app/services/supabase_client_provider.dart';
+import 'package:my_web_app/ui/features/comparison/view_models/comparison_evidence_view_model.dart';
+import 'package:my_web_app/ui/features/comparison/widgets/comparison_evidence_section.dart';
 
 import '../services/growth_acquisition_service.dart';
 
@@ -11,46 +15,51 @@ import '../services/growth_acquisition_service.dart';
 /// a page that speaks directly to that user's context.
 class ComparisonPage extends StatefulWidget {
   final String competitorKey;
+  final CompetitorClaimEvidenceRepository? evidenceRepository;
 
-  const ComparisonPage({super.key, required this.competitorKey});
+  const ComparisonPage({
+    super.key,
+    required this.competitorKey,
+    this.evidenceRepository,
+  });
 
   @override
   State<ComparisonPage> createState() => _ComparisonPageState();
 }
 
 class _ComparisonPageState extends State<ComparisonPage> {
-  String? _pricingTier;
-  double? _pricingStartUsd;
-  String? _pricingNotesJa;
-  String? _japanPresenceLevel;
+  late final ComparisonEvidenceViewModel _evidenceViewModel;
 
   @override
   void initState() {
     super.initState();
-    unawaited(_fetchDbOverlay());
+    _evidenceViewModel = ComparisonEvidenceViewModel(
+      repository: widget.evidenceRepository ??
+          SupabaseCompetitorClaimEvidenceRepository(supabase),
+    )..addListener(_handleEvidenceChanged);
+    unawaited(_evidenceViewModel.load(widget.competitorKey));
   }
 
-  Future<void> _fetchDbOverlay() async {
-    try {
-      final data = await Supabase.instance.client
-          .from('competitors')
-          .select(
-            'pricing_tier, pricing_start_usd, pricing_notes_ja, japan_presence_level',
-          )
-          .eq('id', widget.competitorKey.toLowerCase())
-          .maybeSingle();
-      if (data != null && mounted) {
-        setState(() {
-          _pricingTier = data['pricing_tier'] as String?;
-          final rawUsd = data['pricing_start_usd'];
-          _pricingStartUsd = rawUsd != null ? (rawUsd as num).toDouble() : null;
-          _pricingNotesJa = data['pricing_notes_ja'] as String?;
-          _japanPresenceLevel = data['japan_presence_level'] as String?;
-        });
-      }
-    } catch (_) {
-      // フォールバック: const map のみで表示
+  @override
+  void didUpdateWidget(covariant ComparisonPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.competitorKey != widget.competitorKey) {
+      unawaited(_evidenceViewModel.load(widget.competitorKey));
     }
+  }
+
+  void _handleEvidenceChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    _evidenceViewModel
+      ..removeListener(_handleEvidenceChanged)
+      ..dispose();
+    super.dispose();
   }
 
   @override
@@ -60,10 +69,8 @@ class _ComparisonPageState extends State<ComparisonPage> {
     return _ComparisonShell(
       info: info,
       competitorKey: widget.competitorKey.toLowerCase(),
-      pricingTier: _pricingTier,
-      pricingStartUsd: _pricingStartUsd,
-      pricingNotesJa: _pricingNotesJa,
-      japanPresenceLevel: _japanPresenceLevel,
+      evidenceStatus: _evidenceViewModel.status,
+      evidenceClaims: _evidenceViewModel.claims,
     );
   }
 }
@@ -67152,17 +67159,13 @@ final _competitorInfo = <String, _CompetitorInfo>{
 class _ComparisonShell extends StatefulWidget {
   final _CompetitorInfo info;
   final String competitorKey;
-  final String? pricingTier;
-  final double? pricingStartUsd;
-  final String? pricingNotesJa;
-  final String? japanPresenceLevel;
+  final ComparisonEvidenceStatus evidenceStatus;
+  final List<CompetitorClaimEvidence> evidenceClaims;
   const _ComparisonShell({
     required this.info,
     required this.competitorKey,
-    this.pricingTier,
-    this.pricingStartUsd,
-    this.pricingNotesJa,
-    this.japanPresenceLevel,
+    required this.evidenceStatus,
+    required this.evidenceClaims,
   });
 
   @override
@@ -67597,12 +67600,17 @@ class _ComparisonShellState extends State<_ComparisonShell> {
   _CompetitorInfo get _info => widget.info;
   bool get _hasImportSupport =>
       widget.competitorKey == 'notion' || widget.competitorKey == 'evernote';
-  int get _sharedFeatureCount => _info.features
-      .where((feature) => feature.competitorHas && feature.weHave)
-      .length;
-  int get _ourAdvantageCount => _info.features
-      .where((feature) => !feature.competitorHas && feature.weHave)
-      .length;
+  int get _withheldLegacyClaimCount =>
+      1 + _info.painPoints.length + _info.features.length;
+  List<CompetitorClaimEvidence> get _featureEvidence => widget.evidenceClaims
+      .where((claim) => claim.claimType == CompetitorClaimType.feature)
+      .toList(growable: false);
+  List<CompetitorClaimEvidence> get _otherEvidence => widget.evidenceClaims
+      .where((claim) => claim.claimType != CompetitorClaimType.feature)
+      .toList(growable: false);
+  // Legacy fallback copy remains available for editorial recovery, but it is
+  // deny-by-default and never rendered without row-level evidence metadata.
+  bool get _showLegacyClaims => false;
 
   List<MapEntry<String, _CompetitorInfo>> get _relatedCompetitors {
     final currentCategory = _categoryOf[widget.competitorKey];
@@ -67647,7 +67655,7 @@ class _ComparisonShellState extends State<_ComparisonShell> {
 
   String get _switchStepBody => _hasImportSupport
       ? '${_info.name} のデータをインポートしながら、今の資産を崩さず移行できます。'
-      : 'まずは無料で始めて、${_info.name} では分散していた作業を1か所に集約できます。';
+      : 'まずは無料で始めて、必要な作業だけを1か所に集約できます。';
 
   @override
   Widget build(BuildContext context) {
@@ -67804,44 +67812,8 @@ class _ComparisonShellState extends State<_ComparisonShell> {
                             backgroundColor: _orange.withValues(alpha: 0.18),
                             foregroundColor: _textPrimary,
                           ),
-                        if (widget.pricingTier != null)
-                          _PricingBadge(tier: widget.pricingTier!),
-                        if (widget.japanPresenceLevel != null)
-                          _JapanPresenceBadge(
-                            level: widget.japanPresenceLevel!,
-                          ),
                       ],
                     ),
-                    if (widget.pricingStartUsd != null ||
-                        widget.pricingNotesJa != null)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8),
-                        child: Row(
-                          children: [
-                            if (widget.pricingStartUsd != null)
-                              Text(
-                                '最安 \$${widget.pricingStartUsd?.toStringAsFixed(2)}/月',
-                                style: const TextStyle(
-                                  fontSize: 12,
-                                  color: _textSecondary,
-                                  height: 1.5,
-                                ),
-                              ),
-                            if (widget.pricingStartUsd != null &&
-                                widget.pricingNotesJa != null)
-                              const SizedBox(width: 6),
-                            if (widget.pricingNotesJa != null)
-                              Tooltip(
-                                message: widget.pricingNotesJa ?? '',
-                                child: const Icon(
-                                  Icons.info_outline,
-                                  size: 14,
-                                  color: _textMuted,
-                                ),
-                              ),
-                          ],
-                        ),
-                      ),
                     const SizedBox(height: 22),
                     Text(
                       '${_info.emoji} ${_info.name} の代わりに\n自分株式会社を使う',
@@ -67855,13 +67827,19 @@ class _ComparisonShellState extends State<_ComparisonShell> {
                       ),
                     ),
                     const SizedBox(height: 14),
-                    Text(
-                      _info.tagline,
-                      style: const TextStyle(
+                    const Text(
+                      '公開する比較情報は、根拠URLと確認日を持つ項目だけに限定しています。',
+                      style: TextStyle(
                         fontSize: 16,
                         color: _textSecondary,
                         height: 1.75,
                       ),
+                    ),
+                    const SizedBox(height: 16),
+                    ComparisonEvidenceStatusBanner(
+                      status: widget.evidenceStatus,
+                      verifiedCount: widget.evidenceClaims.length,
+                      withheldLegacyClaimCount: _withheldLegacyClaimCount,
                     ),
                     const SizedBox(height: 24),
                     Wrap(
@@ -67869,15 +67847,15 @@ class _ComparisonShellState extends State<_ComparisonShell> {
                       runSpacing: 14,
                       children: [
                         _buildMetricCard(
-                          icon: Icons.layers_rounded,
-                          label: '共通コア機能',
-                          value: '$_sharedFeatureCount個',
+                          icon: Icons.verified_rounded,
+                          label: '根拠確認済み',
+                          value: '${widget.evidenceClaims.length}件',
                           accent: _info.accentColor,
                         ),
                         _buildMetricCard(
-                          icon: Icons.auto_awesome_rounded,
-                          label: '乗り換えメリット',
-                          value: '+$_ourAdvantageCount個',
+                          icon: Icons.visibility_off_rounded,
+                          label: '旧比較文の公開保留',
+                          value: '$_withheldLegacyClaimCount件',
                           accent: _indigo,
                         ),
                         _buildMetricCard(
@@ -67951,7 +67929,7 @@ class _ComparisonShellState extends State<_ComparisonShell> {
     final cards = [
       _buildOutcomeCard(
         icon: Icons.hub_rounded,
-        title: '${_info.name} だけでは足りない作業をひとつに集約',
+        title: '日常の作業をひとつに集約',
         body: 'ノート・タスク・財務・習慣・AI大学まで、別アプリで分かれていた流れをまとめます。',
         accent: _info.accentColor,
       ),
@@ -67964,7 +67942,7 @@ class _ComparisonShellState extends State<_ComparisonShell> {
       _buildOutcomeCard(
         icon: Icons.auto_graph_rounded,
         title: 'AI が「今日やること」を1件に絞る',
-        body: '${_info.name} の単機能では埋まらない、判断・実行・振り返りまでを一気通貫で支援します。',
+        body: '判断・実行・振り返りまでを、ひとつの流れとして支援します。',
         accent: _indigo,
       ),
     ];
@@ -68005,6 +67983,13 @@ class _ComparisonShellState extends State<_ComparisonShell> {
   }
 
   Widget _buildPainPoints() {
+    if (!_showLegacyClaims) {
+      return ComparisonEvidenceSection(
+        title: '根拠確認済みの比較情報',
+        status: widget.evidenceStatus,
+        claims: _otherEvidence,
+      );
+    }
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
       child: Center(
@@ -68090,6 +68075,13 @@ class _ComparisonShellState extends State<_ComparisonShell> {
   }
 
   Widget _buildFeatureTable() {
+    if (!_showLegacyClaims) {
+      return ComparisonEvidenceSection(
+        title: '根拠確認済みの機能比較',
+        status: widget.evidenceStatus,
+        claims: _featureEvidence,
+      );
+    }
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
       child: Center(
@@ -68213,7 +68205,7 @@ class _ComparisonShellState extends State<_ComparisonShell> {
       _buildStepCard(
         number: '03',
         title: '必要になった機能だけ横に増やす',
-        body: '${_info.name} 単体では届かない資産管理・AI大学・部署AIまで、後から同じアプリ内で広げられます。',
+        body: '資産管理・AI大学・部署AIまで、必要になった機能を後から同じアプリ内で広げられます。',
         accent: _orange,
       ),
     ];
@@ -68726,73 +68718,6 @@ class _ComparisonShellState extends State<_ComparisonShell> {
         foregroundColor: _textPrimary,
         side: const BorderSide(color: _borderColor),
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
-      ),
-    );
-  }
-}
-
-class _PricingBadge extends StatelessWidget {
-  final String tier;
-  const _PricingBadge({required this.tier});
-
-  @override
-  Widget build(BuildContext context) {
-    final (label, color) = switch (tier) {
-      'free' => ('完全無料', const Color(0xFF4CAF50)),
-      'freemium' => ('無料プランあり', const Color(0xFF009688)),
-      'paid' => ('有料', const Color(0xFFFF9800)),
-      'enterprise' => ('要見積', const Color(0xFF607D8B)),
-      _ => ('?', const Color(0xFF9E9E9E)),
-    };
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.15),
-        border: Border.all(color: color.withValues(alpha: 0.4)),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: color,
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-          height: 1.4,
-        ),
-      ),
-    );
-  }
-}
-
-class _JapanPresenceBadge extends StatelessWidget {
-  final String level;
-  const _JapanPresenceBadge({required this.level});
-
-  @override
-  Widget build(BuildContext context) {
-    final (emoji, label, color) = switch (level) {
-      'dominant' => ('🇯🇵', '日本No.1', const Color(0xFFE53935)),
-      'strong' => ('🇯🇵', '日本主要', const Color(0xFFFF6B35)),
-      'growing' => ('📈', '日本成長中', const Color(0xFFFFB300)),
-      'limited' => ('🌐', '日本限定的', const Color(0xFF607D8B)),
-      'not_present' => ('⚠️', '日本未展開', const Color(0xFF9E9E9E)),
-      _ => ('', '', const Color(0xFF9E9E9E)),
-    };
-    if (label.isEmpty) return const SizedBox.shrink();
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
-        border: Border.all(color: color.withValues(alpha: 0.35)),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Text(
-        '$emoji $label',
-        style: TextStyle(
-          color: color,
-          fontSize: 11,
-          height: 1.4,
-        ),
       ),
     );
   }

--- a/lib/services/competitor_claim_evidence_repository.dart
+++ b/lib/services/competitor_claim_evidence_repository.dart
@@ -1,0 +1,43 @@
+import 'package:my_web_app/models/competitor_claim_evidence.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+abstract class CompetitorClaimEvidenceRepository {
+  Future<List<CompetitorClaimEvidence>> fetchForCompetitor(String competitorId);
+}
+
+class SupabaseCompetitorClaimEvidenceRepository
+    implements CompetitorClaimEvidenceRepository {
+  SupabaseCompetitorClaimEvidenceRepository(this._client);
+
+  final SupabaseClient _client;
+
+  @override
+  Future<List<CompetitorClaimEvidence>> fetchForCompetitor(
+    String competitorId,
+  ) async {
+    final normalizedId = competitorId.trim().toLowerCase();
+    if (normalizedId.isEmpty) {
+      return const <CompetitorClaimEvidence>[];
+    }
+
+    final rows = await _client
+        .from('competitor_claim_evidence')
+        .select(
+          'competitor_id,claim_key,claim_type,claim_text,source_url,verified_at',
+        )
+        .eq('competitor_id', normalizedId)
+        .order('claim_type')
+        .order('claim_key');
+
+    final evidence = <CompetitorClaimEvidence>[];
+    for (final row in rows) {
+      final parsed = CompetitorClaimEvidence.tryFromJson(
+        Map<String, dynamic>.from(row),
+      );
+      if (parsed != null && parsed.competitorId == normalizedId) {
+        evidence.add(parsed);
+      }
+    }
+    return List<CompetitorClaimEvidence>.unmodifiable(evidence);
+  }
+}

--- a/lib/ui/features/comparison/view_models/comparison_evidence_view_model.dart
+++ b/lib/ui/features/comparison/view_models/comparison_evidence_view_model.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart';
+import 'package:my_web_app/models/competitor_claim_evidence.dart';
+import 'package:my_web_app/services/competitor_claim_evidence_repository.dart';
+
+enum ComparisonEvidenceStatus { initial, loading, loaded, unavailable }
+
+class ComparisonEvidenceViewModel extends ChangeNotifier {
+  ComparisonEvidenceViewModel({
+    required CompetitorClaimEvidenceRepository repository,
+  }) : _repository = repository;
+
+  final CompetitorClaimEvidenceRepository _repository;
+  ComparisonEvidenceStatus _status = ComparisonEvidenceStatus.initial;
+  List<CompetitorClaimEvidence> _claims = const [];
+  int _requestGeneration = 0;
+
+  ComparisonEvidenceStatus get status => _status;
+  List<CompetitorClaimEvidence> get claims => _claims;
+
+  Future<void> load(String competitorId) async {
+    final generation = ++_requestGeneration;
+    _status = ComparisonEvidenceStatus.loading;
+    _claims = const [];
+    notifyListeners();
+
+    try {
+      final claims = await _repository.fetchForCompetitor(competitorId);
+      if (generation != _requestGeneration) {
+        return;
+      }
+      _claims = claims;
+      _status = ComparisonEvidenceStatus.loaded;
+      notifyListeners();
+    } catch (_) {
+      if (generation != _requestGeneration) {
+        return;
+      }
+      _claims = const [];
+      _status = ComparisonEvidenceStatus.unavailable;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _requestGeneration++;
+    super.dispose();
+  }
+}

--- a/lib/ui/features/comparison/widgets/comparison_evidence_section.dart
+++ b/lib/ui/features/comparison/widgets/comparison_evidence_section.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+import 'package:my_web_app/models/competitor_claim_evidence.dart';
+import 'package:my_web_app/ui/features/comparison/view_models/comparison_evidence_view_model.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+typedef EvidenceSourceLauncher = Future<bool> Function(Uri uri);
+
+class ComparisonEvidenceStatusBanner extends StatelessWidget {
+  const ComparisonEvidenceStatusBanner({
+    super.key,
+    required this.status,
+    required this.verifiedCount,
+    required this.withheldLegacyClaimCount,
+  });
+
+  final ComparisonEvidenceStatus status;
+  final int verifiedCount;
+  final int withheldLegacyClaimCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final (icon, title, body, color) = switch (status) {
+      ComparisonEvidenceStatus.initial || ComparisonEvidenceStatus.loading => (
+          Icons.hourglass_top_rounded,
+          '比較根拠を確認中',
+          '確認が終わるまで、従来の比較文は公開しません。',
+          const Color(0xFF60A5FA),
+        ),
+      ComparisonEvidenceStatus.loaded when verifiedCount > 0 => (
+          Icons.verified_rounded,
+          '根拠確認済み $verifiedCount件',
+          '根拠URLと確認日がある項目だけを表示しています。旧比較文 $withheldLegacyClaimCount件は公開保留です。',
+          const Color(0xFF34D399),
+        ),
+      ComparisonEvidenceStatus.loaded => (
+          Icons.visibility_off_rounded,
+          '比較主張を公開保留中',
+          '根拠URLと確認日が未登録のため、旧比較文 $withheldLegacyClaimCount件は表示していません。',
+          const Color(0xFFFBBF24),
+        ),
+      ComparisonEvidenceStatus.unavailable => (
+          Icons.cloud_off_rounded,
+          '根拠データを取得できません',
+          '取得失敗時に未検証のフォールバック文へ切り替えず、比較主張を公開保留にしています。',
+          const Color(0xFFF87171),
+        ),
+    };
+
+    return Container(
+      key: const Key('comparison-evidence-status'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: color.withValues(alpha: 0.45)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: color, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    color: Color(0xFFF5F7FB),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  body,
+                  style: const TextStyle(
+                    color: Color(0xFFB2BDD3),
+                    fontSize: 13,
+                    height: 1.6,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ComparisonEvidenceSection extends StatelessWidget {
+  const ComparisonEvidenceSection({
+    super.key,
+    required this.title,
+    required this.status,
+    required this.claims,
+    this.sourceLauncher,
+  });
+
+  final String title;
+  final ComparisonEvidenceStatus status;
+  final List<CompetitorClaimEvidence> claims;
+  final EvidenceSourceLauncher? sourceLauncher;
+
+  @override
+  Widget build(BuildContext context) {
+    final body = switch (status) {
+      ComparisonEvidenceStatus.initial ||
+      ComparisonEvidenceStatus.loading =>
+        const _EvidencePlaceholder(
+          key: Key('comparison-evidence-loading'),
+          icon: Icons.hourglass_top_rounded,
+          message: '根拠を確認しています。確認中の比較主張は表示しません。',
+        ),
+      ComparisonEvidenceStatus.unavailable => const _EvidencePlaceholder(
+          key: Key('comparison-evidence-unavailable'),
+          icon: Icons.cloud_off_rounded,
+          message: '根拠データを取得できないため、この比較主張は公開保留です。',
+        ),
+      ComparisonEvidenceStatus.loaded when claims.isEmpty =>
+        const _EvidencePlaceholder(
+          key: Key('comparison-evidence-empty'),
+          icon: Icons.visibility_off_rounded,
+          message: '根拠URLと確認日が未登録のため、この比較主張は公開保留です。',
+        ),
+      ComparisonEvidenceStatus.loaded => Column(
+          key: const Key('comparison-evidence-claims'),
+          children: [
+            for (final claim in claims)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: _EvidenceClaimCard(
+                  claim: claim,
+                  sourceLauncher: sourceLauncher,
+                ),
+              ),
+          ],
+        ),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1040),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: Color(0xFFF5F7FB),
+                  height: 1.4,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                '表示するすべての項目に参照元と確認日を併記します。確認日時点の記録であり、現在の価格や仕様を保証しません。',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: Color(0xFFB2BDD3),
+                  height: 1.7,
+                ),
+              ),
+              const SizedBox(height: 16),
+              body,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EvidenceClaimCard extends StatelessWidget {
+  const _EvidenceClaimCard({required this.claim, required this.sourceLauncher});
+
+  final CompetitorClaimEvidence claim;
+  final EvidenceSourceLauncher? sourceLauncher;
+
+  @override
+  Widget build(BuildContext context) {
+    final verified = claim.verifiedAt.toLocal();
+    final verifiedLabel = '${verified.year.toString().padLeft(4, '0')}-'
+        '${verified.month.toString().padLeft(2, '0')}-'
+        '${verified.day.toString().padLeft(2, '0')}';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: const Color(0xFF12131E),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: const Color(0xFF2A3044)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            claim.claimText,
+            style: const TextStyle(
+              color: Color(0xFFF5F7FB),
+              fontSize: 14,
+              height: 1.7,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 10,
+            runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(
+                '確認日: $verifiedLabel',
+                style: const TextStyle(color: Color(0xFFB2BDD3), fontSize: 12),
+              ),
+              const Text(
+                '確認日時点',
+                style: TextStyle(
+                  color: Color(0xFFFBBF24),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              TextButton.icon(
+                key: Key('comparison-evidence-source-${claim.claimKey}'),
+                onPressed: () async {
+                  final launcher = sourceLauncher ?? _launchSource;
+                  await launcher(claim.sourceUri);
+                },
+                icon: const Icon(Icons.open_in_new_rounded, size: 15),
+                label: Text(
+                  claim.sourceUri.host,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  static Future<bool> _launchSource(Uri uri) =>
+      launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+class _EvidencePlaceholder extends StatelessWidget {
+  const _EvidencePlaceholder({
+    super.key,
+    required this.icon,
+    required this.message,
+  });
+
+  final IconData icon;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: const Color(0xFF12131E),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: const Color(0xFF2A3044)),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: const Color(0xFFFBBF24), size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(
+                color: Color(0xFFB2BDD3),
+                fontSize: 14,
+                height: 1.7,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/supabase/migrations/20260826090000_create_competitor_claim_evidence.sql
+++ b/supabase/migrations/20260826090000_create_competitor_claim_evidence.sql
@@ -1,0 +1,43 @@
+-- Public competitor claims are rendered only when this audit metadata exists.
+-- No prices, feature assertions, Japan-presence values, or other production
+-- competitor data are inserted or changed by this migration.
+create table if not exists public.competitor_claim_evidence (
+  id uuid primary key default gen_random_uuid(),
+  competitor_id text not null
+    references public.competitors(id) on delete cascade,
+  claim_key text not null check (
+    char_length(btrim(claim_key)) between 1 and 120
+  ),
+  claim_type text not null check (
+    claim_type in ('summary', 'pricing', 'feature', 'japan_presence', 'other')
+  ),
+  claim_text text not null check (char_length(btrim(claim_text)) > 0),
+  source_url text not null check (source_url ~ '^https?://[^[:space:]]+$'),
+  verified_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (competitor_id, claim_key)
+);
+
+create index if not exists idx_competitor_claim_evidence_lookup
+  on public.competitor_claim_evidence (competitor_id, claim_type, claim_key);
+
+alter table public.competitor_claim_evidence enable row level security;
+
+drop policy if exists "competitor claim evidence public read"
+  on public.competitor_claim_evidence;
+create policy "competitor claim evidence public read"
+  on public.competitor_claim_evidence
+  for select
+  using (true);
+
+drop policy if exists "competitor claim evidence service write"
+  on public.competitor_claim_evidence;
+create policy "competitor claim evidence service write"
+  on public.competitor_claim_evidence
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+comment on table public.competitor_claim_evidence is
+  'Audit metadata for public comparison claims. Rows require exact display text, a source URL, and verified_at; backfill requires separately approved evidence.';

--- a/test/ui/features/comparison/comparison_evidence_state_test.dart
+++ b/test/ui/features/comparison/comparison_evidence_state_test.dart
@@ -66,7 +66,7 @@ void main() {
 
     test('fails closed without retaining fallback claims', () async {
       final viewModel = ComparisonEvidenceViewModel(
-        repository: _FakeEvidenceRepository(error: StateError('offline')),
+        repository: _FakeEvidenceRepository(error: Exception('offline')),
       );
 
       await viewModel.load('notion');
@@ -159,7 +159,7 @@ class _FakeEvidenceRepository implements CompetitorClaimEvidenceRepository {
   const _FakeEvidenceRepository({this.result = const [], this.error});
 
   final List<CompetitorClaimEvidence> result;
-  final Object? error;
+  final Exception? error;
 
   @override
   Future<List<CompetitorClaimEvidence>> fetchForCompetitor(

--- a/test/ui/features/comparison/comparison_evidence_state_test.dart
+++ b/test/ui/features/comparison/comparison_evidence_state_test.dart
@@ -1,0 +1,173 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/competitor_claim_evidence.dart';
+import 'package:my_web_app/services/competitor_claim_evidence_repository.dart';
+import 'package:my_web_app/ui/features/comparison/view_models/comparison_evidence_view_model.dart';
+import 'package:my_web_app/ui/features/comparison/widgets/comparison_evidence_section.dart';
+
+void main() {
+  group('CompetitorClaimEvidence', () {
+    test('accepts complete auditable evidence', () {
+      final evidence = CompetitorClaimEvidence.tryFromJson({
+        'competitor_id': 'notion',
+        'claim_key': 'pricing-free-plan',
+        'claim_type': 'pricing',
+        'claim_text': '無料プランの公開条件は公式料金ページで確認できます。',
+        'source_url': 'https://www.notion.com/pricing',
+        'verified_at': '2026-08-25T12:00:00+09:00',
+      });
+
+      expect(evidence, isNotNull);
+      expect(evidence!.claimType, CompetitorClaimType.pricing);
+      expect(evidence.sourceUri.host, 'www.notion.com');
+      expect(evidence.verifiedAt.isUtc, isTrue);
+    });
+
+    test('withholds incomplete or non-http evidence', () {
+      expect(
+        CompetitorClaimEvidence.tryFromJson({
+          'competitor_id': 'notion',
+          'claim_key': 'pricing',
+          'claim_type': 'pricing',
+          'claim_text': 'claim',
+          'source_url': 'javascript:alert(1)',
+          'verified_at': '2026-08-25T00:00:00Z',
+        }),
+        isNull,
+      );
+      expect(
+        CompetitorClaimEvidence.tryFromJson({
+          'competitor_id': 'notion',
+          'claim_key': 'pricing',
+          'claim_type': 'pricing',
+          'claim_text': 'claim',
+          'source_url': 'https://example.com',
+        }),
+        isNull,
+      );
+    });
+  });
+
+  group('ComparisonEvidenceViewModel', () {
+    test('loads verified rows and normalizes repository state', () async {
+      final evidence = _evidence();
+      final viewModel = ComparisonEvidenceViewModel(
+        repository: _FakeEvidenceRepository(result: [evidence]),
+      );
+
+      await viewModel.load('notion');
+
+      expect(viewModel.status, ComparisonEvidenceStatus.loaded);
+      expect(viewModel.claims, [evidence]);
+      viewModel.dispose();
+    });
+
+    test('fails closed without retaining fallback claims', () async {
+      final viewModel = ComparisonEvidenceViewModel(
+        repository: _FakeEvidenceRepository(error: StateError('offline')),
+      );
+
+      await viewModel.load('notion');
+
+      expect(viewModel.status, ComparisonEvidenceStatus.unavailable);
+      expect(viewModel.claims, isEmpty);
+      viewModel.dispose();
+    });
+  });
+
+  group('ComparisonEvidenceSection', () {
+    testWidgets('explains that unavailable evidence is publicly withheld', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            backgroundColor: Color(0xFF080812),
+            body: ComparisonEvidenceSection(
+              title: '比較情報',
+              status: ComparisonEvidenceStatus.unavailable,
+              claims: [],
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.byKey(const Key('comparison-evidence-unavailable')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('公開保留'), findsOneWidget);
+    });
+
+    testWidgets('renders claim, verification date, and source action', (
+      tester,
+    ) async {
+      Uri? launched;
+      final evidence = _evidence();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            backgroundColor: const Color(0xFF080812),
+            body: ComparisonEvidenceSection(
+              title: '比較情報',
+              status: ComparisonEvidenceStatus.loaded,
+              claims: [evidence],
+              sourceLauncher: (uri) async {
+                launched = uri;
+                return true;
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text(evidence.claimText), findsOneWidget);
+      expect(find.text('確認日: 2026-08-25'), findsOneWidget);
+      await tester.tap(
+        find.byKey(const Key('comparison-evidence-source-pricing')),
+      );
+      await tester.pump();
+      expect(launched, evidence.sourceUri);
+    });
+  });
+
+  test('migration requires evidence metadata without seeding claims', () {
+    final migration = File(
+      'supabase/migrations/'
+      '20260826090000_create_competitor_claim_evidence.sql',
+    ).readAsStringSync();
+
+    expect(migration, contains('source_url text not null'));
+    expect(migration, contains('verified_at timestamptz not null'));
+    expect(migration, contains('enable row level security'));
+    expect(migration.toLowerCase(), isNot(contains('insert into')));
+  });
+}
+
+CompetitorClaimEvidence _evidence() => CompetitorClaimEvidence(
+      competitorId: 'notion',
+      claimKey: 'pricing',
+      claimType: CompetitorClaimType.pricing,
+      claimText: '公式料金ページで確認した比較情報です。',
+      sourceUri: Uri.parse('https://www.notion.com/pricing'),
+      verifiedAt: DateTime.utc(2026, 8, 25),
+    );
+
+class _FakeEvidenceRepository implements CompetitorClaimEvidenceRepository {
+  const _FakeEvidenceRepository({this.result = const [], this.error});
+
+  final List<CompetitorClaimEvidence> result;
+  final Object? error;
+
+  @override
+  Future<List<CompetitorClaimEvidence>> fetchForCompetitor(
+    String competitorId,
+  ) async {
+    if (error != null) {
+      throw error!;
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
Closes #4726
Related to #2596

## Summary

- add a public-read/service-write `competitor_claim_evidence` audit table requiring exact claim text, source URL, and `verified_at`
- move comparison evidence fetching out of the widget into an injected repository and ChangeNotifier view model
- render only evidence rows; pricing, feature, Japan-presence, tagline, and pain-point fallback claims without evidence are explicitly withheld
- fail closed when evidence fetching fails instead of silently showing the legacy const map
- show the verification date, source host/link, and a clear “confirmation-time snapshot, not a current guarantee” notice
- add model, fallback-state, widget, source-action, and migration tests

## Architecture / data notes

- UI: `ComparisonEvidenceStatusBanner` and `ComparisonEvidenceSection`
- state: `ComparisonEvidenceViewModel`
- data boundary: `CompetitorClaimEvidenceRepository` with Supabase implementation
- schema: new audit overlay only; existing `competitors`, `competitor_features`, prices, legal copy, and production rows are not changed or seeded
- #2596 is deliberately reused/superseded at the presentation boundary: its raw dynamic overlays are no longer public unless a corresponding audited claim row exists

## Validation

- targeted Dart formatting for new files: passed using package language 3.6
- huge-page guard: normalized formatter comparison found 0 content-different lines in `comparison_page.dart`; final page diff is scoped to +86/-161, not the accidental whole-file rewrite
- `git diff --cached --check`: passed (Windows LF/CRLF notices only)
- migration contains no `INSERT`; timestamp follows current main migration history
- duplicate open PR search for #4726/evidence work: none
- local Flutter analyze/test/browser QA deferred because RAM is 92.2% with 1.22 GB free; full GitHub CI is mandatory before merge
- commit/push hook reported `Can't find lefthook in PATH`; commit and remote branch were verified directly

## Minimal E2E Gate

- Implementation-detail independent: widget tests assert the user-visible verified, unavailable, and source-link states.
- Minimal scope: evidence-present and evidence-unavailable paths plus source action.
- E2E-Exception: the route and navigation contract are unchanged; the new evidence/fallback component is covered by focused widget tests, while CI web smoke and production build remain mandatory.

## Visual E2E Evidence

- Changed surface: public comparison pages (`/vs-*`, linked from `/competitors`).
- Browser evidence deferred under the repository RAM safety gate; no screenshot is claimed as proof.
- No generated imagery was used.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: additive empty audit table and fail-closed read path only; no production data seed, price change, destructive SQL, secret, auth expansion, or deployment action.
- Security: source URLs are restricted to HTTP(S) in SQL and Dart; rendered text is plain Flutter text; writes remain service-role only.
- Rollback: revert the commit; the additive empty table can remain inert or be removed by a separately reviewed rollback migration.
- Data migration: schema-only table/index/RLS policies; no existing row is modified and no evidence row is inserted.
- Prod smoke: not performed; deployment remains separately approved and GitHub CI must pass before merge.
- Observability: the UI distinguishes loading, empty, unavailable, and verified states without exposing raw errors.
- Unresolved ultrareview findings: 0.

## Subagent record

No subagent was started because RAM never passed the repository gate twice consecutively. The implementation was reviewed in the lead lane and still requires deterministic GitHub checks.