### PR TITLE
feat(windows): add terminal doctor diagnostics (#2858)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,11 @@ jobs:
         run: ./test/scripts/tools_hub_mcp_smoke_response_test.ps1
         continue-on-error: false
 
+      - name: Test Windows terminal doctor fixtures
+        shell: pwsh
+        run: ./test/scripts/windows_terminal_doctor_test.ps1
+        continue-on-error: false
+
       - name: Check duplicate dispose statements
         if: steps.changes.outputs.flutter == 'true'
         # part 280 実例 (二重 dispose → dispose 中断 → defunct setState) の再発防止。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Test Windows terminal doctor fixtures
         shell: pwsh
-        run: ./test/scripts/windows_terminal_doctor_test.ps1
+        run: ./scripts/windows_terminal_doctor_test.ps1
         continue-on-error: false
 
       - name: Check duplicate dispose statements

--- a/docs/setup/windows-dev-setup.md
+++ b/docs/setup/windows-dev-setup.md
@@ -133,6 +133,44 @@ settings.
 Use this sequence when a terminal fails before the shell prompt appears. Stop
 as soon as the terminal works; do not add antivirus exclusions preemptively.
 
+Start with the repository doctor. It is read-only by default and checks the
+global `HKCU:\Console\ForceV2` legacy-console flag, the `wslconfig.exe /l`
+default distribution (with a locale-neutral registry fallback), and old
+`powershell` / `pwsh` / `wsl` launchers whose CPU time does not change during a
+short sample:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/windows_terminal_doctor.ps1
+```
+
+Interpret the reported Windows codes precisely. `259` is the Win32
+`STILL_ACTIVE` status returned while a process is still running, not evidence
+by itself that the process is hung. `3221225786` (`0xC000013A`) is
+`STATUS_CONTROL_C_EXIT`, commonly produced after Ctrl+C or console closure; it
+does not prove that legacy-console mode caused the termination. Correlate the
+code with the doctor findings and VS Code terminal trace before changing any
+setting or stopping a process.
+
+Use machine-readable output when attaching redacted evidence to an Issue:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/windows_terminal_doctor.ps1 -Json
+```
+
+An idle candidate is not proof that a process is hung. The doctor never stops
+anything by default, excludes its own process ancestry, and never targets
+`wslhost`, `wslservice`, `vmmem`, or Docker Desktop processes. Review the PID
+and any unsaved terminal work first. To request a confirmation prompt for each
+reported user-shell launcher, run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/windows_terminal_doctor.ps1 -OfferStop -Confirm
+```
+
+Do not pass `-Confirm:$false` unless every listed PID has been independently
+verified as disposable. The doctor only reports findings; the manual recovery
+steps below remain the rollback-safe source of truth.
+
 ### 1. Confirm the default WSL distribution
 
 Run both the current WSL command and the compatibility command requested by
@@ -270,6 +308,8 @@ Official references:
 - [VS Code: Troubleshoot terminal launch failures](https://code.visualstudio.com/docs/supporting/troubleshoot-terminal-launch)
 - [Microsoft: Basic commands for WSL](https://learn.microsoft.com/windows/wsl/basic-commands)
 - [Microsoft: Legacy Console mode](https://learn.microsoft.com/windows/console/legacymode)
+- [Microsoft: `GetExitCodeProcess` and `STILL_ACTIVE`](https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess)
+- [Microsoft: `3221225786` / `STATUS_CONTROL_C_EXIT`](https://learn.microsoft.com/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/misc-info)
 - [Microsoft Defender Antivirus exclusions](https://learn.microsoft.com/defender-endpoint/microsoft-defender-antivirus-exclusions-overview)
 - [Docker Desktop WSL 2 backend](https://docs.docker.com/desktop/features/wsl/)
 

--- a/scripts/windows_terminal_doctor.ps1
+++ b/scripts/windows_terminal_doctor.ps1
@@ -1,0 +1,417 @@
+<#
+.SYNOPSIS
+Diagnoses Windows console, stale shell process, and WSL default issues.
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts/windows_terminal_doctor.ps1
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts/windows_terminal_doctor.ps1 -Json
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts/windows_terminal_doctor.ps1 -OfferStop -Confirm
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
+param(
+    [ValidateRange(5, 10080)]
+    [int]$MinimumAgeMinutes = 120,
+
+    [ValidateRange(1, 30)]
+    [int]$SampleSeconds = 2,
+
+    [switch]$OfferStop,
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:VSCodeTerminalHelp = "https://code.visualstudio.com/docs/supporting/troubleshoot-terminal-launch"
+$script:LegacyConsoleHelp = "https://learn.microsoft.com/windows/console/legacymode"
+$script:WslHelp = "https://learn.microsoft.com/windows/wsl/basic-commands"
+
+function Get-LegacyConsoleAssessment {
+    [CmdletBinding()]
+    param([AllowNull()][object]$ForceV2)
+
+    if ($null -eq $ForceV2) {
+        return [pscustomobject]@{
+            ForceV2 = $null
+            IsLegacy = $false
+            Status = "default-modern"
+            Message = "HKCU:\Console\ForceV2 is not set; Windows uses the modern console default."
+        }
+    }
+
+    try {
+        $value = [int]$ForceV2
+    } catch {
+        return [pscustomobject]@{
+            ForceV2 = [string]$ForceV2
+            IsLegacy = $false
+            Status = "unknown"
+            Message = "HKCU:\Console\ForceV2 is not a recognized DWORD value."
+        }
+    }
+
+    if ($value -eq 0) {
+        return [pscustomobject]@{
+            ForceV2 = $value
+            IsLegacy = $true
+            Status = "legacy-enabled"
+            Message = "Legacy console mode is enabled globally (ForceV2=0)."
+        }
+    }
+
+    if ($value -eq 1) {
+        return [pscustomobject]@{
+            ForceV2 = $value
+            IsLegacy = $false
+            Status = "modern-enabled"
+            Message = "Modern console features are enabled (ForceV2=1)."
+        }
+    }
+
+    return [pscustomobject]@{
+        ForceV2 = $value
+        IsLegacy = $false
+        Status = "unknown"
+        Message = "HKCU:\Console\ForceV2 has an unsupported value: $value."
+    }
+}
+
+function Read-LegacyConsoleForceV2 {
+    [CmdletBinding()]
+    param()
+
+    try {
+        return Get-ItemPropertyValue `
+            -LiteralPath "HKCU:\Console" `
+            -Name "ForceV2" `
+            -ErrorAction Stop
+    } catch [System.Management.Automation.ItemNotFoundException] {
+        return $null
+    } catch [System.Management.Automation.PSArgumentException] {
+        return $null
+    }
+}
+
+function Get-WslDefaultFromLegacyOutput {
+    [CmdletBinding()]
+    param([AllowEmptyString()][string]$OutputText)
+
+    if ([string]::IsNullOrWhiteSpace($OutputText)) {
+        return $null
+    }
+
+    $normalized = $OutputText.Replace("`0", "")
+    foreach ($line in ($normalized -split "`r?`n")) {
+        $trimmed = $line.Trim()
+        if ($trimmed -match "^(?<name>.+?)\s+\((?:Default|既定|既定値)\)\s*$") {
+            return $Matches["name"].Trim()
+        }
+    }
+
+    return $null
+}
+
+function Get-WslDefaultAssessment {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()][string]$WslConfigOutput,
+        [AllowNull()][string]$RegistryDefault
+    )
+
+    $parsedDefault = Get-WslDefaultFromLegacyOutput -OutputText $WslConfigOutput
+    if (-not [string]::IsNullOrWhiteSpace($parsedDefault)) {
+        $defaultDistribution = $parsedDefault
+        $source = "wslconfig.exe /l"
+    } elseif (-not [string]::IsNullOrWhiteSpace($RegistryDefault)) {
+        $defaultDistribution = $RegistryDefault.Trim()
+        $source = "HKCU Lxss registry fallback"
+    } else {
+        $defaultDistribution = $null
+        $source = "unavailable"
+    }
+
+    $isDockerInternal = $false
+    if ($null -ne $defaultDistribution) {
+        $isDockerInternal = $defaultDistribution -match "^(?i:docker-desktop(?:-data)?)$"
+    }
+
+    if ($isDockerInternal) {
+        $status = "invalid-docker-default"
+        $message = "Docker Desktop internal distribution '$defaultDistribution' is the WSL default. Select an interactive Linux distribution."
+    } elseif ($null -eq $defaultDistribution) {
+        $status = "unknown"
+        $message = "The default WSL distribution could not be determined."
+    } else {
+        $status = "interactive-default"
+        $message = "The WSL default is '$defaultDistribution'."
+    }
+
+    return [pscustomobject]@{
+        DefaultDistribution = $defaultDistribution
+        Source = $source
+        IsDockerInternal = $isDockerInternal
+        Status = $status
+        Message = $message
+    }
+}
+
+function Read-WslRegistryDefault {
+    [CmdletBinding()]
+    param()
+
+    $lxssPath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss"
+    try {
+        $defaultId = Get-ItemPropertyValue `
+            -LiteralPath $lxssPath `
+            -Name "DefaultDistribution" `
+            -ErrorAction Stop
+        $idText = [string]$defaultId
+        if ($idText -notmatch "^\{") {
+            $idText = ([guid]$idText).ToString("B")
+        }
+        return Get-ItemPropertyValue `
+            -LiteralPath (Join-Path $lxssPath $idText) `
+            -Name "DistributionName" `
+            -ErrorAction Stop
+    } catch {
+        return $null
+    }
+}
+
+function Read-WslConfigOutput {
+    [CmdletBinding()]
+    param()
+
+    if (-not (Get-Command "wslconfig.exe" -ErrorAction SilentlyContinue)) {
+        return ""
+    }
+
+    try {
+        return (& wslconfig.exe /l 2>&1 | Out-String)
+    } catch {
+        return ""
+    }
+}
+
+function Get-WindowsProcessSnapshot {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        Get-CimInstance Win32_Process | ForEach-Object {
+            $creationTime = $null
+            if ($null -ne $_.CreationDate) {
+                $creationTime = [datetime]$_.CreationDate
+            }
+            [pscustomobject]@{
+                Name = [string]$_.Name
+                ProcessId = [int]$_.ProcessId
+                ParentProcessId = [int]$_.ParentProcessId
+                CreationTime = $creationTime
+                CpuTicks = ([uint64]$_.KernelModeTime + [uint64]$_.UserModeTime)
+            }
+        }
+    )
+}
+
+function Get-ProtectedProcessIds {
+    [CmdletBinding()]
+    param(
+        [object[]]$Processes,
+        [int]$CurrentProcessId
+    )
+
+    $byId = @{}
+    foreach ($process in $Processes) {
+        $byId[[int]$process.ProcessId] = $process
+    }
+
+    $protected = New-Object System.Collections.Generic.List[int]
+    $candidateId = $CurrentProcessId
+    while ($candidateId -gt 0 -and -not $protected.Contains($candidateId)) {
+        $protected.Add($candidateId)
+        if (-not $byId.ContainsKey($candidateId)) {
+            break
+        }
+        $candidateId = [int]$byId[$candidateId].ParentProcessId
+    }
+
+    return @($protected)
+}
+
+function Get-StaleShellProcessCandidates {
+    [CmdletBinding()]
+    param(
+        [object[]]$FirstSnapshot,
+        [object[]]$SecondSnapshot,
+        [datetime]$Now,
+        [int]$MinimumAgeMinutes,
+        [int[]]$ProtectedProcessIds = @()
+    )
+
+    $allowedNames = @("powershell", "pwsh", "wsl")
+    $firstById = @{}
+    foreach ($process in $FirstSnapshot) {
+        $firstById[[int]$process.ProcessId] = $process
+    }
+
+    $results = New-Object System.Collections.Generic.List[object]
+    foreach ($process in $SecondSnapshot) {
+        $processId = [int]$process.ProcessId
+        $name = ([string]$process.Name).ToLowerInvariant() -replace "\.exe$", ""
+        if ($allowedNames -notcontains $name) {
+            continue
+        }
+        if ($ProtectedProcessIds -contains $processId) {
+            continue
+        }
+        if (-not $firstById.ContainsKey($processId)) {
+            continue
+        }
+
+        $previous = $firstById[$processId]
+        if ([uint64]$previous.CpuTicks -ne [uint64]$process.CpuTicks) {
+            continue
+        }
+        if ($null -eq $process.CreationTime) {
+            continue
+        }
+
+        $age = $Now - [datetime]$process.CreationTime
+        if ($age.TotalMinutes -lt $MinimumAgeMinutes) {
+            continue
+        }
+
+        $results.Add([pscustomobject]@{
+            Name = $name
+            ProcessId = $processId
+            ParentProcessId = [int]$process.ParentProcessId
+            AgeMinutes = [math]::Floor($age.TotalMinutes)
+            CpuChangedDuringSample = $false
+        })
+    }
+
+    return @($results | Sort-Object AgeMinutes -Descending)
+}
+
+function Invoke-WindowsTerminalDoctor {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
+    param(
+        [int]$MinimumAgeMinutes,
+        [int]$SampleSeconds,
+        [switch]$OfferStop
+    )
+
+    if ($env:OS -ne "Windows_NT") {
+        return [pscustomobject]@{
+            Status = "skipped-non-windows"
+            LegacyConsole = $null
+            Wsl = $null
+            StaleProcessCandidates = @()
+            StoppedProcessIds = @()
+            References = @($script:VSCodeTerminalHelp, $script:LegacyConsoleHelp, $script:WslHelp)
+        }
+    }
+
+    $legacy = Get-LegacyConsoleAssessment -ForceV2 (Read-LegacyConsoleForceV2)
+    $wsl = Get-WslDefaultAssessment `
+        -WslConfigOutput (Read-WslConfigOutput) `
+        -RegistryDefault (Read-WslRegistryDefault)
+
+    $firstSnapshot = Get-WindowsProcessSnapshot
+    Start-Sleep -Seconds $SampleSeconds
+    $secondSnapshot = Get-WindowsProcessSnapshot
+    $protectedIds = Get-ProtectedProcessIds `
+        -Processes $secondSnapshot `
+        -CurrentProcessId $PID
+    $candidates = Get-StaleShellProcessCandidates `
+        -FirstSnapshot $firstSnapshot `
+        -SecondSnapshot $secondSnapshot `
+        -Now (Get-Date) `
+        -MinimumAgeMinutes $MinimumAgeMinutes `
+        -ProtectedProcessIds $protectedIds
+
+    $stopped = New-Object System.Collections.Generic.List[int]
+    if ($OfferStop) {
+        foreach ($candidate in $candidates) {
+            $target = "$($candidate.Name) PID $($candidate.ProcessId), idle for at least $SampleSeconds seconds, age $($candidate.AgeMinutes) minutes"
+            if ($PSCmdlet.ShouldProcess($target, "Stop stale shell candidate")) {
+                Stop-Process -Id $candidate.ProcessId -ErrorAction Stop
+                $stopped.Add([int]$candidate.ProcessId)
+            }
+        }
+    }
+
+    $hasFinding = $legacy.IsLegacy -or $wsl.IsDockerInternal -or $candidates.Count -gt 0
+    return [pscustomobject]@{
+        Status = $(if ($hasFinding) { "warning" } else { "ok" })
+        LegacyConsole = $legacy
+        Wsl = $wsl
+        StaleProcessCandidates = @($candidates)
+        StoppedProcessIds = @($stopped)
+        References = @($script:VSCodeTerminalHelp, $script:LegacyConsoleHelp, $script:WslHelp)
+    }
+}
+
+function Show-WindowsTerminalDoctorResult {
+    [CmdletBinding()]
+    param(
+        [object]$Result,
+        [switch]$AsJson,
+        [switch]$StopWasOffered
+    )
+
+    if ($AsJson) {
+        $Result | ConvertTo-Json -Depth 6
+        return
+    }
+
+    Write-Host "Windows terminal doctor: $($Result.Status)"
+    if ($Result.Status -eq "skipped-non-windows") {
+        Write-Host "This diagnostic only runs on Windows."
+    } else {
+        Write-Host "Legacy console: $($Result.LegacyConsole.Message)"
+        Write-Host "WSL default: $($Result.Wsl.Message)"
+        if ($Result.StaleProcessCandidates.Count -gt 0) {
+            Write-Host ""
+            Write-Host "Idle shell candidates (not proof of a hang):" -ForegroundColor Yellow
+            $Result.StaleProcessCandidates | Format-Table Name, ProcessId, ParentProcessId, AgeMinutes -AutoSize
+            if (-not $StopWasOffered) {
+                Write-Host "Review ownership and work first. To confirm each stop interactively, rerun with -OfferStop -Confirm." -ForegroundColor Yellow
+            }
+        } else {
+            Write-Host "Idle shell candidates: none"
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Official references:"
+    foreach ($reference in $Result.References) {
+        Write-Host "- $reference"
+    }
+}
+
+if ($MyInvocation.InvocationName -ne ".") {
+    $invokeParameters = @{
+        MinimumAgeMinutes = $MinimumAgeMinutes
+        SampleSeconds = $SampleSeconds
+        OfferStop = $OfferStop
+    }
+    if ($PSBoundParameters.ContainsKey("WhatIf")) {
+        $invokeParameters["WhatIf"] = $PSBoundParameters["WhatIf"]
+    }
+    if ($PSBoundParameters.ContainsKey("Confirm")) {
+        $invokeParameters["Confirm"] = $PSBoundParameters["Confirm"]
+    }
+
+    $doctorResult = Invoke-WindowsTerminalDoctor @invokeParameters
+    Show-WindowsTerminalDoctorResult `
+        -Result $doctorResult `
+        -AsJson:$Json `
+        -StopWasOffered:$OfferStop
+}

--- a/scripts/windows_terminal_doctor.ps1
+++ b/scripts/windows_terminal_doctor.ps1
@@ -329,12 +329,14 @@ function Invoke-WindowsTerminalDoctor {
     $protectedIds = Get-ProtectedProcessIds `
         -Processes $secondSnapshot `
         -CurrentProcessId $PID
-    $candidates = Get-StaleShellProcessCandidates `
-        -FirstSnapshot $firstSnapshot `
-        -SecondSnapshot $secondSnapshot `
-        -Now (Get-Date) `
-        -MinimumAgeMinutes $MinimumAgeMinutes `
-        -ProtectedProcessIds $protectedIds
+    $candidates = @(
+        Get-StaleShellProcessCandidates `
+            -FirstSnapshot $firstSnapshot `
+            -SecondSnapshot $secondSnapshot `
+            -Now (Get-Date) `
+            -MinimumAgeMinutes $MinimumAgeMinutes `
+            -ProtectedProcessIds $protectedIds
+    )
 
     $stopped = New-Object System.Collections.Generic.List[int]
     if ($OfferStop) {

--- a/scripts/windows_terminal_doctor_test.ps1
+++ b/scripts/windows_terminal_doctor_test.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 . (Join-Path $repoRoot "scripts\windows_terminal_doctor.ps1")
 
 function Assert-Equal {

--- a/test/scripts/windows_terminal_doctor_test.ps1
+++ b/test/scripts/windows_terminal_doctor_test.ps1
@@ -1,0 +1,72 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+. (Join-Path $repoRoot "scripts\windows_terminal_doctor.ps1")
+
+function Assert-Equal {
+    param(
+        [object]$Actual,
+        [object]$Expected,
+        [string]$Message
+    )
+    if ($Actual -ne $Expected) {
+        throw "$Message. Expected '$Expected', got '$Actual'."
+    }
+}
+
+$legacy = Get-LegacyConsoleAssessment -ForceV2 0
+Assert-Equal $legacy.IsLegacy $true "ForceV2=0 must be reported as legacy"
+Assert-Equal $legacy.Status "legacy-enabled" "Legacy status mismatch"
+
+$modern = Get-LegacyConsoleAssessment -ForceV2 1
+Assert-Equal $modern.IsLegacy $false "ForceV2=1 must be modern"
+
+$englishWsl = @"
+Windows Subsystem for Linux Distributions:
+Ubuntu (Default)
+docker-desktop
+"@
+$wsl = Get-WslDefaultAssessment -WslConfigOutput $englishWsl -RegistryDefault "Debian"
+Assert-Equal $wsl.DefaultDistribution "Ubuntu" "wslconfig output must win over fallback"
+Assert-Equal $wsl.IsDockerInternal $false "Ubuntu must be accepted"
+
+$nulSeparatedWsl = "d`0o`0c`0k`0e`0r`0-`0d`0e`0s`0k`0t`0o`0p`0-`0d`0a`0t`0a`0 `0(`0D`0e`0f`0a`0u`0l`0t`0)`0"
+$dockerWsl = Get-WslDefaultAssessment -WslConfigOutput $nulSeparatedWsl -RegistryDefault $null
+Assert-Equal $dockerWsl.DefaultDistribution "docker-desktop-data" "UTF-16-style NULs must be removed"
+Assert-Equal $dockerWsl.IsDockerInternal $true "Docker data distro must be rejected as default"
+
+$fallbackWsl = Get-WslDefaultAssessment -WslConfigOutput "header only" -RegistryDefault "Debian"
+Assert-Equal $fallbackWsl.DefaultDistribution "Debian" "Registry fallback must be used for localized output"
+
+$now = [datetime]"2026-08-27T04:00:00Z"
+$first = @(
+    [pscustomobject]@{ Name = "pwsh.exe"; ProcessId = 10; ParentProcessId = 1; CreationTime = $now.AddHours(-4); CpuTicks = 100 },
+    [pscustomobject]@{ Name = "powershell.exe"; ProcessId = 11; ParentProcessId = 1; CreationTime = $now.AddHours(-4); CpuTicks = 100 },
+    [pscustomobject]@{ Name = "wsl.exe"; ProcessId = 12; ParentProcessId = 1; CreationTime = $now.AddMinutes(-5); CpuTicks = 100 },
+    [pscustomobject]@{ Name = "wslhost.exe"; ProcessId = 13; ParentProcessId = 1; CreationTime = $now.AddHours(-4); CpuTicks = 100 }
+)
+$second = @(
+    [pscustomobject]@{ Name = "pwsh.exe"; ProcessId = 10; ParentProcessId = 1; CreationTime = $now.AddHours(-4); CpuTicks = 100 },
+    [pscustomobject]@{ Name = "powershell.exe"; ProcessId = 11; ParentProcessId = 1; CreationTime = $now.AddHours(-4); CpuTicks = 101 },
+    [pscustomobject]@{ Name = "wsl.exe"; ProcessId = 12; ParentProcessId = 1; CreationTime = $now.AddMinutes(-5); CpuTicks = 100 },
+    [pscustomobject]@{ Name = "wslhost.exe"; ProcessId = 13; ParentProcessId = 1; CreationTime = $now.AddHours(-4); CpuTicks = 100 }
+)
+$candidates = Get-StaleShellProcessCandidates `
+    -FirstSnapshot $first `
+    -SecondSnapshot $second `
+    -Now $now `
+    -MinimumAgeMinutes 120 `
+    -ProtectedProcessIds @()
+Assert-Equal $candidates.Count 1 "Only old CPU-idle user shell launchers may be candidates"
+Assert-Equal $candidates[0].ProcessId 10 "Unexpected idle candidate"
+
+$protected = Get-StaleShellProcessCandidates `
+    -FirstSnapshot $first `
+    -SecondSnapshot $second `
+    -Now $now `
+    -MinimumAgeMinutes 120 `
+    -ProtectedProcessIds @(10)
+Assert-Equal $protected.Count 0 "The active process ancestry must be protected"
+
+Write-Host "windows_terminal_doctor_test: PASS"

--- a/test/scripts/windows_terminal_doctor_test.ps1
+++ b/test/scripts/windows_terminal_doctor_test.ps1
@@ -52,21 +52,25 @@ $second = @(
     [pscustomobject]@{ Name = "wsl.exe"; ProcessId = 12; ParentProcessId = 1; CreationTime = $now.AddMinutes(-5); CpuTicks = 100 },
     [pscustomobject]@{ Name = "wslhost.exe"; ProcessId = 13; ParentProcessId = 1; CreationTime = $now.AddHours(-4); CpuTicks = 100 }
 )
-$candidates = Get-StaleShellProcessCandidates `
-    -FirstSnapshot $first `
-    -SecondSnapshot $second `
-    -Now $now `
-    -MinimumAgeMinutes 120 `
-    -ProtectedProcessIds @()
+$candidates = @(
+    Get-StaleShellProcessCandidates `
+        -FirstSnapshot $first `
+        -SecondSnapshot $second `
+        -Now $now `
+        -MinimumAgeMinutes 120 `
+        -ProtectedProcessIds @()
+)
 Assert-Equal $candidates.Count 1 "Only old CPU-idle user shell launchers may be candidates"
 Assert-Equal $candidates[0].ProcessId 10 "Unexpected idle candidate"
 
-$protected = Get-StaleShellProcessCandidates `
-    -FirstSnapshot $first `
-    -SecondSnapshot $second `
-    -Now $now `
-    -MinimumAgeMinutes 120 `
-    -ProtectedProcessIds @(10)
+$protected = @(
+    Get-StaleShellProcessCandidates `
+        -FirstSnapshot $first `
+        -SecondSnapshot $second `
+        -Now $now `
+        -MinimumAgeMinutes 120 `
+        -ProtectedProcessIds @(10)
+)
 Assert-Equal $protected.Count 0 "The active process ancestry must be protected"
 
 Write-Host "windows_terminal_doctor_test: PASS"


### PR DESCRIPTION
## Summary
- add a read-only-by-default Windows terminal doctor for legacy-console, WSL default, and stale shell launcher diagnostics
- use two process snapshots, minimum age, and active-ancestry exclusion; never target WSL/Docker infrastructure processes
- require explicit `-OfferStop -Confirm` before stopping any reported user-shell candidate
- parse `wslconfig.exe /l` with an Lxss registry fallback and flag Docker internal defaults
- document the correct meanings of 259 (`STILL_ACTIVE`) and 3221225786 (`STATUS_CONTROL_C_EXIT`)
- add deterministic cross-platform PowerShell fixtures to CI

## Validation
- `git diff --check`: PASS
- local PowerShell fixture test: deferred because RAM gate failed (94.8%→93.0%, free 0.81GB→1.10GB)
- required GitHub Actions CI: pending
- no Flutter, Dart, Supabase service, database, UI, or browser behavior changed

## Safety
- default execution is diagnostic only
- command lines and environment values are not emitted
- current process ancestry is protected
- `wslhost`, `wslservice`, `vmmem`, and Docker processes are never candidates
- candidate idleness is explicitly not treated as proof of a hang

## Minimal E2E Gate
- [x] Exception: Windows developer diagnostic script and documentation only; no product route or UI changed.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI-only workflow change adds one deterministic fixture invocation; the diagnostic script is read-only by default and process termination requires explicit per-process confirmation. No deploy, auth, secret, migration, production, or permission behavior changes.

Closes #2858