### PR TITLE
chore(vscode): standardize split terminal workflow (#2857)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
           python scripts/cicd_efficiency_test.py
           python scripts/pre_commit_quality_gate_test.py
           python scripts/container_cleanup_guard_test.py
+          python scripts/vscode_terminal_settings_test.py
 
       - name: Setup Flutter
         if: steps.changes.outputs.flutter == 'true'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
   "deno.unstable": [],
   "files.encoding": "utf8",
   "terminal.integrated.cwd": "${workspaceFolder}",
+  "terminal.integrated.splitCwd": "workspaceRoot",
   "terminal.integrated.defaultProfile.windows": "my_web_app PowerShell",
   "terminal.integrated.profiles.windows": {
     "my_web_app PowerShell": {

--- a/docs/VSCODE_TERMINAL_TROUBLESHOOTING.md
+++ b/docs/VSCODE_TERMINAL_TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # VS Code Terminal Troubleshooting Guide
 
-Status: repo-managed wiki page for Issue #1294.
+Status: repo-managed wiki page for Issues #1294 and #2857.
 
 This guide standardizes first-response checks when the VS Code integrated
 terminal fails to start, exits immediately, or returns a shell exit code before
@@ -117,6 +117,74 @@ code --disable-extensions .
 If this works, re-enable extensions in small batches. Terminal, shell
 integration, environment, Docker, remote development, and AI coding extensions
 are the first suspects.
+
+### Repository split-terminal standard
+
+This repository pins the following workspace behavior in
+`.vscode/settings.json`:
+
+```json
+{
+  "terminal.integrated.cwd": "${workspaceFolder}",
+  "terminal.integrated.splitCwd": "workspaceRoot"
+}
+```
+
+`workspaceRoot` is intentional. A split made from a terminal that has moved
+into `supabase/`, `web/`, or another subdirectory starts at the repository
+root, so Flutter and Supabase commands do not silently run against different
+project roots. In a multi-root workspace VS Code asks which root to use.
+
+Do not add `terminal.integrated.inheritEnv` to the workspace file. Current VS
+Code defines it as an application-scoped user setting with a default of
+`true`; it cannot be standardized per workspace, and it has no effect on
+Windows. On macOS and Linux, developers who changed the user setting to
+`false` should restore it to `true` unless they intentionally need a stripped
+shell environment.
+
+The behavior above follows the current VS Code
+[split-terminal documentation](https://code.visualstudio.com/docs/terminal/basics#_groups-split-panes)
+and the official
+[`inheritEnv` configuration schema](https://github.com/microsoft/vscode/blob/main/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts).
+
+After changing either the user setting or the workspace settings, close the
+old terminals, open a new terminal, split it, and compare both panes:
+
+```powershell
+# Windows PowerShell (run in both panes)
+(Get-Location).Path
+$env:Path
+$env:PYTHONUTF8
+Get-Command flutter
+Get-Command supabase
+```
+
+```bash
+# macOS/Linux (run in both panes)
+pwd
+printf '%s\n' "$PATH" "$PYTHONUTF8"
+command -v flutter
+command -v supabase
+```
+
+Both panes must start at the repository root. `PATH`, `PYTHONUTF8`, and command
+resolution must agree. If they do not, compare the VS Code user setting,
+login-shell profile, and `terminal.integrated.env.{platform}` before changing
+the repository settings.
+
+### Recommended Flutter + Supabase layout
+
+Use one terminal group split into three panes. Keep each pane at the workspace
+root and let each CLI discover its own project files.
+
+| Pane | Long-running owner | Typical commands |
+| --- | --- | --- |
+| Left | Supabase local stack / functions | `supabase start`, `supabase status`, `supabase functions serve` |
+| Top right | Flutter daemon | `flutter run -d chrome` |
+| Bottom right | Short checks and logs | `flutter test <target>`, `supabase functions logs <name>` |
+
+Do not place tokens or `.env` values in `.vscode/settings.json`. Load secrets
+through the existing local environment or approved secret workflow instead.
 
 ## 4. Exit Code Reading Guide
 

--- a/scripts/vscode_terminal_settings_test.py
+++ b/scripts/vscode_terminal_settings_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_PATH = ROOT / ".vscode" / "settings.json"
+GUIDE_PATH = ROOT / "docs" / "VSCODE_TERMINAL_TROUBLESHOOTING.md"
+
+
+class VsCodeTerminalSettingsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+        cls.guide = GUIDE_PATH.read_text(encoding="utf-8")
+
+    def test_split_terminals_always_start_at_workspace_root(self) -> None:
+        self.assertEqual(
+            self.settings["terminal.integrated.cwd"], "${workspaceFolder}"
+        )
+        self.assertEqual(
+            self.settings["terminal.integrated.splitCwd"], "workspaceRoot"
+        )
+
+    def test_application_scoped_inherit_env_is_not_misconfigured(self) -> None:
+        self.assertNotIn("terminal.integrated.inheritEnv", self.settings)
+        self.assertIn("application-scoped user setting", self.guide)
+        self.assertIn("default of", self.guide)
+        self.assertIn("`true`", self.guide)
+        self.assertIn("no effect on\nWindows", self.guide)
+
+    def test_workspace_environment_contract_is_preserved(self) -> None:
+        for platform in ("windows", "osx", "linux"):
+            env = self.settings[f"terminal.integrated.env.{platform}"]
+            self.assertEqual(env["PYTHONUTF8"], "1")
+            self.assertEqual(env["PYTHONIOENCODING"], "utf-8")
+
+    def test_parallel_flutter_supabase_layout_is_documented(self) -> None:
+        for marker in (
+            "Recommended Flutter + Supabase layout",
+            "supabase start",
+            "supabase functions serve",
+            "flutter run -d chrome",
+            "Get-Command flutter",
+            "Get-Command supabase",
+        ):
+            self.assertIn(marker, self.guide)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- pin split terminals to the repository root with `terminal.integrated.splitCwd = workspaceRoot`
- document why `terminal.integrated.inheritEnv` stays out of workspace settings and how to compare CWD/PATH/tool resolution across panes
- document the recommended Supabase / Flutter / short-check three-pane layout
- add a deterministic static settings/docs test to CI

## Validation
- `git diff --check`: PASS
- local Python test: deferred because RAM gate failed (92.6%→89.0%, free 1.17GB→1.73GB)
- required GitHub Actions CI: pending
- no Flutter, Dart, Deno, Supabase runtime, UI, or browser behavior changed

## Minimal E2E Gate
- [x] Exception: workspace configuration and documentation only; no user-visible product route or UI changed.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI-only change adds one deterministic Python test invocation; no deploy, auth, secret, migration, production, or permission behavior changes.

## Change type
- [x] Documentation
- [x] Test
- [x] CI/CD
- [x] No breaking change
- [x] No deployment or environment-variable change required

Closes #2857