### PR TITLE
fix(backup): apply Storage compatibility as owner

### DIFF
--- a/.github/workflows/supabase-backup-restore.yml
+++ b/.github/workflows/supabase-backup-restore.yml
@@ -165,7 +165,9 @@ jobs:
             --dbname postgres \
             --single-transaction \
             --variable ON_ERROR_STOP=1 \
+            --command 'SET ROLE supabase_storage_admin' \
             --file /tmp/storage-compat.sql \
+            --command 'RESET ROLE' \
             --file /tmp/roles.sql \
             --file /tmp/schema.sql \
             --file /tmp/pgmq-bootstrap.sql \

--- a/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
+++ b/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
@@ -74,16 +74,18 @@ The workflow may run only on `refs/heads/main` and has read-only repository perm
 4. Encrypt the bundle with encrypted headers, verify it is non-empty, and delete plaintext.
 5. Decrypt into a new runner directory and verify every digest and byte size.
 6. Start a fresh local Supabase Postgres 17 target with no repository migrations.
-7. Recreate non-partitioned, logged PGMQ queue relations found as matching `pgmq.q_*` / `pgmq.a_*` COPY
+7. Apply the checksum-verified Storage compatibility migration as the local
+   `supabase_storage_admin` table owner, then immediately reset the session role to `postgres`.
+8. Recreate non-partitioned, logged PGMQ queue relations found as matching `pgmq.q_*` / `pgmq.a_*` COPY
    pairs. The CLI intentionally omits extension-managed DDL, so these relations must exist before
    queue rows can be restored. Remove the bootstrap metadata rows only when source PGMQ metadata is
    present, allowing the source metadata to be restored without a duplicate key.
-8. Restore roles, schema, and data in a single transaction with `ON_ERROR_STOP=1`.
-9. Advance each restored PGMQ queue sequence to its maximum restored message ID.
-10. Parse every `COPY` block for the `public` and `pgmq` schemas and assert the restored row count
+9. Restore roles, schema, and data in a single transaction with `ON_ERROR_STOP=1`.
+10. Advance each restored PGMQ queue sequence to its maximum restored message ID.
+11. Parse every `COPY` block for the `public` and `pgmq` schemas and assert the restored row count
     of every table.
-11. Stop/delete the ephemeral restore target and remove decrypted SQL.
-12. Upload only the encrypted bundle and sanitized evidence for 35 days.
+12. Stop/delete the ephemeral restore target and remove decrypted SQL.
+13. Upload only the encrypted bundle and sanitized evidence for 35 days.
 
 This proves that the exact encrypted artifact can be decrypted and that application-owned database
 tables plus durable PGMQ messages can be restored outside the source project. It never writes to
@@ -210,6 +212,9 @@ therefore verifies and applies the exact upstream additive migration
 `45969060b55102f56af317b0d7981434be58927de1ff76e1e1789139a3f2defc`) to the ephemeral target.
 It is vendored byte-for-byte from Supabase Storage tag `v1.71.0`, commit
 `e05eb148dce70c55d7b4d9b524a3b20835b1e165`; it never runs against production or staging.
+The local Supabase image owns the affected tables as `supabase_storage_admin`, so the restore
+transaction uses that existing role only for this migration and resets to `postgres` before
+restoring the exported roles, schema, and data.
 
 Upgrade the CLI pin deliberately when its local Storage schema includes migration 0062, then remove
 the compatibility file and checksum in the same PR. A restore failure caused by a missing managed

--- a/test/scripts/test_supabase_backup_verify.py
+++ b/test/scripts/test_supabase_backup_verify.py
@@ -113,6 +113,19 @@ COPY "public"."notes" ("id", "body") FROM stdin;
             payload = build_manifest(root, "ref")
             self.assertIsInstance(json.dumps(payload), str)
 
+    def test_storage_compatibility_runs_as_local_storage_owner(self) -> None:
+        workflow = (
+            ROOT / ".github" / "workflows" / "supabase-backup-restore.yml"
+        ).read_text(encoding="utf-8")
+        set_role = "--command 'SET ROLE supabase_storage_admin'"
+        compatibility = "--file /tmp/storage-compat.sql"
+        reset_role = "--command 'RESET ROLE'"
+        roles_restore = "--file /tmp/roles.sql"
+
+        self.assertLess(workflow.index(set_role), workflow.index(compatibility))
+        self.assertLess(workflow.index(compatibility), workflow.index(reset_role))
+        self.assertLess(workflow.index(reset_role), workflow.index(roles_restore))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes the latest restore-drill blocker for #1291.

The local Supabase image owns `storage.buckets` and `storage.objects` as `supabase_storage_admin`. Run the checksum-verified upstream Storage compatibility migration under that existing role, then reset to `postgres` before restoring exported roles/schema/data.

Validation:
- `python test/scripts/test_supabase_backup_verify.py` (9 passed)
- `python -m unittest discover -s test/scripts -p test_check_github_actions_security_policy.py` (3 passed)
- `python scripts/check_github_actions_security_policy.py --root .github/workflows` (121 workflows passed)
- `git diff --check --no-ext-diff`

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: owner-role-only-storage-compat