### PR TITLE
feat(notion): retry rate limits and monitor sync (#1289)

### DIFF
--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -110,10 +110,10 @@ jobs:
               echo "::warning::Notion sync EF idle timeout — batch too large for Supabase 150s limit (will retry next hour)"
               exit 0
             fi
-            # Notion API rate limit (HTTP 429) → soft-fail (will retry next hour)
+            # EF 内 retry が尽きた 429 は fail させ、resilience watch が再実行・通知する。
             if echo "$RESP" | grep -q "rate_limited\|\"429\""; then
-              echo "::warning::Notion API rate limited (HTTP 429) — will retry next cron"
-              exit 0
+              echo "::error::Notion API rate limit retries exhausted (HTTP 429)"
+              exit 1
             fi
             # Notion DB-level inaccessible (share with Integration / DB deleted) → always soft-fail
             if echo "$RESP" | grep -q "Could not find database"; then

--- a/.github/workflows/schedule-resilience-watch.yml
+++ b/.github/workflows/schedule-resilience-watch.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Inspect schedules without retrying runs or writing issues"
+        description: "Inspect workflows without retrying runs or writing issues"
         required: false
         default: "false"
 
@@ -22,7 +22,7 @@ jobs:
       actions: write
       contents: read
       issues: write
-    name: Watch scheduled workflow resilience
+    name: Watch production workflow resilience
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Watch scheduled workflows
+      - name: Watch production workflows
         env:
           GH_TOKEN: ${{ github.token }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}

--- a/scripts/schedule_resilience_watch.py
+++ b/scripts/schedule_resilience_watch.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Retry and alert guard for scheduled GitHub Actions workflows.
+"""Retry and alert guard for production GitHub Actions workflows.
 
-The guard watches a small set of production schedules, retries failed scheduled
-runs once, and opens/updates a workflow-failure issue when retry is exhausted or
-the schedule has stopped producing runs.
+The guard watches a small set of scheduled and deployment workflows, retries
+failed runs once, and opens/updates a workflow-failure issue when retry is
+exhausted or an expected schedule has stopped producing runs.
 """
 
 from __future__ import annotations
@@ -36,6 +36,7 @@ class WorkflowTarget:
     key: str
     workflow_file: str
     max_age_hours: int
+    event: str = "schedule"
 
 
 TARGETS = (
@@ -43,6 +44,8 @@ TARGETS = (
     WorkflowTarget("cs-check", "cs-check.yml", 3),
     WorkflowTarget("competitor-monitoring", "competitor-monitoring.yml", 30),
     WorkflowTarget("health-monitor", "health-monitor.yml", 3),
+    WorkflowTarget("notion-sync", "notion-sync.yml", 10),
+    WorkflowTarget("deploy-prod", "deploy-prod.yml", 0, "push"),
 )
 
 
@@ -71,9 +74,9 @@ def evaluate_target(
             "reason": "missing-run",
             "title": f"[Schedule監視] {target.key} missing run",
             "body": (
-                f"No scheduled run was found for `{target.workflow_file}`. "
-                "This may mean the schedule is disabled or GitHub Actions did "
-                "not dispatch it."
+                f"No run was found for `{target.workflow_file}`. "
+                f"Expected event: `{target.event}`. This may mean the workflow "
+                "is disabled or GitHub Actions did not dispatch it."
             ),
         }
 
@@ -102,7 +105,11 @@ def evaluate_target(
         return {**base, "action": "observe", "reason": f"run-{status}"}
 
     if conclusion in OK_CONCLUSIONS:
-        if age_hours is not None and age_hours > target.max_age_hours:
+        if (
+            target.max_age_hours > 0
+            and age_hours is not None
+            and age_hours > target.max_age_hours
+        ):
             return {
                 **base,
                 "action": "alert",
@@ -172,8 +179,14 @@ class GitHubClient:
                 return {}
             return json.loads(payload)
 
-    def scheduled_runs(self, workflow_file: str, *, limit: int) -> list[dict[str, Any]]:
-        query = urlencode({"branch": "main", "event": "schedule", "per_page": str(limit)})
+    def workflow_runs(
+        self,
+        workflow_file: str,
+        *,
+        event: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        query = urlencode({"branch": "main", "event": event, "per_page": str(limit)})
         path = f"/repos/{self.repo}/actions/workflows/{quote(workflow_file)}/runs?{query}"
         payload = self.request("GET", path)
         runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
@@ -270,7 +283,11 @@ def main(argv: list[str]) -> int:
     results: list[dict[str, Any]] = []
 
     for target in TARGETS:
-        runs = client.scheduled_runs(target.workflow_file, limit=args.limit)
+        runs = client.workflow_runs(
+            target.workflow_file,
+            event=target.event,
+            limit=args.limit,
+        )
         result = evaluate_target(target, runs, now, max_attempts=args.max_attempts)
 
         if result["action"] == "retry":

--- a/scripts/schedule_resilience_watch_test.py
+++ b/scripts/schedule_resilience_watch_test.py
@@ -6,7 +6,13 @@ from __future__ import annotations
 import unittest
 from datetime import datetime, timedelta, timezone
 
-from schedule_resilience_watch import WorkflowTarget, evaluate_target, render_summary
+from schedule_resilience_watch import (
+    GitHubClient,
+    TARGETS,
+    WorkflowTarget,
+    evaluate_target,
+    render_summary,
+)
 
 
 NOW = datetime(2026, 5, 8, 3, 0, tzinfo=timezone.utc)
@@ -62,6 +68,37 @@ class ScheduleResilienceWatchTest(unittest.TestCase):
         )
         self.assertEqual(result["action"], "alert")
         self.assertEqual(result["reason"], "stale-success")
+
+    def test_deploy_success_does_not_alert_only_because_it_is_old(self) -> None:
+        deploy = WorkflowTarget("deploy-prod", "deploy-prod.yml", 0, "push")
+        result = evaluate_target(
+            deploy,
+            [run(created_at=(NOW - timedelta(days=30)).isoformat().replace("+00:00", "Z"))],
+            NOW,
+            max_attempts=2,
+        )
+        self.assertEqual(result["action"], "healthy")
+        self.assertEqual(result["reason"], "latest-success")
+
+    def test_notion_and_deploy_workflows_are_monitored(self) -> None:
+        targets = {target.key: target for target in TARGETS}
+        self.assertEqual(targets["notion-sync"].event, "schedule")
+        self.assertEqual(targets["deploy-prod"].event, "push")
+
+    def test_workflow_runs_filters_by_requested_event(self) -> None:
+        class RecordingClient(GitHubClient):
+            requested_path = ""
+
+            def request(self, method, path, body=None):
+                self.requested_path = path
+                return {"workflow_runs": [{"id": 7}]}
+
+        client = RecordingClient("owner/repo", "token")
+        runs = client.workflow_runs("deploy-prod.yml", event="push", limit=5)
+
+        self.assertEqual(runs, [{"id": 7}])
+        self.assertIn("event=push", client.requested_path)
+        self.assertIn("per_page=5", client.requested_path)
 
     def test_summary_mentions_actions(self) -> None:
         summary = render_summary(

--- a/supabase/functions/_shared/external_fetch.ts
+++ b/supabase/functions/_shared/external_fetch.ts
@@ -26,8 +26,10 @@ export interface ExternalFetchOptions {
   baseDelayMs?: number;
   maxDelayMs?: number;
   retryStatuses?: number[];
+  jitterRatio?: number;
   traceId?: string;
   fetcher?: Fetcher;
+  random?: () => number;
   sleep?: Sleeper;
 }
 
@@ -91,6 +93,7 @@ export async function externalFetch(
     baseDelayMs,
     Math.floor(options.maxDelayMs ?? 5_000),
   );
+  const jitterRatio = Math.min(1, Math.max(0, options.jitterRatio ?? 0));
   // 429 は既定でリトライしない: rate-limit 到達後の自動再試行は全 call を
   // 最大 4 倍に増幅し、プラットフォーム側からは bot 的アクセス継続に見える
   // (2026-07-12 Qiita アカウント停止インシデントの加重要因)。
@@ -99,6 +102,7 @@ export async function externalFetch(
     options.retryStatuses ?? [408, 500, 502, 503, 504],
   );
   const fetcher = options.fetcher ?? fetch;
+  const random = options.random ?? Math.random;
   const sleep = options.sleep ??
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
@@ -146,9 +150,12 @@ export async function externalFetch(
 
     if (attempt < maxAttempts) {
       const exponentialDelayMs = baseDelayMs * 2 ** (attempt - 1);
+      const jitteredExponentialDelayMs = Math.round(
+        exponentialDelayMs * (1 + jitterRatio * random()),
+      );
       const requestedDelayMs = retryAfterMs === null
-        ? exponentialDelayMs
-        : Math.max(exponentialDelayMs, retryAfterMs);
+        ? jitteredExponentialDelayMs
+        : Math.max(jitteredExponentialDelayMs, retryAfterMs);
       const delayMs = Math.min(maxDelayMs, requestedDelayMs);
       if (delayMs > 0) {
         await sleep(delayMs);

--- a/supabase/functions/_shared/external_fetch.ts
+++ b/supabase/functions/_shared/external_fetch.ts
@@ -8,6 +8,18 @@ type Fetcher = (
 
 type Sleeper = (ms: number) => Promise<void>;
 
+function retryAfterDelayMs(value: string | null, nowMs: number): number | null {
+  if (!value) return null;
+  const seconds = Number(value.trim());
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1_000);
+  }
+
+  const retryAtMs = Date.parse(value);
+  if (!Number.isFinite(retryAtMs)) return null;
+  return Math.max(0, retryAtMs - nowMs);
+}
+
 export interface ExternalFetchOptions {
   retries?: number;
   timeoutMs?: number;
@@ -92,6 +104,7 @@ export async function externalFetch(
 
   let lastError: ExternalFetchError | null = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let retryAfterMs: number | null = null;
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     try {
@@ -104,6 +117,10 @@ export async function externalFetch(
       }
 
       const responseBody = await response.clone().text().catch(() => "");
+      retryAfterMs = retryAfterDelayMs(
+        response.headers.get("retry-after"),
+        Date.now(),
+      );
       lastError = new ExternalFetchError({
         targetApi,
         attempts: attempt,
@@ -128,7 +145,11 @@ export async function externalFetch(
     }
 
     if (attempt < maxAttempts) {
-      const delayMs = Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
+      const exponentialDelayMs = baseDelayMs * 2 ** (attempt - 1);
+      const requestedDelayMs = retryAfterMs === null
+        ? exponentialDelayMs
+        : Math.max(exponentialDelayMs, retryAfterMs);
+      const delayMs = Math.min(maxDelayMs, requestedDelayMs);
       if (delayMs > 0) {
         await sleep(delayMs);
       }

--- a/supabase/functions/_shared/external_fetch_test.ts
+++ b/supabase/functions/_shared/external_fetch_test.ts
@@ -104,6 +104,31 @@ Deno.test("externalFetch honors bounded Retry-After for opted-in 429", async () 
   assertEquals(delays, [1_500]);
 });
 
+Deno.test("externalFetch can add deterministic exponential jitter", async () => {
+  let calls = 0;
+  const delays: number[] = [];
+  await externalFetch("notion", "https://example.test/resource", {}, {
+    retries: 1,
+    baseDelayMs: 1_000,
+    jitterRatio: 0.2,
+    random: () => 0.5,
+    sleep: (ms) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+    fetcher: () => {
+      calls += 1;
+      return Promise.resolve(
+        new Response(calls === 1 ? "temporary" : "ok", {
+          status: calls === 1 ? 503 : 200,
+        }),
+      );
+    },
+  });
+
+  assertEquals(delays, [1_100]);
+});
+
 Deno.test("externalFetch reports exhausted timeout as user-facing temporary error", async () => {
   const error = await assertRejects(
     () =>

--- a/supabase/functions/_shared/external_fetch_test.ts
+++ b/supabase/functions/_shared/external_fetch_test.ts
@@ -11,14 +11,18 @@ import {
 
 Deno.test("externalFetch retries retryable HTTP statuses", async () => {
   let calls = 0;
+  const delays: number[] = [];
   const response = await externalFetch(
     "test-api",
     "https://example.test/resource",
     {},
     {
       retries: 2,
-      baseDelayMs: 0,
-      sleep: async () => {},
+      baseDelayMs: 100,
+      sleep: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
       fetcher: () => {
         calls += 1;
         return Promise.resolve(
@@ -31,22 +35,73 @@ Deno.test("externalFetch retries retryable HTTP statuses", async () => {
   );
 
   assertEquals(calls, 3);
+  assertEquals(delays, [100, 200]);
   assertEquals(response.status, 200);
 });
 
 Deno.test("externalFetch returns non-retryable client errors", async () => {
+  let calls = 0;
+  const delays: number[] = [];
   const response = await externalFetch(
     "test-api",
     "https://example.test/resource",
     {},
     {
       retries: 2,
-      fetcher: () =>
-        Promise.resolve(new Response("bad request", { status: 400 })),
+      sleep: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+      fetcher: () => {
+        calls += 1;
+        return Promise.resolve(
+          new Response("validation detail", {
+            status: 400,
+          }),
+        );
+      },
     },
   );
 
   assertEquals(response.status, 400);
+  assertEquals(await response.text(), "validation detail");
+  assertEquals(calls, 1);
+  assertEquals(delays, []);
+});
+
+Deno.test("externalFetch honors bounded Retry-After for opted-in 429", async () => {
+  let calls = 0;
+  const delays: number[] = [];
+  const response = await externalFetch(
+    "notion",
+    "https://example.test/resource",
+    {},
+    {
+      retries: 1,
+      baseDelayMs: 500,
+      maxDelayMs: 1_500,
+      retryStatuses: [429, 503],
+      sleep: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+      fetcher: () => {
+        calls += 1;
+        return Promise.resolve(
+          calls === 1
+            ? new Response("rate_limited", {
+              status: 429,
+              headers: { "Retry-After": "2" },
+            })
+            : new Response("ok", { status: 200 }),
+        );
+      },
+    },
+  );
+
+  assertEquals(response.status, 200);
+  assertEquals(calls, 2);
+  assertEquals(delays, [1_500]);
 });
 
 Deno.test("externalFetch reports exhausted timeout as user-facing temporary error", async () => {

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -1218,15 +1218,39 @@ async function notionFetch(
   path: string,
   init: RequestInit = {},
 ): Promise<Response> {
-  return await externalFetch(
+  const traceId = `schedule-hub.notion${path}`;
+  const response = await externalFetch(
     "notion",
     `https://api.notion.com/v1${path}`,
     {
       ...init,
       headers: mergeHeaders(notionHeaders(token), init.headers),
     },
-    { traceId: `schedule-hub.notion${path}` },
+    {
+      traceId,
+      retryStatuses: [408, 429, 500, 502, 503, 504],
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+    },
   );
+
+  // Retryable responses only reach this point after succeeding; exhausted
+  // retries throw ExternalFetchError. Log validation/auth details immediately
+  // without retrying so CI and Edge logs retain Notion's request context.
+  if (!response.ok) {
+    const detail = await response.clone().text().catch(() => "");
+    console.error(JSON.stringify({
+      level: "ERROR",
+      at: new Date().toISOString(),
+      target_api: "notion",
+      status: response.status,
+      retryable: false,
+      response_body: detail.slice(0, 500),
+      request_id: response.headers.get("x-notion-request-id"),
+      trace_id: traceId,
+    }));
+  }
+  return response;
 }
 
 async function configuredNotionDataSourceId(

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -1231,6 +1231,7 @@ async function notionFetch(
       retryStatuses: [408, 429, 500, 502, 503, 504],
       baseDelayMs: 1_000,
       maxDelayMs: 30_000,
+      jitterRatio: 0.2,
     },
   );
 


### PR DESCRIPTION
## Summary

- Opt Notion requests into retries for 429 plus temporary 408/5xx responses without changing the repository-wide default that deliberately excludes 429.
- Preserve exponential backoff, add bounded additive jitter, and honor Notion's integer-seconds `Retry-After` header within the Edge Function delay budget.
- Log bounded response body, status, Notion request ID, and trace ID immediately for non-retryable 4xx responses.
- Monitor `notion-sync.yml` scheduled runs and `deploy-prod.yml` push runs; retry failed jobs once and create/update a `workflow-failure` Issue after exhaustion.
- Make exhausted Notion 429 responses fail the workflow so the resilience watcher and existing failure handler can notify developers.

Closes #1289

## Validation

- `deno fmt --check` passed for all changed TypeScript files.
- `python scripts/schedule_resilience_watch_test.py`: 8 tests passed.
- GitHub Actions security policy: 120 workflows passed.
- GitHub Actions Node runtime policy: 223 uses passed.
- `git diff --check` passed.
- Focused Deno tests cover 503 exponential delays, immediate 400 return/detail retention, bounded `Retry-After`, deterministic jitter, and exhausted temporary errors. Local Deno test execution is deferred because host RAM remains above 88% with less than 2 GB free; GitHub CI is authoritative.

## Official references

- https://developers.notion.com/reference/request-limits
- https://developers.notion.com/reference/status-codes
- https://developers.notion.com/reference/query-a-data-source

## Subagent orchestration

No subagent was launched: the measured host did not meet the safety threshold of RAM below 85% and more than 2 GB free twice consecutively. This does not reduce deterministic CI coverage.

## Merge/deploy gates

- Keep Draft until Deno tests, actionlint, security policy, and automated agent review pass.
- After merge, require production Edge Function deployment success.
- Dispatch a one-row Notion sync and a dry-run resilience watch to verify live execution/monitor visibility before closing the Issue.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Backend-only Notion retry middleware and GitHub Actions monitoring change; no user-visible route changed. Focused Deno/Python unit tests cover retryable, non-retryable, Retry-After, workflow event, and monitoring behavior; CI is authoritative.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 ultrareview is unavailable in this Codex-owned Issue lane. Keep the PR draft until deterministic CI and automated agent review pass; production deployment and the dry-run resilience check occur only after merge.