### PR TITLE
fix(backup): connect as Storage owner for compatibility

### DIFF
--- a/.github/workflows/supabase-backup-restore.yml
+++ b/.github/workflows/supabase-backup-restore.yml
@@ -161,13 +161,16 @@ jobs:
           docker cp "$pgmq_bootstrap" "$db_container:/tmp/pgmq-bootstrap.sql"
           docker cp "$pgmq_finalize" "$db_container:/tmp/pgmq-finalize.sql"
           docker exec "$db_container" psql \
+            --username supabase_storage_admin \
+            --dbname postgres \
+            --single-transaction \
+            --variable ON_ERROR_STOP=1 \
+            --file /tmp/storage-compat.sql
+          docker exec "$db_container" psql \
             --username postgres \
             --dbname postgres \
             --single-transaction \
             --variable ON_ERROR_STOP=1 \
-            --command 'SET ROLE supabase_storage_admin' \
-            --file /tmp/storage-compat.sql \
-            --command 'RESET ROLE' \
             --file /tmp/roles.sql \
             --file /tmp/schema.sql \
             --file /tmp/pgmq-bootstrap.sql \

--- a/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
+++ b/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
@@ -74,8 +74,9 @@ The workflow may run only on `refs/heads/main` and has read-only repository perm
 4. Encrypt the bundle with encrypted headers, verify it is non-empty, and delete plaintext.
 5. Decrypt into a new runner directory and verify every digest and byte size.
 6. Start a fresh local Supabase Postgres 17 target with no repository migrations.
-7. Apply the checksum-verified Storage compatibility migration as the local
-   `supabase_storage_admin` table owner, then immediately reset the session role to `postgres`.
+7. Connect as the local `supabase_storage_admin` table owner and apply the checksum-verified
+   Storage compatibility migration in its own fail-closed transaction. Reconnect as `postgres`
+   for the exported roles, schema, and data restore.
 8. Recreate non-partitioned, logged PGMQ queue relations found as matching `pgmq.q_*` / `pgmq.a_*` COPY
    pairs. The CLI intentionally omits extension-managed DDL, so these relations must exist before
    queue rows can be restored. Remove the bootstrap metadata rows only when source PGMQ metadata is
@@ -212,9 +213,10 @@ therefore verifies and applies the exact upstream additive migration
 `45969060b55102f56af317b0d7981434be58927de1ff76e1e1789139a3f2defc`) to the ephemeral target.
 It is vendored byte-for-byte from Supabase Storage tag `v1.71.0`, commit
 `e05eb148dce70c55d7b4d9b524a3b20835b1e165`; it never runs against production or staging.
-The local Supabase image owns the affected tables as `supabase_storage_admin`, so the restore
-transaction uses that existing role only for this migration and resets to `postgres` before
-restoring the exported roles, schema, and data.
+The local Supabase image owns the affected tables as the login-enabled
+`supabase_storage_admin` role. The workflow connects as that existing owner only for this migration,
+then opens a separate `postgres` transaction for the exported roles, schema, and data. It does not
+depend on `postgres` being allowed to use `SET ROLE`, which varies across local image revisions.
 
 Upgrade the CLI pin deliberately when its local Storage schema includes migration 0062, then remove
 the compatibility file and checksum in the same PR. A restore failure caused by a missing managed

--- a/test/scripts/test_supabase_backup_verify.py
+++ b/test/scripts/test_supabase_backup_verify.py
@@ -113,18 +113,22 @@ COPY "public"."notes" ("id", "body") FROM stdin;
             payload = build_manifest(root, "ref")
             self.assertIsInstance(json.dumps(payload), str)
 
-    def test_storage_compatibility_runs_as_local_storage_owner(self) -> None:
+    def test_storage_compatibility_connects_as_local_storage_owner(self) -> None:
         workflow = (
             ROOT / ".github" / "workflows" / "supabase-backup-restore.yml"
         ).read_text(encoding="utf-8")
-        set_role = "--command 'SET ROLE supabase_storage_admin'"
+        owner_login = "--username supabase_storage_admin"
         compatibility = "--file /tmp/storage-compat.sql"
-        reset_role = "--command 'RESET ROLE'"
+        postgres_login = "--username postgres"
         roles_restore = "--file /tmp/roles.sql"
 
-        self.assertLess(workflow.index(set_role), workflow.index(compatibility))
-        self.assertLess(workflow.index(compatibility), workflow.index(reset_role))
-        self.assertLess(workflow.index(reset_role), workflow.index(roles_restore))
+        owner_index = workflow.index(owner_login)
+        compatibility_index = workflow.index(compatibility)
+        postgres_index = workflow.index(postgres_login, compatibility_index)
+        self.assertLess(owner_index, compatibility_index)
+        self.assertLess(compatibility_index, postgres_index)
+        self.assertLess(postgres_index, workflow.index(roles_restore))
+        self.assertNotIn("SET ROLE supabase_storage_admin", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up for #1291 after restore drill 32955043213 failed before executing the Storage compatibility SQL.

The local `postgres` role cannot `SET ROLE supabase_storage_admin` in this image revision. Execute only the checksum-verified upstream compatibility migration through a separate login as the existing table owner, then restore exported roles/schema/data in the original `postgres` transaction.

Validation:
- `python test/scripts/test_supabase_backup_verify.py` (9 passed)
- `python -m unittest discover -s test/scripts -p test_check_github_actions_security_policy.py` (3 passed)
- `python scripts/check_github_actions_security_policy.py --root .github/workflows` (121 workflows passed)
- `git diff --check --no-ext-diff`

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: isolated-storage-owner-login