### PR TITLE
fix: prevent personal KPI card overflow (#1333)

### DIFF
--- a/lib/pages/personal_dashboard_page.dart
+++ b/lib/pages/personal_dashboard_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 
 import '../models/kgi_csf_kpi.dart';
 import '../widgets/kgi_csf_kpi_panel.dart';
+import '../widgets/personal_dashboard_kpi_card.dart';
 import 'package:my_web_app/utils/tab_route_url_sync.dart';
 
 enum PersonalDashboardDataMode { live, fallback }
@@ -34,7 +35,7 @@ PersonalDashboardGridSpec personalDashboardGridSpec(double maxWidth) {
   }
   return const PersonalDashboardGridSpec(
     crossAxisCount: 1,
-    childAspectRatio: 2.7,
+    childAspectRatio: 2.2,
   );
 }
 
@@ -407,6 +408,15 @@ class _PersonalDashboardPageState extends State<PersonalDashboardPage>
     final taskRate = (_kpiData['task_rate'] as num?)?.toDouble() ?? 0.0;
 
     final focusHours = '${(focusMinutes / 60).toStringAsFixed(1)}h';
+    final noteSubtitle =
+        noteGrowth > 0 ? '+$noteGrowth 今週' : '記録が増えると週次差分を表示';
+    final taskSubtitle = taskRate > 0
+        ? '達成率 ${(taskRate * 100).toStringAsFixed(0)}%'
+        : '記録前でも達成率バーを表示';
+    final focusSubtitle =
+        focusMinutes > 0 ? '合計 $focusMinutes分' : 'ポモドーロや集中ログを待機中';
+    final habitSubtitle =
+        habitStreak >= 7 ? '🔥 週間達成！' : '習慣が入ると継続日数を追跡';
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -458,35 +468,33 @@ class _PersonalDashboardPageState extends State<PersonalDashboardPage>
                 mainAxisSpacing: 12,
                 childAspectRatio: gridSpec.childAspectRatio,
                 children: [
-                  _kpiCard(
-                    '総ノート数',
-                    totalNotes.toString(),
-                    Icons.note_alt,
-                    const Color(0xFF7C3AED),
-                    noteGrowth > 0 ? '+$noteGrowth 今週' : '記録が増えると週次差分を表示',
+                  PersonalDashboardKpiCard(
+                    label: '総ノート数',
+                    value: totalNotes.toString(),
+                    icon: Icons.note_alt,
+                    color: const Color(0xFF7C3AED),
+                    subtitle: noteSubtitle,
                   ),
-                  _kpiCard(
-                    'タスク完了',
-                    tasksCompleted.toString(),
-                    Icons.task_alt,
-                    const Color(0xFF059669),
-                    taskRate > 0
-                        ? '達成率 ${(taskRate * 100).toStringAsFixed(0)}%'
-                        : '記録前でも達成率バーを表示',
+                  PersonalDashboardKpiCard(
+                    label: 'タスク完了',
+                    value: tasksCompleted.toString(),
+                    icon: Icons.task_alt,
+                    color: const Color(0xFF059669),
+                    subtitle: taskSubtitle,
                   ),
-                  _kpiCard(
-                    '集中時間',
-                    focusHours,
-                    Icons.timer,
-                    const Color(0xFFDC2626),
-                    focusMinutes > 0 ? '合計 $focusMinutes分' : 'ポモドーロや集中ログを待機中',
+                  PersonalDashboardKpiCard(
+                    label: '集中時間',
+                    value: focusHours,
+                    icon: Icons.timer,
+                    color: const Color(0xFFDC2626),
+                    subtitle: focusSubtitle,
                   ),
-                  _kpiCard(
-                    '習慣ストリーク',
-                    '$habitStreak日',
-                    Icons.local_fire_department,
-                    const Color(0xFFF59E0B),
-                    habitStreak >= 7 ? '🔥 週間達成！' : '習慣が入ると継続日数を追跡',
+                  PersonalDashboardKpiCard(
+                    label: '習慣ストリーク',
+                    value: '$habitStreak日',
+                    icon: Icons.local_fire_department,
+                    color: const Color(0xFFF59E0B),
+                    subtitle: habitSubtitle,
                   ),
                 ],
               );
@@ -638,75 +646,6 @@ class _PersonalDashboardPageState extends State<PersonalDashboardPage>
       targetLabel: '70%以上',
       progress: (taskRatePercent / 70).clamp(0, 1).toDouble(),
       metrics: metrics,
-    );
-  }
-
-  Widget _kpiCard(
-    String label,
-    String value,
-    IconData icon,
-    Color color,
-    String? subtitle,
-  ) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: isDark ? const Color(0xFF1A1A1A) : Colors.white,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: isDark ? const Color(0xFF2A2A2A) : const Color(0xFFE2E8F0),
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Row(
-            children: [
-              Icon(icon, size: 18, color: color),
-              const SizedBox(width: 6),
-              Expanded(
-                child: Text(
-                  label,
-                  style: const TextStyle(
-                    fontSize: 11,
-                    color: Color(0xFF64748B),
-                    fontWeight: FontWeight.w500,
-                    height: 1.5,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
-          ),
-          Text(
-            value,
-            style: TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.w800,
-              color: color,
-              height: 1.5,
-            ),
-          ),
-          if (subtitle != null)
-            Text(
-              subtitle,
-              style: const TextStyle(
-                fontSize: 10,
-                height: 1.5,
-                color: Color(0xFF94A3B8),
-              ),
-            ),
-        ],
-      ),
     );
   }
 

--- a/lib/pages/personal_dashboard_page.dart
+++ b/lib/pages/personal_dashboard_page.dart
@@ -408,15 +408,13 @@ class _PersonalDashboardPageState extends State<PersonalDashboardPage>
     final taskRate = (_kpiData['task_rate'] as num?)?.toDouble() ?? 0.0;
 
     final focusHours = '${(focusMinutes / 60).toStringAsFixed(1)}h';
-    final noteSubtitle =
-        noteGrowth > 0 ? '+$noteGrowth 今週' : '記録が増えると週次差分を表示';
+    final noteSubtitle = noteGrowth > 0 ? '+$noteGrowth 今週' : '記録が増えると週次差分を表示';
     final taskSubtitle = taskRate > 0
         ? '達成率 ${(taskRate * 100).toStringAsFixed(0)}%'
         : '記録前でも達成率バーを表示';
     final focusSubtitle =
         focusMinutes > 0 ? '合計 $focusMinutes分' : 'ポモドーロや集中ログを待機中';
-    final habitSubtitle =
-        habitStreak >= 7 ? '🔥 週間達成！' : '習慣が入ると継続日数を追跡';
+    final habitSubtitle = habitStreak >= 7 ? '🔥 週間達成！' : '習慣が入ると継続日数を追跡';
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),

--- a/lib/widgets/personal_dashboard_kpi_card.dart
+++ b/lib/widgets/personal_dashboard_kpi_card.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+/// A KPI card whose contents scale down together when copy or values grow.
+///
+/// The dashboard uses a fixed-aspect-ratio grid, so allowing an inner Column to
+/// choose an unconstrained height can otherwise produce a RenderFlex overflow.
+class PersonalDashboardKpiCard extends StatelessWidget {
+  const PersonalDashboardKpiCard({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.color,
+    this.subtitle,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+  final Color color;
+  final String? subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final semanticLabel = <String>[
+      label,
+      value,
+      if (subtitle != null) subtitle!,
+    ].join('、');
+
+    return Semantics(
+      label: semanticLabel,
+      container: true,
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1A1A1A) : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isDark ? const Color(0xFF2A2A2A) : const Color(0xFFE2E8F0),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.04),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return FittedBox(
+              alignment: Alignment.topLeft,
+              fit: BoxFit.scaleDown,
+              child: SizedBox(
+                width: constraints.maxWidth,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(icon, size: 18, color: color),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            label,
+                            style: const TextStyle(
+                              fontSize: 11,
+                              color: Color(0xFF64748B),
+                              fontWeight: FontWeight.w500,
+                              height: 1.5,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      value,
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.w800,
+                        color: color,
+                        height: 1.5,
+                      ),
+                    ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        subtitle!,
+                        style: const TextStyle(
+                          fontSize: 10,
+                          height: 1.5,
+                          color: Color(0xFF94A3B8),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/test/pages/personal_dashboard_page_test.dart
+++ b/test/pages/personal_dashboard_page_test.dart
@@ -21,7 +21,7 @@ void main() {
       final spec = personalDashboardGridSpec(420);
 
       expect(spec.crossAxisCount, 1);
-      expect(spec.childAspectRatio, 2.7);
+      expect(spec.childAspectRatio, 2.2);
     });
   });
 

--- a/test/web_import_smoke_test.dart
+++ b/test/web_import_smoke_test.dart
@@ -46,8 +46,7 @@ void main() {
                   value: '123,456,789,012.34時間',
                   icon: Icons.monitor_heart_outlined,
                   color: Color(0xFF0891B2),
-                  subtitle:
-                      '前週から大きく変化した場合も、説明文を欠落させずカード内に収めて表示します。',
+                  subtitle: '前週から大きく変化した場合も、説明文を欠落させずカード内に収めて表示します。',
                 ),
               ),
             ),

--- a/test/web_import_smoke_test.dart
+++ b/test/web_import_smoke_test.dart
@@ -1,6 +1,7 @@
 @TestOn('browser')
 library;
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/main.dart' as app;
 import 'package:my_web_app/pages/ai_assistant_chat_page.dart';
@@ -8,7 +9,9 @@ import 'package:my_web_app/pages/election_victory_page.dart';
 import 'package:my_web_app/pages/gemini_university_v2_page.dart';
 import 'package:my_web_app/pages/guitar_recording_studio_page.dart';
 import 'package:my_web_app/pages/home_page.dart';
+import 'package:my_web_app/pages/personal_dashboard_page.dart';
 import 'package:my_web_app/pages/work_menu_page.dart';
+import 'package:my_web_app/widgets/personal_dashboard_kpi_card.dart';
 
 void main() {
   test('web-only app imports compile on Chrome', () {
@@ -19,5 +22,40 @@ void main() {
     expect(ElectionVictoryPage, isNotNull);
     expect(GuitarRecordingStudioPage, isNotNull);
     expect(AiAssistantChatPage, isNotNull);
+  });
+
+  testWidgets('long personal dashboard KPI content fits in Chrome', (
+    tester,
+  ) async {
+    const dashboardWidth = 320.0;
+    final spec = personalDashboardGridSpec(dashboardWidth);
+    final cardWidth = dashboardWidth - 32;
+    final cardHeight = cardWidth / spec.childAspectRatio;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.3)),
+          child: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: cardWidth,
+                height: cardHeight,
+                child: const PersonalDashboardKpiCard(
+                  label: '非常に長いKPIカードのラベルでも内容を最後まで保持する',
+                  value: '123,456,789,012.34時間',
+                  icon: Icons.monitor_heart_outlined,
+                  color: Color(0xFF0891B2),
+                  subtitle:
+                      '前週から大きく変化した場合も、説明文を欠落させずカード内に収めて表示します。',
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/web_import_smoke_test.dart
+++ b/test/web_import_smoke_test.dart
@@ -29,7 +29,7 @@ void main() {
   ) async {
     const dashboardWidth = 320.0;
     final spec = personalDashboardGridSpec(dashboardWidth);
-    final cardWidth = dashboardWidth - 32;
+    const cardWidth = dashboardWidth - 32;
     final cardHeight = cardWidth / spec.childAspectRatio;
 
     await tester.pumpWidget(

--- a/test/widgets/personal_dashboard_kpi_card_test.dart
+++ b/test/widgets/personal_dashboard_kpi_card_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/personal_dashboard_page.dart';
+import 'package:my_web_app/widgets/personal_dashboard_kpi_card.dart';
+
+void main() {
+  testWidgets('long KPI content fits every responsive grid size', (
+    tester,
+  ) async {
+    const dashboardWidths = <double>[1280, 900, 420, 320];
+    const label = '非常に長いKPIカードのラベルでも内容を最後まで保持する';
+    const value = '123,456,789,012.34時間';
+    const subtitle = '前週から大きく変化した場合も、説明文を欠落させずカード内に収めて表示します。';
+
+    for (final dashboardWidth in dashboardWidths) {
+      final spec = personalDashboardGridSpec(dashboardWidth);
+      final gridWidth = dashboardWidth - 32;
+      final gapWidth = (spec.crossAxisCount - 1) * 12;
+      final cardWidth = (gridWidth - gapWidth) / spec.crossAxisCount;
+      final cardHeight = cardWidth / spec.childAspectRatio;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(1.3)),
+            child: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: cardWidth,
+                  height: cardHeight,
+                  child: const PersonalDashboardKpiCard(
+                    label: label,
+                    value: value,
+                    icon: Icons.monitor_heart_outlined,
+                    color: Color(0xFF0891B2),
+                    subtitle: subtitle,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'dashboard width $dashboardWidth must not overflow',
+      );
+      expect(find.text(label), findsOneWidget);
+      expect(find.text(value), findsOneWidget);
+      expect(find.text(subtitle), findsOneWidget);
+    }
+  });
+}


### PR DESCRIPTION
## 概要

KPIカードの固定比率グリッドで長いラベル・値・説明文が縦方向へあふれないよう、カードを独立Widget化して制約内へ一体で縮小します。モバイル1列時の `childAspectRatio` も 2.7 から 2.2 へ下げ、カードの高さを確保します。

Closes #1333

## 変更内容

- `PersonalDashboardKpiCard` を追加し、長い内容を `FittedBox(scaleDown)` で欠落させずカード内へ収容
- 1列レイアウトの比率を 2.2 へ調整
- 1280 / 900 / 420 / 320px、文字倍率1.3、長い値・説明文を対象にWidget回帰テストを追加
- 既存Chrome smokeに320px長文カードの実描画テストを追加

## 検証

- `git diff --check`: passed
- ローカルFlutter test/analyze/browser: RAM 92%台・空き約1.2GBのため未実行
- PR CIで VM tests / Chrome web import smoke / production web build を実行

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: VMで4レスポンシブ幅、Chromeで最狭320pxの1ケースです。
- E2E: 既存 `test/web_import_smoke_test.dart` をChromeで実行し、ブラウザー描画を検証します。
- E2E-Exception: 認証を伴う本番E2Eは対象外とし、Chrome Widget testで最小のブラウザー回帰を検証します。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 表示専用Widgetとテストの低リスク変更で、DB・認証・課金・外部API・権限変更を含みません。

## サブエージェント

未使用。RAM安全条件（使用率85%未満かつ空き2GB超を2回連続）を満たさなかったため、Codex #1が隔離worktreeで実装しました。