### PR TITLE
fix(ops): align restore drill with current Supabase schema (#1291)

### DIFF
--- a/.github/workflows/supabase-backup-restore.yml
+++ b/.github/workflows/supabase-backup-restore.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v3
         with:
-          version: 2.84.2
+          # Keep the ephemeral Auth/Storage schemas aligned with production.
+          # Older 2.84.2 lacked auth.custom_oauth_providers.custom_claims_allowlist.
+          version: 2.115.0
 
       - name: Validate protected inputs
         shell: bash

--- a/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
+++ b/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
@@ -191,6 +191,11 @@ following logged compensating controls are mandatory.
 | Before deletion/transfer | Fresh backup + restore drill within 24 hours and explicit Owner approval |
 | After schema/Auth/Storage changes | Confirm the logical dump and restore scope still covers the change |
 
+The workflow pins Supabase CLI 2.115.0 because its local Auth schema matches the production
+`auth.custom_oauth_providers.custom_claims_allowlist` column observed during the first drill.
+Upgrade the pin deliberately when production's managed Auth/Storage schema moves forward; a restore
+failure caused by a missing managed column is a compatibility failure and must not be waived.
+
 ## 9. Official references
 
 - [Supabase Database Backups](https://supabase.com/docs/guides/platform/backups)


### PR DESCRIPTION
## Summary
- update the backup/restore workflow from Supabase CLI 2.84.2 to 2.115.0
- align the ephemeral managed Auth schema with production
- record the exact compatibility failure and forbid waiving managed-schema drift

## Root cause evidence
Initial live run 32938831016 completed production roles/schema/data dump, AES-256 encryption, plaintext removal, decrypt, and digest verification. Restore then failed transactionally because the old local Auth schema did not contain `auth.custom_oauth_providers.custom_claims_allowlist`, which exists in the production data dump.

## Validation
- actionlint 1.7.12: pass
- GitHub Actions security policy: 121 workflows pass
- git diff check: pass

## Safety
Production remains read-only. The failed transaction was against an ephemeral local Supabase target, and no database artifact was uploaded.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 review is unavailable in this Codex-only Issue lane; production access is read-only and closure requires a successful isolated live restore.
