### PR TITLE
fix: harden note comment authorization (#2668)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -191,6 +191,43 @@ jobs:
         if: steps.changes.outputs.migration == 'true'
         run: python scripts/check_migration_timestamps.py
 
+      - name: Setup Python for DB and Edge smoke
+        if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Setup Deno for DB and Edge smoke
+        if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
+        shell: bash
+        env:
+          DENO_VERSION: v2.9.1
+        run: bash scripts/ci/install_deno_from_github.sh
+
+      - name: Install DB and Edge smoke dependencies
+        if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "testcontainers[postgres]>=4.8,<5" "psycopg[binary]>=3.2,<4"
+
+      - name: Gate production changes with DB and Edge smoke
+        if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+        run: |
+          python test/scripts/test_testcontainers_supabase_smoke.py
+          python scripts/testcontainers_supabase_smoke.py --plan
+          python scripts/testcontainers_supabase_smoke.py --artifacts-dir .testcontainers-logs
+
+      - name: Upload production DB and Edge smoke artifacts
+        if: always() && (steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: production-testcontainers-smoke-logs
+          path: .testcontainers-logs/
+          if-no-files-found: ignore
+          include-hidden-files: true
+
       - name: Setup Supabase CLI
         if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v3

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -124,6 +124,20 @@ jobs:
             --github-output "$GITHUB_OUTPUT" \
             "${args[@]}"
 
+      - name: Detect DB and Edge smoke scope
+        id: db_edge_smoke
+        shell: bash
+        env:
+          FORCE_ALL: ${{ github.event_name != 'push' }}
+        run: |
+          if [ "$FORCE_ALL" = "true" ] || grep -Eq \
+            '^(supabase/(migrations|functions)/|scripts/(testcontainers_supabase_smoke.py|requirements-testcontainers.txt)|test/fixtures/testcontainers/|test/scripts/test_testcontainers_supabase_smoke.py)' \
+            .deploy-logs/changed-files.txt; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "required=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Flutter
         if: steps.changes.outputs.web == 'true'
         uses: ./.github/actions/setup-flutter-sdk
@@ -192,26 +206,24 @@ jobs:
         run: python scripts/check_migration_timestamps.py
 
       - name: Setup Python for DB and Edge smoke
-        if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
+        if: steps.db_edge_smoke.outputs.required == 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.12"
+          python-version: "3.12.14"
 
       - name: Setup Deno for DB and Edge smoke
-        if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
+        if: steps.db_edge_smoke.outputs.required == 'true'
         shell: bash
         env:
           DENO_VERSION: v2.9.1
         run: bash scripts/ci/install_deno_from_github.sh
 
       - name: Install DB and Edge smoke dependencies
-        if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "testcontainers[postgres]>=4.8,<5" "psycopg[binary]>=3.2,<4"
+        if: steps.db_edge_smoke.outputs.required == 'true'
+        run: python -m pip install --requirement scripts/requirements-testcontainers.txt
 
       - name: Gate production changes with DB and Edge smoke
-        if: steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true'
+        if: steps.db_edge_smoke.outputs.required == 'true'
         env:
           TESTCONTAINERS_RYUK_DISABLED: "true"
         run: |
@@ -220,7 +232,7 @@ jobs:
           python scripts/testcontainers_supabase_smoke.py --artifacts-dir .testcontainers-logs
 
       - name: Upload production DB and Edge smoke artifacts
-        if: always() && (steps.changes.outputs.migration == 'true' || steps.changes.outputs.edge == 'true')
+        if: always() && steps.db_edge_smoke.outputs.required == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: production-testcontainers-smoke-logs

--- a/.github/workflows/testcontainers-integration.yml
+++ b/.github/workflows/testcontainers-integration.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".github/workflows/testcontainers-integration.yml"
       - "scripts/testcontainers_supabase_smoke.py"
+      - "scripts/requirements-testcontainers.txt"
       - "test/fixtures/testcontainers/**"
       - "test/scripts/test_testcontainers_supabase_smoke.py"
       - "docs/testing/testcontainers_supabase_smoke.md"
@@ -37,7 +38,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.12"
+          python-version: "3.12.14"
 
       - name: Setup Deno
         shell: bash
@@ -49,9 +50,7 @@ jobs:
         run: docker version
 
       - name: Install smoke dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "testcontainers[postgres]>=4.8,<5" "psycopg[binary]>=3.2,<4"
+        run: python -m pip install --requirement scripts/requirements-testcontainers.txt
 
       - name: Unit-test smoke helpers
         run: python test/scripts/test_testcontainers_supabase_smoke.py

--- a/docs/testing/testcontainers_supabase_smoke.md
+++ b/docs/testing/testcontainers_supabase_smoke.md
@@ -14,6 +14,13 @@ Function work without using production Supabase credentials.
 - Impersonates `anon` and `authenticated` roles to prove that a missing tenant
   claim returns no rows, cross-tenant writes fail with SQLSTATE `42501`, and an
   authenticated user sees only their own rows.
+- Applies the Issue #2668 note-comment authorization migration twice and checks
+  the full note-owner, public-viewer, verified-workspace-member, unrelated-user,
+  and service-role matrix. The fixture also proves that legacy forged public
+  memo rows, unverified memberships, and forged team shares grant no access.
+- Verifies least-privilege column grants, immutable comment owner/note fields,
+  the authenticated and actor-rate-limited invite-code RPC, bounded comment
+  content, and removal of all eight permissive legacy comment policies.
 - Runs `scripts/check_edge_function_imports.py` so real Edge Functions keep the
   ADR-required `npm:@supabase/supabase-js@2` import rule.
 - Runs `deno check` for `supabase/functions/health-check/index.ts`.
@@ -27,6 +34,12 @@ This is not a full local Supabase stack. It is the first CI gate that proves the
 DB migration/seed boundary and an Edge-like Deno function boundary can run
 without production secrets. Broader coverage can add more fixture migrations or
 function probes while keeping the same artifact contract.
+
+Pull requests that touch Supabase migrations or functions run the standalone
+`DB + Edge smoke` workflow. The production deploy workflow runs the same smoke
+again before applying a migration or deploying an Edge Function, so a direct or
+operator-triggered deployment cannot pass the DB/Edge boundary without the
+deterministic checks succeeding.
 
 ## Artifacts
 

--- a/docs/testing/testcontainers_supabase_smoke.md
+++ b/docs/testing/testcontainers_supabase_smoke.md
@@ -7,6 +7,9 @@ Function work without using production Supabase credentials.
 
 - Starts a disposable `postgres:16-alpine` container through
   `testcontainers-python`.
+- Installs the exact Python environment declared in
+  `scripts/requirements-testcontainers.txt`; production and pull-request smoke
+  runs use the same pinned Python 3.12.14 toolchain.
 - Applies the fixture migrations in `test/fixtures/testcontainers/sql/`.
 - Seeds representative `profiles`, `wbs_tasks`, and `ai_circuit_breaker` rows.
 - Applies the real Issue #2773 migration and verifies fail-closed RLS for the
@@ -40,6 +43,13 @@ Pull requests that touch Supabase migrations or functions run the standalone
 again before applying a migration or deploying an Edge Function, so a direct or
 operator-triggered deployment cannot pass the DB/Edge boundary without the
 deterministic checks succeeding.
+
+The note-comment hardening is intentionally forward-only. After the database
+migration applies, do not roll the web client back to the legacy direct
+`team_memberships` insert flow because that path is denied by the new RLS.
+Keep the RPC-capable client deployed or ship a forward fix. Existing legitimate
+members must receive the current invite code again (or be re-added by the team
+owner) before workspace comments and shares become available.
 
 ## Artifacts
 

--- a/lib/pages/team_workspace_page.dart
+++ b/lib/pages/team_workspace_page.dart
@@ -737,14 +737,14 @@ class _JoinTeamDialogState extends State<_JoinTeamDialog> {
           TextField(
             controller: _codeController,
             decoration: const InputDecoration(
-              labelText: '招待コード (8文字)',
+              labelText: '招待コード (8文字または32文字)',
               border: OutlineInputBorder(),
               prefixIcon: Icon(Icons.vpn_key_outlined),
             ),
             autofocus: true,
             inputFormatters: [
               FilteringTextInputFormatter.allow(RegExp(r'[a-z0-9A-Z]')),
-              LengthLimitingTextInputFormatter(8),
+              LengthLimitingTextInputFormatter(32),
             ],
           ),
         ],

--- a/lib/pages/team_workspace_page.dart
+++ b/lib/pages/team_workspace_page.dart
@@ -131,8 +131,7 @@ class _TeamWorkspacePageState extends State<TeamWorkspacePage>
   }
 
   Future<void> _joinByInviteCode() async {
-    final userId = _supabase.auth.currentUser?.id;
-    if (userId == null) return;
+    if (_supabase.auth.currentUser == null) return;
 
     String code = '';
     final result = await showDialog<bool>(
@@ -145,10 +144,11 @@ class _TeamWorkspacePageState extends State<TeamWorkspacePage>
 
     setState(() => _isLoading = true);
     try {
-      final teams = await _supabase
-          .from('teams')
-          .select('id, name')
-          .eq('invite_code', code.trim());
+      final response = await _supabase.rpc(
+        'join_team_with_invite_code',
+        params: {'p_invite_code': code.trim()},
+      );
+      final teams = response as List<dynamic>;
       if (teams.isEmpty) {
         if (mounted) {
           setState(() => _isLoading = false);
@@ -158,16 +158,11 @@ class _TeamWorkspacePageState extends State<TeamWorkspacePage>
         }
         return;
       }
-      final teamId = teams.first['id'] as String;
-      await _supabase.from('team_memberships').insert({
-        'team_id': teamId,
-        'user_id': userId,
-        'role': 'member',
-      });
+      final team = teams.first as Map<String, dynamic>;
       await _loadTeams();
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('「${teams.first['name']}」に参加しました')),
+          SnackBar(content: Text('「${team['team_name']}」に参加しました')),
         );
       }
       // ignore: avoid_catches_without_on_clauses

--- a/scripts/requirements-testcontainers.txt
+++ b/scripts/requirements-testcontainers.txt
@@ -1,0 +1,14 @@
+# Reproducible DB + Edge smoke environment. Keep direct and transitive packages
+# pinned to the versions proven by GitHub Actions run 32999902525.
+certifi==2026.7.22
+charset-normalizer==3.5.1
+docker==7.2.0
+idna==3.19
+psycopg[binary]==3.3.4
+psycopg-binary==3.3.4
+python-dotenv==1.2.3
+requests==2.34.2
+testcontainers[postgres]==4.15.0
+typing-extensions==4.16.0
+urllib3==2.7.0
+wrapt==2.3.0

--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -86,6 +86,7 @@ NOTE_TEAM_MEMBER = "00000000-0000-4000-8000-000000002670"
 NOTE_OUTSIDER = "00000000-0000-4000-8000-000000002671"
 NOTE_OWNER_ADDED_MEMBER = "00000000-0000-4000-8000-000000002672"
 NOTE_TEAM_ID = "00000000-0000-4000-8000-000000002673"
+NOTE_INVITE_CODE = "26682668266826682668266826682668"
 NOTE_PRIVATE_ID = 266801
 NOTE_PUBLIC_ID = 266802
 NOTE_TEAM_ID_VALUE = 266803
@@ -917,8 +918,8 @@ def seed_note_comments_security_fixture(conn: Any) -> None:
         )
         cur.execute(
             "insert into public.teams (id, name, owner_id, invite_code) "
-            "values (%s::uuid, 'Issue 2668 team', %s::uuid, 'INVITE2668')",
-            (NOTE_TEAM_ID, NOTE_OWNER),
+            "values (%s::uuid, 'Issue 2668 team', %s::uuid, %s)",
+            (NOTE_TEAM_ID, NOTE_OWNER, NOTE_INVITE_CODE),
         )
         cur.executemany(
             "insert into public.team_memberships (team_id, user_id, role) "
@@ -1101,6 +1102,18 @@ def check_note_comments_security(conn: Any) -> dict[str, Any]:
     if initial_counts != expected_initial_counts:
         raise AssertionError(f"unexpected initial comment visibility: {initial_counts}")
 
+    unverified_team_rows = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_OUTSIDER,
+        statement="select invite_code from public.teams where id = %s::uuid",
+        params=(NOTE_TEAM_ID,),
+    )
+    if unverified_team_rows:
+        raise AssertionError(
+            f"unverified legacy member can read invite code: {unverified_team_rows}"
+        )
+
     denied_sqlstates = {
         "anon_write": note_comments_expect_sqlstate(
             conn,
@@ -1226,7 +1239,8 @@ def check_note_comments_security(conn: Any) -> dict[str, Any]:
         conn,
         role="authenticated",
         user_id=NOTE_TEAM_MEMBER,
-        statement="select * from public.join_team_with_invite_code('INVITE2668')",
+        statement="select * from public.join_team_with_invite_code(%s)",
+        params=(NOTE_INVITE_CODE,),
     )
     if (
         len(joined) != 1
@@ -1236,6 +1250,15 @@ def check_note_comments_security(conn: Any) -> dict[str, Any]:
         raise AssertionError(f"invite RPC returned unexpected team: {joined}")
     if comment_count("authenticated", NOTE_TEAM_MEMBER, NOTE_TEAM_ID_VALUE) != 1:
         raise AssertionError("verified member cannot read team comments")
+    verified_team_rows = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_TEAM_MEMBER,
+        statement="select invite_code from public.teams where id = %s::uuid",
+        params=(NOTE_TEAM_ID,),
+    )
+    if verified_team_rows != [(NOTE_INVITE_CODE,)]:
+        raise AssertionError(f"verified member cannot read team: {verified_team_rows}")
     if comment_count("authenticated", NOTE_TEAM_MEMBER, NOTE_PRIVATE_ID) != 0:
         raise AssertionError("forged legacy team share granted private access")
 
@@ -1365,6 +1388,7 @@ def check_note_comments_security(conn: Any) -> dict[str, Any]:
         "functions": [f"{schema}.{name}" for schema, name, *_ in functions],
         "table_privileges": table_privileges,
         "initial_visibility": initial_counts,
+        "unverified_member_team_visibility": len(unverified_team_rows),
         "denied_sqlstates": denied_sqlstates,
         "invalid_invite_attempts": outsider_attempt_count,
         "rate_limit_sqlstate": rate_limit_sqlstate,

--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -1228,7 +1228,11 @@ def check_note_comments_security(conn: Any) -> dict[str, Any]:
         user_id=NOTE_TEAM_MEMBER,
         statement="select * from public.join_team_with_invite_code('INVITE2668')",
     )
-    if joined != [(NOTE_TEAM_ID, "Issue 2668 team")]:
+    if (
+        len(joined) != 1
+        or str(joined[0][0]) != NOTE_TEAM_ID
+        or joined[0][1] != "Issue 2668 team"
+    ):
         raise AssertionError(f"invite RPC returned unexpected team: {joined}")
     if comment_count("authenticated", NOTE_TEAM_MEMBER, NOTE_TEAM_ID_VALUE) != 1:
         raise AssertionError("verified member cannot read team comments")

--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -5,7 +5,8 @@ The smoke intentionally avoids production Supabase credentials. It starts a
 disposable Postgres container, applies a small migration/seed fixture, verifies
 the Issue #2773 fail-closed RLS migration, Issue #2484 asset-chat isolation, and
 Issue #4091 app-analytics write boundary, checks the real Edge Function import
-policy, and runs a Deno HTTP fixture against the container. Logs are written as
+policy, Issue #2668 note-comment authorization, and runs a Deno HTTP fixture
+against the container. Logs are written as
 artifacts so CI failures point to the migration, function, or seed boundary that
 broke.
 """
@@ -73,6 +74,21 @@ APP_ANALYTICS_SECURITY_MIGRATION = (
     / "migrations"
     / "20260827003000_harden_app_analytics_writes.sql"
 )
+NOTE_COMMENTS_SECURITY_MIGRATION = (
+    ROOT
+    / "supabase"
+    / "migrations"
+    / "20260827032000_harden_note_comments_authorization.sql"
+)
+NOTE_OWNER = "00000000-0000-4000-8000-000000002668"
+NOTE_PUBLIC_VIEWER = "00000000-0000-4000-8000-000000002669"
+NOTE_TEAM_MEMBER = "00000000-0000-4000-8000-000000002670"
+NOTE_OUTSIDER = "00000000-0000-4000-8000-000000002671"
+NOTE_OWNER_ADDED_MEMBER = "00000000-0000-4000-8000-000000002672"
+NOTE_TEAM_ID = "00000000-0000-4000-8000-000000002673"
+NOTE_PRIVATE_ID = 266801
+NOTE_PUBLIC_ID = 266802
+NOTE_TEAM_ID_VALUE = 266803
 AI_UNIVERSITY_MIGRATION = (
     ROOT
     / "supabase"
@@ -325,6 +341,19 @@ def build_plan(sql_dir: Path, edge_fixture: Path, actual_edge_function: Path) ->
             "poisoned legacy counters cannot overflow new event writes",
             "service_role retains required aggregate DML privileges",
             "migration applies twice without reopening public writes",
+        ],
+        "note_comments_migration": NOTE_COMMENTS_SECURITY_MIGRATION.relative_to(
+            ROOT
+        ).as_posix(),
+        "note_comments_checks": [
+            "all eight permissive legacy policies are replaced by four canonical policies",
+            "anonymous users can read only valid public-note comments",
+            "authenticated note owners and verified workspace members have scoped access",
+            "body user_id forgery and writes to unrelated private notes are denied",
+            "direct self-join and forged public/workspace shares cannot grant access",
+            "invite-code attempts are actor-scoped and rate-limited",
+            "comment authors can update content and delete only their own rows",
+            "migration applies twice without reopening legacy authorization paths",
         ],
         "ai_university_migration": AI_UNIVERSITY_MIGRATION.relative_to(ROOT).as_posix(),
         "ai_university_checks": [
@@ -804,6 +833,537 @@ def check_issue_2773_rls(conn: Any) -> dict[str, Any]:
         "missing_write_sqlstate": missing_write_sqlstate,
         "cross_tenant_sqlstate": cross_tenant_sqlstate,
         "anon_access": "denied on all audited tables",
+    }
+
+
+def note_comments_run_as(
+    conn: Any,
+    *,
+    role: str,
+    user_id: str | None,
+    statement: str,
+    params: tuple[Any, ...] = (),
+) -> list[tuple[Any, ...]]:
+    if role not in {"anon", "authenticated", "service_role"}:
+        raise ValueError(f"unexpected role for note-comments query: {role}")
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(f"set local role {role}")
+            cur.execute(
+                "select set_config('request.jwt.claim.sub', %s, true)",
+                (user_id or "",),
+            )
+            cur.execute(statement, params)
+            if cur.description is None:
+                return []
+            return [tuple(row) for row in cur.fetchall()]
+
+
+def note_comments_expect_sqlstate(
+    conn: Any,
+    *,
+    role: str,
+    user_id: str | None,
+    statement: str,
+    expected: str,
+    params: tuple[Any, ...] = (),
+) -> str:
+    try:
+        note_comments_run_as(
+            conn,
+            role=role,
+            user_id=user_id,
+            statement=statement,
+            params=params,
+        )
+    except Exception as exc:  # psycopg is loaded only for the integration run.
+        sqlstate = getattr(exc, "sqlstate", None)
+        if sqlstate != expected:
+            raise AssertionError(
+                f"expected SQLSTATE {expected}, got {sqlstate}: {exc}"
+            ) from exc
+        return str(sqlstate)
+    raise AssertionError(f"note-comments operation unexpectedly succeeded ({expected})")
+
+
+def seed_note_comments_security_fixture(conn: Any) -> None:
+    with conn.cursor() as cur:
+        cur.executemany(
+            "insert into auth.users (id) values (%s::uuid)",
+            [
+                (NOTE_OWNER,),
+                (NOTE_PUBLIC_VIEWER,),
+                (NOTE_TEAM_MEMBER,),
+                (NOTE_OUTSIDER,),
+                (NOTE_OWNER_ADDED_MEMBER,),
+            ],
+        )
+        cur.executemany(
+            "insert into public.notes (id, user_id, content) "
+            "values (%s, %s::uuid, %s)",
+            [
+                (NOTE_PRIVATE_ID, NOTE_OWNER, "private note"),
+                (NOTE_PUBLIC_ID, NOTE_OWNER, "public note"),
+                (NOTE_TEAM_ID_VALUE, NOTE_OWNER, "team note"),
+            ],
+        )
+        cur.executemany(
+            "insert into public.public_memos "
+            "(note_id, user_id, title, is_public) values (%s, %s::uuid, %s, true)",
+            [
+                (NOTE_PUBLIC_ID, NOTE_OWNER, "valid public memo"),
+                (NOTE_PRIVATE_ID, NOTE_OUTSIDER, "legacy forged public memo"),
+            ],
+        )
+        cur.execute(
+            "insert into public.teams (id, name, owner_id, invite_code) "
+            "values (%s::uuid, 'Issue 2668 team', %s::uuid, 'INVITE2668')",
+            (NOTE_TEAM_ID, NOTE_OWNER),
+        )
+        cur.executemany(
+            "insert into public.team_memberships (team_id, user_id, role) "
+            "values (%s::uuid, %s::uuid, 'member')",
+            [
+                (NOTE_TEAM_ID, NOTE_TEAM_MEMBER),
+                (NOTE_TEAM_ID, NOTE_OUTSIDER),
+            ],
+        )
+        cur.executemany(
+            "insert into public.team_shared_notes (team_id, note_id, shared_by) "
+            "values (%s::uuid, %s, %s::uuid)",
+            [
+                (NOTE_TEAM_ID, NOTE_TEAM_ID_VALUE, NOTE_OWNER),
+                (NOTE_TEAM_ID, NOTE_PRIVATE_ID, NOTE_OUTSIDER),
+            ],
+        )
+        cur.executemany(
+            "insert into public.note_comments (note_id, user_id, content) "
+            "values (%s, %s::uuid, %s)",
+            [
+                (NOTE_PRIVATE_ID, NOTE_OWNER, "owner private comment"),
+                (NOTE_PRIVATE_ID, NOTE_OUTSIDER, "legacy forged private comment"),
+                (NOTE_PUBLIC_ID, NOTE_OWNER, "public comment"),
+                (NOTE_TEAM_ID_VALUE, NOTE_OWNER, "team comment"),
+            ],
+        )
+    conn.commit()
+
+
+def check_note_comments_security(conn: Any) -> dict[str, Any]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "select policyname, cmd, roles from pg_policies "
+            "where schemaname = 'public' and tablename = 'note_comments' "
+            "order by policyname"
+        )
+        policies = [tuple(row) for row in cur.fetchall()]
+        cur.execute(
+            "select n.nspname, p.proname, p.prosecdef, "
+            "coalesce(p.proconfig, array[]::text[]), "
+            "not exists (select 1 from aclexplode(coalesce(p.proacl, "
+            "acldefault('f', p.proowner))) acl where acl.grantee = 0 "
+            "and acl.privilege_type = 'EXECUTE') "
+            "from pg_proc p join pg_namespace n on n.oid = p.pronamespace "
+            "where (n.nspname, p.proname) in "
+            "(('note_comments_private', 'owns_note'), "
+            "('note_comments_private', 'owns_team'), "
+            "('note_comments_private', 'can_participate_in_team'), "
+            "('note_comments_private', 'is_valid_team_note_share'), "
+            "('note_comments_private', 'can_access_note_comments'), "
+            "('note_comments_private', 'can_read_public_memo'), "
+            "('note_comments_private', 'stamp_owner_added_membership'), "
+            "('public', 'join_team_with_invite_code')) "
+            "order by n.nspname, p.proname"
+        )
+        functions = [tuple(row) for row in cur.fetchall()]
+        cur.execute(
+            "select coalesce(reloptions, array[]::text[]) from pg_class c "
+            "join pg_namespace n on n.oid = c.relnamespace "
+            "where n.nspname = 'public' and c.relname = 'note_comment_counts'"
+        )
+        view_options = list(cur.fetchone()[0])
+    conn.commit()
+
+    expected_policies = [
+        ("note_comments_delete_author", "DELETE", "{authenticated}"),
+        ("note_comments_insert_authorized", "INSERT", "{authenticated}"),
+        ("note_comments_select_authorized", "SELECT", "{anon,authenticated}"),
+        ("note_comments_update_author", "UPDATE", "{authenticated}"),
+    ]
+    normalized_policies = [
+        (name, command, str(roles)) for name, command, roles in policies
+    ]
+    if normalized_policies != expected_policies:
+        raise AssertionError(f"unexpected note_comments policies: {policies}")
+    if len(functions) != 8:
+        raise AssertionError(f"unexpected note authorization functions: {functions}")
+    for schema, name, security_definer, proconfig, public_revoked in functions:
+        if not security_definer:
+            raise AssertionError(f"{schema}.{name} is not SECURITY DEFINER")
+        if not any(str(item).startswith("search_path=") for item in proconfig):
+            raise AssertionError(f"{schema}.{name} search_path is not pinned: {proconfig}")
+        if not public_revoked:
+            raise AssertionError(f"PUBLIC retains EXECUTE on {schema}.{name}")
+    if "security_invoker=true" not in view_options:
+        raise AssertionError(f"note_comment_counts is not security_invoker: {view_options}")
+
+    table_privileges: dict[str, dict[str, bool]] = {}
+    with conn.cursor() as cur:
+        for role in ("anon", "authenticated"):
+            table_privileges[role] = {}
+            for privilege in ("SELECT", "INSERT", "UPDATE", "DELETE"):
+                cur.execute(
+                    "select has_table_privilege(%s, 'public.note_comments', %s)",
+                    (role, privilege),
+                )
+                table_privileges[role][privilege] = bool(cur.fetchone()[0])
+        cur.execute(
+            "select has_table_privilege('anon', 'public.note_comment_counts', 'SELECT'), "
+            "has_table_privilege('authenticated', 'public.note_comment_counts', 'SELECT')"
+        )
+        view_browser_access = tuple(bool(item) for item in cur.fetchone())
+        cur.execute(
+            "select has_function_privilege('anon', "
+            "'public.join_team_with_invite_code(text)', 'EXECUTE'), "
+            "has_function_privilege('authenticated', "
+            "'public.join_team_with_invite_code(text)', 'EXECUTE')"
+        )
+        rpc_access = tuple(bool(item) for item in cur.fetchone())
+        authenticated_columns: dict[str, dict[str, bool]] = {}
+        for column in ("id", "note_id", "user_id", "content", "created_at"):
+            authenticated_columns[column] = {}
+            for privilege in ("INSERT", "UPDATE"):
+                cur.execute(
+                    "select has_column_privilege('authenticated', "
+                    "'public.note_comments', %s, %s)",
+                    (column, privilege),
+                )
+                authenticated_columns[column][privilege] = bool(cur.fetchone()[0])
+    conn.commit()
+
+    expected_table_privileges = {
+        "anon": {"SELECT": True, "INSERT": False, "UPDATE": False, "DELETE": False},
+        "authenticated": {
+            "SELECT": True,
+            "INSERT": False,
+            "UPDATE": False,
+            "DELETE": True,
+        },
+    }
+    if table_privileges != expected_table_privileges:
+        raise AssertionError(f"unexpected note_comments ACL: {table_privileges}")
+    if view_browser_access != (False, False):
+        raise AssertionError(f"browser roles can read comment counts: {view_browser_access}")
+    if rpc_access != (False, True):
+        raise AssertionError(f"unexpected invite RPC ACL: {rpc_access}")
+    expected_columns = {
+        "id": {"INSERT": False, "UPDATE": False},
+        "note_id": {"INSERT": True, "UPDATE": False},
+        "user_id": {"INSERT": True, "UPDATE": False},
+        "content": {"INSERT": True, "UPDATE": True},
+        "created_at": {"INSERT": False, "UPDATE": False},
+    }
+    if authenticated_columns != expected_columns:
+        raise AssertionError(f"unexpected note_comments column ACL: {authenticated_columns}")
+
+    def comment_count(role: str, user_id: str | None, note_id: int) -> int:
+        rows = note_comments_run_as(
+            conn,
+            role=role,
+            user_id=user_id,
+            statement="select count(*) from public.note_comments where note_id = %s",
+            params=(note_id,),
+        )
+        return int(rows[0][0])
+
+    initial_counts = {
+        "anon_private": comment_count("anon", None, NOTE_PRIVATE_ID),
+        "anon_public": comment_count("anon", None, NOTE_PUBLIC_ID),
+        "owner_private": comment_count("authenticated", NOTE_OWNER, NOTE_PRIVATE_ID),
+        "outsider_private": comment_count(
+            "authenticated", NOTE_OUTSIDER, NOTE_PRIVATE_ID
+        ),
+        "unverified_member_team": comment_count(
+            "authenticated", NOTE_TEAM_MEMBER, NOTE_TEAM_ID_VALUE
+        ),
+    }
+    expected_initial_counts = {
+        "anon_private": 0,
+        "anon_public": 1,
+        "owner_private": 2,
+        "outsider_private": 0,
+        "unverified_member_team": 0,
+    }
+    if initial_counts != expected_initial_counts:
+        raise AssertionError(f"unexpected initial comment visibility: {initial_counts}")
+
+    denied_sqlstates = {
+        "anon_write": note_comments_expect_sqlstate(
+            conn,
+            role="anon",
+            user_id=None,
+            statement=(
+                "insert into public.note_comments (note_id, user_id, content) "
+                "values (%s, %s::uuid, 'anon write')"
+            ),
+            params=(NOTE_PUBLIC_ID, NOTE_PUBLIC_VIEWER),
+            expected="42501",
+        ),
+        "missing_claim_write": note_comments_expect_sqlstate(
+            conn,
+            role="authenticated",
+            user_id=None,
+            statement=(
+                "insert into public.note_comments (note_id, user_id, content) "
+                "values (%s, %s::uuid, 'missing claim')"
+            ),
+            params=(NOTE_PRIVATE_ID, NOTE_OWNER),
+            expected="42501",
+        ),
+        "forged_body_user": note_comments_expect_sqlstate(
+            conn,
+            role="authenticated",
+            user_id=NOTE_PUBLIC_VIEWER,
+            statement=(
+                "insert into public.note_comments (note_id, user_id, content) "
+                "values (%s, %s::uuid, 'forged user')"
+            ),
+            params=(NOTE_PUBLIC_ID, NOTE_OUTSIDER),
+            expected="42501",
+        ),
+        "unrelated_private_write": note_comments_expect_sqlstate(
+            conn,
+            role="authenticated",
+            user_id=NOTE_OUTSIDER,
+            statement=(
+                "insert into public.note_comments (note_id, user_id, content) "
+                "values (%s, %s::uuid, 'private write')"
+            ),
+            params=(NOTE_PRIVATE_ID, NOTE_OUTSIDER),
+            expected="42501",
+        ),
+        "direct_self_join": note_comments_expect_sqlstate(
+            conn,
+            role="authenticated",
+            user_id=NOTE_PUBLIC_VIEWER,
+            statement=(
+                "insert into public.team_memberships (team_id, user_id, role) "
+                "values (%s::uuid, %s::uuid, 'member')"
+            ),
+            params=(NOTE_TEAM_ID, NOTE_PUBLIC_VIEWER),
+            expected="42501",
+        ),
+        "forged_publication": note_comments_expect_sqlstate(
+            conn,
+            role="authenticated",
+            user_id=NOTE_OUTSIDER,
+            statement=(
+                "insert into public.public_memos "
+                "(note_id, user_id, title, is_public) "
+                "values (%s, %s::uuid, 'forged', true)"
+            ),
+            params=(NOTE_TEAM_ID_VALUE, NOTE_OUTSIDER),
+            expected="42501",
+        ),
+        "forged_team_share": note_comments_expect_sqlstate(
+            conn,
+            role="authenticated",
+            user_id=NOTE_OUTSIDER,
+            statement=(
+                "insert into public.team_shared_notes (team_id, note_id, shared_by) "
+                "values (%s::uuid, %s, %s::uuid)"
+            ),
+            params=(NOTE_TEAM_ID, NOTE_PUBLIC_ID, NOTE_OUTSIDER),
+            expected="42501",
+        ),
+    }
+
+    invalid_invite = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_OUTSIDER,
+        statement="select * from public.join_team_with_invite_code('INVALID2668')",
+    )
+    if invalid_invite:
+        raise AssertionError(f"invalid invite returned a team: {invalid_invite}")
+    for attempt in range(2, 11):
+        repeated_invalid = note_comments_run_as(
+            conn,
+            role="authenticated",
+            user_id=NOTE_OUTSIDER,
+            statement="select * from public.join_team_with_invite_code(%s)",
+            params=(f"INVALID{attempt:04d}",),
+        )
+        if repeated_invalid:
+            raise AssertionError(
+                f"invalid invite attempt {attempt} returned a team: {repeated_invalid}"
+            )
+    rate_limit_sqlstate = note_comments_expect_sqlstate(
+        conn,
+        role="authenticated",
+        user_id=NOTE_OUTSIDER,
+        statement="select * from public.join_team_with_invite_code('INVALID0011')",
+        expected="P0001",
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            "select attempt_count from note_comments_private.team_invite_attempts "
+            "where user_id = %s::uuid",
+            (NOTE_OUTSIDER,),
+        )
+        outsider_attempt_count = int(cur.fetchone()[0])
+    conn.commit()
+    if outsider_attempt_count != 10:
+        raise AssertionError(f"invite attempt was not recorded: {outsider_attempt_count}")
+    if comment_count("authenticated", NOTE_OUTSIDER, NOTE_TEAM_ID_VALUE) != 0:
+        raise AssertionError("invalid invite verified a legacy membership")
+
+    joined = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_TEAM_MEMBER,
+        statement="select * from public.join_team_with_invite_code('INVITE2668')",
+    )
+    if joined != [(NOTE_TEAM_ID, "Issue 2668 team")]:
+        raise AssertionError(f"invite RPC returned unexpected team: {joined}")
+    if comment_count("authenticated", NOTE_TEAM_MEMBER, NOTE_TEAM_ID_VALUE) != 1:
+        raise AssertionError("verified member cannot read team comments")
+    if comment_count("authenticated", NOTE_TEAM_MEMBER, NOTE_PRIVATE_ID) != 0:
+        raise AssertionError("forged legacy team share granted private access")
+
+    owner_added = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_OWNER,
+        statement=(
+            "insert into public.team_memberships (team_id, user_id, role) "
+            "values (%s::uuid, %s::uuid, 'member') returning invite_verified_at"
+        ),
+        params=(NOTE_TEAM_ID, NOTE_OWNER_ADDED_MEMBER),
+    )
+    if not owner_added or owner_added[0][0] is None:
+        raise AssertionError("owner-added membership was not verified")
+    if comment_count(
+        "authenticated", NOTE_OWNER_ADDED_MEMBER, NOTE_TEAM_ID_VALUE
+    ) != 1:
+        raise AssertionError("owner-added member cannot read team comments")
+
+    member_insert = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_TEAM_MEMBER,
+        statement=(
+            "insert into public.note_comments (note_id, user_id, content) "
+            "values (%s, %s::uuid, 'member comment') returning id"
+        ),
+        params=(NOTE_TEAM_ID_VALUE, NOTE_TEAM_MEMBER),
+    )
+    if len(member_insert) != 1:
+        raise AssertionError("verified member could not create a team comment")
+
+    public_insert = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_PUBLIC_VIEWER,
+        statement=(
+            "insert into public.note_comments (note_id, user_id, content) "
+            "values (%s, %s::uuid, 'viewer comment') returning id"
+        ),
+        params=(NOTE_PUBLIC_ID, NOTE_PUBLIC_VIEWER),
+    )
+    public_comment_id = str(public_insert[0][0])
+    updated = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_PUBLIC_VIEWER,
+        statement=(
+            "update public.note_comments set content = 'viewer edited' "
+            "where id = %s::uuid returning content"
+        ),
+        params=(public_comment_id,),
+    )
+    if updated != [("viewer edited",)]:
+        raise AssertionError(f"author content update failed: {updated}")
+    owner_update = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_OWNER,
+        statement=(
+            "update public.note_comments set content = 'owner overwrite' "
+            "where id = %s::uuid returning id"
+        ),
+        params=(public_comment_id,),
+    )
+    if owner_update:
+        raise AssertionError("note owner updated another author's comment")
+    denied_sqlstates["immutable_note_id"] = note_comments_expect_sqlstate(
+        conn,
+        role="authenticated",
+        user_id=NOTE_PUBLIC_VIEWER,
+        statement=(
+            "update public.note_comments set note_id = %s "
+            "where id = %s::uuid"
+        ),
+        params=(NOTE_PRIVATE_ID, public_comment_id),
+        expected="42501",
+    )
+    owner_delete = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_OWNER,
+        statement="delete from public.note_comments where id = %s::uuid returning id",
+        params=(public_comment_id,),
+    )
+    if owner_delete:
+        raise AssertionError("note owner deleted another author's comment")
+    author_delete = note_comments_run_as(
+        conn,
+        role="authenticated",
+        user_id=NOTE_PUBLIC_VIEWER,
+        statement="delete from public.note_comments where id = %s::uuid returning id",
+        params=(public_comment_id,),
+    )
+    if len(author_delete) != 1:
+        raise AssertionError("comment author could not delete own comment")
+
+    for key, content in (("blank_content", "   "), ("oversized_content", "x" * 2001)):
+        denied_sqlstates[key] = note_comments_expect_sqlstate(
+            conn,
+            role="authenticated",
+            user_id=NOTE_OWNER,
+            statement=(
+                "insert into public.note_comments (note_id, user_id, content) "
+                "values (%s, %s::uuid, %s)"
+            ),
+            params=(NOTE_PRIVATE_ID, NOTE_OWNER, content),
+            expected="23514",
+        )
+
+    service_rows = note_comments_run_as(
+        conn,
+        role="service_role",
+        user_id=None,
+        statement=(
+            "insert into public.note_comments (note_id, user_id, content) "
+            "values (%s, %s::uuid, 'service comment') returning id"
+        ),
+        params=(NOTE_PRIVATE_ID, NOTE_OWNER),
+    )
+    if len(service_rows) != 1:
+        raise AssertionError("service_role note comment DML regressed")
+
+    return {
+        "policies": normalized_policies,
+        "functions": [f"{schema}.{name}" for schema, name, *_ in functions],
+        "table_privileges": table_privileges,
+        "initial_visibility": initial_counts,
+        "denied_sqlstates": denied_sqlstates,
+        "invalid_invite_attempts": outsider_attempt_count,
+        "rate_limit_sqlstate": rate_limit_sqlstate,
+        "verified_member_team_comments": comment_count(
+            "authenticated", NOTE_TEAM_MEMBER, NOTE_TEAM_ID_VALUE
+        ),
+        "service_role_dml": "passed",
     }
 
 
@@ -1717,6 +2277,10 @@ def run_smoke(args: argparse.Namespace) -> int:
             apply_sql_fixture(conn, APP_ANALYTICS_SECURITY_MIGRATION, artifacts_dir)
             apply_sql_fixture(conn, APP_ANALYTICS_SECURITY_MIGRATION, artifacts_dir)
             app_analytics_security = check_app_analytics_security(conn)
+            seed_note_comments_security_fixture(conn)
+            apply_sql_fixture(conn, NOTE_COMMENTS_SECURITY_MIGRATION, artifacts_dir)
+            apply_sql_fixture(conn, NOTE_COMMENTS_SECURITY_MIGRATION, artifacts_dir)
+            note_comments_security = check_note_comments_security(conn)
             apply_sql_fixture(conn, ASSET_CHAT_MIGRATION, artifacts_dir)
             seed_asset_chat_fixture(conn)
             asset_chat_rls = check_asset_chat_rls(conn)
@@ -1736,6 +2300,7 @@ def run_smoke(args: argparse.Namespace) -> int:
             "tables": counts,
             "tenant_rls": tenant_rls,
             "app_analytics_security": app_analytics_security,
+            "note_comments_security": note_comments_security,
             "asset_chat_rls": asset_chat_rls,
             "tax_records_rls": tax_records_rls,
             "ai_university": ai_university,

--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -985,13 +985,17 @@ def check_note_comments_security(conn: Any) -> dict[str, Any]:
     conn.commit()
 
     expected_policies = [
-        ("note_comments_delete_author", "DELETE", "{authenticated}"),
-        ("note_comments_insert_authorized", "INSERT", "{authenticated}"),
-        ("note_comments_select_authorized", "SELECT", "{anon,authenticated}"),
-        ("note_comments_update_author", "UPDATE", "{authenticated}"),
+        ("note_comments_delete_author", "DELETE", ("authenticated",)),
+        ("note_comments_insert_authorized", "INSERT", ("authenticated",)),
+        (
+            "note_comments_select_authorized",
+            "SELECT",
+            ("anon", "authenticated"),
+        ),
+        ("note_comments_update_author", "UPDATE", ("authenticated",)),
     ]
     normalized_policies = [
-        (name, command, str(roles)) for name, command, roles in policies
+        (name, command, tuple(roles)) for name, command, roles in policies
     ]
     if normalized_policies != expected_policies:
         raise AssertionError(f"unexpected note_comments policies: {policies}")

--- a/supabase/migrations/20260827032000_harden_note_comments_authorization.sql
+++ b/supabase/migrations/20260827032000_harden_note_comments_authorization.sql
@@ -346,7 +346,7 @@ BEGIN
 
   INSERT INTO public.team_memberships (team_id, user_id, role)
   VALUES (v_team_id, v_actor, 'member')
-  ON CONFLICT (team_id, user_id) DO NOTHING;
+  ON CONFLICT ON CONSTRAINT team_memberships_team_id_user_id_key DO NOTHING;
 
   UPDATE public.team_memberships AS tm
   SET invite_verified_at = clock_timestamp()

--- a/supabase/migrations/20260827032000_harden_note_comments_authorization.sql
+++ b/supabase/migrations/20260827032000_harden_note_comments_authorization.sql
@@ -264,7 +264,7 @@ BEGIN
       AND t.owner_id = (SELECT auth.uid())
   ) THEN
     NEW.invite_verified_at := COALESCE(NEW.invite_verified_at, clock_timestamp());
-  ELSE
+  ELSIF (SELECT auth.uid()) IS NOT NULL THEN
     NEW.invite_verified_at := NULL;
   END IF;
   RETURN NEW;
@@ -281,6 +281,23 @@ REVOKE ALL ON public.team_memberships FROM PUBLIC, anon, authenticated;
 GRANT SELECT, DELETE ON public.team_memberships TO authenticated;
 GRANT INSERT (team_id, user_id, role) ON public.team_memberships TO authenticated;
 GRANT ALL ON public.team_memberships TO service_role;
+
+-- The legacy teams policy trusted every membership row and exposed invite_code.
+-- Only owners and verified members may read the team row after this migration.
+DROP POLICY IF EXISTS "teams_select" ON public.teams;
+DROP POLICY IF EXISTS teams_select_authorized ON public.teams;
+CREATE POLICY teams_select_authorized
+  ON public.teams FOR SELECT TO authenticated
+  USING (
+    owner_id = (SELECT auth.uid())
+    OR EXISTS (
+      SELECT 1
+      FROM public.team_memberships AS tm
+      WHERE tm.team_id = teams.id
+        AND tm.user_id = (SELECT auth.uid())
+        AND tm.invite_verified_at IS NOT NULL
+    )
+  );
 
 CREATE TABLE IF NOT EXISTS note_comments_private.team_invite_attempts (
   user_id uuid PRIMARY KEY,

--- a/supabase/migrations/20260827032000_harden_note_comments_authorization.sql
+++ b/supabase/migrations/20260827032000_harden_note_comments_authorization.sql
@@ -1,4 +1,5 @@
 -- Issue #2668: make note comment authorization fail closed.
+-- nocheck: time-relative -- UPDATE targets team_memberships only; no date trigger applies.
 --
 -- The original feature accumulated two generations of permissive policies.
 -- PostgreSQL ORs permissive policies, so adding a stricter policy without

--- a/supabase/migrations/20260827032000_harden_note_comments_authorization.sql
+++ b/supabase/migrations/20260827032000_harden_note_comments_authorization.sql
@@ -1,0 +1,456 @@
+-- Issue #2668: make note comment authorization fail closed.
+--
+-- The original feature accumulated two generations of permissive policies.
+-- PostgreSQL ORs permissive policies, so adding a stricter policy without
+-- removing every legacy policy would leave the old write path open.
+
+CREATE SCHEMA IF NOT EXISTS note_comments_private;
+REVOKE ALL ON SCHEMA note_comments_private FROM PUBLIC;
+GRANT USAGE ON SCHEMA note_comments_private TO anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION note_comments_private.owns_note(p_note_id bigint)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.notes AS n
+    WHERE n.id = p_note_id
+      AND n.user_id = (SELECT auth.uid())
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION note_comments_private.owns_team(p_team_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.teams AS t
+    WHERE t.id = p_team_id
+      AND t.owner_id = (SELECT auth.uid())
+  )
+$$;
+
+ALTER TABLE public.team_memberships
+  ADD COLUMN IF NOT EXISTS invite_verified_at timestamptz;
+
+CREATE OR REPLACE FUNCTION note_comments_private.can_participate_in_team(p_team_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.teams AS t
+    WHERE t.id = p_team_id
+      AND (
+        t.owner_id = (SELECT auth.uid())
+        OR EXISTS (
+          SELECT 1
+          FROM public.team_memberships AS tm
+          WHERE tm.team_id = t.id
+            AND tm.user_id = (SELECT auth.uid())
+            AND tm.invite_verified_at IS NOT NULL
+        )
+      )
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION note_comments_private.is_valid_team_note_share(
+  p_team_id uuid,
+  p_note_id bigint,
+  p_shared_by uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    note_comments_private.can_participate_in_team(p_team_id)
+    AND EXISTS (
+      SELECT 1
+      FROM public.notes AS n
+      WHERE n.id = p_note_id
+        AND n.user_id = p_shared_by
+    )
+$$;
+
+CREATE OR REPLACE FUNCTION note_comments_private.can_access_note_comments(p_note_id bigint)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.notes AS n
+    WHERE n.id = p_note_id
+      AND (
+        n.user_id = (SELECT auth.uid())
+        OR EXISTS (
+          SELECT 1
+          FROM public.public_memos AS pm
+          WHERE pm.note_id = n.id
+            AND pm.user_id = n.user_id
+            AND pm.is_public IS TRUE
+        )
+        OR (
+          (SELECT auth.uid()) IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM public.team_shared_notes AS tsn
+            JOIN public.teams AS t ON t.id = tsn.team_id
+            WHERE tsn.note_id = n.id
+              AND tsn.shared_by = n.user_id
+              AND (
+                t.owner_id = (SELECT auth.uid())
+                OR EXISTS (
+                  SELECT 1
+                  FROM public.team_memberships AS tm
+                  WHERE tm.team_id = t.id
+                    AND tm.user_id = (SELECT auth.uid())
+                    AND tm.invite_verified_at IS NOT NULL
+                )
+              )
+          )
+        )
+      )
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION note_comments_private.can_read_public_memo(p_public_memo_id bigint)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.public_memos AS pm
+    JOIN public.notes AS n
+      ON n.id = pm.note_id
+     AND n.user_id = pm.user_id
+    WHERE pm.id = p_public_memo_id
+      AND (
+        pm.is_public IS TRUE
+        OR pm.user_id = (SELECT auth.uid())
+      )
+  )
+$$;
+
+REVOKE ALL ON FUNCTION note_comments_private.owns_note(bigint) FROM PUBLIC;
+REVOKE ALL ON FUNCTION note_comments_private.owns_team(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION note_comments_private.can_participate_in_team(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION note_comments_private.is_valid_team_note_share(uuid, bigint, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION note_comments_private.can_access_note_comments(bigint) FROM PUBLIC;
+REVOKE ALL ON FUNCTION note_comments_private.can_read_public_memo(bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION note_comments_private.owns_note(bigint) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION note_comments_private.owns_team(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION note_comments_private.can_participate_in_team(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION note_comments_private.is_valid_team_note_share(uuid, bigint, uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION note_comments_private.can_access_note_comments(bigint)
+  TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION note_comments_private.can_read_public_memo(bigint)
+  TO anon, authenticated, service_role;
+
+-- A public memo is authoritative only when its user owns the referenced note.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'public_memos_note_id_fkey'
+      AND conrelid = 'public.public_memos'::regclass
+  ) THEN
+    ALTER TABLE public.public_memos
+      ADD CONSTRAINT public_memos_note_id_fkey
+      FOREIGN KEY (note_id) REFERENCES public.notes(id) ON DELETE CASCADE
+      NOT VALID;
+  END IF;
+END
+$$;
+
+DROP POLICY IF EXISTS "Public memos viewable by all" ON public.public_memos;
+DROP POLICY IF EXISTS "Users can insert own public memos" ON public.public_memos;
+DROP POLICY IF EXISTS "Users can update own public memos" ON public.public_memos;
+DROP POLICY IF EXISTS "Users can delete own public memos" ON public.public_memos;
+DROP POLICY IF EXISTS public_memos_select_authorized ON public.public_memos;
+DROP POLICY IF EXISTS public_memos_insert_owner ON public.public_memos;
+DROP POLICY IF EXISTS public_memos_update_owner ON public.public_memos;
+DROP POLICY IF EXISTS public_memos_delete_owner ON public.public_memos;
+
+CREATE POLICY public_memos_select_authorized
+  ON public.public_memos FOR SELECT TO anon, authenticated
+  USING (note_comments_private.can_read_public_memo(id));
+
+CREATE POLICY public_memos_insert_owner
+  ON public.public_memos FOR INSERT TO authenticated
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND note_comments_private.owns_note(note_id)
+  );
+
+CREATE POLICY public_memos_update_owner
+  ON public.public_memos FOR UPDATE TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    AND note_comments_private.owns_note(note_id)
+  )
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND note_comments_private.owns_note(note_id)
+  );
+
+CREATE POLICY public_memos_delete_owner
+  ON public.public_memos FOR DELETE TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    AND note_comments_private.owns_note(note_id)
+  );
+
+-- Direct self-join is no longer an authorization path. Existing rows remain
+-- intact but do not grant comment access until re-verified by invite code.
+DROP POLICY IF EXISTS "team_memberships_select" ON public.team_memberships;
+DROP POLICY IF EXISTS "team_memberships_insert" ON public.team_memberships;
+DROP POLICY IF EXISTS "team_memberships_delete" ON public.team_memberships;
+DROP POLICY IF EXISTS team_memberships_select_authorized ON public.team_memberships;
+DROP POLICY IF EXISTS team_memberships_insert_owner ON public.team_memberships;
+DROP POLICY IF EXISTS team_memberships_delete_authorized ON public.team_memberships;
+
+CREATE POLICY team_memberships_select_authorized
+  ON public.team_memberships FOR SELECT TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    OR note_comments_private.owns_team(team_id)
+  );
+
+CREATE POLICY team_memberships_insert_owner
+  ON public.team_memberships FOR INSERT TO authenticated
+  WITH CHECK (note_comments_private.owns_team(team_id));
+
+CREATE POLICY team_memberships_delete_authorized
+  ON public.team_memberships FOR DELETE TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    OR note_comments_private.owns_team(team_id)
+  );
+
+CREATE OR REPLACE FUNCTION note_comments_private.stamp_owner_added_membership()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.teams AS t
+    WHERE t.id = NEW.team_id
+      AND t.owner_id = (SELECT auth.uid())
+  ) THEN
+    NEW.invite_verified_at := COALESCE(NEW.invite_verified_at, clock_timestamp());
+  ELSE
+    NEW.invite_verified_at := NULL;
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+REVOKE ALL ON FUNCTION note_comments_private.stamp_owner_added_membership() FROM PUBLIC;
+DROP TRIGGER IF EXISTS stamp_owner_added_membership ON public.team_memberships;
+CREATE TRIGGER stamp_owner_added_membership
+  BEFORE INSERT ON public.team_memberships
+  FOR EACH ROW EXECUTE FUNCTION note_comments_private.stamp_owner_added_membership();
+
+REVOKE ALL ON public.team_memberships FROM PUBLIC, anon, authenticated;
+GRANT SELECT, DELETE ON public.team_memberships TO authenticated;
+GRANT INSERT (team_id, user_id, role) ON public.team_memberships TO authenticated;
+GRANT ALL ON public.team_memberships TO service_role;
+
+CREATE TABLE IF NOT EXISTS note_comments_private.team_invite_attempts (
+  user_id uuid PRIMARY KEY,
+  window_started_at timestamptz NOT NULL,
+  attempt_count integer NOT NULL CHECK (attempt_count > 0)
+);
+REVOKE ALL ON note_comments_private.team_invite_attempts FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.join_team_with_invite_code(p_invite_code text)
+RETURNS TABLE (team_id uuid, team_name text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_team_id uuid;
+  v_team_name text;
+  v_code text := btrim(p_invite_code);
+  v_attempt_count integer;
+  v_now timestamptz := clock_timestamp();
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Authentication required';
+  END IF;
+
+  INSERT INTO note_comments_private.team_invite_attempts AS attempts (
+    user_id,
+    window_started_at,
+    attempt_count
+  )
+  VALUES (v_actor, v_now, 1)
+  ON CONFLICT (user_id) DO UPDATE
+  SET
+    window_started_at = CASE
+      WHEN attempts.window_started_at < v_now - interval '15 minutes' THEN v_now
+      ELSE attempts.window_started_at
+    END,
+    attempt_count = CASE
+      WHEN attempts.window_started_at < v_now - interval '15 minutes' THEN 1
+      ELSE attempts.attempt_count + 1
+    END
+  RETURNING attempt_count INTO v_attempt_count;
+
+  IF v_attempt_count > 10 THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0001',
+      MESSAGE = 'Invite attempts temporarily limited';
+  END IF;
+
+  IF v_code = '' OR char_length(v_code) > 128 THEN
+    RETURN;
+  END IF;
+
+  SELECT t.id, t.name
+  INTO v_team_id, v_team_name
+  FROM public.teams AS t
+  WHERE t.invite_code = v_code;
+
+  IF v_team_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.team_memberships (team_id, user_id, role)
+  VALUES (v_team_id, v_actor, 'member')
+  ON CONFLICT (team_id, user_id) DO NOTHING;
+
+  UPDATE public.team_memberships AS tm
+  SET invite_verified_at = clock_timestamp()
+  WHERE tm.team_id = v_team_id
+    AND tm.user_id = v_actor;
+
+  RETURN QUERY SELECT v_team_id, v_team_name;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.join_team_with_invite_code(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.join_team_with_invite_code(text)
+  TO authenticated, service_role;
+
+ALTER TABLE public.teams
+  ALTER COLUMN invite_code SET DEFAULT replace(gen_random_uuid()::text, '-', '');
+
+-- A team share is valid only when the sharer owns the note and participates in
+-- the team. Old forged rows remain stored but grant no access.
+DROP POLICY IF EXISTS "team_shared_notes_select" ON public.team_shared_notes;
+DROP POLICY IF EXISTS "team_shared_notes_insert" ON public.team_shared_notes;
+DROP POLICY IF EXISTS "team_shared_notes_delete" ON public.team_shared_notes;
+DROP POLICY IF EXISTS team_shared_notes_select_authorized ON public.team_shared_notes;
+DROP POLICY IF EXISTS team_shared_notes_insert_note_owner ON public.team_shared_notes;
+DROP POLICY IF EXISTS team_shared_notes_delete_authorized ON public.team_shared_notes;
+
+CREATE POLICY team_shared_notes_select_authorized
+  ON public.team_shared_notes FOR SELECT TO authenticated
+  USING (note_comments_private.is_valid_team_note_share(team_id, note_id, shared_by));
+
+CREATE POLICY team_shared_notes_insert_note_owner
+  ON public.team_shared_notes FOR INSERT TO authenticated
+  WITH CHECK (
+    shared_by = (SELECT auth.uid())
+    AND note_comments_private.owns_note(note_id)
+    AND note_comments_private.can_participate_in_team(team_id)
+  );
+
+CREATE POLICY team_shared_notes_delete_authorized
+  ON public.team_shared_notes FOR DELETE TO authenticated
+  USING (
+    shared_by = (SELECT auth.uid())
+    OR note_comments_private.owns_team(team_id)
+  );
+
+REVOKE ALL ON public.team_shared_notes FROM PUBLIC, anon, authenticated;
+GRANT SELECT, DELETE ON public.team_shared_notes TO authenticated;
+GRANT INSERT (team_id, note_id, shared_by) ON public.team_shared_notes
+  TO authenticated;
+GRANT ALL ON public.team_shared_notes TO service_role;
+
+-- Remove both generations plus any canonical policies from a previous retry.
+DROP POLICY IF EXISTS "Comments on public notes are viewable by everyone" ON public.note_comments;
+DROP POLICY IF EXISTS "Users can create comments" ON public.note_comments;
+DROP POLICY IF EXISTS "Users can update their own comments" ON public.note_comments;
+DROP POLICY IF EXISTS "Users can delete their own comments" ON public.note_comments;
+DROP POLICY IF EXISTS "Users can view own note comments" ON public.note_comments;
+DROP POLICY IF EXISTS "Users can insert own note comments" ON public.note_comments;
+DROP POLICY IF EXISTS "Users can update own note comments" ON public.note_comments;
+DROP POLICY IF EXISTS "Users can delete own note comments" ON public.note_comments;
+DROP POLICY IF EXISTS note_comments_select_authorized ON public.note_comments;
+DROP POLICY IF EXISTS note_comments_insert_authorized ON public.note_comments;
+DROP POLICY IF EXISTS note_comments_update_author ON public.note_comments;
+DROP POLICY IF EXISTS note_comments_delete_author ON public.note_comments;
+
+CREATE POLICY note_comments_select_authorized
+  ON public.note_comments FOR SELECT TO anon, authenticated
+  USING (note_comments_private.can_access_note_comments(note_id));
+
+CREATE POLICY note_comments_insert_authorized
+  ON public.note_comments FOR INSERT TO authenticated
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND note_comments_private.can_access_note_comments(note_id)
+  );
+
+CREATE POLICY note_comments_update_author
+  ON public.note_comments FOR UPDATE TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    AND note_comments_private.can_access_note_comments(note_id)
+  )
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND note_comments_private.can_access_note_comments(note_id)
+  );
+
+CREATE POLICY note_comments_delete_author
+  ON public.note_comments FOR DELETE TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+ALTER TABLE public.note_comments
+  DROP CONSTRAINT IF EXISTS note_comments_content_bounded_check;
+ALTER TABLE public.note_comments
+  ADD CONSTRAINT note_comments_content_bounded_check
+  CHECK (char_length(btrim(content)) BETWEEN 1 AND 2000)
+  NOT VALID;
+
+REVOKE ALL ON public.note_comments FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON public.note_comments TO anon, authenticated;
+GRANT INSERT (note_id, user_id, content) ON public.note_comments TO authenticated;
+GRANT UPDATE (content) ON public.note_comments TO authenticated;
+GRANT DELETE ON public.note_comments TO authenticated;
+GRANT ALL ON public.note_comments TO service_role;
+
+ALTER VIEW public.note_comment_counts SET (security_invoker = true);
+REVOKE ALL ON public.note_comment_counts FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON public.note_comment_counts TO service_role;

--- a/test/fixtures/testcontainers/sql/005_note_comments_base.sql
+++ b/test/fixtures/testcontainers/sql/005_note_comments_base.sql
@@ -1,0 +1,110 @@
+create table notes (
+  id bigint primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content text not null default ''
+);
+
+create table public_memos (
+  id bigserial primary key,
+  note_id bigint not null,
+  user_id uuid references auth.users(id) on delete cascade,
+  title text not null,
+  content text,
+  is_public boolean default true,
+  unique (note_id, user_id)
+);
+
+create table teams (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  description text not null default '',
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  invite_code text unique not null default substr(md5(random()::text), 1, 8),
+  created_at timestamptz not null default now()
+);
+
+create table team_memberships (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null default 'member' check (role in ('member', 'admin')),
+  joined_at timestamptz not null default now(),
+  unique (team_id, user_id)
+);
+
+create table team_shared_notes (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  note_id bigint not null references notes(id) on delete cascade,
+  shared_by uuid not null references auth.users(id) on delete cascade,
+  shared_at timestamptz not null default now(),
+  unique (team_id, note_id)
+);
+
+create table note_comments (
+  id uuid primary key default gen_random_uuid(),
+  note_id bigint not null references notes(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public_memos enable row level security;
+alter table teams enable row level security;
+alter table team_memberships enable row level security;
+alter table team_shared_notes enable row level security;
+alter table note_comments enable row level security;
+
+create policy "Public memos viewable by all" on public_memos for select
+  using (is_public = true or auth.uid() = user_id);
+create policy "Users can insert own public memos" on public_memos for insert
+  with check (auth.uid() = user_id);
+create policy "Users can update own public memos" on public_memos for update
+  using (auth.uid() = user_id);
+create policy "Users can delete own public memos" on public_memos for delete
+  using (auth.uid() = user_id);
+
+create policy "team_memberships_select" on team_memberships for select
+  using (user_id = auth.uid());
+create policy "team_memberships_insert" on team_memberships for insert
+  with check (user_id = auth.uid());
+create policy "team_memberships_delete" on team_memberships for delete
+  using (user_id = auth.uid());
+create policy "teams_select" on teams for select using (owner_id = auth.uid());
+create policy "teams_insert" on teams for insert with check (owner_id = auth.uid());
+create policy "teams_update" on teams for update using (owner_id = auth.uid());
+create policy "teams_delete" on teams for delete using (owner_id = auth.uid());
+create policy "team_shared_notes_select" on team_shared_notes for select
+  using (shared_by = auth.uid());
+create policy "team_shared_notes_insert" on team_shared_notes for insert
+  with check (shared_by = auth.uid());
+create policy "team_shared_notes_delete" on team_shared_notes for delete
+  using (shared_by = auth.uid());
+
+create policy "Comments on public notes are viewable by everyone"
+  on note_comments for select using (true);
+create policy "Users can create comments"
+  on note_comments for insert with check (auth.uid() = user_id);
+create policy "Users can update their own comments"
+  on note_comments for update using (auth.uid() = user_id);
+create policy "Users can delete their own comments"
+  on note_comments for delete using (auth.uid() = user_id);
+create policy "Users can view own note comments"
+  on note_comments for select using (auth.uid() = user_id);
+create policy "Users can insert own note comments"
+  on note_comments for insert with check (auth.uid() = user_id);
+create policy "Users can update own note comments"
+  on note_comments for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+create policy "Users can delete own note comments"
+  on note_comments for delete using (auth.uid() = user_id);
+
+create view note_comment_counts as
+select note_id, count(*) as comments_count from note_comments group by note_id;
+
+grant all privileges on table notes, public_memos, teams, team_memberships,
+  team_shared_notes, note_comments, note_comment_counts
+to anon, authenticated, service_role;
+grant usage, select on all sequences in schema public
+to anon, authenticated, service_role;

--- a/test/fixtures/testcontainers/sql/005_note_comments_base.sql
+++ b/test/fixtures/testcontainers/sql/005_note_comments_base.sql
@@ -71,7 +71,14 @@ create policy "team_memberships_insert" on team_memberships for insert
   with check (user_id = auth.uid());
 create policy "team_memberships_delete" on team_memberships for delete
   using (user_id = auth.uid());
-create policy "teams_select" on teams for select using (owner_id = auth.uid());
+create policy "teams_select" on teams for select
+  using (
+    owner_id = auth.uid()
+    or exists (
+      select 1 from team_memberships tm
+      where tm.team_id = teams.id and tm.user_id = auth.uid()
+    )
+  );
 create policy "teams_insert" on teams for insert with check (owner_id = auth.uid());
 create policy "teams_update" on teams for update using (owner_id = auth.uid());
 create policy "teams_delete" on teams for delete using (owner_id = auth.uid());

--- a/test/scripts/test_testcontainers_supabase_smoke.py
+++ b/test/scripts/test_testcontainers_supabase_smoke.py
@@ -150,6 +150,21 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
             plan["actual_edge_checks"],
         )
 
+    def test_plan_includes_note_comments_authorization_boundary(self) -> None:
+        plan = module.build_plan(
+            ROOT / "test" / "fixtures" / "testcontainers" / "sql",
+            ROOT / "test" / "fixtures" / "testcontainers" / "edge-db-smoke.ts",
+            ROOT / "supabase" / "functions" / "health-check" / "index.ts",
+        )
+        self.assertEqual(
+            plan["note_comments_migration"],
+            "supabase/migrations/20260827032000_harden_note_comments_authorization.sql",
+        )
+        checks = " ".join(plan["note_comments_checks"])
+        self.assertIn("body user_id forgery", checks)
+        self.assertIn("direct self-join", checks)
+        self.assertIn("applies twice", checks)
+
     def test_tenant_role_count_rejects_untrusted_identifiers(self) -> None:
         with self.assertRaisesRegex(ValueError, "unexpected role"):
             module.issue_2773_role_count(
@@ -160,6 +175,26 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
             )
         with self.assertRaisesRegex(ValueError, "unexpected table"):
             module.issue_2773_role_count(None, "authenticated", None, "pg_authid")
+
+    def test_note_comments_runner_rejects_untrusted_role(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unexpected role"):
+            module.note_comments_run_as(
+                None,
+                role="postgres",
+                user_id=None,
+                statement="select 1",
+            )
+
+    def test_team_join_uses_authenticated_rpc_boundary(self) -> None:
+        source = (ROOT / "lib" / "pages" / "team_workspace_page.dart").read_text(
+            encoding="utf-8"
+        )
+        join_method = source.split("Future<void> _joinByInviteCode() async {", 1)[1]
+        join_method = join_method.split("Future<void> _deleteTeam", 1)[0]
+        self.assertIn("'join_team_with_invite_code'", join_method)
+        self.assertIn("'p_invite_code': code.trim()", join_method)
+        self.assertNotIn(".from('team_memberships').insert", join_method)
+        self.assertNotIn("'user_id'", join_method)
 
     def test_asset_chat_role_count_rejects_untrusted_identifiers(self) -> None:
         with self.assertRaisesRegex(ValueError, "unexpected role"):

--- a/test/scripts/test_testcontainers_supabase_smoke.py
+++ b/test/scripts/test_testcontainers_supabase_smoke.py
@@ -195,6 +195,8 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
         self.assertIn("'p_invite_code': code.trim()", join_method)
         self.assertNotIn(".from('team_memberships').insert", join_method)
         self.assertNotIn("'user_id'", join_method)
+        self.assertIn("招待コード (8文字または32文字)", source)
+        self.assertIn("LengthLimitingTextInputFormatter(32)", source)
 
     def test_asset_chat_role_count_rejects_untrusted_identifiers(self) -> None:
         with self.assertRaisesRegex(ValueError, "unexpected role"):


### PR DESCRIPTION
Closes #2668

## Summary
- replace all eight permissive legacy note_comments policies with four canonical RLS policies
- validate note ownership, real public publication ownership, and verified workspace membership through pinned SECURITY DEFINER helpers
- close invite-code self-join and forged public/team-share authorization paths
- route Flutter invite joins through an authenticated, actor-derived, rate-limited RPC
- restrict comment writes to content-safe column grants and disable browser access to the aggregate count view
- run the reusable Testcontainers DB + Edge smoke before production migrations or Edge deployments

## Security behavior
- anonymous users can read comments only on valid public memos
- authenticated users can comment only where they have note access and cannot forge body user_id
- comment authors can update content only and delete only their own comments
- old membership rows remain stored but cannot grant comment access until re-verified by invite code or an owner-authorized insert
- old forged publication/share rows remain stored but are ignored as authorization evidence
- new team invite codes use 128-bit UUID-derived values; attempts are limited to 10 per actor per 15 minutes

## Validation
- python test/scripts/test_testcontainers_supabase_smoke.py: 17 passed
- python scripts/check_migration_timestamps.py: 1,978 unique timestamps, passed
- git diff --check: passed
- local full Testcontainers smoke reached the Docker boundary, then stopped because Docker Desktop was not running; no SQL assertion failed locally
- PR DB + Edge smoke and production pre-deploy smoke are required before merge/deploy by this delivery process

## Subagent record
- Franklin: read-only schema/RLS audit; found eight OR-composed policies plus untrusted public_memos, memberships, shares, and count-view paths; no edits/tests/cleanup
- Aristotle: read-only CI/Testcontainers audit; confirmed the reusable harness and identified the production deploy gate location; no edits/tests/cleanup
- Dewey: read-only client/Edge boundary audit; confirmed Flutter uses direct Data API RLS and that the old Edge/core-hub paths are incompatible; no edits/tests/cleanup
- Lead validation remains deterministic; subagent findings were treated as review input only

## Cleanup impact
- isolated worktree only
- generated failed-run logs and incidental deno.lock changes removed before commit
- root worktree and other task worktrees were not modified

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code review is unavailable in this user-directed Codex task; three scoped read-only security reviews and deterministic CI are used instead.
- Rollback: stop deploy before migration; after deployment, use a forward migration to restore prior grants/policies only if required. Do not roll back stored comments, memberships, or shares.
- Data migration: no rows are deleted or rewritten. Existing memberships remain unverified until invite or owner verification; invalid legacy publications and shares are retained but ignored for authorization.
- Prod smoke: production deploy runs the full DB + Edge Testcontainers gate before migrations, then the existing migration/deploy verification.
- Observability: Testcontainers summary and failure artifacts are uploaded on PR and production runs; deployment job status is the release signal.
- Unresolved ultrareview findings: none (exception path; no Claude ultrareview was run).


## Minimal E2E Gate
- Implementation-detail independent: the security test asserts role-visible input/output and row effects, not private implementation internals.
- Minimal scope: about 3 cases are the authorized happy path, denied cross-user path, and invalid/empty invite path.
- E2E: Playwright or Flutter integration_test is not added; the disposable Postgres Testcontainers integration flow is the end-to-end mechanism for this RLS/RPC boundary.
- E2E-Exception: authenticated invite UI cannot be exercised safely without CI user credentials; Testcontainers proves the real SQL boundary and a static contract proves the Flutter page calls the RPC without body user_id.
