### PR TITLE
fix(backup): upload from configured backup root

### DIFF
--- a/.github/workflows/supabase-backup-restore.yml
+++ b/.github/workflows/supabase-backup-restore.yml
@@ -227,8 +227,8 @@ jobs:
         with:
           name: supabase-production-backup-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            ${{ runner.temp }}/supabase-backup/bundle/*.7z
-            ${{ runner.temp }}/supabase-backup/bundle/restore-evidence.json
+            ${{ env.BACKUP_ROOT }}/bundle/*.7z
+            ${{ env.BACKUP_ROOT }}/bundle/restore-evidence.json
           if-no-files-found: error
           retention-days: 35
           compression-level: 0

--- a/test/scripts/test_supabase_backup_verify.py
+++ b/test/scripts/test_supabase_backup_verify.py
@@ -136,6 +136,18 @@ COPY "public"."notes" ("id", "body") FROM stdin;
         self.assertLess(postgres_index, workflow.index(roles_restore))
         self.assertNotIn("SET ROLE supabase_storage_admin", workflow)
 
+    def test_artifact_upload_uses_the_backup_root(self) -> None:
+        workflow = (
+            ROOT / ".github" / "workflows" / "supabase-backup-restore.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("${{ env.BACKUP_ROOT }}/bundle/*.7z", workflow)
+        self.assertIn(
+            "${{ env.BACKUP_ROOT }}/bundle/restore-evidence.json",
+            workflow,
+        )
+        self.assertNotIn("${{ runner.temp }}/supabase-backup", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up for #1291 after restore drill 32962562258 successfully completed the isolated restore and evidence generation, then failed only because the upload step used a different root path.

Use the job's canonical `${{ env.BACKUP_ROOT }}` for both encrypted archive and sanitized evidence upload. A regression test prevents reintroducing `${{ runner.temp }}/supabase-backup` while the actual files are under `/tmp/supabase-backup`.

Validation:
- `python test/scripts/test_supabase_backup_verify.py` (10 passed)
- `python -m unittest discover -s test/scripts -p test_check_github_actions_security_policy.py` (3 passed)
- `python scripts/check_github_actions_security_policy.py --root .github/workflows` (121 workflows passed)
- `git diff --check --no-ext-diff`

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: encrypted-artifact-path-alignment