### PR TITLE
fix(backup): authenticate Storage owner over loopback

### DIFF
--- a/.github/workflows/supabase-backup-restore.yml
+++ b/.github/workflows/supabase-backup-restore.yml
@@ -160,12 +160,16 @@ jobs:
           docker cp "$assertions" "$db_container:/tmp/restore-assertions.sql"
           docker cp "$pgmq_bootstrap" "$db_container:/tmp/pgmq-bootstrap.sql"
           docker cp "$pgmq_finalize" "$db_container:/tmp/pgmq-finalize.sql"
-          docker exec "$db_container" psql \
-            --username supabase_storage_admin \
-            --dbname postgres \
-            --single-transaction \
-            --variable ON_ERROR_STOP=1 \
-            --file /tmp/storage-compat.sql
+          docker exec "$db_container" sh -c '
+            export PGPASSWORD="$POSTGRES_PASSWORD"
+            exec psql \
+              --host 127.0.0.1 \
+              --username supabase_storage_admin \
+              --dbname postgres \
+              --single-transaction \
+              --variable ON_ERROR_STOP=1 \
+              --file /tmp/storage-compat.sql
+          '
           docker exec "$db_container" psql \
             --username postgres \
             --dbname postgres \

--- a/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
+++ b/docs/SUPABASE_BACKUP_RESTORE_RUNBOOK.md
@@ -74,9 +74,10 @@ The workflow may run only on `refs/heads/main` and has read-only repository perm
 4. Encrypt the bundle with encrypted headers, verify it is non-empty, and delete plaintext.
 5. Decrypt into a new runner directory and verify every digest and byte size.
 6. Start a fresh local Supabase Postgres 17 target with no repository migrations.
-7. Connect as the local `supabase_storage_admin` table owner and apply the checksum-verified
-   Storage compatibility migration in its own fail-closed transaction. Reconnect as `postgres`
-   for the exported roles, schema, and data restore.
+7. Connect over container-local loopback TCP as the local `supabase_storage_admin` table owner,
+   using the database password already injected into the ephemeral container, and apply the
+   checksum-verified Storage compatibility migration in its own fail-closed transaction. Reconnect
+   as `postgres` for the exported roles, schema, and data restore.
 8. Recreate non-partitioned, logged PGMQ queue relations found as matching `pgmq.q_*` / `pgmq.a_*` COPY
    pairs. The CLI intentionally omits extension-managed DDL, so these relations must exist before
    queue rows can be restored. Remove the bootstrap metadata rows only when source PGMQ metadata is
@@ -215,8 +216,10 @@ It is vendored byte-for-byte from Supabase Storage tag `v1.71.0`, commit
 `e05eb148dce70c55d7b4d9b524a3b20835b1e165`; it never runs against production or staging.
 The local Supabase image owns the affected tables as the login-enabled
 `supabase_storage_admin` role. The workflow connects as that existing owner only for this migration,
-then opens a separate `postgres` transaction for the exported roles, schema, and data. It does not
-depend on `postgres` being allowed to use `SET ROLE`, which varies across local image revisions.
+then opens a separate `postgres` transaction for the exported roles, schema, and data. The owner
+connection uses the ephemeral container's existing `POSTGRES_PASSWORD` over loopback TCP without
+printing or copying the value into repository source. It does not depend on local socket peer
+authentication or on `postgres` being allowed to use `SET ROLE`, both of which vary across images.
 
 Upgrade the CLI pin deliberately when its local Storage schema includes migration 0062, then remove
 the compatibility file and checksum in the same PR. A restore failure caused by a missing managed

--- a/test/scripts/test_supabase_backup_verify.py
+++ b/test/scripts/test_supabase_backup_verify.py
@@ -117,14 +117,20 @@ COPY "public"."notes" ("id", "body") FROM stdin;
         workflow = (
             ROOT / ".github" / "workflows" / "supabase-backup-restore.yml"
         ).read_text(encoding="utf-8")
+        local_password = 'export PGPASSWORD="$POSTGRES_PASSWORD"'
+        loopback = "--host 127.0.0.1"
         owner_login = "--username supabase_storage_admin"
         compatibility = "--file /tmp/storage-compat.sql"
         postgres_login = "--username postgres"
         roles_restore = "--file /tmp/roles.sql"
 
+        password_index = workflow.index(local_password)
+        loopback_index = workflow.index(loopback, password_index)
         owner_index = workflow.index(owner_login)
         compatibility_index = workflow.index(compatibility)
         postgres_index = workflow.index(postgres_login, compatibility_index)
+        self.assertLess(password_index, loopback_index)
+        self.assertLess(loopback_index, owner_index)
         self.assertLess(owner_index, compatibility_index)
         self.assertLess(compatibility_index, postgres_index)
         self.assertLess(postgres_index, workflow.index(roles_restore))


### PR DESCRIPTION
Follow-up for #1291 after restore drill 32956827884 hit local socket peer authentication for `supabase_storage_admin`.

The official Supabase CLI injects `POSTGRES_PASSWORD` into the ephemeral DB container. Without printing or copying that value into source, run the owner-only compatibility migration over container-local loopback TCP, then keep the exported roles/schema/data restore on the original `postgres` path.

Validation:
- `python test/scripts/test_supabase_backup_verify.py` (9 passed)
- `python -m unittest discover -s test/scripts -p test_check_github_actions_security_policy.py` (3 passed)
- `python scripts/check_github_actions_security_policy.py --root .github/workflows` (121 workflows passed)
- `git diff --check --no-ext-diff`

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ephemeral-loopback-owner-auth