### PR TITLE
fix: Edge Function監査のSupabase upsert競合を解消

### DIFF
--- a/.github/workflows/edge-function-audit.yml
+++ b/.github/workflows/edge-function-audit.yml
@@ -127,7 +127,7 @@ jobs:
             -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
             -H "Content-Type: application/json" \
             -H "Prefer: resolution=merge-duplicates" \
-            "$SUPABASE_URL/rest/v1/edge_function_ui_status" \
+            "$SUPABASE_URL/rest/v1/edge_function_ui_status?on_conflict=function_name" \
             -d @/tmp/upsert_payload.json \
             --max-time 15)
 
@@ -152,6 +152,7 @@ jobs:
           else
             echo "⚠️ Supabase upsert 失敗 (HTTP $HTTP_CODE)"
             cat /tmp/upsert_result.json 2>/dev/null || true
+            exit 1
           fi
 
       - name: Create/Update Issue if missing functions


### PR DESCRIPTION
## 概要

- 実地監査run 32920625415で、edge_function_ui_statusへのPOSTがHTTP 409になった原因を修正します。
- PostgREST upsertへ on_conflict=function_name を指定し、既存unique行を正しく更新します。
- 非2xx時はexit 1とし、同期失敗後にIssue Close処理へ進まないようにします。

Relates to #4848

## 検証

- YAML parse: PASS
- Upsert Bash block bash -n: PASS
- check_github_actions_script_injection.py: PASS
- check_cicd_path_filters.py: PASS
- git diff --check: PASS

## Minimal E2E Gate

- Implementation-detail independent: the workflow is verified through the actual Supabase HTTP result.
- Minimal scope: existing-row upsert success, non-2xx failure, and downstream Issue-close gating.
- E2E: GitHub Actions workflow_dispatch is the black-box route.
- E2E-Exception: Workflow-only retry correction; no application route or interaction changed.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Narrow PostgREST conflict-target correction and fail-fast only; no secret value, schema, migration, application behavior, or deploy-control change.
