### PR TITLE
fix: align restore drill with storage schema

### DIFF
--- a/.github/workflows/supabase-backup-restore.yml
+++ b/.github/workflows/supabase-backup-restore.yml
@@ -150,6 +150,10 @@ jobs:
             exit 1
           fi
 
+          echo "45969060b55102f56af317b0d7981434be58927de1ff76e1e1789139a3f2defc  scripts/sql/supabase_storage_v1_71_0_0062.sql" \
+            | sha256sum --check
+          docker cp scripts/sql/supabase_storage_v1_71_0_0062.sql \
+            "$db_container:/tmp/storage-compat.sql"
           docker cp "$restore_input/roles.sql" "$db_container:/tmp/roles.sql"
           docker cp "$restore_input/schema.sql" "$db_container:/tmp/schema.sql"
           docker cp "$restore_input/data.sql" "$db_container:/tmp/data.sql"
@@ -161,6 +165,7 @@ jobs:
             --dbname postgres \
             --single-transaction \
             --variable ON_ERROR_STOP=1 \
+            --file /tmp/storage-compat.sql \
             --file /tmp/roles.sql \
             --file /tmp/schema.sql \
             --file /tmp/pgmq-bootstrap.sql \

--- a/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
+++ b/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
@@ -204,12 +204,21 @@ following logged compensating controls are mandatory.
 
 The workflow pins Supabase CLI 2.115.0 because its local Auth schema matches the production
 `auth.custom_oauth_providers.custom_claims_allowlist` column observed during the first drill.
-Upgrade the pin deliberately when production's managed Auth/Storage schema moves forward; a restore
-failure caused by a missing managed column is a compatibility failure and must not be waived.
+Production Storage moved to v1.71.0 after that CLI release. Before applying the dump, the workflow
+therefore verifies and applies the exact upstream additive migration
+`scripts/sql/supabase_storage_v1_71_0_0062.sql` (SHA-256
+`45969060b55102f56af317b0d7981434be58927de1ff76e1e1789139a3f2defc`) to the ephemeral target.
+It is vendored byte-for-byte from Supabase Storage tag `v1.71.0`, commit
+`e05eb148dce70c55d7b4d9b524a3b20835b1e165`; it never runs against production or staging.
+
+Upgrade the CLI pin deliberately when its local Storage schema includes migration 0062, then remove
+the compatibility file and checksum in the same PR. A restore failure caused by a missing managed
+column is a compatibility failure and must not be waived.
 
 ## 9. Official references
 
 - [Supabase Database Backups](https://supabase.com/docs/guides/platform/backups)
 - [Backup and Restore using the CLI](https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore)
 - [Restore dashboard backup](https://supabase.com/docs/guides/platform/migrating-within-supabase/dashboard-restore)
+- [Supabase Storage v1.71.0 migration 0062](https://github.com/supabase/storage/blob/v1.71.0/migrations/tenant/0062-object-versioning-core.sql)
 - [Transfer projects](https://supabase.com/docs/guides/platform/project-transfer)

--- a/scripts/sql/supabase_storage_v1_71_0_0062.sql
+++ b/scripts/sql/supabase_storage_v1_71_0_0062.sql
@@ -1,0 +1,53 @@
+-- Establish the additive, dark schema shared by object versioning and lifecycle.
+-- No bucket can be enabled until a later writer-protocol migration and constraints are removed.
+
+ALTER TABLE storage.buckets
+ADD COLUMN IF NOT EXISTS versioning_status text NOT NULL DEFAULT 'DISABLED';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_versioning_status_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_versioning_status_check CHECK (
+      versioning_status IN ('DISABLED', 'ENABLED', 'SUSPENDED')
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_versioning_standard_only_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_versioning_standard_only_check CHECK (
+      type = 'STANDARD'
+      OR versioning_status = 'DISABLED'
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_versioning_dark_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_versioning_dark_check CHECK (
+      versioning_status = 'DISABLED'
+    );
+  END IF;
+END;
+$$;
+
+-- The existing nullable version column, objects_pkey(id), and bucketid_objname
+-- unique index intentionally remain unchanged in this wave.
+ALTER TABLE storage.objects
+ADD COLUMN IF NOT EXISTS archived_at timestamptz,
+ADD COLUMN IF NOT EXISTS is_delete_marker boolean NOT NULL DEFAULT false,
+ADD COLUMN IF NOT EXISTS is_versioned boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- apply Supabase Storage v1.71.0 migration 0062 to the ephemeral restore target before loading the production dump
- verify the vendored upstream SQL with its pinned SHA-256 before execution
- document provenance, isolation, and the removal condition once stable CLI catches up

## Root cause
Run 32949923129 restored the PGMQ relations and proceeded through most data COPY blocks, then failed because production Storage includes versioning_status and related object-versioning columns introduced by Storage v1.71.0 on 2026-08-24. The latest stable CLI 2.115.0 was released on 2026-08-18, so its local Storage schema predates that additive migration.

## Validation
- upstream file SHA-256: 45969060b55102f56af317b0d7981434be58927de1ff76e1e1789139a3f2defc
- python test/scripts/test_supabase_backup_verify.py (8 passed)
- python -m unittest discover -s test/scripts -p test_check_github_actions_security_policy.py (3 passed)
- python scripts/check_github_actions_security_policy.py --root .github/workflows (121 workflows passed)
- git diff --check

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude review is unavailable in this Codex-only lane; the checksum-pinned upstream SQL runs only on an ephemeral local target, production remains read-only, and closure requires a successful live drill.

Refs #1291