### PR TITLE
fix: make schedule resilience checks cache-safe

### DIFF
--- a/scripts/schedule_resilience_watch.py
+++ b/scripts/schedule_resilience_watch.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
@@ -29,6 +30,8 @@ BAD_CONCLUSIONS = {
     "startup_failure",
     "timed_out",
 }
+REPOSITORY_RUNS_PER_PAGE = 100
+REPOSITORY_RUNS_MAX_PAGES = 10
 
 
 @dataclass(frozen=True)
@@ -37,6 +40,8 @@ class WorkflowTarget:
     workflow_file: str
     max_age_hours: int
     event: str = "schedule"
+    introduced_at: datetime | None = None
+    require_bootstrap_success: bool = False
 
 
 TARGETS = (
@@ -45,7 +50,13 @@ TARGETS = (
     WorkflowTarget("competitor-monitoring", "competitor-monitoring.yml", 30),
     WorkflowTarget("health-monitor", "health-monitor.yml", 3),
     WorkflowTarget("notion-sync", "notion-sync.yml", 10),
-    WorkflowTarget("supabase-backup-restore", "supabase-backup-restore.yml", 192),
+    WorkflowTarget(
+        "supabase-backup-restore",
+        "supabase-backup-restore.yml",
+        192,
+        introduced_at=datetime(2026, 8, 26, 6, 35, 33, tzinfo=timezone.utc),
+        require_bootstrap_success=True,
+    ),
     WorkflowTarget("deploy-prod", "deploy-prod.yml", 0, "push"),
 )
 
@@ -61,16 +72,206 @@ def run_url(run: dict[str, Any]) -> str:
     return str(run.get("html_url") or run.get("url") or "")
 
 
+def sort_runs_newest(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def key(run: dict[str, Any]) -> tuple[datetime, int]:
+        created_at = parse_time(str(run.get("created_at") or ""))
+        if created_at is None:
+            raise ValueError("Workflow run is missing created_at")
+        return (
+            created_at,
+            int(run.get("id") or 0),
+        )
+
+    return sorted(runs, key=key, reverse=True)
+
+
+def workflow_path_matches(path: object, workflow_file: str) -> bool:
+    actual = str(path or "").split("@", 1)[0]
+    return actual == f".github/workflows/{workflow_file}"
+
+
+def merge_runs(*run_groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: dict[object, dict[str, Any]] = {}
+    anonymous_index = 0
+    for runs in run_groups:
+        for run in runs:
+            run_id = run.get("id")
+            key: object = run_id if run_id is not None else f"anonymous-{anonymous_index}"
+            anonymous_index += 1
+            merged[key] = run
+    return sort_runs_newest(list(merged.values()))
+
+
+def repository_revalidation_start(
+    target: WorkflowTarget,
+    runs: list[dict[str, Any]],
+    now: datetime,
+) -> datetime:
+    if runs:
+        newest = sort_runs_newest(runs)[0]
+        created_at = parse_time(str(newest.get("created_at") or ""))
+        if created_at is None:
+            raise ValueError("Workflow run is missing created_at")
+        if (
+            target.max_age_hours <= 0
+            or now - created_at <= timedelta(hours=target.max_age_hours)
+        ):
+            return created_at - timedelta(seconds=1)
+
+    window_hours = target.max_age_hours if target.max_age_hours > 0 else 24 * 30
+    window_start = now - timedelta(hours=window_hours)
+    if target.introduced_at is None:
+        return window_start
+    return max(target.introduced_at, window_start)
+
+
+def merge_revalidated_runs(
+    primary_runs: list[dict[str, Any]],
+    repository_runs: list[dict[str, Any]],
+    *,
+    created_after: datetime,
+) -> list[dict[str, Any]]:
+    primary_runs = sort_runs_newest(primary_runs)
+    repository_runs = sort_runs_newest(repository_runs)
+    if primary_runs:
+        primary = primary_runs[0]
+        primary_created_at = parse_time(str(primary.get("created_at") or ""))
+        if primary_created_at is None:
+            raise ValueError("Workflow run is missing created_at")
+        if primary_created_at >= created_after:
+            primary_id = primary.get("id")
+            if primary_id is None or not any(
+                candidate.get("id") == primary_id for candidate in repository_runs
+            ):
+                raise RuntimeError("Repository run listing did not confirm the primary latest run")
+            return merge_runs(primary_runs, repository_runs)
+    return repository_runs
+
+
+def issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {
+        str(label.get("name") or "")
+        for label in labels
+        if isinstance(label, dict)
+    }
+
+
+def is_schedule_watch_issue(issue: dict[str, Any], target: WorkflowTarget) -> bool:
+    if "pull_request" in issue:
+        return False
+    if not {"workflow-failure", "automation"}.issubset(issue_labels(issue)):
+        return False
+    user = issue.get("user")
+    if not isinstance(user, dict) or str(user.get("login") or "") != "github-actions[bot]":
+        return False
+
+    allowed_titles = {
+        f"[Schedule監視] {target.key} missing run",
+        f"[Schedule監視] {target.key} stale schedule",
+        f"[Schedule監視] {target.key} failure",
+        f"[Schedule監視] {target.key} unexpected conclusion",
+        f"[Schedule監視] {target.key} rerun failed",
+        f"[Schedule監視] {target.key} workflow disabled",
+        f"[Schedule監視] {target.key} stuck run",
+    }
+    if str(issue.get("title") or "") not in allowed_titles:
+        return False
+
+    body = str(issue.get("body") or "")
+    marker_target = re.search(
+        r"(?m)^<!-- schedule_resilience_target: ([^\r\n]+) -->$",
+        body,
+    )
+    marker_workflow = re.search(
+        r"(?m)^<!-- schedule_resilience_workflow: ([^\r\n]+) -->$",
+        body,
+    )
+    if marker_target or marker_workflow:
+        return (
+            marker_target is not None
+            and marker_target.group(1) == target.key
+            and marker_workflow is not None
+            and marker_workflow.group(1) == target.workflow_file
+        )
+
+    if not body.startswith("Schedule resilience watch detected a problem.\n"):
+        return False
+    legacy_target = re.search(r"(?m)^- Target: `([^`\r\n]+)`$", body)
+    legacy_workflow = re.search(r"(?m)^- Workflow file: `([^`\r\n]+)`$", body)
+    return (
+        legacy_target is not None
+        and legacy_target.group(1) == target.key
+        and legacy_workflow is not None
+        and legacy_workflow.group(1) == target.workflow_file
+    )
+
+
 def evaluate_target(
     target: WorkflowTarget,
     runs: list[dict[str, Any]],
     now: datetime,
     *,
     max_attempts: int,
+    fallback_runs: list[dict[str, Any]] | None = None,
+    workflow_state: str = "active",
 ) -> dict[str, Any]:
+    runs = sort_runs_newest(runs)
+    fallback_runs = sort_runs_newest(fallback_runs or [])
     if not runs:
+        if workflow_state != "active":
+            return {
+                "target": target.key,
+                "workflow_file": target.workflow_file,
+                "action": "alert",
+                "reason": "workflow-disabled",
+                "title": f"[Schedule監視] {target.key} workflow disabled",
+                "body": (
+                    f"`{target.workflow_file}` is `{workflow_state}` and cannot "
+                    f"produce the expected `{target.event}` run."
+                ),
+            }
+
+        latest_fallback = (fallback_runs or [None])[0]
+        grace_deadline = (
+            target.introduced_at
+            + timedelta(hours=target.max_age_hours)
+            if target.introduced_at is not None and target.max_age_hours > 0
+            else None
+        )
+        if (
+            target.require_bootstrap_success
+            and isinstance(latest_fallback, dict)
+            and target.introduced_at is not None
+            and grace_deadline is not None
+        ):
+            fallback_created_at = parse_time(str(latest_fallback.get("created_at") or ""))
+            if (
+                now < grace_deadline
+                and fallback_created_at is not None
+                and fallback_created_at >= target.introduced_at
+                and str(latest_fallback.get("event") or "") == "workflow_dispatch"
+                and str(latest_fallback.get("status") or "") == "completed"
+                and str(latest_fallback.get("conclusion") or "") == "success"
+            ):
+                return {
+                    "target": target.key,
+                    "workflow_file": target.workflow_file,
+                    "run_id": latest_fallback.get("id"),
+                    "run_attempt": int(latest_fallback.get("run_attempt") or 1),
+                    "status": "completed",
+                    "conclusion": "success",
+                    "url": run_url(latest_fallback),
+                    "created_at": latest_fallback.get("created_at"),
+                    "action": "observe",
+                    "reason": "awaiting-first-scheduled-run",
+                    "grace_deadline": grace_deadline.isoformat(),
+                }
         return {
             "target": target.key,
+            "workflow_file": target.workflow_file,
             "action": "alert",
             "reason": "missing-run",
             "title": f"[Schedule監視] {target.key} missing run",
@@ -103,9 +304,35 @@ def evaluate_target(
     }
 
     if status != "completed":
+        if (
+            target.max_age_hours > 0
+            and age_hours is not None
+            and age_hours > target.max_age_hours
+        ):
+            return {
+                **base,
+                "action": "alert",
+                "reason": f"stuck-run-{status}",
+                "title": f"[Schedule監視] {target.key} stuck run",
+                "body": (
+                    f"`{target.workflow_file}` has remained `{status}` for "
+                    f"{age_hours:.1f}h, exceeding the {target.max_age_hours}h guard."
+                ),
+            }
         return {**base, "action": "observe", "reason": f"run-{status}"}
 
     if conclusion in OK_CONCLUSIONS:
+        if target.require_bootstrap_success and conclusion != "success":
+            return {
+                **base,
+                "action": "alert",
+                "reason": f"unexpected-conclusion-{conclusion}",
+                "title": f"[Schedule監視] {target.key} unexpected conclusion",
+                "body": (
+                    f"`{target.workflow_file}` requires a successful backup run, "
+                    f"but the latest conclusion was `{conclusion}`."
+                ),
+            }
         if (
             target.max_age_hours > 0
             and age_hours is not None
@@ -164,8 +391,12 @@ class GitHubClient:
         headers = {
             "Accept": "application/vnd.github+json",
             "Content-Type": "application/json",
+            "User-Agent": "my-web-app-schedule-resilience-watch",
             "X-GitHub-Api-Version": "2022-11-28",
         }
+        if method == "GET":
+            headers["Cache-Control"] = "no-cache"
+            headers["Pragma"] = "no-cache"
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
         request = Request(
@@ -184,30 +415,87 @@ class GitHubClient:
         self,
         workflow_file: str,
         *,
-        event: str,
+        event: str | None,
         limit: int,
     ) -> list[dict[str, Any]]:
-        query = urlencode({"branch": "main", "event": event, "per_page": str(limit)})
+        query_params = {"branch": "main", "per_page": str(limit)}
+        if event:
+            query_params["event"] = event
+        query = urlencode(query_params)
         path = f"/repos/{self.repo}/actions/workflows/{quote(workflow_file)}/runs?{query}"
         payload = self.request("GET", path)
         runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
-        return runs if isinstance(runs, list) else []
+        return sort_runs_newest(runs) if isinstance(runs, list) else []
+
+    def repository_workflow_runs(
+        self,
+        workflow_file: str,
+        *,
+        event: str,
+        created_after: datetime,
+    ) -> list[dict[str, Any]]:
+        matches: list[dict[str, Any]] = []
+        for page in range(1, REPOSITORY_RUNS_MAX_PAGES + 1):
+            query = urlencode(
+                {
+                    "branch": "main",
+                    "event": event,
+                    "created": f">={created_after.astimezone(timezone.utc).isoformat()}",
+                    "per_page": str(REPOSITORY_RUNS_PER_PAGE),
+                    "page": str(page),
+                }
+            )
+            payload = self.request("GET", f"/repos/{self.repo}/actions/runs?{query}")
+            page_runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
+            if not isinstance(page_runs, list):
+                raise RuntimeError("Repository workflow runs response is invalid")
+            matches.extend(
+                run
+                for run in page_runs
+                if isinstance(run, dict) and workflow_path_matches(run.get("path"), workflow_file)
+            )
+            if len(page_runs) < REPOSITORY_RUNS_PER_PAGE:
+                return sort_runs_newest(matches)
+        raise RuntimeError("Repository workflow runs pagination was incomplete")
+
+    def workflow_state(self, workflow_file: str) -> str:
+        path = f"/repos/{self.repo}/actions/workflows/{quote(workflow_file)}"
+        payload = self.request("GET", path)
+        return str(payload.get("state") or "unknown") if isinstance(payload, dict) else "unknown"
 
     def rerun_failed_jobs(self, run_id: int) -> None:
         self.request("POST", f"/repos/{self.repo}/actions/runs/{run_id}/rerun-failed-jobs", {})
 
-    def open_or_update_issue(self, title: str, body: str) -> str:
-        labels = "workflow-failure"
-        issues = self.request(
-            "GET",
-            f"/repos/{self.repo}/issues?{urlencode({'state': 'open', 'labels': labels, 'per_page': '100'})}",
-        )
-        if isinstance(issues, list):
-            for issue in issues:
-                if issue.get("title") == title and "pull_request" not in issue:
-                    number = issue.get("number")
-                    self.request("POST", f"/repos/{self.repo}/issues/{number}/comments", {"body": body})
-                    return str(issue.get("html_url") or "")
+    def open_workflow_failure_issues(self) -> list[dict[str, Any]]:
+        issues: list[dict[str, Any]] = []
+        for page in range(1, 11):
+            query = urlencode(
+                {
+                    "state": "open",
+                    "labels": "workflow-failure",
+                    "per_page": "100",
+                    "page": str(page),
+                }
+            )
+            payload = self.request("GET", f"/repos/{self.repo}/issues?{query}")
+            if not isinstance(payload, list):
+                raise RuntimeError("Open workflow-failure Issue response is invalid")
+            issues.extend(issue for issue in payload if isinstance(issue, dict))
+            if len(payload) < 100:
+                return issues
+        raise RuntimeError("Open workflow-failure Issue pagination was incomplete")
+
+    def open_or_update_issue(
+        self,
+        target: WorkflowTarget,
+        title: str,
+        body: str,
+    ) -> str:
+        for issue in self.open_workflow_failure_issues():
+            if is_schedule_watch_issue(issue, target):
+                number = issue.get("number")
+                self.request("POST", f"/repos/{self.repo}/issues/{number}/comments", {"body": body})
+                return str(issue.get("html_url") or "")
 
         created = self.request(
             "POST",
@@ -219,6 +507,68 @@ class GitHubClient:
             },
         )
         return str(created.get("html_url") or "")
+
+    def issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        comments: list[dict[str, Any]] = []
+        for page in range(1, 11):
+            query = urlencode({"per_page": "100", "page": str(page)})
+            payload = self.request(
+                "GET",
+                f"/repos/{self.repo}/issues/{issue_number}/comments?{query}",
+            )
+            if not isinstance(payload, list):
+                raise RuntimeError("Issue comments response is invalid")
+            comments.extend(comment for comment in payload if isinstance(comment, dict))
+            if len(payload) < 100:
+                return comments
+        raise RuntimeError("Issue comments pagination was incomplete")
+
+    def close_recovered_issues(
+        self,
+        target: WorkflowTarget,
+        result: dict[str, Any],
+        now: datetime,
+    ) -> list[str]:
+        closed: list[str] = []
+        for issue in self.open_workflow_failure_issues():
+            number = issue.get("number")
+            if not is_schedule_watch_issue(issue, target) or not isinstance(number, int):
+                continue
+
+            recovery_marker = f"<!-- schedule_resilience_recovery: {target.key} -->"
+            comment = "\n".join(
+                [
+                    "Schedule resilience watch confirmed a healthy monitoring state.",
+                    "",
+                    f"- Target: `{target.key}`",
+                    f"- Workflow file: `{target.workflow_file}`",
+                    f"- Recovery reason: `{result.get('reason', 'healthy')}`",
+                    f"- Status/conclusion: `{result.get('status')}` / `{result.get('conclusion')}`",
+                    f"- Checked at: `{now.isoformat()}`",
+                    f"- Run: {result.get('url') or 'not applicable'}",
+                    "",
+                    "Closing this workflow-failure alert automatically. "
+                    "A later regression will open a new canonical alert.",
+                    recovery_marker,
+                ]
+            )
+            existing_comments = self.issue_comments(number)
+            if not any(
+                recovery_marker in str(existing.get("body") or "")
+                for existing in existing_comments
+            ):
+                self.request(
+                    "POST",
+                    f"/repos/{self.repo}/issues/{number}/comments",
+                    {"body": comment},
+                )
+            self.request(
+                "PATCH",
+                f"/repos/{self.repo}/issues/{number}",
+                {"state": "closed", "state_reason": "completed"},
+            )
+            closed.append(str(issue.get("html_url") or ""))
+        return closed
 
 
 def issue_body(result: dict[str, Any], now: datetime) -> str:
@@ -241,7 +591,15 @@ def issue_body(result: dict[str, Any], now: datetime) -> str:
         )
     if result.get("body"):
         lines.extend(["", str(result["body"])])
-    lines.extend(["", "Codex #1 route: old PS#1 workflow-health lane is absorbed by Codex #1."])
+    lines.extend(
+        [
+            "",
+            "Codex #1 route: old PS#1 workflow-health lane is absorbed by Codex #1.",
+            "<!-- schedule_resilience_issue: v1 -->",
+            f"<!-- schedule_resilience_target: {result['target']} -->",
+            f"<!-- schedule_resilience_workflow: {result.get('workflow_file', '')} -->",
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -284,12 +642,67 @@ def main(argv: list[str]) -> int:
     results: list[dict[str, Any]] = []
 
     for target in TARGETS:
-        runs = client.workflow_runs(
-            target.workflow_file,
-            event=target.event,
-            limit=args.limit,
+        primary_error = ""
+        try:
+            try:
+                primary_runs = client.workflow_runs(
+                    target.workflow_file,
+                    event=target.event,
+                    limit=args.limit,
+                )
+            except (HTTPError, URLError, RuntimeError, ValueError) as exc:
+                primary_runs = []
+                primary_error = type(exc).__name__
+
+            created_after = repository_revalidation_start(target, primary_runs, now)
+            repository_runs = client.repository_workflow_runs(
+                target.workflow_file,
+                event=target.event,
+                created_after=created_after,
+            )
+            runs = merge_revalidated_runs(
+                primary_runs,
+                repository_runs,
+                created_after=created_after,
+            )
+            if target.max_age_hours <= 0 and not runs:
+                raise RuntimeError("Event-driven workflow freshness could not be verified")
+
+            should_bootstrap = not runs and target.event == "schedule"
+            fallback_runs = (
+                client.repository_workflow_runs(
+                    target.workflow_file,
+                    event="workflow_dispatch",
+                    created_after=repository_revalidation_start(target, [], now),
+                )
+                if should_bootstrap and target.require_bootstrap_success
+                else []
+            )
+            workflow_state = (
+                client.workflow_state(target.workflow_file) if should_bootstrap else "active"
+            )
+        except (HTTPError, URLError, RuntimeError, ValueError) as exc:
+            results.append(
+                {
+                    "target": target.key,
+                    "workflow_file": target.workflow_file,
+                    "action": "observe",
+                    "reason": "freshness-unverified",
+                    "verification_error": type(exc).__name__,
+                }
+            )
+            continue
+
+        result = evaluate_target(
+            target,
+            runs,
+            now,
+            max_attempts=args.max_attempts,
+            fallback_runs=fallback_runs,
+            workflow_state=workflow_state,
         )
-        result = evaluate_target(target, runs, now, max_attempts=args.max_attempts)
+        if primary_error:
+            result["primary_verification_error"] = primary_error
 
         if result["action"] == "retry":
             if args.dry_run:
@@ -298,18 +711,46 @@ def main(argv: list[str]) -> int:
                 try:
                     client.rerun_failed_jobs(int(result["run_id"]))
                     result["write"] = "rerun-failed-jobs"
-                except HTTPError as exc:
+                except (HTTPError, URLError, RuntimeError) as exc:
                     result["action"] = "alert"
-                    result["reason"] = f"rerun-failed-http-{exc.code}"
+                    error_name = (
+                        f"http-{exc.code}" if isinstance(exc, HTTPError) else type(exc).__name__.lower()
+                    )
+                    result["reason"] = f"rerun-failed-{error_name}"
                     result["title"] = f"[Schedule監視] {target.key} rerun failed"
-                    result["body"] = f"Failed to rerun `{target.workflow_file}` via GitHub API: HTTP {exc.code}."
+                    result["body"] = (
+                        f"Failed to rerun `{target.workflow_file}` via GitHub API: {error_name}."
+                    )
 
         if result["action"] == "alert":
             body = issue_body(result, now)
             if args.dry_run:
                 result["issue_url"] = "dry-run"
             else:
-                result["issue_url"] = client.open_or_update_issue(str(result["title"]), body)
+                try:
+                    result["issue_url"] = client.open_or_update_issue(
+                        target,
+                        str(result["title"]),
+                        body,
+                    )
+                except (HTTPError, URLError, RuntimeError) as exc:
+                    result["issue_write_error"] = (
+                        f"HTTP {exc.code}" if isinstance(exc, HTTPError) else type(exc).__name__
+                    )
+        elif (
+            result["action"] == "healthy"
+            and result.get("status") == "completed"
+            and result.get("conclusion") == "success"
+        ):
+            if args.dry_run:
+                result["recovered_issues"] = "dry-run"
+            else:
+                try:
+                    result["recovered_issues"] = client.close_recovered_issues(target, result, now)
+                except (HTTPError, URLError, RuntimeError) as exc:
+                    result["recovery_close_error"] = (
+                        f"HTTP {exc.code}" if isinstance(exc, HTTPError) else type(exc).__name__
+                    )
 
         results.append(result)
 
@@ -324,7 +765,13 @@ def main(argv: list[str]) -> int:
             json.dumps({"checked_at": now.isoformat(), "results": results}, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
-    return 0
+    has_operational_error = any(
+        result.get("reason") == "freshness-unverified"
+        or "issue_write_error" in result
+        or "recovery_close_error" in result
+        for result in results
+    )
+    return 1 if has_operational_error else 0
 
 
 if __name__ == "__main__":

--- a/scripts/schedule_resilience_watch_test.py
+++ b/scripts/schedule_resilience_watch_test.py
@@ -3,14 +3,22 @@
 
 from __future__ import annotations
 
+import io
+import os
 import unittest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 from schedule_resilience_watch import (
     GitHubClient,
     TARGETS,
     WorkflowTarget,
     evaluate_target,
+    is_schedule_watch_issue,
+    issue_body,
+    main,
+    merge_revalidated_runs,
+    repository_revalidation_start,
     render_summary,
 )
 
@@ -69,6 +77,21 @@ class ScheduleResilienceWatchTest(unittest.TestCase):
         self.assertEqual(result["action"], "alert")
         self.assertEqual(result["reason"], "stale-success")
 
+    def test_evaluation_sorts_runs_newest_instead_of_trusting_api_order(self) -> None:
+        older = run(
+            id=1,
+            created_at=(NOW - timedelta(hours=5)).isoformat().replace("+00:00", "Z"),
+        )
+        newer = run(
+            id=2,
+            created_at=(NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+        )
+
+        result = evaluate_target(TARGET, [older, newer], NOW, max_attempts=2)
+
+        self.assertEqual(result["action"], "healthy")
+        self.assertEqual(result["run_id"], 2)
+
     def test_deploy_success_does_not_alert_only_because_it_is_old(self) -> None:
         deploy = WorkflowTarget("deploy-prod", "deploy-prod.yml", 0, "push")
         result = evaluate_target(
@@ -91,14 +114,446 @@ class ScheduleResilienceWatchTest(unittest.TestCase):
 
             def request(self, method, path, body=None):
                 self.requested_path = path
-                return {"workflow_runs": [{"id": 7}]}
+                return {"workflow_runs": [run(id=7)]}
 
         client = RecordingClient("owner/repo", "token")
         runs = client.workflow_runs("deploy-prod.yml", event="push", limit=5)
 
-        self.assertEqual(runs, [{"id": 7}])
+        self.assertEqual([item["id"] for item in runs], [7])
         self.assertIn("event=push", client.requested_path)
         self.assertIn("per_page=5", client.requested_path)
+        self.assertNotIn("cache_bust", client.requested_path)
+
+    @patch("schedule_resilience_watch.urlopen")
+    def test_get_requests_force_revalidation_but_post_requests_do_not(self, mocked_urlopen) -> None:
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b"{}"
+
+        mocked_urlopen.return_value = FakeResponse()
+        client = GitHubClient("owner/repo", "token")
+
+        client.request("GET", "/repos/owner/repo/actions/runs")
+        get_request = mocked_urlopen.call_args.args[0]
+        self.assertEqual(get_request.get_header("Cache-control"), "no-cache")
+        self.assertEqual(get_request.get_header("Pragma"), "no-cache")
+        self.assertEqual(
+            get_request.get_header("User-agent"),
+            "my-web-app-schedule-resilience-watch",
+        )
+
+        client.request("POST", "/repos/owner/repo/issues", {"title": "test"})
+        post_request = mocked_urlopen.call_args.args[0]
+        self.assertIsNone(post_request.get_header("Cache-control"))
+
+    def test_repository_fallback_filters_exact_workflow_path(self) -> None:
+        class RepositoryClient(GitHubClient):
+            def request(self, method, path, body=None):
+                self.requested_path = path
+                return {
+                    "workflow_runs": [
+                        {**run(id=9), "path": ".github/workflows/cs-check.yml@main"},
+                        {**run(id=10), "path": ".github/workflows/cs-check.yml.bak"},
+                    ]
+                }
+
+        client = RepositoryClient("owner/repo", "token")
+        runs = client.repository_workflow_runs(
+            "cs-check.yml",
+            event="schedule",
+            created_after=NOW - timedelta(hours=3),
+        )
+
+        self.assertEqual([item["id"] for item in runs], [9])
+        self.assertIn("created=%3E%3D", client.requested_path)
+        self.assertIn("event=schedule", client.requested_path)
+
+    def test_repository_fallback_can_replace_a_stale_primary_run(self) -> None:
+        stale = run(
+            id=1,
+            created_at=(NOW - timedelta(hours=5)).isoformat().replace("+00:00", "Z"),
+        )
+        fresh = run(
+            id=2,
+            created_at=(NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+        )
+
+        created_after = repository_revalidation_start(TARGET, [stale], NOW)
+        runs = merge_revalidated_runs([stale], [fresh], created_after=created_after)
+        result = evaluate_target(TARGET, runs, NOW, max_attempts=2)
+
+        self.assertEqual(result["action"], "healthy")
+        self.assertEqual(result["run_id"], 2)
+
+    def test_stale_failure_is_not_retried_when_fresh_window_is_empty(self) -> None:
+        stale_failure = run(
+            id=1,
+            conclusion="failure",
+            created_at=(NOW - timedelta(hours=5)).isoformat().replace("+00:00", "Z"),
+        )
+        created_after = repository_revalidation_start(TARGET, [stale_failure], NOW)
+        runs = merge_revalidated_runs(
+            [stale_failure],
+            [],
+            created_after=created_after,
+        )
+
+        result = evaluate_target(TARGET, runs, NOW, max_attempts=2)
+
+        self.assertEqual(result["action"], "alert")
+        self.assertEqual(result["reason"], "missing-run")
+
+    def test_fresh_primary_must_be_confirmed_by_repository_listing(self) -> None:
+        fresh = run(id=7)
+        created_after = repository_revalidation_start(TARGET, [fresh], NOW)
+
+        with self.assertRaisesRegex(RuntimeError, "did not confirm"):
+            merge_revalidated_runs([fresh], [], created_after=created_after)
+
+    def test_event_driven_primary_must_also_be_confirmed(self) -> None:
+        deploy = WorkflowTarget("deploy-prod", "deploy-prod.yml", 0, "push")
+        fresh = run(id=8)
+        created_after = repository_revalidation_start(deploy, [fresh], NOW)
+
+        with self.assertRaisesRegex(RuntimeError, "did not confirm"):
+            merge_revalidated_runs([fresh], [], created_after=created_after)
+
+    def test_bootstrap_success_graces_only_the_first_scheduled_run(self) -> None:
+        introduced_at = NOW - timedelta(hours=2)
+        backup = WorkflowTarget(
+            "backup",
+            "backup.yml",
+            192,
+            introduced_at=introduced_at,
+            require_bootstrap_success=True,
+        )
+        result = evaluate_target(
+            backup,
+            [],
+            NOW,
+            max_attempts=2,
+            fallback_runs=[
+                run(
+                    event="workflow_dispatch",
+                    created_at=(NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+                )
+            ],
+        )
+
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["reason"], "awaiting-first-scheduled-run")
+        self.assertEqual(result["workflow_file"], "backup.yml")
+
+    def test_bootstrap_success_cannot_extend_the_fixed_grace_deadline(self) -> None:
+        backup = WorkflowTarget(
+            "backup",
+            "backup.yml",
+            192,
+            introduced_at=NOW - timedelta(hours=193),
+            require_bootstrap_success=True,
+        )
+        result = evaluate_target(
+            backup,
+            [],
+            NOW,
+            max_attempts=2,
+            fallback_runs=[
+                run(
+                    event="workflow_dispatch",
+                    created_at=(NOW - timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+                )
+            ],
+        )
+
+        self.assertEqual(result["action"], "alert")
+        self.assertEqual(result["reason"], "missing-run")
+
+    def test_bootstrap_grace_rejects_failure_and_disabled_workflow(self) -> None:
+        backup = WorkflowTarget(
+            "backup",
+            "backup.yml",
+            192,
+            introduced_at=NOW - timedelta(hours=2),
+            require_bootstrap_success=True,
+        )
+        failed = evaluate_target(
+            backup,
+            [],
+            NOW,
+            max_attempts=2,
+            fallback_runs=[run(event="workflow_dispatch", conclusion="failure")],
+        )
+        disabled = evaluate_target(
+            backup,
+            [],
+            NOW,
+            max_attempts=2,
+            fallback_runs=[run(event="workflow_dispatch")],
+            workflow_state="disabled_manually",
+        )
+
+        self.assertEqual(failed["reason"], "missing-run")
+        self.assertEqual(disabled["reason"], "workflow-disabled")
+
+    def test_backup_requires_success_instead_of_skipped_or_neutral(self) -> None:
+        backup = WorkflowTarget(
+            "backup",
+            "backup.yml",
+            192,
+            require_bootstrap_success=True,
+        )
+
+        for conclusion in ("skipped", "neutral"):
+            with self.subTest(conclusion=conclusion):
+                result = evaluate_target(
+                    backup,
+                    [run(conclusion=conclusion)],
+                    NOW,
+                    max_attempts=2,
+                )
+                self.assertEqual(result["action"], "alert")
+                self.assertEqual(
+                    result["reason"],
+                    f"unexpected-conclusion-{conclusion}",
+                )
+
+    def test_old_in_progress_run_alerts_as_stuck(self) -> None:
+        result = evaluate_target(
+            TARGET,
+            [
+                run(
+                    status="in_progress",
+                    conclusion=None,
+                    created_at=(NOW - timedelta(hours=4)).isoformat().replace("+00:00", "Z"),
+                )
+            ],
+            NOW,
+            max_attempts=2,
+        )
+
+        self.assertEqual(result["action"], "alert")
+        self.assertEqual(result["reason"], "stuck-run-in_progress")
+
+    def test_recovery_closes_only_matching_monitor_issues(self) -> None:
+        class RecordingClient(GitHubClient):
+            writes: list[tuple[str, str, dict | None]] = []
+
+            def request(self, method, path, body=None):
+                if method == "GET":
+                    if "/comments?" in path:
+                        return []
+                    return [
+                        {
+                            "number": 10,
+                            "title": "[Schedule監視] cs-check stale schedule",
+                            "html_url": "https://github.example/issues/10",
+                            "user": {"login": "github-actions[bot]"},
+                            "labels": [
+                                {"name": "workflow-failure"},
+                                {"name": "automation"},
+                            ],
+                            "body": (
+                                "Schedule resilience watch detected a problem.\n\n"
+                                "- Target: `cs-check`\n"
+                                "- Workflow file: `cs-check.yml`\n"
+                            ),
+                        },
+                        {
+                            "number": 11,
+                            "title": "[Schedule監視] daily-report stale schedule",
+                            "html_url": "https://github.example/issues/11",
+                            "user": {"login": "github-actions[bot]"},
+                            "labels": [
+                                {"name": "workflow-failure"},
+                                {"name": "automation"},
+                            ],
+                            "body": (
+                                "Schedule resilience watch detected a problem.\n\n"
+                                "- Target: `daily-report`\n"
+                                "- Workflow file: `daily-report.yml`\n"
+                            ),
+                        },
+                        {
+                            "number": 12,
+                            "title": "[Schedule監視] cs-check stale schedule",
+                            "pull_request": {},
+                        },
+                        {
+                            "number": 13,
+                            "title": "[Schedule監視] cs-check stale schedule",
+                            "user": {"login": "github-actions[bot]"},
+                            "labels": [{"name": "bug"}, {"name": "security"}],
+                            "body": (
+                                "Schedule resilience watch detected a problem.\n\n"
+                                "- Target: `cs-check`\n"
+                                "- Workflow file: `cs-check.yml`\n"
+                            ),
+                        },
+                    ]
+                self.writes.append((method, path, body))
+                return {}
+
+        client = RecordingClient("owner/repo", "token")
+        closed = client.close_recovered_issues(
+            TARGET,
+            {"reason": "latest-success", "url": "https://github.example/runs/1"},
+            NOW,
+        )
+
+        self.assertEqual(closed, ["https://github.example/issues/10"])
+        self.assertEqual([method for method, _, _ in client.writes], ["POST", "PATCH"])
+        self.assertEqual(client.writes[1][1], "/repos/owner/repo/issues/10")
+        self.assertEqual(
+            client.writes[1][2],
+            {"state": "closed", "state_reason": "completed"},
+        )
+
+    def test_recovery_comment_is_idempotent_after_partial_failure(self) -> None:
+        class RecordingClient(GitHubClient):
+            writes: list[tuple[str, str, dict | None]] = []
+
+            def request(self, method, path, body=None):
+                if method == "GET" and "/comments?" in path:
+                    return [{"body": "<!-- schedule_resilience_recovery: cs-check -->"}]
+                if method == "GET":
+                    return [
+                        {
+                            "number": 10,
+                            "title": "[Schedule監視] cs-check stale schedule",
+                            "html_url": "https://github.example/issues/10",
+                            "user": {"login": "github-actions[bot]"},
+                            "labels": [
+                                {"name": "workflow-failure"},
+                                {"name": "automation"},
+                            ],
+                            "body": (
+                                "Schedule resilience watch detected a problem.\n\n"
+                                "- Target: `cs-check`\n"
+                                "- Workflow file: `cs-check.yml`\n"
+                            ),
+                        }
+                    ]
+                self.writes.append((method, path, body))
+                return {}
+
+        client = RecordingClient("owner/repo", "token")
+        client.close_recovered_issues(
+            TARGET,
+            {"reason": "latest-success", "url": "https://github.example/runs/1"},
+            NOW,
+        )
+
+        self.assertEqual([method for method, _, _ in client.writes], ["PATCH"])
+
+    def test_legacy_issue_with_blank_workflow_is_not_auto_closed(self) -> None:
+        issue = {
+            "number": 4886,
+            "title": "[Schedule監視] supabase-backup-restore missing run",
+            "user": {"login": "github-actions[bot]"},
+            "labels": [
+                {"name": "workflow-failure"},
+                {"name": "automation"},
+            ],
+            "body": (
+                "Schedule resilience watch detected a problem.\n\n"
+                "- Target: `supabase-backup-restore`\n"
+                "- Workflow file: ``\n"
+            ),
+        }
+        backup = next(target for target in TARGETS if target.key == "supabase-backup-restore")
+
+        self.assertFalse(is_schedule_watch_issue(issue, backup))
+
+    def test_issue_body_adds_strict_target_markers(self) -> None:
+        body = issue_body(
+            {
+                "target": "cs-check",
+                "workflow_file": "cs-check.yml",
+                "reason": "stale-success",
+            },
+            NOW,
+        )
+
+        self.assertIn("<!-- schedule_resilience_issue: v1 -->", body)
+        self.assertIn("<!-- schedule_resilience_target: cs-check -->", body)
+        self.assertIn("<!-- schedule_resilience_workflow: cs-check.yml -->", body)
+
+    def test_main_fails_closed_without_repository_confirmation(self) -> None:
+        class InconsistentClient:
+            writes: list[str] = []
+
+            def workflow_runs(self, *_args, **_kwargs):
+                return [
+                    run(
+                        id=77,
+                        created_at=(datetime.now(timezone.utc) - timedelta(hours=1))
+                        .isoformat()
+                        .replace("+00:00", "Z"),
+                    )
+                ]
+
+            def repository_workflow_runs(self, *_args, **_kwargs):
+                return []
+
+            def rerun_failed_jobs(self, *_args, **_kwargs):
+                self.writes.append("rerun")
+
+            def open_or_update_issue(self, *_args, **_kwargs):
+                self.writes.append("issue")
+
+            def close_recovered_issues(self, *_args, **_kwargs):
+                self.writes.append("close")
+
+        client = InconsistentClient()
+        with (
+            patch.dict(os.environ, {"GITHUB_TOKEN": "test-token"}, clear=False),
+            patch("schedule_resilience_watch.GitHubClient", return_value=client),
+            patch("schedule_resilience_watch.TARGETS", (TARGET,)),
+            patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            exit_code = main(["--repo", "owner/repo"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(client.writes, [])
+
+    def test_main_uses_repository_fallback_when_primary_api_fails(self) -> None:
+        class FallbackClient:
+            writes: list[str] = []
+
+            def workflow_runs(self, *_args, **_kwargs):
+                raise RuntimeError("primary unavailable")
+
+            def repository_workflow_runs(self, *_args, **_kwargs):
+                return [
+                    run(
+                        id=88,
+                        created_at=(datetime.now(timezone.utc) - timedelta(hours=1))
+                        .isoformat()
+                        .replace("+00:00", "Z"),
+                    )
+                ]
+
+            def close_recovered_issues(self, *_args, **_kwargs):
+                self.writes.append("close")
+                return []
+
+        client = FallbackClient()
+        with (
+            patch.dict(os.environ, {"GITHUB_TOKEN": "test-token"}, clear=False),
+            patch("schedule_resilience_watch.GitHubClient", return_value=client),
+            patch("schedule_resilience_watch.TARGETS", (TARGET,)),
+            patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            exit_code = main(["--repo", "owner/repo"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(client.writes, ["close"])
 
     def test_summary_mentions_actions(self) -> None:
         summary = render_summary(


### PR DESCRIPTION
## Summary

- Revalidate every monitored workflow against the repository-wide Actions API with no-cache headers before any rerun, Issue write, or recovery close.
- Fail closed on inconsistent/incomplete API results and return a non-zero status for unverified monitoring state.
- Add strict, idempotent recovery closure for owned bot Issues.
- Treat the new weekly backup workflow as `awaiting-first-scheduled-run` only during its fixed bootstrap window after a successful manual run.
- Require backup success and alert on stale in-progress runs.

## Related Issues

Refs #4882
Refs #4883
Refs #4884
Refs #4885
Refs #4886

The Issues intentionally remain open through merge. A post-merge non-dry-run watch will close #4882-#4885 with recovery evidence. #4886 will be closed separately as the confirmed pre-first-cron false positive because its legacy body omitted the workflow filename and is deliberately excluded from automatic matching.

## Validation

- `python -m py_compile scripts/schedule_resilience_watch.py scripts/schedule_resilience_watch_test.py`
- `python scripts/schedule_resilience_watch_test.py` — 26 tests passed
- `git diff --check`
- Local PAT dry-run — all current targets resolved; #4882-#4885 targets healthy, #4886 awaiting first scheduled run
- Branch `GITHUB_TOKEN` workflow dry-run — [run 32977584976](https://github.com/kanta13jp1/my_web_app/actions/runs/32977584976) passed and selected the current successful runs rather than cached historical runs

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Non-UI monitoring script; 26 deterministic Python tests plus branch workflow_dispatch dry-run cover healthy, error/fail-closed, and recovery/bootstrap paths.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 unavailable in this Codex lane; three independent Codex read-only reviews completed, deterministic tests and post-merge monitoring will verify.

## Subagent record

- API safety reviewer: reviewed repository fallback, cache behavior, fail-closed semantics, and write safety. Its P1 findings caused mandatory repository confirmation for all targets and no-write behavior for inconsistent responses.
- Issue lifecycle reviewer: reviewed #4882-#4886 live evidence, strict bot/label/title/body ownership matching, and post-merge close criteria.
- Bootstrap/test reviewer: reviewed #4886 fixed grace, backup conclusions, stuck runs, partial-close idempotency, and regression coverage.
- Validation impact: expanded the suite from 17 to 26 tests and added a real branch workflow run using the Actions token path that originally reproduced the defect.
- Cleanup impact: all subagents were read-only; they created no branches, worktrees, files, or GitHub writes.

## Scope notes

- No UI, route, browser, database, migration, or environment-variable change.
- No generated imagery.
- No special rollout step beyond merge and the recorded post-merge monitor run.
- Breaking changes: none.