### PR TITLE
資産管理: 解約済みサブスクを削除しObsidianから反映

### DIFF
--- a/docs/OBSIDIAN_INGEST_PIPELINE.md
+++ b/docs/OBSIDIAN_INGEST_PIPELINE.md
@@ -117,3 +117,22 @@ read, insert, and update only their own staging rows and cannot delete them.
 - Import selected note bodies through a separately approved, encrypted path.
 - Complete the seven Notion parity checks before any Notion deletion or
   subscription cancellation.
+
+## Asset Management Vault Import
+
+The asset-management page reads a selected local vault entirely in the
+browser. It supports balance tables and explicit subscription cancellation
+tables. A cancellation table is recognized only inside a Markdown section
+whose heading contains `解約` or `停止済み`, with the columns `サービス名`,
+`終了日 / 停止日`, and `状態`.
+
+Only rows explicitly marked `解約完了`, `解約済み`, `停止済み`, `停止完了`,
+`終了済み`, or `終了完了` are considered. The page previews exact matches
+against currently registered recurring subscriptions. Missing and ambiguous
+matches remain read-only and are never deleted. Absence from the vault is not
+interpreted as cancellation.
+
+After final confirmation, selected matches are removed from current recurring
+fixed costs and written to the existing deletion-tombstone mirror so another
+device cannot restore them. Historical monthly and transaction records remain
+unchanged. Markdown bodies and local file paths are not uploaded.

--- a/lib/models/asset_obsidian_vault_import.dart
+++ b/lib/models/asset_obsidian_vault_import.dart
@@ -51,6 +51,55 @@ class AssetObsidianExistingBalance {
   final double amount;
 }
 
+class AssetObsidianExistingSubscription {
+  const AssetObsidianExistingSubscription({
+    required this.id,
+    required this.name,
+    required this.amount,
+  });
+
+  final String id;
+  final String name;
+  final double amount;
+}
+
+enum AssetObsidianSubscriptionCancellationStatus {
+  matched,
+  notRegistered,
+  conflict,
+}
+
+class AssetObsidianSubscriptionCancellationCandidate {
+  const AssetObsidianSubscriptionCancellationCandidate({
+    required this.sourceSubscriptionName,
+    required this.sourceStatus,
+    required this.status,
+    required this.sourcePaths,
+    this.endedAt,
+    this.matchedSubscriptionId,
+    this.matchedSubscriptionName,
+    this.matchedMonthlyAmount,
+    this.conflictingSubscriptionNames = const <String>[],
+  });
+
+  final String sourceSubscriptionName;
+  final String sourceStatus;
+  final String? endedAt;
+  final AssetObsidianSubscriptionCancellationStatus status;
+  final List<String> sourcePaths;
+  final String? matchedSubscriptionId;
+  final String? matchedSubscriptionName;
+  final double? matchedMonthlyAmount;
+  final List<String> conflictingSubscriptionNames;
+
+  String get id =>
+      'subscription-cancellation_${matchedSubscriptionId ?? sourceSubscriptionName}';
+
+  bool get isDeletable =>
+      status == AssetObsidianSubscriptionCancellationStatus.matched &&
+      matchedSubscriptionId != null;
+}
+
 class AssetObsidianImportCandidate {
   const AssetObsidianImportCandidate({
     required this.accountName,
@@ -88,14 +137,39 @@ class AssetObsidianImportPreview {
     required this.recognizedFileCount,
     required this.candidates,
     required this.warnings,
+    this.recognizedCancellationFileCount = 0,
+    this.subscriptionCancellations =
+        const <AssetObsidianSubscriptionCancellationCandidate>[],
   });
 
   final int scannedFileCount;
   final int recognizedFileCount;
+  final int recognizedCancellationFileCount;
   final List<AssetObsidianImportCandidate> candidates;
+  final List<AssetObsidianSubscriptionCancellationCandidate>
+  subscriptionCancellations;
   final List<String> warnings;
 
   List<AssetObsidianImportCandidate> get initiallySelected => candidates
       .where((candidate) => candidate.isImportable)
       .toList(growable: false);
+
+  List<AssetObsidianSubscriptionCancellationCandidate>
+  get initiallySelectedSubscriptionCancellations => subscriptionCancellations
+      .where((candidate) => candidate.isDeletable)
+      .toList(growable: false);
+}
+
+class AssetObsidianApplySelection {
+  const AssetObsidianApplySelection({
+    this.balances = const <AssetObsidianImportCandidate>[],
+    this.subscriptionCancellations =
+        const <AssetObsidianSubscriptionCancellationCandidate>[],
+  });
+
+  final List<AssetObsidianImportCandidate> balances;
+  final List<AssetObsidianSubscriptionCancellationCandidate>
+  subscriptionCancellations;
+
+  int get totalCount => balances.length + subscriptionCancellations.length;
 }

--- a/lib/models/asset_obsidian_vault_import.dart
+++ b/lib/models/asset_obsidian_vault_import.dart
@@ -147,7 +147,7 @@ class AssetObsidianImportPreview {
   final int recognizedCancellationFileCount;
   final List<AssetObsidianImportCandidate> candidates;
   final List<AssetObsidianSubscriptionCancellationCandidate>
-  subscriptionCancellations;
+      subscriptionCancellations;
   final List<String> warnings;
 
   List<AssetObsidianImportCandidate> get initiallySelected => candidates
@@ -155,9 +155,10 @@ class AssetObsidianImportPreview {
       .toList(growable: false);
 
   List<AssetObsidianSubscriptionCancellationCandidate>
-  get initiallySelectedSubscriptionCancellations => subscriptionCancellations
-      .where((candidate) => candidate.isDeletable)
-      .toList(growable: false);
+      get initiallySelectedSubscriptionCancellations =>
+          subscriptionCancellations
+              .where((candidate) => candidate.isDeletable)
+              .toList(growable: false);
 }
 
 class AssetObsidianApplySelection {
@@ -169,7 +170,7 @@ class AssetObsidianApplySelection {
 
   final List<AssetObsidianImportCandidate> balances;
   final List<AssetObsidianSubscriptionCancellationCandidate>
-  subscriptionCancellations;
+      subscriptionCancellations;
 
   int get totalCount => balances.length + subscriptionCancellations.length;
 }

--- a/lib/models/asset_obsidian_vault_import.dart
+++ b/lib/models/asset_obsidian_vault_import.dart
@@ -92,12 +92,16 @@ class AssetObsidianSubscriptionCancellationCandidate {
   final double? matchedMonthlyAmount;
   final List<String> conflictingSubscriptionNames;
 
-  String get id =>
-      'subscription-cancellation_${matchedSubscriptionId ?? sourceSubscriptionName}';
+  String get id {
+    final target = matchedSubscriptionId ?? sourceSubscriptionName;
+    return 'subscription-cancellation_${status.name}_'
+        '${target.length}:${target}_'
+        '${sourceSubscriptionName.length}:$sourceSubscriptionName';
+  }
 
   bool get isDeletable =>
       status == AssetObsidianSubscriptionCancellationStatus.matched &&
-      matchedSubscriptionId != null;
+      (matchedSubscriptionId?.trim().isNotEmpty ?? false);
 }
 
 class AssetObsidianImportCandidate {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -11309,6 +11309,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   /// 定期固定費の削除トゥームストーンを DB 側の atomic union/remove RPC で
   /// サーバへ反映する。whole-blob upsert による端末間 lost-update を避ける。
+  // ignore: unused_element
   Future<bool> _mirrorRecurringFixedCostsDeleted({
     bool mirrorCurrentOnSuccess = false,
   }) {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -6966,22 +6966,66 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return balances;
   }
 
+  List<AssetObsidianExistingSubscription>
+      _obsidianImportExistingSubscriptions() {
+    return <AssetObsidianExistingSubscription>[
+      for (final cost in _recurringFixedCosts)
+        if (cost.category == AssetRecurringFixedCostCategory.subscription)
+          AssetObsidianExistingSubscription(
+            id: cost.id,
+            name: cost.name,
+            amount: cost.amount,
+          ),
+    ];
+  }
+
   Future<void> _showObsidianVaultImportDialog() async {
-    final importedCount = await showDialog<int>(
+    final imported = await showDialog<AssetObsidianApplySelection>(
       context: context,
       barrierDismissible: false,
       builder: (dialogContext) => AssetObsidianVaultImportDialog(
         existingBalances: _obsidianImportExistingBalances(),
-        onApply: _applyObsidianVaultBalances,
+        existingSubscriptions: _obsidianImportExistingSubscriptions(),
+        onApply: _applyObsidianVaultSelection,
       ),
     );
-    if (!mounted || importedCount == null || importedCount == 0) return;
+    if (!mounted || imported == null || imported.totalCount == 0) return;
+    final summaries = <String>[
+      if (imported.balances.isNotEmpty) '残高${imported.balances.length}件を反映',
+      if (imported.subscriptionCancellations.isNotEmpty)
+        '解約済みサブスク${imported.subscriptionCancellations.length}件を削除',
+    ];
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('✅ Obsidian保管庫から$importedCount件の残高を反映しました'),
+        content: Text('✅ Obsidian保管庫から${summaries.join('、')}しました'),
         backgroundColor: const Color(0xFF047857),
       ),
     );
+  }
+
+  Future<void> _applyObsidianVaultSelection(
+    AssetObsidianApplySelection selection,
+  ) async {
+    if (selection.balances.isNotEmpty) {
+      await _applyObsidianVaultBalances(selection.balances);
+    }
+    if (selection.subscriptionCancellations.isEmpty) return;
+
+    final selectedIds = selection.subscriptionCancellations
+        .map((candidate) => candidate.matchedSubscriptionId)
+        .whereType<String>()
+        .toSet();
+    final subscriptions = _recurringFixedCosts
+        .where(
+          (cost) =>
+              cost.category == AssetRecurringFixedCostCategory.subscription &&
+              selectedIds.contains(cost.id),
+        )
+        .toList(growable: false);
+    if (subscriptions.length != selectedIds.length) {
+      throw StateError('削除候補が現在のサブスク登録と一致しません。再読込してください。');
+    }
+    await _deleteRecurringFixedCosts(subscriptions);
   }
 
   /// 確認済みのObsidian残高だけを本日のスナップショットとして一括保存する。
@@ -11616,19 +11660,37 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_mirrorRecurringFixedCosts());
   }
 
-  void _deleteRecurringFixedCost(AssetRecurringFixedCost cost) {
-    setState(() {
-      _recurringFixedCosts = _recurringFixedCosts
-          .where((existing) => existing.id != cost.id)
-          .toList();
-    });
-    _persistInBackground(
-      _recurringFixedCostStore.save(_recurringFixedCosts),
-      'recurring fixed cost delete',
-    );
-    // 削除をトゥームストーン化して他端末へ伝播 (union/backfill で復活させない)。
-    unawaited(_recordRecurringFixedCostTombstone(cost.id, deleted: true));
-    unawaited(_mirrorRecurringFixedCosts());
+  Future<void> _deleteRecurringFixedCosts(
+    Iterable<AssetRecurringFixedCost> costs,
+  ) async {
+    final ids = costs
+        .map((cost) => cost.id)
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    if (ids.isEmpty) return;
+    final next = _recurringFixedCosts
+        .where((existing) => !ids.contains(existing.id))
+        .toList(growable: false);
+    if (next.length == _recurringFixedCosts.length) return;
+
+    await _recurringFixedCostStore.save(next);
+    final store = await SharedPreferences.getInstance();
+    for (final id in ids) {
+      await _recurringFixedCostTombstones.addId(store, id);
+    }
+    if (mounted) {
+      setState(() => _recurringFixedCosts = next);
+    } else {
+      _recurringFixedCosts = next;
+    }
+    await Future.wait(<Future<void>>[
+      _mirrorRecurringFixedCostsDeleted(),
+      _mirrorRecurringFixedCosts(),
+    ]);
+  }
+
+  Future<void> _deleteRecurringFixedCost(AssetRecurringFixedCost cost) {
+    return _deleteRecurringFixedCosts(<AssetRecurringFixedCost>[cost]);
   }
 
   Future<void> _openRecurringFixedCostEditor({
@@ -11658,11 +11720,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _confirmDeleteRecurringFixedCost(
     AssetRecurringFixedCost cost,
   ) async {
+    final isSubscription =
+        cost.category == AssetRecurringFixedCostCategory.subscription;
+    final formattedMonthlyAmount =
+        NumberFormat('#,##0').format(cost.amount.round());
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: const Text('定期固定費を削除'),
-        content: Text('「${cost.name}」を削除しますか?'),
+        title: Text(isSubscription ? 'サブスクを削除' : '定期固定費を削除'),
+        content: Text(
+          isSubscription
+              ? '「${cost.name}」（月額 ¥$formattedMonthlyAmount）を現在のサブスクから'
+                  '削除しますか？過去の月次履歴・取引履歴は残ります。'
+              : '「${cost.name}」を削除しますか？',
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(false),
@@ -11676,7 +11747,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ),
     );
     if (confirmed == true) {
-      _deleteRecurringFixedCost(cost);
+      await _deleteRecurringFixedCost(cost);
     }
   }
 

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -11265,50 +11265,115 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 他端末へ削除を伝播する (リボ設定と同じパターン)。
   static const MirrorTombstoneStore _recurringFixedCostTombstones =
       MirrorTombstoneStore(storageKey: 'recurring_fixed_costs_deleted_v1');
+  static const String _recurringTombstoneAddPrefix = 'add:';
+  static const String _recurringTombstoneRemovePrefix = 'remove:';
+
+  String _recurringTombstoneOperation(String id, {required bool deleted}) =>
+      '${deleted ? _recurringTombstoneAddPrefix : _recurringTombstoneRemovePrefix}$id';
+
+  Set<String> _recurringTombstoneOperationIds(
+    Set<String> operations,
+    String prefix,
+  ) =>
+      <String>{
+        for (final operation in operations)
+          if (operation.startsWith(prefix) && operation.length > prefix.length)
+            operation.substring(prefix.length),
+      };
+
+  Future<void> _queueRecurringFixedCostTombstoneOperation(
+    SharedPreferences store,
+    String id, {
+    required bool deleted,
+  }) {
+    return _syncDirtyKeysStore.updateDirty(
+      _recurringFixedCostsDeletedMirrorKey,
+      addKeys: <String>[
+        _recurringTombstoneOperation(id, deleted: deleted),
+      ],
+      removeKeys: <String>[
+        _recurringTombstoneOperation(id, deleted: !deleted),
+      ],
+      prefs: store,
+    );
+  }
 
   /// 削除はトゥームストーン化、再追加 (同 id) は解除する。
   Future<void> _recordRecurringFixedCostTombstone(
     String id, {
     required bool deleted,
   }) async {
+    if (id.isEmpty) return;
     final store = await SharedPreferences.getInstance();
+    await _queueRecurringFixedCostTombstoneOperation(
+      store,
+      id,
+      deleted: deleted,
+    );
     if (deleted) {
       await _recurringFixedCostTombstones.addId(store, id);
     } else {
       await _recurringFixedCostTombstones.removeId(store, id);
     }
-    unawaited(
-      _mirrorRecurringFixedCostsDeleted(
-        addIds: deleted ? <String>[id] : const <String>[],
-        removeIds: deleted ? const <String>[] : <String>[id],
-      ),
-    );
+  }
+
+  Future<void> _syncRecurringFixedCostReadditions(Iterable<String> ids) async {
+    for (final id in ids.where((value) => value.isNotEmpty).toSet()) {
+      await _recordRecurringFixedCostTombstone(id, deleted: false);
+    }
+    final tombstonesSynced = await _mirrorRecurringFixedCostsDeleted();
+    if (tombstonesSynced) {
+      await _mirrorRecurringFixedCosts();
+    } else if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('端末では保存済みです。サーバー同期は次回オンライン時に再試行します。'),
+          backgroundColor: Color(0xFFB45309),
+        ),
+      );
+    }
   }
 
   /// 定期固定費の削除トゥームストーンを DB 側の atomic union/remove RPC で
   /// サーバへ反映する。whole-blob upsert による端末間 lost-update を避ける。
-  Future<void> _mirrorRecurringFixedCostsDeleted({
-    Iterable<String> addIds = const <String>[],
-    Iterable<String> removeIds = const <String>[],
-    bool throwOnFailure = false,
-  }) async {
+  Future<bool> _mirrorRecurringFixedCostsDeleted() async {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
-      return;
+      return true;
     }
-    final additions = addIds.where((id) => id.trim().isNotEmpty).toSet();
-    final removals = removeIds.where((id) => id.trim().isNotEmpty).toSet();
-    if (additions.isEmpty && removals.isEmpty) return;
+    final store = await SharedPreferences.getInstance();
+    final pending = await _syncDirtyKeysStore.loadDirty(
+      _recurringFixedCostsDeletedMirrorKey,
+      prefs: store,
+    );
+    final additions = _recurringTombstoneOperationIds(
+      pending,
+      _recurringTombstoneAddPrefix,
+    );
+    final removals = _recurringTombstoneOperationIds(
+      pending,
+      _recurringTombstoneRemovePrefix,
+    );
+    if (additions.isEmpty && removals.isEmpty) return true;
     try {
       await _supabase.rpc('apply_recurring_fixed_cost_tombstones', params: {
         'p_add_ids': additions.toList(growable: false)..sort(),
         'p_remove_ids': removals.toList(growable: false)..sort(),
       });
-    } catch (e, stackTrace) {
+      await _syncDirtyKeysStore.updateDirty(
+        _recurringFixedCostsDeletedMirrorKey,
+        removeKeys: <String>[
+          for (final id in additions)
+            _recurringTombstoneOperation(id, deleted: true),
+          for (final id in removals)
+            _recurringTombstoneOperation(id, deleted: false),
+        ],
+        prefs: store,
+      );
+      return true;
+    } catch (e) {
       debugPrint('recurring fixed cost tombstone mirror upsert failed: $e');
-      if (throwOnFailure) {
-        Error.throwWithStackTrace(e, stackTrace);
-      }
+      return false;
     }
   }
 
@@ -11321,30 +11386,74 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     try {
       final store = await SharedPreferences.getInstance();
       Map<String, dynamic>? value = debugMirror;
+      var remoteExists = debugMirror != null;
       if (value == null) {
         final rows = await _bootSelectPrefMirror(
           _recurringFixedCostsDeletedMirrorKey,
         );
         if (rows.isNotEmpty) {
+          remoteExists = true;
           final raw = rows.first['value'];
-          if (raw is Map) {
-            value = Map<String, dynamic>.from(raw);
+          if (raw is! Map || raw['ids'] is! List) {
+            throw const FormatException(
+              'recurring fixed cost tombstone mirror is malformed',
+            );
           }
+          value = Map<String, dynamic>.from(raw);
         }
       }
       final remoteIds = MirrorTombstoneStore.decodeMirror(value).toSet();
-      if (remoteIds.isNotEmpty) {
-        await _recurringFixedCostTombstones.mergeRemoteIds(store, remoteIds);
-      }
-      final mergedIds = _recurringFixedCostTombstones.activeIds(store);
-      final missingOnServer = mergedIds.difference(remoteIds);
-      if (debugMirror == null && missingOnServer.isNotEmpty) {
-        unawaited(
-          _mirrorRecurringFixedCostsDeleted(addIds: missingOnServer),
+      var pending = await _syncDirtyKeysStore.loadDirty(
+        _recurringFixedCostsDeletedMirrorKey,
+        prefs: store,
+      );
+      final localIds = _recurringFixedCostTombstones.activeIds(store);
+      final pendingRemovals = _recurringTombstoneOperationIds(
+        pending,
+        _recurringTombstoneRemovePrefix,
+      );
+      if (!remoteExists && localIds.isNotEmpty) {
+        final legacyAdds = localIds.difference(pendingRemovals);
+        await _syncDirtyKeysStore.updateDirty(
+          _recurringFixedCostsDeletedMirrorKey,
+          addKeys: <String>[
+            for (final id in legacyAdds)
+              _recurringTombstoneOperation(id, deleted: true),
+          ],
+          prefs: store,
+        );
+        pending = await _syncDirtyKeysStore.loadDirty(
+          _recurringFixedCostsDeletedMirrorKey,
+          prefs: store,
         );
       }
+
+      final desiredIds = remoteExists
+          ? Set<String>.from(remoteIds)
+          : Set<String>.from(localIds);
+      desiredIds.addAll(
+        _recurringTombstoneOperationIds(
+          pending,
+          _recurringTombstoneAddPrefix,
+        ),
+      );
+      desiredIds.removeAll(
+        _recurringTombstoneOperationIds(
+          pending,
+          _recurringTombstoneRemovePrefix,
+        ),
+      );
+      for (final id in localIds.difference(desiredIds)) {
+        await _recurringFixedCostTombstones.removeId(store, id);
+      }
+      for (final id in desiredIds.difference(localIds)) {
+        await _recurringFixedCostTombstones.addId(store, id);
+      }
+      if (debugMirror == null && pending.isNotEmpty) {
+        unawaited(_mirrorRecurringFixedCostsDeleted());
+      }
       final next = _recurringFixedCosts
-          .where((cost) => !mergedIds.contains(cost.id))
+          .where((cost) => !desiredIds.contains(cost.id))
           .toList();
       if (next.length == _recurringFixedCosts.length || !mounted) {
         return;
@@ -11698,11 +11807,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       'recurring fixed cost save',
     );
     // 編集/再追加は id 再利用解除 (tombstone 除去) + ローカル編集を dirty 記録。
-    unawaited(_recordRecurringFixedCostTombstone(cost.id, deleted: false));
     unawaited(
       _syncDirtyKeysStore.markDirty(_recurringFixedCostsMirrorKey, cost.id),
     );
-    unawaited(_mirrorRecurringFixedCosts());
+    unawaited(_syncRecurringFixedCostReadditions(<String>[cost.id]));
   }
 
   Future<void> _deleteRecurringFixedCosts(
@@ -11719,12 +11827,31 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final store = await SharedPreferences.getInstance();
     final tombstonesBefore = _recurringFixedCostTombstones.activeIds(store);
     final addedTombstones = ids.difference(tombstonesBefore);
+    final pendingBefore = await _syncDirtyKeysStore.loadDirty(
+      _recurringFixedCostsDeletedMirrorKey,
+      prefs: store,
+    );
+    final affectedOperations = <String>{
+      for (final id in ids) _recurringTombstoneOperation(id, deleted: true),
+      for (final id in ids) _recurringTombstoneOperation(id, deleted: false),
+    };
     try {
       for (final id in ids) {
+        await _queueRecurringFixedCostTombstoneOperation(
+          store,
+          id,
+          deleted: true,
+        );
         await _recurringFixedCostTombstones.addId(store, id);
       }
       await _recurringFixedCostStore.save(next);
     } catch (error, stackTrace) {
+      await _syncDirtyKeysStore.updateDirty(
+        _recurringFixedCostsDeletedMirrorKey,
+        addKeys: pendingBefore.intersection(affectedOperations),
+        removeKeys: affectedOperations,
+        prefs: store,
+      );
       for (final id in addedTombstones) {
         await _recurringFixedCostTombstones.removeId(store, id);
       }
@@ -11735,13 +11862,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } else {
       _recurringFixedCosts = next;
     }
-    // 削除トゥームストーンがサーバへ届いてから現行リストを更新する。前者が
-    // 失敗した場合は stale mirror を配信せず、次回bootのbackfillで再試行する。
-    await _mirrorRecurringFixedCostsDeleted(
-      addIds: ids,
-      throwOnFailure: true,
-    );
-    await _mirrorRecurringFixedCosts(throwOnFailure: true);
+    // サーバ同期が失敗しても dirty operation を保持し、次回bootで再試行する。
+    // stale current mirror はtombstone同期成功後だけ更新する。
+    final tombstonesSynced = await _mirrorRecurringFixedCostsDeleted();
+    if (tombstonesSynced) {
+      await _mirrorRecurringFixedCosts();
+    } else if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('端末では削除済みです。サーバー同期は次回オンライン時に再試行します。'),
+          backgroundColor: Color(0xFFB45309),
+        ),
+      );
+    }
   }
 
   Future<void> _deleteRecurringFixedCost(AssetRecurringFixedCost cost) {
@@ -11942,12 +12075,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       'subscription statement import',
     );
     for (final cost in added) {
-      unawaited(_recordRecurringFixedCostTombstone(cost.id, deleted: false));
       unawaited(
         _syncDirtyKeysStore.markDirty(_recurringFixedCostsMirrorKey, cost.id),
       );
     }
-    unawaited(_mirrorRecurringFixedCosts());
+    unawaited(
+      _syncRecurringFixedCostReadditions(added.map((cost) => cost.id)),
+    );
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('${added.length}件のサブスクを棚卸しに追加しました。')),
     );

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -208,6 +208,45 @@ List<AssetLiabilityAccount> incomeDestinationAccountOptions(
     ..sort((a, b) => b.balance.compareTo(a.balance));
 }
 
+/// Obsidian の解約候補を、現在のサブスク登録へ fail-closed で再照合する。
+/// プレビュー後に対象が編集・削除された場合や、不正な候補が渡された場合は、
+/// 残高を含む一切の変更を始める前に例外として中断する。
+@visibleForTesting
+List<AssetRecurringFixedCost> validateObsidianSubscriptionCancellations(
+  List<AssetObsidianSubscriptionCancellationCandidate> candidates,
+  List<AssetRecurringFixedCost> currentCosts,
+) {
+  if (candidates.isEmpty) return const <AssetRecurringFixedCost>[];
+
+  final ids = <String>{};
+  final currentById = <String, List<AssetRecurringFixedCost>>{};
+  for (final cost in currentCosts) {
+    if (cost.category != AssetRecurringFixedCostCategory.subscription) continue;
+    currentById
+        .putIfAbsent(cost.id, () => <AssetRecurringFixedCost>[])
+        .add(cost);
+  }
+
+  final validated = <AssetRecurringFixedCost>[];
+  for (final candidate in candidates) {
+    final id = candidate.matchedSubscriptionId?.trim() ?? '';
+    if (!candidate.isDeletable || id.isEmpty || !ids.add(id)) {
+      throw StateError('削除候補が一意な登録済みサブスクではありません。再読込してください。');
+    }
+    final matches = currentById[id] ?? const <AssetRecurringFixedCost>[];
+    if (matches.length != 1) {
+      throw StateError('削除候補が現在のサブスク登録と一致しません。再読込してください。');
+    }
+    final current = matches.single;
+    if (candidate.matchedSubscriptionName != current.name ||
+        candidate.matchedMonthlyAmount != current.amount) {
+      throw StateError('削除候補がプレビュー後に変更されました。再読込してください。');
+    }
+    validated.add(current);
+  }
+  return validated;
+}
+
 class _PaymentSourceCandidate {
   final AssetLiabilityAccount account;
   final double currentBalance;
@@ -7006,25 +7045,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _applyObsidianVaultSelection(
     AssetObsidianApplySelection selection,
   ) async {
+    final subscriptions = validateObsidianSubscriptionCancellations(
+      selection.subscriptionCancellations,
+      _recurringFixedCosts,
+    );
     if (selection.balances.isNotEmpty) {
       await _applyObsidianVaultBalances(selection.balances);
     }
-    if (selection.subscriptionCancellations.isEmpty) return;
-
-    final selectedIds = selection.subscriptionCancellations
-        .map((candidate) => candidate.matchedSubscriptionId)
-        .whereType<String>()
-        .toSet();
-    final subscriptions = _recurringFixedCosts
-        .where(
-          (cost) =>
-              cost.category == AssetRecurringFixedCostCategory.subscription &&
-              selectedIds.contains(cost.id),
-        )
-        .toList(growable: false);
-    if (subscriptions.length != selectedIds.length) {
-      throw StateError('削除候補が現在のサブスク登録と一致しません。再読込してください。');
-    }
+    if (subscriptions.isEmpty) return;
     await _deleteRecurringFixedCosts(subscriptions);
   }
 
@@ -10854,7 +10882,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final localHasExtra = localBefore.keys.any(
         (key) => !tombstoned.contains(key) && !serverConfigs.containsKey(key),
       );
-      if (localHasExtra && debugMirror == null) {
+      final serverHasTombstoned = serverConfigs.keys.any(tombstoned.contains);
+      if ((localHasExtra || serverHasTombstoned) && debugMirror == null) {
         unawaited(_mirrorRecurringFixedCosts());
       }
     } catch (e) {
@@ -10863,7 +10892,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// 定期固定費の全量を `asset_pref_mirror` へ 1 行 upsert する。
-  Future<void> _mirrorRecurringFixedCosts() async {
+  Future<void> _mirrorRecurringFixedCosts({bool throwOnFailure = false}) async {
     unawaited(_syncTimestampStore.markChanged(_recurringFixedCostsMirrorKey));
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
@@ -10880,8 +10909,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       });
       // 全量 upsert 成功 = 全 id 同期済み → dirty クリア。
       await _syncDirtyKeysStore.clearDomain(_recurringFixedCostsMirrorKey);
-    } catch (e) {
+    } catch (e, stackTrace) {
       debugPrint('recurring fixed cost mirror upsert failed: $e');
+      if (throwOnFailure) {
+        Error.throwWithStackTrace(e, stackTrace);
+      }
     }
   }
 
@@ -11245,26 +11277,38 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } else {
       await _recurringFixedCostTombstones.removeId(store, id);
     }
-    unawaited(_mirrorRecurringFixedCostsDeleted());
+    unawaited(
+      _mirrorRecurringFixedCostsDeleted(
+        addIds: deleted ? <String>[id] : const <String>[],
+        removeIds: deleted ? const <String>[] : <String>[id],
+      ),
+    );
   }
 
-  /// 定期固定費の削除トゥームストーンをサーバへ反映 (他端末伝播)。
-  Future<void> _mirrorRecurringFixedCostsDeleted() async {
+  /// 定期固定費の削除トゥームストーンを DB 側の atomic union/remove RPC で
+  /// サーバへ反映する。whole-blob upsert による端末間 lost-update を避ける。
+  Future<void> _mirrorRecurringFixedCostsDeleted({
+    Iterable<String> addIds = const <String>[],
+    Iterable<String> removeIds = const <String>[],
+    bool throwOnFailure = false,
+  }) async {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
       return;
     }
+    final additions = addIds.where((id) => id.trim().isNotEmpty).toSet();
+    final removals = removeIds.where((id) => id.trim().isNotEmpty).toSet();
+    if (additions.isEmpty && removals.isEmpty) return;
     try {
-      final store = await SharedPreferences.getInstance();
-      final ids = _recurringFixedCostTombstones.activeIds(store);
-      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
-        'user_id': userId,
-        'pref_key': _recurringFixedCostsDeletedMirrorKey,
-        'value': MirrorTombstoneStore.encodeMirror(ids),
-        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      await _supabase.rpc('apply_recurring_fixed_cost_tombstones', params: {
+        'p_add_ids': additions.toList(growable: false)..sort(),
+        'p_remove_ids': removals.toList(growable: false)..sort(),
       });
-    } catch (e) {
+    } catch (e, stackTrace) {
       debugPrint('recurring fixed cost tombstone mirror upsert failed: $e');
+      if (throwOnFailure) {
+        Error.throwWithStackTrace(e, stackTrace);
+      }
     }
   }
 
@@ -11275,31 +11319,32 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
+      final store = await SharedPreferences.getInstance();
       Map<String, dynamic>? value = debugMirror;
       if (value == null) {
         final rows = await _bootSelectPrefMirror(
           _recurringFixedCostsDeletedMirrorKey,
         );
-        if (rows.isEmpty) {
-          return;
+        if (rows.isNotEmpty) {
+          final raw = rows.first['value'];
+          if (raw is Map) {
+            value = Map<String, dynamic>.from(raw);
+          }
         }
-        final raw = rows.first['value'];
-        if (raw is! Map) {
-          return;
-        }
-        value = Map<String, dynamic>.from(raw);
       }
-      final ids = MirrorTombstoneStore.decodeMirror(value);
-      if (ids.isEmpty) {
-        return;
+      final remoteIds = MirrorTombstoneStore.decodeMirror(value).toSet();
+      if (remoteIds.isNotEmpty) {
+        await _recurringFixedCostTombstones.mergeRemoteIds(store, remoteIds);
       }
-      final store = await SharedPreferences.getInstance();
-      final incoming = await _recurringFixedCostTombstones.mergeRemoteIds(
-        store,
-        ids,
-      );
+      final mergedIds = _recurringFixedCostTombstones.activeIds(store);
+      final missingOnServer = mergedIds.difference(remoteIds);
+      if (debugMirror == null && missingOnServer.isNotEmpty) {
+        unawaited(
+          _mirrorRecurringFixedCostsDeleted(addIds: missingOnServer),
+        );
+      }
       final next = _recurringFixedCosts
-          .where((cost) => !incoming.contains(cost.id))
+          .where((cost) => !mergedIds.contains(cost.id))
           .toList();
       if (next.length == _recurringFixedCosts.length || !mounted) {
         return;
@@ -11671,20 +11716,32 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         .toList(growable: false);
     if (next.length == _recurringFixedCosts.length) return;
 
-    await _recurringFixedCostStore.save(next);
     final store = await SharedPreferences.getInstance();
-    for (final id in ids) {
-      await _recurringFixedCostTombstones.addId(store, id);
+    final tombstonesBefore = _recurringFixedCostTombstones.activeIds(store);
+    final addedTombstones = ids.difference(tombstonesBefore);
+    try {
+      for (final id in ids) {
+        await _recurringFixedCostTombstones.addId(store, id);
+      }
+      await _recurringFixedCostStore.save(next);
+    } catch (error, stackTrace) {
+      for (final id in addedTombstones) {
+        await _recurringFixedCostTombstones.removeId(store, id);
+      }
+      Error.throwWithStackTrace(error, stackTrace);
     }
     if (mounted) {
       setState(() => _recurringFixedCosts = next);
     } else {
       _recurringFixedCosts = next;
     }
-    await Future.wait(<Future<void>>[
-      _mirrorRecurringFixedCostsDeleted(),
-      _mirrorRecurringFixedCosts(),
-    ]);
+    // 削除トゥームストーンがサーバへ届いてから現行リストを更新する。前者が
+    // 失敗した場合は stale mirror を配信せず、次回bootのbackfillで再試行する。
+    await _mirrorRecurringFixedCostsDeleted(
+      addIds: ids,
+      throwOnFailure: true,
+    );
+    await _mirrorRecurringFixedCosts(throwOnFailure: true);
   }
 
   Future<void> _deleteRecurringFixedCost(AssetRecurringFixedCost cost) {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -11663,10 +11663,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _deleteRecurringFixedCosts(
     Iterable<AssetRecurringFixedCost> costs,
   ) async {
-    final ids = costs
-        .map((cost) => cost.id)
-        .where((id) => id.isNotEmpty)
-        .toSet();
+    final ids =
+        costs.map((cost) => cost.id).where((id) => id.isNotEmpty).toSet();
     if (ids.isEmpty) return;
     final next = _recurringFixedCosts
         .where((existing) => !ids.contains(existing.id))

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -50,6 +50,7 @@ import 'package:my_web_app/services/investment_asset_repository.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
+import 'package:my_web_app/services/asset_recurring_tombstone_sync_service.dart';
 import 'package:my_web_app/services/fx_rate_service.dart';
 import 'package:my_web_app/services/asset_recurring_suggestion_ignore_store.dart';
 import 'package:my_web_app/services/asset_subscription_audit_catalog.dart';
@@ -342,6 +343,10 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final List<AssetRecurringFixedCost>? debugInitialRecurringFixedCosts;
 
+  /// テスト専用: 定期固定費のローカル保存失敗を注入する。
+  @visibleForTesting
+  final AssetRecurringFixedCostStore? debugRecurringFixedCostStore;
+
   /// テスト専用: 定期固定費の集約ミラー値 (`{id: {...}}`) を注入し、端末間同期
   /// (起動時の union マージ復元) をネットワークなしで検証する。
   @visibleForTesting
@@ -406,6 +411,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugRevolvingDeletedMirror,
     this.debugWatchlistDeletedMirror,
     this.debugInitialRecurringFixedCosts,
+    this.debugRecurringFixedCostStore,
     this.debugRecurringFixedCostsMirror,
     this.debugRecurringFixedCostsDeletedMirror,
     this.debugSubscriptionAuditMirror,
@@ -563,6 +569,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 防止 / #3415 保守的 per-key ガード)。
   final AssetSyncDirtyKeysStore _syncDirtyKeysStore =
       const AssetSyncDirtyKeysStore();
+  final AssetRecurringTombstoneSyncService _recurringTombstoneSyncService =
+      AssetRecurringTombstoneSyncService.shared;
 
   /// ミラー読み取りを Supabase 正本化 (LWW) するか。テスト注入優先・既定はビルド時フラグ。
   bool get _mirrorReadsAuthoritative =>
@@ -969,8 +977,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   static const String _salaryAmountMirrorKey = 'salary_amount';
   final AssetRevolvingCreditConfigStore _revolvingConfigStore =
       const AssetRevolvingCreditConfigStore();
-  final AssetRecurringFixedCostStore _recurringFixedCostStore =
-      const AssetRecurringFixedCostStore();
+  late final AssetRecurringFixedCostStore _recurringFixedCostStore =
+      widget.debugRecurringFixedCostStore ??
+          const AssetRecurringFixedCostStore();
   static const String _recurringFixedCostsMirrorKey = 'recurring_fixed_costs';
   static const String _recurringFixedCostsDeletedMirrorKey =
       'recurring_fixed_costs_deleted';
@@ -10892,7 +10901,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// 定期固定費の全量を `asset_pref_mirror` へ 1 行 upsert する。
-  Future<void> _mirrorRecurringFixedCosts({bool throwOnFailure = false}) async {
+  Future<void> _mirrorRecurringFixedCosts({bool throwOnFailure = false}) {
+    return _recurringTombstoneSyncService.runSerialized(
+      () => _mirrorRecurringFixedCostsNow(throwOnFailure: throwOnFailure),
+    );
+  }
+
+  Future<void> _mirrorRecurringFixedCostsNow({
+    bool throwOnFailure = false,
+  }) async {
     unawaited(_syncTimestampStore.markChanged(_recurringFixedCostsMirrorKey));
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
@@ -11265,120 +11282,74 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 他端末へ削除を伝播する (リボ設定と同じパターン)。
   static const MirrorTombstoneStore _recurringFixedCostTombstones =
       MirrorTombstoneStore(storageKey: 'recurring_fixed_costs_deleted_v1');
-  static const String _recurringTombstoneAddPrefix = 'add:';
-  static const String _recurringTombstoneRemovePrefix = 'remove:';
+  static const String _recurringTombstoneLegacyMigrationKey =
+      'recurring_fixed_cost_tombstone_pending_v2_migrated';
 
   String _recurringTombstoneOperation(String id, {required bool deleted}) =>
-      '${deleted ? _recurringTombstoneAddPrefix : _recurringTombstoneRemovePrefix}$id';
+      AssetRecurringTombstoneSyncService.operation(id, deleted: deleted);
 
   Set<String> _recurringTombstoneOperationIds(
     Set<String> operations,
     String prefix,
   ) =>
-      <String>{
-        for (final operation in operations)
-          if (operation.startsWith(prefix) && operation.length > prefix.length)
-            operation.substring(prefix.length),
-      };
+      AssetRecurringTombstoneSyncService.operationIds(operations, prefix);
 
   Future<void> _queueRecurringFixedCostTombstoneOperation(
     SharedPreferences store,
     String id, {
     required bool deleted,
   }) {
-    return _syncDirtyKeysStore.updateDirty(
+    return _recurringTombstoneSyncService.queue(
       _recurringFixedCostsDeletedMirrorKey,
-      addKeys: <String>[
-        _recurringTombstoneOperation(id, deleted: deleted),
-      ],
-      removeKeys: <String>[
-        _recurringTombstoneOperation(id, deleted: !deleted),
-      ],
+      id,
+      deleted: deleted,
       prefs: store,
     );
   }
 
-  /// 削除はトゥームストーン化、再追加 (同 id) は解除する。
-  Future<void> _recordRecurringFixedCostTombstone(
-    String id, {
-    required bool deleted,
-  }) async {
-    if (id.isEmpty) return;
-    final store = await SharedPreferences.getInstance();
-    await _queueRecurringFixedCostTombstoneOperation(
-      store,
-      id,
-      deleted: deleted,
-    );
-    if (deleted) {
-      await _recurringFixedCostTombstones.addId(store, id);
-    } else {
-      await _recurringFixedCostTombstones.removeId(store, id);
-    }
-  }
-
-  Future<void> _syncRecurringFixedCostReadditions(Iterable<String> ids) async {
-    for (final id in ids.where((value) => value.isNotEmpty).toSet()) {
-      await _recordRecurringFixedCostTombstone(id, deleted: false);
-    }
-    final tombstonesSynced = await _mirrorRecurringFixedCostsDeleted();
-    if (tombstonesSynced) {
-      await _mirrorRecurringFixedCosts();
-    } else if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('端末では保存済みです。サーバー同期は次回オンライン時に再試行します。'),
-          backgroundColor: Color(0xFFB45309),
-        ),
-      );
-    }
-  }
-
   /// 定期固定費の削除トゥームストーンを DB 側の atomic union/remove RPC で
   /// サーバへ反映する。whole-blob upsert による端末間 lost-update を避ける。
-  Future<bool> _mirrorRecurringFixedCostsDeleted() async {
+  Future<bool> _mirrorRecurringFixedCostsDeleted({
+    bool mirrorCurrentOnSuccess = false,
+  }) {
+    return _recurringTombstoneSyncService.runSerialized(
+      () => _mirrorRecurringFixedCostsDeletedNow(
+        mirrorCurrentOnSuccess: mirrorCurrentOnSuccess,
+      ),
+    );
+  }
+
+  Future<bool> _mirrorRecurringFixedCostsDeletedNow({
+    bool mirrorCurrentOnSuccess = false,
+  }) async {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
       return true;
     }
     final store = await SharedPreferences.getInstance();
-    final pending = await _syncDirtyKeysStore.loadDirty(
-      _recurringFixedCostsDeletedMirrorKey,
+    return _recurringTombstoneSyncService.syncNow(
+      prefKey: _recurringFixedCostsDeletedMirrorKey,
       prefs: store,
+      rpc: (additions, removals) async {
+        await _supabase.rpc('apply_recurring_fixed_cost_tombstones', params: {
+          'p_add_ids': additions,
+          'p_remove_ids': removals,
+        });
+      },
+      afterSync: mirrorCurrentOnSuccess
+          ? () => _mirrorRecurringFixedCostsNow(throwOnFailure: true)
+          : null,
     );
-    final additions = _recurringTombstoneOperationIds(
-      pending,
-      _recurringTombstoneAddPrefix,
-    );
-    final removals = _recurringTombstoneOperationIds(
-      pending,
-      _recurringTombstoneRemovePrefix,
-    );
-    if (additions.isEmpty && removals.isEmpty) return true;
-    try {
-      await _supabase.rpc('apply_recurring_fixed_cost_tombstones', params: {
-        'p_add_ids': additions.toList(growable: false)..sort(),
-        'p_remove_ids': removals.toList(growable: false)..sort(),
-      });
-      await _syncDirtyKeysStore.updateDirty(
-        _recurringFixedCostsDeletedMirrorKey,
-        removeKeys: <String>[
-          for (final id in additions)
-            _recurringTombstoneOperation(id, deleted: true),
-          for (final id in removals)
-            _recurringTombstoneOperation(id, deleted: false),
-        ],
-        prefs: store,
-      );
-      return true;
-    } catch (e) {
-      debugPrint('recurring fixed cost tombstone mirror upsert failed: $e');
-      return false;
-    }
   }
 
   /// 他端末で削除された定期固定費を取り込み、ローカルからも除去する。
-  Future<void> _pullRecurringFixedCostDeleted() async {
+  Future<void> _pullRecurringFixedCostDeleted() {
+    return _recurringTombstoneSyncService.runSerialized(
+      _pullRecurringFixedCostDeletedNow,
+    );
+  }
+
+  Future<void> _pullRecurringFixedCostDeletedNow() async {
     final debugMirror = widget.debugRecurringFixedCostsDeletedMirror;
     if (debugMirror == null && _supabase.auth.currentUser == null) {
       return;
@@ -11410,9 +11381,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final localIds = _recurringFixedCostTombstones.activeIds(store);
       final pendingRemovals = _recurringTombstoneOperationIds(
         pending,
-        _recurringTombstoneRemovePrefix,
+        AssetRecurringTombstoneSyncService.removePrefix,
       );
-      if (!remoteExists && localIds.isNotEmpty) {
+      final needsLegacyMigration =
+          !(store.getBool(_recurringTombstoneLegacyMigrationKey) ?? false);
+      if (needsLegacyMigration && localIds.isNotEmpty) {
         final legacyAdds = localIds.difference(pendingRemovals);
         await _syncDirtyKeysStore.updateDirty(
           _recurringFixedCostsDeletedMirrorKey,
@@ -11422,10 +11395,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ],
           prefs: store,
         );
+        await store.setBool(_recurringTombstoneLegacyMigrationKey, true);
         pending = await _syncDirtyKeysStore.loadDirty(
           _recurringFixedCostsDeletedMirrorKey,
           prefs: store,
         );
+      } else if (needsLegacyMigration) {
+        await store.setBool(_recurringTombstoneLegacyMigrationKey, true);
       }
 
       final desiredIds = remoteExists
@@ -11434,13 +11410,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       desiredIds.addAll(
         _recurringTombstoneOperationIds(
           pending,
-          _recurringTombstoneAddPrefix,
+          AssetRecurringTombstoneSyncService.addPrefix,
         ),
       );
       desiredIds.removeAll(
         _recurringTombstoneOperationIds(
           pending,
-          _recurringTombstoneRemovePrefix,
+          AssetRecurringTombstoneSyncService.removePrefix,
         ),
       );
       for (final id in localIds.difference(desiredIds)) {
@@ -11449,22 +11425,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       for (final id in desiredIds.difference(localIds)) {
         await _recurringFixedCostTombstones.addId(store, id);
       }
-      if (debugMirror == null && pending.isNotEmpty) {
-        unawaited(_mirrorRecurringFixedCostsDeleted());
-      }
       final next = _recurringFixedCosts
           .where((cost) => !desiredIds.contains(cost.id))
           .toList();
-      if (next.length == _recurringFixedCosts.length || !mounted) {
-        return;
+      if (!mounted) return;
+      if (next.length != _recurringFixedCosts.length) {
+        setState(() {
+          _recurringFixedCosts = next;
+        });
+        await _recurringFixedCostStore.save(next, prefs: store);
       }
-      setState(() {
-        _recurringFixedCosts = next;
-      });
-      _persistInBackground(
-        _recurringFixedCostStore.save(next),
-        'recurring fixed cost tombstone pull save',
-      );
+      if (debugMirror == null && pending.isNotEmpty) {
+        await _mirrorRecurringFixedCostsDeletedNow(
+          mirrorCurrentOnSuccess: true,
+        );
+      }
     } catch (e) {
       debugPrint('recurring fixed cost tombstone pull failed: $e');
     }
@@ -11790,35 +11765,149 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
-  void _saveRecurringFixedCost(AssetRecurringFixedCost cost) {
-    setState(() {
-      final next = List<AssetRecurringFixedCost>.from(_recurringFixedCosts);
-      final index = next.indexWhere((existing) => existing.id == cost.id);
-      if (index >= 0) {
-        next[index] = cost;
-      } else {
-        next.add(cost);
+  Future<bool> _commitRecurringFixedCostReadditionsNow({
+    required List<AssetRecurringFixedCost> previous,
+    required List<AssetRecurringFixedCost> next,
+    required Set<String> ids,
+  }) async {
+    if (ids.isEmpty) return true;
+    final store = await SharedPreferences.getInstance();
+    final tombstonesBefore = _recurringFixedCostTombstones.activeIds(store);
+    final pendingBefore = await _syncDirtyKeysStore.loadDirty(
+      _recurringFixedCostsDeletedMirrorKey,
+      prefs: store,
+    );
+    final currentDirtyBefore = await _syncDirtyKeysStore.loadDirty(
+      _recurringFixedCostsMirrorKey,
+      prefs: store,
+    );
+    final affectedOperations = <String>{
+      for (final id in ids) _recurringTombstoneOperation(id, deleted: true),
+      for (final id in ids) _recurringTombstoneOperation(id, deleted: false),
+    };
+    try {
+      // Journal the re-add intent before publishing the new current list. The
+      // whole sequence owns the shared FIFO, so boot/delete sync cannot consume
+      // the intent between these writes.
+      for (final id in ids) {
+        await _queueRecurringFixedCostTombstoneOperation(
+          store,
+          id,
+          deleted: false,
+        );
       }
-      next.sort(_compareRecurringFixedCostsByPaymentDay);
+      await _recurringFixedCostStore.save(next, prefs: store);
+      for (final id in ids) {
+        await _recurringFixedCostTombstones.removeId(store, id);
+        await _syncDirtyKeysStore.markDirty(
+          _recurringFixedCostsMirrorKey,
+          id,
+          prefs: store,
+        );
+      }
+    } catch (error, stackTrace) {
+      try {
+        await _syncDirtyKeysStore.updateDirty(
+          _recurringFixedCostsDeletedMirrorKey,
+          addKeys: pendingBefore.intersection(affectedOperations),
+          removeKeys: affectedOperations,
+          prefs: store,
+        );
+        await _syncDirtyKeysStore.updateDirty(
+          _recurringFixedCostsMirrorKey,
+          addKeys: currentDirtyBefore.intersection(ids),
+          removeKeys: ids,
+          prefs: store,
+        );
+      } catch (rollbackError) {
+        debugPrint(
+            'recurring fixed cost dirty rollback failed: $rollbackError');
+      }
+      try {
+        await _recurringFixedCostStore.save(previous, prefs: store);
+      } catch (rollbackError) {
+        debugPrint('recurring fixed cost data rollback failed: $rollbackError');
+      }
+      try {
+        for (final id in ids) {
+          if (tombstonesBefore.contains(id)) {
+            await _recurringFixedCostTombstones.addId(store, id);
+          } else {
+            await _recurringFixedCostTombstones.removeId(store, id);
+          }
+        }
+      } catch (rollbackError) {
+        debugPrint(
+          'recurring fixed cost tombstone rollback failed: $rollbackError',
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+
+    if (mounted) {
+      setState(() => _recurringFixedCosts = next);
+    } else {
       _recurringFixedCosts = next;
-    });
-    _persistInBackground(
-      _recurringFixedCostStore.save(_recurringFixedCosts),
-      'recurring fixed cost save',
+    }
+    final synced = await _mirrorRecurringFixedCostsDeletedNow(
+      mirrorCurrentOnSuccess: true,
     );
-    // 編集/再追加は id 再利用解除 (tombstone 除去) + ローカル編集を dirty 記録。
-    unawaited(
-      _syncDirtyKeysStore.markDirty(_recurringFixedCostsMirrorKey, cost.id),
-    );
-    unawaited(_syncRecurringFixedCostReadditions(<String>[cost.id]));
+    if (!synced && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('端末では保存済みです。サーバー同期は次回オンライン時に再試行します。'),
+          backgroundColor: Color(0xFFB45309),
+        ),
+      );
+    }
+    return synced;
+  }
+
+  Future<void> _saveRecurringFixedCost(AssetRecurringFixedCost cost) async {
+    try {
+      await _recurringTombstoneSyncService.runSerialized(() async {
+        final previous = List<AssetRecurringFixedCost>.from(
+          _recurringFixedCosts,
+        );
+        final next = List<AssetRecurringFixedCost>.from(previous);
+        final index = next.indexWhere((existing) => existing.id == cost.id);
+        if (index >= 0) {
+          next[index] = cost;
+        } else {
+          next.add(cost);
+        }
+        next.sort(_compareRecurringFixedCostsByPaymentDay);
+        await _commitRecurringFixedCostReadditionsNow(
+          previous: previous,
+          next: next,
+          ids: <String>{cost.id},
+        );
+      });
+    } catch (error) {
+      debugPrint('recurring fixed cost save failed: $error');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('定期固定費を保存できませんでした。元の状態を保持しています。'),
+            backgroundColor: Color(0xFFB91C1C),
+          ),
+        );
+      }
+    }
   }
 
   Future<void> _deleteRecurringFixedCosts(
     Iterable<AssetRecurringFixedCost> costs,
-  ) async {
+  ) {
     final ids =
         costs.map((cost) => cost.id).where((id) => id.isNotEmpty).toSet();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return Future<void>.value();
+    return _recurringTombstoneSyncService.runSerialized(
+      () => _deleteRecurringFixedCostsNow(ids),
+    );
+  }
+
+  Future<void> _deleteRecurringFixedCostsNow(Set<String> ids) async {
     final next = _recurringFixedCosts
         .where((existing) => !ids.contains(existing.id))
         .toList(growable: false);
@@ -11864,10 +11953,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     // サーバ同期が失敗しても dirty operation を保持し、次回bootで再試行する。
     // stale current mirror はtombstone同期成功後だけ更新する。
-    final tombstonesSynced = await _mirrorRecurringFixedCostsDeleted();
-    if (tombstonesSynced) {
-      await _mirrorRecurringFixedCosts();
-    } else if (mounted) {
+    final tombstonesSynced = await _mirrorRecurringFixedCostsDeletedNow(
+      mirrorCurrentOnSuccess: true,
+    );
+    if (!tombstonesSynced && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text('端末では削除済みです。サーバー同期は次回オンライン時に再試行します。'),
@@ -11901,7 +11990,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       usdJpyRateAsOf: _usdJpyRate?.asOf,
     );
     if (result != null) {
-      _saveRecurringFixedCost(result);
+      await _saveRecurringFixedCost(result);
     }
   }
 
@@ -12046,44 +12135,48 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         false;
   }
 
-  void _importSubscriptionStatementCosts(
+  Future<void> _importSubscriptionStatementCosts(
     List<AssetRecurringFixedCost> importedCosts,
-  ) {
+  ) async {
     if (importedCosts.isEmpty) return;
-    final next = List<AssetRecurringFixedCost>.from(_recurringFixedCosts);
-    final existingNames = <String>{
-      for (final cost in next) _normalizeSubscriptionName(cost.name),
-    };
-    final added = <AssetRecurringFixedCost>[];
-    for (final cost in importedCosts) {
-      final normalized = _normalizeSubscriptionName(cost.name);
-      if (normalized.isEmpty || existingNames.contains(normalized)) continue;
-      next.add(cost);
-      added.add(cost);
-      existingNames.add(normalized);
-    }
-    if (added.isEmpty) {
+    final addedCount = await _recurringTombstoneSyncService.runSerialized(
+      () async {
+        final previous = List<AssetRecurringFixedCost>.from(
+          _recurringFixedCosts,
+        );
+        final next = List<AssetRecurringFixedCost>.from(previous);
+        final existingNames = <String>{
+          for (final cost in next) _normalizeSubscriptionName(cost.name),
+        };
+        final added = <AssetRecurringFixedCost>[];
+        for (final cost in importedCosts) {
+          final normalized = _normalizeSubscriptionName(cost.name);
+          if (normalized.isEmpty || existingNames.contains(normalized)) {
+            continue;
+          }
+          next.add(cost);
+          added.add(cost);
+          existingNames.add(normalized);
+        }
+        if (added.isEmpty) return 0;
+        next.sort(_compareRecurringFixedCostsByPaymentDay);
+        await _commitRecurringFixedCostReadditionsNow(
+          previous: previous,
+          next: next,
+          ids: added.map((cost) => cost.id).toSet(),
+        );
+        return added.length;
+      },
+    );
+    if (!mounted) return;
+    if (addedCount == 0) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('追加できる新しいサブスクはありませんでした。')),
       );
       return;
     }
-    next.sort(_compareRecurringFixedCostsByPaymentDay);
-    setState(() => _recurringFixedCosts = next);
-    _persistInBackground(
-      _recurringFixedCostStore.save(next),
-      'subscription statement import',
-    );
-    for (final cost in added) {
-      unawaited(
-        _syncDirtyKeysStore.markDirty(_recurringFixedCostsMirrorKey, cost.id),
-      );
-    }
-    unawaited(
-      _syncRecurringFixedCostReadditions(added.map((cost) => cost.id)),
-    );
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('${added.length}件のサブスクを棚卸しに追加しました。')),
+      SnackBar(content: Text('$addedCount件のサブスクを棚卸しに追加しました。')),
     );
   }
 

--- a/lib/services/asset_obsidian_vault_import_service.dart
+++ b/lib/services/asset_obsidian_vault_import_service.dart
@@ -6,9 +6,13 @@ class AssetObsidianVaultImportService {
   AssetObsidianImportPreview preview({
     required List<AssetObsidianVaultFile> files,
     required List<AssetObsidianExistingBalance> existingBalances,
+    List<AssetObsidianExistingSubscription> existingSubscriptions =
+        const <AssetObsidianExistingSubscription>[],
   }) {
     final parsed = <_ParsedBalance>[];
+    final parsedCancellations = <_ParsedSubscriptionCancellation>[];
     final recognizedPaths = <String>{};
+    final recognizedCancellationPaths = <String>{};
     final warnings = <String>[];
 
     for (final file in files) {
@@ -16,7 +20,11 @@ class AssetObsidianVaultImportService {
       if (result.recognized) {
         recognizedPaths.add(file.relativePath);
       }
+      if (result.recognizedCancellationTable) {
+        recognizedCancellationPaths.add(file.relativePath);
+      }
       parsed.addAll(result.balances);
+      parsedCancellations.addAll(result.subscriptionCancellations);
       warnings.addAll(result.warnings);
     }
 
@@ -43,16 +51,18 @@ class AssetObsidianVaultImportService {
       final latestRecords = records
           .where((record) => _sameDate(record.observedDate, latestDate))
           .toList(growable: false);
-      final uniqueAmounts =
-          latestRecords.map((record) => record.amount).toSet();
+      final uniqueAmounts = latestRecords
+          .map((record) => record.amount)
+          .toSet();
       final first = latestRecords.first;
       final existing = existingByKey[entry.key];
       final resolvedName = existing?.accountName ?? first.accountName;
-      final sourcePaths = latestRecords
-          .map((record) => record.sourcePath)
-          .toSet()
-          .toList(growable: false)
-        ..sort();
+      final sourcePaths =
+          latestRecords
+              .map((record) => record.sourcePath)
+              .toSet()
+              .toList(growable: false)
+            ..sort();
 
       if (uniqueAmounts.length > 1) {
         final amounts = uniqueAmounts.toList()..sort();
@@ -98,16 +108,120 @@ class AssetObsidianVaultImportService {
           ? statusCompare
           : a.accountName.compareTo(b.accountName);
     });
-    if (recognizedPaths.isEmpty) {
-      warnings.add('対応する残高表が見つかりませんでした。');
+    final cancellationCandidates = _matchSubscriptionCancellations(
+      parsedCancellations,
+      existingSubscriptions,
+    );
+    if (recognizedPaths.isEmpty && recognizedCancellationPaths.isEmpty) {
+      warnings.add('対応する残高表または解約済みサブスク表が見つかりませんでした。');
     }
 
     return AssetObsidianImportPreview(
       scannedFileCount: files.length,
       recognizedFileCount: recognizedPaths.length,
+      recognizedCancellationFileCount: recognizedCancellationPaths.length,
       candidates: candidates,
+      subscriptionCancellations: cancellationCandidates,
       warnings: warnings.toSet().toList(growable: false),
     );
+  }
+
+  List<AssetObsidianSubscriptionCancellationCandidate>
+  _matchSubscriptionCancellations(
+    List<_ParsedSubscriptionCancellation> parsed,
+    List<AssetObsidianExistingSubscription> existingSubscriptions,
+  ) {
+    final existingByKey = <String, List<AssetObsidianExistingSubscription>>{};
+    for (final subscription in existingSubscriptions) {
+      existingByKey
+          .putIfAbsent(
+            _subscriptionKey(subscription.name),
+            () => <AssetObsidianExistingSubscription>[],
+          )
+          .add(subscription);
+    }
+
+    final parsedByKey = <String, List<_ParsedSubscriptionCancellation>>{};
+    for (final cancellation in parsed) {
+      parsedByKey
+          .putIfAbsent(
+            _subscriptionKey(cancellation.subscriptionName),
+            () => <_ParsedSubscriptionCancellation>[],
+          )
+          .add(cancellation);
+    }
+
+    final candidates = <AssetObsidianSubscriptionCancellationCandidate>[];
+    for (final entry in parsedByKey.entries) {
+      final sourceRows = entry.value;
+      final first = sourceRows.first;
+      final matches =
+          existingByKey[entry.key] ??
+          const <AssetObsidianExistingSubscription>[];
+      final sourcePaths =
+          sourceRows
+              .map((row) => row.sourcePath)
+              .toSet()
+              .toList(growable: false)
+            ..sort();
+      final sourceStatuses = sourceRows
+          .map((row) => row.status)
+          .toSet()
+          .toList(growable: false);
+      final endedAtValues = sourceRows
+          .map((row) => row.endedAt)
+          .whereType<String>()
+          .where((value) => value.isNotEmpty)
+          .toSet()
+          .toList(growable: false);
+
+      if (matches.length == 1) {
+        final match = matches.single;
+        candidates.add(
+          AssetObsidianSubscriptionCancellationCandidate(
+            sourceSubscriptionName: first.subscriptionName,
+            sourceStatus: sourceStatuses.join(' / '),
+            endedAt: endedAtValues.isEmpty ? null : endedAtValues.join(' / '),
+            status: AssetObsidianSubscriptionCancellationStatus.matched,
+            sourcePaths: sourcePaths,
+            matchedSubscriptionId: match.id,
+            matchedSubscriptionName: match.name,
+            matchedMonthlyAmount: match.amount,
+          ),
+        );
+        continue;
+      }
+
+      if (matches.length > 1) {
+        candidates.add(
+          AssetObsidianSubscriptionCancellationCandidate(
+            sourceSubscriptionName: first.subscriptionName,
+            sourceStatus: sourceStatuses.join(' / '),
+            endedAt: endedAtValues.isEmpty ? null : endedAtValues.join(' / '),
+            status: AssetObsidianSubscriptionCancellationStatus.conflict,
+            sourcePaths: sourcePaths,
+            conflictingSubscriptionNames: matches
+                .map((subscription) => subscription.name)
+                .toList(growable: false),
+          ),
+        );
+        continue;
+      }
+
+      candidates.add(
+        AssetObsidianSubscriptionCancellationCandidate(
+          sourceSubscriptionName: first.subscriptionName,
+          sourceStatus: sourceStatuses.join(' / '),
+          endedAt: endedAtValues.isEmpty ? null : endedAtValues.join(' / '),
+          status: AssetObsidianSubscriptionCancellationStatus.notRegistered,
+          sourcePaths: sourcePaths,
+        ),
+      );
+    }
+    candidates.sort(
+      (a, b) => a.sourceSubscriptionName.compareTo(b.sourceSubscriptionName),
+    );
+    return candidates;
   }
 
   AssetObsidianImportStatus _statusFor({
@@ -130,12 +244,47 @@ class AssetObsidianVaultImportService {
   _ParseResult _parseFile(AssetObsidianVaultFile file) {
     final lines = file.content.split(RegExp(r'\r?\n'));
     final balances = <_ParsedBalance>[];
+    final subscriptionCancellations = <_ParsedSubscriptionCancellation>[];
     final warnings = <String>[];
     var recognized = false;
+    var recognizedCancellationTable = false;
+    var currentHeading = '';
 
     for (var index = 0; index < lines.length; index++) {
+      final heading = RegExp(
+        r'^#{1,6}\s+(.+)$',
+      ).firstMatch(lines[index].trim());
+      if (heading != null) {
+        currentHeading = _cleanCell(heading.group(1)!);
+        continue;
+      }
       final header = _tableCells(lines[index]);
       if (header == null) continue;
+
+      final subscriptionNameIndex = _columnIndex(header, 'サービス名');
+      final endedAtIndex = header.indexWhere(
+        (cell) => cell.contains('終了日') || cell.contains('停止日'),
+      );
+      final cancellationStatusIndex = _columnIndex(header, '状態');
+      final isCancellationSection =
+          currentHeading.contains('解約') || currentHeading.contains('停止済み');
+      if (isCancellationSection &&
+          subscriptionNameIndex >= 0 &&
+          endedAtIndex >= 0 &&
+          cancellationStatusIndex >= 0) {
+        recognizedCancellationTable = true;
+        index = _parseSubscriptionCancellationTable(
+          lines: lines,
+          headerIndex: index,
+          nameIndex: subscriptionNameIndex,
+          endedAtIndex: endedAtIndex,
+          statusIndex: cancellationStatusIndex,
+          sourcePath: file.relativePath,
+          cancellations: subscriptionCancellations,
+          warnings: warnings,
+        );
+        continue;
+      }
 
       final confirmedDateIndex = _columnIndex(header, '確認日');
       final accountIndex = _columnIndex(header, '口座・サービス名');
@@ -183,9 +332,59 @@ class AssetObsidianVaultImportService {
 
     return _ParseResult(
       recognized: recognized,
+      recognizedCancellationTable: recognizedCancellationTable,
       balances: balances,
+      subscriptionCancellations: subscriptionCancellations,
       warnings: warnings,
     );
+  }
+
+  int _parseSubscriptionCancellationTable({
+    required List<String> lines,
+    required int headerIndex,
+    required int nameIndex,
+    required int endedAtIndex,
+    required int statusIndex,
+    required String sourcePath,
+    required List<_ParsedSubscriptionCancellation> cancellations,
+    required List<String> warnings,
+  }) {
+    var index = headerIndex + 1;
+    if (index < lines.length && _isSeparatorRow(lines[index])) index++;
+    for (; index < lines.length; index++) {
+      final cells = _tableCells(lines[index]);
+      if (cells == null) break;
+      final maxIndex = [
+        nameIndex,
+        endedAtIndex,
+        statusIndex,
+      ].reduce((a, b) => a > b ? a : b);
+      if (cells.length <= maxIndex) continue;
+      final name = _cleanCell(cells[nameIndex]);
+      final status = _cleanCell(cells[statusIndex]);
+      if (name.isEmpty || status.isEmpty) {
+        warnings.add('$sourcePath:${index + 1}: 解約済みサブスク行を読み飛ばしました。');
+        continue;
+      }
+      if (!_isExplicitCancellationStatus(status)) {
+        continue;
+      }
+      final endedAt = _cleanCell(cells[endedAtIndex]);
+      cancellations.add(
+        _ParsedSubscriptionCancellation(
+          subscriptionName: name,
+          status: status,
+          endedAt: endedAt.isEmpty ? null : endedAt,
+          sourcePath: sourcePath,
+        ),
+      );
+    }
+    return index - 1;
+  }
+
+  bool _isExplicitCancellationStatus(String value) {
+    final normalized = value.replaceAll(RegExp(r'\s+'), '');
+    return RegExp(r'(解約完了|解約済み|停止済み|停止完了|終了済み|終了完了)').hasMatch(normalized);
   }
 
   int _parseAccountTable({
@@ -287,6 +486,7 @@ class AssetObsidianVaultImportService {
       .trim()
       .replaceAll('**', '')
       .replaceAll('__', '')
+      .replaceAll('~~', '')
       .replaceAll('`', '')
       .trim();
 
@@ -341,6 +541,21 @@ class AssetObsidianVaultImportService {
       .replaceAll('）', ')')
       .replaceAll(RegExp(r'[\s()・]'), '');
 
+  String _subscriptionKey(String value) {
+    final compact = _cleanCell(value)
+        .toLowerCase()
+        .replaceAll('（', '(')
+        .replaceAll('）', ')')
+        .replaceAll(RegExp(r'[\s()・._\-*/]'), '');
+    const aliases = <String, String>{
+      'microsoftxboxgame': 'xboxgamepass',
+      'microsoftxboxgamepass': 'xboxgamepass',
+      'xboxgamepassultimate': 'xboxgamepass',
+      'netkeibacom': 'netkeiba',
+    };
+    return aliases[compact] ?? compact;
+  }
+
   bool _sameDate(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 }
@@ -361,14 +576,32 @@ class _ParsedBalance {
   final String sourcePath;
 }
 
+class _ParsedSubscriptionCancellation {
+  const _ParsedSubscriptionCancellation({
+    required this.subscriptionName,
+    required this.status,
+    required this.endedAt,
+    required this.sourcePath,
+  });
+
+  final String subscriptionName;
+  final String status;
+  final String? endedAt;
+  final String sourcePath;
+}
+
 class _ParseResult {
   const _ParseResult({
     required this.recognized,
+    required this.recognizedCancellationTable,
     required this.balances,
+    required this.subscriptionCancellations,
     required this.warnings,
   });
 
   final bool recognized;
+  final bool recognizedCancellationTable;
   final List<_ParsedBalance> balances;
+  final List<_ParsedSubscriptionCancellation> subscriptionCancellations;
   final List<String> warnings;
 }

--- a/lib/services/asset_obsidian_vault_import_service.dart
+++ b/lib/services/asset_obsidian_vault_import_service.dart
@@ -378,7 +378,14 @@ class AssetObsidianVaultImportService {
 
   bool _isExplicitCancellationStatus(String value) {
     final normalized = value.replaceAll(RegExp(r'\s+'), '');
-    return RegExp(r'(解約完了|解約済み|停止済み|停止完了|終了済み|終了完了)').hasMatch(normalized);
+    return const <String>{
+      '解約完了',
+      '解約済み',
+      '停止済み',
+      '停止完了',
+      '終了済み',
+      '終了完了',
+    }.contains(normalized);
   }
 
   int _parseAccountTable({
@@ -536,18 +543,20 @@ class AssetObsidianVaultImportService {
       .replaceAll(RegExp(r'[\s()・]'), '');
 
   String _subscriptionKey(String value) {
-    final compact = _cleanCell(value)
+    final normalized = _cleanCell(value)
         .toLowerCase()
         .replaceAll('（', '(')
         .replaceAll('）', ')')
-        .replaceAll(RegExp(r'[\s()・._\-*/]'), '');
+        .replaceAll('　', ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
     const aliases = <String, String>{
-      'microsoftxboxgame': 'xboxgamepass',
-      'microsoftxboxgamepass': 'xboxgamepass',
-      'xboxgamepassultimate': 'xboxgamepass',
-      'netkeibacom': 'netkeiba',
+      'microsoft*xbox game': 'xbox game pass',
+      'microsoft*xbox game pass': 'xbox game pass',
+      'xbox game pass ultimate': 'xbox game pass',
+      'netkeiba.com': 'netkeiba',
     };
-    return aliases[compact] ?? compact;
+    return aliases[normalized] ?? normalized;
   }
 
   bool _sameDate(DateTime a, DateTime b) =>

--- a/lib/services/asset_obsidian_vault_import_service.dart
+++ b/lib/services/asset_obsidian_vault_import_service.dart
@@ -51,18 +51,16 @@ class AssetObsidianVaultImportService {
       final latestRecords = records
           .where((record) => _sameDate(record.observedDate, latestDate))
           .toList(growable: false);
-      final uniqueAmounts = latestRecords
-          .map((record) => record.amount)
-          .toSet();
+      final uniqueAmounts =
+          latestRecords.map((record) => record.amount).toSet();
       final first = latestRecords.first;
       final existing = existingByKey[entry.key];
       final resolvedName = existing?.accountName ?? first.accountName;
-      final sourcePaths =
-          latestRecords
-              .map((record) => record.sourcePath)
-              .toSet()
-              .toList(growable: false)
-            ..sort();
+      final sourcePaths = latestRecords
+          .map((record) => record.sourcePath)
+          .toSet()
+          .toList(growable: false)
+        ..sort();
 
       if (uniqueAmounts.length > 1) {
         final amounts = uniqueAmounts.toList()..sort();
@@ -127,7 +125,7 @@ class AssetObsidianVaultImportService {
   }
 
   List<AssetObsidianSubscriptionCancellationCandidate>
-  _matchSubscriptionCancellations(
+      _matchSubscriptionCancellations(
     List<_ParsedSubscriptionCancellation> parsed,
     List<AssetObsidianExistingSubscription> existingSubscriptions,
   ) {
@@ -155,19 +153,15 @@ class AssetObsidianVaultImportService {
     for (final entry in parsedByKey.entries) {
       final sourceRows = entry.value;
       final first = sourceRows.first;
-      final matches =
-          existingByKey[entry.key] ??
+      final matches = existingByKey[entry.key] ??
           const <AssetObsidianExistingSubscription>[];
-      final sourcePaths =
-          sourceRows
-              .map((row) => row.sourcePath)
-              .toSet()
-              .toList(growable: false)
-            ..sort();
-      final sourceStatuses = sourceRows
-          .map((row) => row.status)
+      final sourcePaths = sourceRows
+          .map((row) => row.sourcePath)
           .toSet()
-          .toList(growable: false);
+          .toList(growable: false)
+        ..sort();
+      final sourceStatuses =
+          sourceRows.map((row) => row.status).toSet().toList(growable: false);
       final endedAtValues = sourceRows
           .map((row) => row.endedAt)
           .whereType<String>()

--- a/lib/services/asset_recurring_tombstone_sync_service.dart
+++ b/lib/services/asset_recurring_tombstone_sync_service.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/foundation.dart';
+import 'package:my_web_app/services/asset_sync_dirty_keys_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+typedef AssetRecurringTombstoneRpc = Future<void> Function(
+  List<String> additions,
+  List<String> removals,
+);
+
+/// Serializes recurring-fixed-cost tombstone synchronization application-wide.
+///
+/// Each scheduled operation loads its own pending snapshot only after the
+/// previous RPC has acknowledged its snapshot. This prevents a delayed delete
+/// RPC from arriving after a later re-add RPC and restoring the wrong server
+/// state.
+class AssetRecurringTombstoneSyncService {
+  AssetRecurringTombstoneSyncService({
+    AssetSyncDirtyKeysStore dirtyKeysStore = const AssetSyncDirtyKeysStore(),
+  }) : _dirtyKeysStore = dirtyKeysStore;
+
+  static const String addPrefix = 'add:';
+  static const String removePrefix = 'remove:';
+  static AssetRecurringTombstoneSyncService _shared =
+      AssetRecurringTombstoneSyncService();
+
+  /// App-scoped queue so a replaced page cannot overlap an older page's RPC.
+  static AssetRecurringTombstoneSyncService get shared => _shared;
+
+  @visibleForTesting
+  static void resetSharedForTest() {
+    _shared = AssetRecurringTombstoneSyncService();
+  }
+
+  final AssetSyncDirtyKeysStore _dirtyKeysStore;
+  Future<void>? _tail;
+
+  static String operation(String id, {required bool deleted}) =>
+      '${deleted ? addPrefix : removePrefix}$id';
+
+  static Set<String> operationIds(Set<String> operations, String prefix) =>
+      <String>{
+        for (final operation in operations)
+          if (operation.startsWith(prefix) && operation.length > prefix.length)
+            operation.substring(prefix.length),
+      };
+
+  Future<void> queue(
+    String prefKey,
+    String id, {
+    required bool deleted,
+    required SharedPreferences prefs,
+  }) {
+    return _dirtyKeysStore.updateDirty(
+      prefKey,
+      addKeys: <String>[operation(id, deleted: deleted)],
+      removeKeys: <String>[operation(id, deleted: !deleted)],
+      prefs: prefs,
+    );
+  }
+
+  /// Runs snapshot -> RPC -> exact-snapshot acknowledgement in FIFO order.
+  Future<bool> sync({
+    required String prefKey,
+    required SharedPreferences prefs,
+    required AssetRecurringTombstoneRpc rpc,
+    Future<void> Function()? afterSync,
+  }) {
+    return runSerialized(
+      () => syncNow(
+        prefKey: prefKey,
+        prefs: prefs,
+        rpc: rpc,
+        afterSync: afterSync,
+      ),
+    );
+  }
+
+  /// Adds [operation] to the same application-wide FIFO as tombstone RPCs.
+  Future<T> runSerialized<T>(Future<T> Function() operation) {
+    final scheduled = (_tail ?? Future<void>.value()).then(
+      (_) => operation(),
+    );
+    _tail = scheduled.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    return scheduled;
+  }
+
+  /// Executes one sync while the caller already owns [runSerialized].
+  Future<bool> syncNow({
+    required String prefKey,
+    required SharedPreferences prefs,
+    required AssetRecurringTombstoneRpc rpc,
+    required Future<void> Function()? afterSync,
+  }) async {
+    try {
+      final pending = await _dirtyKeysStore.loadDirty(
+        prefKey,
+        prefs: prefs,
+      );
+      final additions = operationIds(pending, addPrefix);
+      final removals = operationIds(pending, removePrefix);
+      if (additions.isEmpty && removals.isEmpty) return true;
+
+      final sortedAdditions = additions.toList(growable: false)..sort();
+      final sortedRemovals = removals.toList(growable: false)..sort();
+      await rpc(sortedAdditions, sortedRemovals);
+      if (afterSync != null) {
+        await afterSync();
+      }
+      await _dirtyKeysStore.updateDirty(
+        prefKey,
+        removeKeys: <String>[
+          for (final id in additions) operation(id, deleted: true),
+          for (final id in removals) operation(id, deleted: false),
+        ],
+        prefs: prefs,
+      );
+      return true;
+    } catch (error) {
+      debugPrint('recurring fixed cost tombstone mirror upsert failed: $error');
+      return false;
+    }
+  }
+}

--- a/lib/services/asset_sync_dirty_keys_store.dart
+++ b/lib/services/asset_sync_dirty_keys_store.dart
@@ -126,6 +126,34 @@ class AssetSyncDirtyKeysStore {
     });
   }
 
+  /// [prefKey] の dirty 集合を 1 回のロック区間で差分更新する。
+  /// 同じ論理IDの add/remove のように、相反する操作を入れ替える用途で使う。
+  Future<void> updateDirty(
+    String prefKey, {
+    Iterable<String> addKeys = const <String>[],
+    Iterable<String> removeKeys = const <String>[],
+    SharedPreferences? prefs,
+  }) {
+    final additions = addKeys.where((key) => key.isNotEmpty).toSet();
+    final removals = removeKeys.where((key) => key.isNotEmpty).toSet();
+    if (additions.isEmpty && removals.isEmpty) {
+      return Future<void>.value();
+    }
+    return _runLocked(() async {
+      final store = prefs ?? await SharedPreferences.getInstance();
+      final all = await _loadAll(store);
+      final dirty = all[prefKey] ?? <String>{};
+      dirty.removeAll(removals);
+      dirty.addAll(additions);
+      if (dirty.isEmpty) {
+        all.remove(prefKey);
+      } else {
+        all[prefKey] = dirty;
+      }
+      await _writeAll(store, all);
+    });
+  }
+
   /// [prefKey] ドメインの全 dirty キーを消す (= 全量 upsert 成功で同期済み)。
   Future<void> clearDomain(
     String prefKey, {

--- a/lib/widgets/asset_obsidian_vault_import_dialog.dart
+++ b/lib/widgets/asset_obsidian_vault_import_dialog.dart
@@ -4,8 +4,8 @@ import 'package:my_web_app/models/asset_obsidian_vault_import.dart';
 import 'package:my_web_app/services/asset_obsidian_vault_import_service.dart';
 import 'package:my_web_app/utils/asset_obsidian_vault_picker.dart';
 
-typedef AssetObsidianVaultPicker =
-    Future<AssetObsidianVaultSelection?> Function();
+typedef AssetObsidianVaultPicker = Future<AssetObsidianVaultSelection?>
+    Function();
 
 class AssetObsidianVaultImportDialog extends StatefulWidget {
   const AssetObsidianVaultImportDialog({
@@ -52,7 +52,7 @@ class _AssetObsidianVaultImportDialogState
   }
 
   List<AssetObsidianSubscriptionCancellationCandidate>
-  get _selectedSubscriptionCancellations {
+      get _selectedSubscriptionCancellations {
     final preview = _preview;
     if (preview == null) {
       return const <AssetObsidianSubscriptionCancellationCandidate>[];
@@ -78,9 +78,8 @@ class _AssetObsidianVaultImportDialogState
       setState(() {
         _selection = selection;
         _preview = preview;
-        _selectedBalanceIds = preview.initiallySelected
-            .map((candidate) => candidate.id)
-            .toSet();
+        _selectedBalanceIds =
+            preview.initiallySelected.map((candidate) => candidate.id).toSet();
         _selectedCancellationIds = preview
             .initiallySelectedSubscriptionCancellations
             .map((candidate) => candidate.id)
@@ -224,9 +223,8 @@ class _AssetObsidianVaultImportDialogState
                   const Text('この機能はChromeなどのWebブラウザ版で利用できます。')
                 else
                   OutlinedButton.icon(
-                    onPressed: _isSelecting || _isApplying
-                        ? null
-                        : _selectVault,
+                    onPressed:
+                        _isSelecting || _isApplying ? null : _selectVault,
                     icon: _isSelecting
                         ? const SizedBox(
                             width: 18,
@@ -322,9 +320,8 @@ class _AssetObsidianVaultImportDialogState
         ),
         if (preview != null)
           FilledButton.icon(
-            onPressed: selectedCount == 0 || _isApplying
-                ? null
-                : _confirmAndApply,
+            onPressed:
+                selectedCount == 0 || _isApplying ? null : _confirmAndApply,
             icon: _isApplying
                 ? const SizedBox(
                     width: 18,
@@ -339,12 +336,11 @@ class _AssetObsidianVaultImportDialogState
   }
 
   Widget _buildPrivacyNotice() => _buildMessageBox(
-    icon: Icons.shield_outlined,
-    color: const Color(0xFF047857),
-    text:
-        'Markdown本文はこのブラウザ内だけで解析します。確認後に選択した口座名と残高、'
-        'または照合済みサブスクIDだけを反映し、本文とローカルパスは保存しません。',
-  );
+        icon: Icons.shield_outlined,
+        color: const Color(0xFF047857),
+        text: 'Markdown本文はこのブラウザ内だけで解析します。確認後に選択した口座名と残高、'
+            'または照合済みサブスクIDだけを反映し、本文とローカルパスは保存しません。',
+      );
 
   Widget _buildPreviewHeader(AssetObsidianImportPreview preview) {
     return Container(
@@ -593,17 +589,17 @@ class _AssetObsidianVaultImportDialogState
   ) {
     final (label, color) = switch (status) {
       AssetObsidianSubscriptionCancellationStatus.matched => (
-        '削除候補',
-        const Color(0xFFB45309),
-      ),
+          '削除候補',
+          const Color(0xFFB45309),
+        ),
       AssetObsidianSubscriptionCancellationStatus.notRegistered => (
-        '未登録',
-        const Color(0xFF64748B),
-      ),
+          '未登録',
+          const Color(0xFF64748B),
+        ),
       AssetObsidianSubscriptionCancellationStatus.conflict => (
-        '競合',
-        const Color(0xFFB91C1C),
-      ),
+          '競合',
+          const Color(0xFFB91C1C),
+        ),
     };
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),

--- a/lib/widgets/asset_obsidian_vault_import_dialog.dart
+++ b/lib/widgets/asset_obsidian_vault_import_dialog.dart
@@ -58,7 +58,11 @@ class _AssetObsidianVaultImportDialogState
       return const <AssetObsidianSubscriptionCancellationCandidate>[];
     }
     return preview.subscriptionCancellations
-        .where((candidate) => _selectedCancellationIds.contains(candidate.id))
+        .where(
+          (candidate) =>
+              candidate.isDeletable &&
+              _selectedCancellationIds.contains(candidate.id),
+        )
         .toList(growable: false);
   }
 

--- a/lib/widgets/asset_obsidian_vault_import_dialog.dart
+++ b/lib/widgets/asset_obsidian_vault_import_dialog.dart
@@ -4,13 +4,14 @@ import 'package:my_web_app/models/asset_obsidian_vault_import.dart';
 import 'package:my_web_app/services/asset_obsidian_vault_import_service.dart';
 import 'package:my_web_app/utils/asset_obsidian_vault_picker.dart';
 
-typedef AssetObsidianVaultPicker = Future<AssetObsidianVaultSelection?>
-    Function();
+typedef AssetObsidianVaultPicker =
+    Future<AssetObsidianVaultSelection?> Function();
 
 class AssetObsidianVaultImportDialog extends StatefulWidget {
   const AssetObsidianVaultImportDialog({
     super.key,
     required this.existingBalances,
+    this.existingSubscriptions = const <AssetObsidianExistingSubscription>[],
     required this.onApply,
     this.importService = const AssetObsidianVaultImportService(),
     this.pickVault = pickAssetObsidianVault,
@@ -18,8 +19,8 @@ class AssetObsidianVaultImportDialog extends StatefulWidget {
   });
 
   final List<AssetObsidianExistingBalance> existingBalances;
-  final Future<void> Function(List<AssetObsidianImportCandidate> candidates)
-      onApply;
+  final List<AssetObsidianExistingSubscription> existingSubscriptions;
+  final Future<void> Function(AssetObsidianApplySelection selection) onApply;
   final AssetObsidianVaultImportService importService;
   final AssetObsidianVaultPicker pickVault;
   final bool? pickerSupported;
@@ -33,7 +34,8 @@ class _AssetObsidianVaultImportDialogState
     extends State<AssetObsidianVaultImportDialog> {
   AssetObsidianVaultSelection? _selection;
   AssetObsidianImportPreview? _preview;
-  Set<String> _selectedIds = <String>{};
+  Set<String> _selectedBalanceIds = <String>{};
+  Set<String> _selectedCancellationIds = <String>{};
   bool _isSelecting = false;
   bool _isApplying = false;
   String? _error;
@@ -45,7 +47,18 @@ class _AssetObsidianVaultImportDialogState
     final preview = _preview;
     if (preview == null) return const <AssetObsidianImportCandidate>[];
     return preview.candidates
-        .where((candidate) => _selectedIds.contains(candidate.id))
+        .where((candidate) => _selectedBalanceIds.contains(candidate.id))
+        .toList(growable: false);
+  }
+
+  List<AssetObsidianSubscriptionCancellationCandidate>
+  get _selectedSubscriptionCancellations {
+    final preview = _preview;
+    if (preview == null) {
+      return const <AssetObsidianSubscriptionCancellationCandidate>[];
+    }
+    return preview.subscriptionCancellations
+        .where((candidate) => _selectedCancellationIds.contains(candidate.id))
         .toList(growable: false);
   }
 
@@ -60,12 +73,18 @@ class _AssetObsidianVaultImportDialogState
       final preview = widget.importService.preview(
         files: selection.files,
         existingBalances: widget.existingBalances,
+        existingSubscriptions: widget.existingSubscriptions,
       );
       setState(() {
         _selection = selection;
         _preview = preview;
-        _selectedIds =
-            preview.initiallySelected.map((candidate) => candidate.id).toSet();
+        _selectedBalanceIds = preview.initiallySelected
+            .map((candidate) => candidate.id)
+            .toSet();
+        _selectedCancellationIds = preview
+            .initiallySelectedSubscriptionCancellations
+            .map((candidate) => candidate.id)
+            .toSet();
       });
     } on AssetObsidianVaultPickerException catch (error) {
       if (mounted) setState(() => _error = error.message);
@@ -81,12 +100,17 @@ class _AssetObsidianVaultImportDialogState
   }
 
   Future<void> _confirmAndApply() async {
-    final selected = _selectedCandidates;
-    if (selected.isEmpty) return;
+    final selectedBalances = _selectedCandidates;
+    final selectedCancellations = _selectedSubscriptionCancellations;
+    final selection = AssetObsidianApplySelection(
+      balances: selectedBalances,
+      subscriptionCancellations: selectedCancellations,
+    );
+    if (selection.totalCount == 0) return;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: Text('${selected.length}件の残高を本日分として反映しますか？'),
+        title: Text(_confirmationTitle(selection)),
         content: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 520, maxHeight: 360),
           child: SingleChildScrollView(
@@ -95,14 +119,36 @@ class _AssetObsidianVaultImportDialogState
               mainAxisSize: MainAxisSize.min,
               children: [
                 const Text(
-                  '保管庫の確認日は鮮度判定に使い、資産管理サイトには反映時点の残高として保存します。使途不明金は自動生成しません。',
+                  '残高は反映時点の値として保存し、使途不明金は自動生成しません。'
+                  '解約済みサブスクは現在の定期固定費から削除しますが、過去の月次履歴・取引履歴は残します。',
                 ),
-                const SizedBox(height: 12),
-                for (final candidate in selected)
+                if (selectedBalances.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  const Text(
+                    '残高',
+                    style: TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                ],
+                for (final candidate in selectedBalances)
                   Padding(
                     padding: const EdgeInsets.only(bottom: 6),
                     child: Text(
                       '・${candidate.accountName}: ${_formatYen(candidate.amount)}',
+                    ),
+                  ),
+                if (selectedCancellations.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  const Text(
+                    '削除するサブスク',
+                    style: TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                ],
+                for (final candidate in selectedCancellations)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 6),
+                    child: Text(
+                      '・${candidate.matchedSubscriptionName}: '
+                      '${_formatYen(candidate.matchedMonthlyAmount ?? 0)}/月',
                     ),
                   ),
               ],
@@ -128,12 +174,12 @@ class _AssetObsidianVaultImportDialogState
       _error = null;
     });
     try {
-      await widget.onApply(selected);
-      if (mounted) Navigator.of(context).pop(selected.length);
+      await widget.onApply(selection);
+      if (mounted) Navigator.of(context).pop(selection);
     } catch (_) {
       if (mounted) {
         setState(() {
-          _error = '残高の反映に失敗しました。通信状態を確認して再試行してください。';
+          _error = '選択内容の反映に失敗しました。通信状態を確認して再試行してください。';
         });
       }
     } finally {
@@ -141,16 +187,26 @@ class _AssetObsidianVaultImportDialogState
     }
   }
 
+  String _confirmationTitle(AssetObsidianApplySelection selection) {
+    final parts = <String>[
+      if (selection.balances.isNotEmpty) '残高${selection.balances.length}件',
+      if (selection.subscriptionCancellations.isNotEmpty)
+        'サブスク${selection.subscriptionCancellations.length}件',
+    ];
+    return '${parts.join('・')}を反映しますか？';
+  }
+
   @override
   Widget build(BuildContext context) {
     final preview = _preview;
-    final selectedCount = _selectedCandidates.length;
+    final selectedCount =
+        _selectedCandidates.length + _selectedSubscriptionCancellations.length;
     return AlertDialog(
       title: const Row(
         children: [
           Icon(Icons.folder_open, color: Color(0xFF7C3AED)),
           SizedBox(width: 10),
-          Expanded(child: Text('Obsidian保管庫から残高を取込')),
+          Expanded(child: Text('Obsidian保管庫から資産情報を取込')),
         ],
       ),
       content: ConstrainedBox(
@@ -168,8 +224,9 @@ class _AssetObsidianVaultImportDialogState
                   const Text('この機能はChromeなどのWebブラウザ版で利用できます。')
                 else
                   OutlinedButton.icon(
-                    onPressed:
-                        _isSelecting || _isApplying ? null : _selectVault,
+                    onPressed: _isSelecting || _isApplying
+                        ? null
+                        : _selectVault,
                     icon: _isSelecting
                         ? const SizedBox(
                             width: 18,
@@ -205,9 +262,12 @@ class _AssetObsidianVaultImportDialogState
                       ),
                   ],
                   const SizedBox(height: 12),
-                  if (preview.candidates.isEmpty)
-                    const Text('取込候補はありません。')
-                  else
+                  if (preview.candidates.isNotEmpty) ...[
+                    const _PreviewSectionTitle(
+                      icon: Icons.account_balance_wallet_outlined,
+                      label: '残高の反映候補',
+                    ),
+                    const SizedBox(height: 8),
                     LayoutBuilder(
                       builder: (context, constraints) => Column(
                         children: [
@@ -222,6 +282,33 @@ class _AssetObsidianVaultImportDialogState
                         ],
                       ),
                     ),
+                  ],
+                  if (preview.subscriptionCancellations.isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    const _PreviewSectionTitle(
+                      icon: Icons.unsubscribe_outlined,
+                      label: '解約済みサブスクの削除候補',
+                    ),
+                    const SizedBox(height: 8),
+                    LayoutBuilder(
+                      builder: (context, constraints) => Column(
+                        children: [
+                          for (final candidate
+                              in preview.subscriptionCancellations)
+                            Padding(
+                              padding: const EdgeInsets.only(bottom: 8),
+                              child: _buildSubscriptionCancellationCandidate(
+                                candidate,
+                                compact: constraints.maxWidth < 680,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                  if (preview.candidates.isEmpty &&
+                      preview.subscriptionCancellations.isEmpty)
+                    const Text('取込候補はありません。'),
                 ],
               ],
             ),
@@ -235,8 +322,9 @@ class _AssetObsidianVaultImportDialogState
         ),
         if (preview != null)
           FilledButton.icon(
-            onPressed:
-                selectedCount == 0 || _isApplying ? null : _confirmAndApply,
+            onPressed: selectedCount == 0 || _isApplying
+                ? null
+                : _confirmAndApply,
             icon: _isApplying
                 ? const SizedBox(
                     width: 18,
@@ -251,10 +339,12 @@ class _AssetObsidianVaultImportDialogState
   }
 
   Widget _buildPrivacyNotice() => _buildMessageBox(
-        icon: Icons.shield_outlined,
-        color: const Color(0xFF047857),
-        text: 'Markdown本文はこのブラウザ内だけで解析します。確認後に選択した口座名と残高だけを資産管理サイトへ保存します。',
-      );
+    icon: Icons.shield_outlined,
+    color: const Color(0xFF047857),
+    text:
+        'Markdown本文はこのブラウザ内だけで解析します。確認後に選択した口座名と残高、'
+        'または照合済みサブスクIDだけを反映し、本文とローカルパスは保存しません。',
+  );
 
   Widget _buildPreviewHeader(AssetObsidianImportPreview preview) {
     return Container(
@@ -275,7 +365,9 @@ class _AssetObsidianVaultImportDialogState
           ),
           Text('Markdown ${preview.scannedFileCount}件'),
           Text('残高表 ${preview.recognizedFileCount}件'),
-          Text('候補 ${preview.candidates.length}件'),
+          Text('解約表 ${preview.recognizedCancellationFileCount}件'),
+          Text('残高候補 ${preview.candidates.length}件'),
+          Text('解約候補 ${preview.subscriptionCancellations.length}件'),
         ],
       ),
     );
@@ -285,7 +377,7 @@ class _AssetObsidianVaultImportDialogState
     AssetObsidianImportCandidate candidate, {
     required bool compact,
   }) {
-    final selected = _selectedIds.contains(candidate.id);
+    final selected = _selectedBalanceIds.contains(candidate.id);
     final details = _candidateDetails(candidate);
     final checkbox = Checkbox(
       value: selected,
@@ -293,8 +385,8 @@ class _AssetObsidianVaultImportDialogState
           ? (value) {
               setState(() {
                 value == true
-                    ? _selectedIds.add(candidate.id)
-                    : _selectedIds.remove(candidate.id);
+                    ? _selectedBalanceIds.add(candidate.id)
+                    : _selectedBalanceIds.remove(candidate.id);
               });
             }
           : null,
@@ -370,6 +462,104 @@ class _AssetObsidianVaultImportDialogState
     );
   }
 
+  Widget _buildSubscriptionCancellationCandidate(
+    AssetObsidianSubscriptionCancellationCandidate candidate, {
+    required bool compact,
+  }) {
+    final selected = _selectedCancellationIds.contains(candidate.id);
+    final checkbox = Checkbox(
+      value: selected,
+      onChanged: candidate.isDeletable && !_isApplying
+          ? (value) {
+              setState(() {
+                value == true
+                    ? _selectedCancellationIds.add(candidate.id)
+                    : _selectedCancellationIds.remove(candidate.id);
+              });
+            }
+          : null,
+    );
+    final name = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          candidate.sourceSubscriptionName,
+          style: const TextStyle(fontWeight: FontWeight.w800),
+        ),
+        if (candidate.matchedSubscriptionName != null &&
+            candidate.matchedSubscriptionName !=
+                candidate.sourceSubscriptionName)
+          Text(
+            '登録名: ${candidate.matchedSubscriptionName}',
+            style: _detailStyle,
+          ),
+      ],
+    );
+    final amount = candidate.matchedMonthlyAmount == null
+        ? const SizedBox.shrink()
+        : Text(
+            '${_formatYen(candidate.matchedMonthlyAmount!)}/月',
+            textAlign: TextAlign.right,
+            style: const TextStyle(
+              color: Color(0xFFB91C1C),
+              fontWeight: FontWeight.w900,
+            ),
+          );
+    final details = _subscriptionCancellationDetails(candidate);
+    final status = _buildSubscriptionCancellationStatus(candidate.status);
+
+    return Semantics(
+      label: '${candidate.sourceSubscriptionName}、$details',
+      child: Container(
+        key: ValueKey('obsidian-cancellation-${candidate.id}'),
+        width: double.infinity,
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: candidate.isDeletable
+              ? const Color(0xFFFFFBEB)
+              : const Color(0xFFF8FAFC),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: const Color(0xFFE2E8F0)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            checkbox,
+            const SizedBox(width: 4),
+            Expanded(
+              child: compact
+                  ? Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        name,
+                        const SizedBox(height: 6),
+                        amount,
+                        const SizedBox(height: 5),
+                        status,
+                        const SizedBox(height: 5),
+                        Text(details, style: _detailStyle),
+                      ],
+                    )
+                  : Row(
+                      children: [
+                        Expanded(flex: 4, child: name),
+                        Expanded(flex: 2, child: amount),
+                        const SizedBox(width: 12),
+                        status,
+                        const SizedBox(width: 12),
+                        Expanded(
+                          flex: 4,
+                          child: Text(details, style: _detailStyle),
+                        ),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   TextStyle get _detailStyle =>
       const TextStyle(fontSize: 11, color: Color(0xFF64748B), height: 1.4);
 
@@ -389,10 +579,65 @@ class _AssetObsidianVaultImportDialogState
       ),
       child: Text(
         label,
-        style:
-            TextStyle(fontSize: 11, fontWeight: FontWeight.w800, color: color),
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+          color: color,
+        ),
       ),
     );
+  }
+
+  Widget _buildSubscriptionCancellationStatus(
+    AssetObsidianSubscriptionCancellationStatus status,
+  ) {
+    final (label, color) = switch (status) {
+      AssetObsidianSubscriptionCancellationStatus.matched => (
+        '削除候補',
+        const Color(0xFFB45309),
+      ),
+      AssetObsidianSubscriptionCancellationStatus.notRegistered => (
+        '未登録',
+        const Color(0xFF64748B),
+      ),
+      AssetObsidianSubscriptionCancellationStatus.conflict => (
+        '競合',
+        const Color(0xFFB91C1C),
+      ),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  String _subscriptionCancellationDetails(
+    AssetObsidianSubscriptionCancellationCandidate candidate,
+  ) {
+    final source = candidate.endedAt == null
+        ? '保管庫: ${candidate.sourceStatus}'
+        : '保管庫: ${candidate.sourceStatus} / ${candidate.endedAt}';
+    if (candidate.status ==
+        AssetObsidianSubscriptionCancellationStatus.notRegistered) {
+      return '$source / 現在の登録なし（変更しません）';
+    }
+    if (candidate.status ==
+        AssetObsidianSubscriptionCancellationStatus.conflict) {
+      return '$source / 同名登録が複数: '
+          '${candidate.conflictingSubscriptionNames.join(' / ')}';
+    }
+    return '$source / 過去履歴は保持';
   }
 
   String _candidateDetails(AssetObsidianImportCandidate candidate) {
@@ -430,6 +675,24 @@ class _AssetObsidianVaultImportDialogState
           Expanded(child: Text(text, style: const TextStyle(height: 1.45))),
         ],
       ),
+    );
+  }
+}
+
+class _PreviewSectionTitle extends StatelessWidget {
+  const _PreviewSectionTitle({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, size: 18, color: Theme.of(context).colorScheme.primary),
+        const SizedBox(width: 8),
+        Text(label, style: const TextStyle(fontWeight: FontWeight.w800)),
+      ],
     );
   }
 }

--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -6,9 +6,9 @@ disposable Postgres container, applies a small migration/seed fixture, verifies
 the Issue #2773 fail-closed RLS migration, Issue #2484 asset-chat isolation,
 Issue #4091 app-analytics write boundary, and Issue #1202 voice-dubbing quota
 state machine, Issue #1233 resource-optimizer tenant/analysis/quota contracts,
-Issue #4956 WBS administrator/review contracts, checks the real Edge Function
-import policy, Issue #2668 note-comment authorization, and runs a Deno HTTP
-fixture against the container.
+Issue #4956 WBS administrator/review contracts, Issue #4927 recurring-cost
+tombstone concurrency, checks the real Edge Function import policy, Issue #2668
+note-comment authorization, and runs a Deno HTTP fixture against the container.
 Logs are written as
 artifacts so CI failures point to the migration, function, or seed boundary that
 broke.
@@ -135,6 +135,15 @@ ISSUE_4956_WBS_ADMIN_REVIEW_SQL_FILES = (
     / "20260828153722_repair_wbs_admin_review_contract.sql",
     ROOT / "supabase" / "tests" / "issue4956_wbs_admin_review_contract.sql",
 )
+ISSUE_4927_RECURRING_TOMBSTONE_SQL_FILES = (
+    ROOT / "supabase" / "migrations" / "20260612230000_asset_pref_mirror.sql",
+    ROOT
+    / "supabase"
+    / "migrations"
+    / "20260828164000_atomic_recurring_fixed_cost_tombstones.sql",
+    ROOT / "supabase" / "tests" / "issue4927_recurring_tombstone_contract.sql",
+)
+ISSUE_4927_USER = "00000000-0000-4000-8000-000000004927"
 VIDEO_ARTIFACT_SQL_FILES = (
     ROOT / "supabase" / "tests" / "video_service_bootstrap.sql",
     ROOT / "supabase" / "migrations" / "20260819165405_create_first_party_video_service.sql",
@@ -448,6 +457,18 @@ def build_plan(sql_dir: Path, edge_fixture: Path, actual_edge_function: Path) ->
             "manual_override is accepted only as an explicit administrator write",
             "migration applies twice in the disposable database",
         ],
+        "issue_4927_recurring_tombstone_sql": [
+            path.relative_to(ROOT).as_posix()
+            for path in ISSUE_4927_RECURRING_TOMBSTONE_SQL_FILES
+        ],
+        "issue_4927_recurring_tombstone_checks": [
+            "RPC normalizes empty, whitespace, duplicate, and NULL IDs",
+            "add/remove of the same ID is fail-closed with removal winning",
+            "malformed existing mirror values are rejected without overwrite",
+            "direct whole-blob writes to the dedicated key are rejected",
+            "two concurrent authenticated additions both survive",
+            "migration applies twice in the disposable database",
+        ],
         "video_artifact_contract": [
             path.relative_to(ROOT).as_posix() for path in VIDEO_ARTIFACT_SQL_FILES
         ],
@@ -489,6 +510,61 @@ def apply_sql_fixture(conn: Any, path: Path, artifacts_dir: Path) -> None:
                 cur.execute(statement)
         conn.commit()
         log.write("ok\n")
+
+
+def check_issue_4927_tombstone_concurrency(
+    conn: Any,
+    connection_url: str,
+    connect: Any,
+) -> dict[str, Any]:
+    """Race two authenticated additions and require an atomic server union."""
+
+    barrier = threading.Barrier(2)
+
+    def add_once(item_id: str) -> None:
+        with connect(connection_url, connect_timeout=10) as worker_conn:
+            with worker_conn.cursor() as cur:
+                cur.execute("set role authenticated")
+                cur.execute(
+                    "select set_config('request.jwt.claim.sub', %s, false)",
+                    (ISSUE_4927_USER,),
+                )
+                cur.execute(
+                    "select set_config('request.jwt.claim.role', 'authenticated', false)"
+                )
+                barrier.wait(timeout=10)
+                cur.execute(
+                    "select public.apply_recurring_fixed_cost_tombstones"
+                    "(%s, %s)",
+                    ([item_id], []),
+                )
+            worker_conn.commit()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(add_once, "concurrent-a"),
+            executor.submit(add_once, "concurrent-b"),
+        ]
+        for future in futures:
+            future.result(timeout=30)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "select value -> 'ids' from public.asset_pref_mirror "
+            "where user_id = %s::uuid and pref_key = 'recurring_fixed_costs_deleted'",
+            (ISSUE_4927_USER,),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        raise AssertionError("Issue #4927 tombstone mirror row is missing")
+    ids = set(row[0] or [])
+    expected = {"concurrent-a", "concurrent-b"}
+    if not expected.issubset(ids):
+        raise AssertionError(
+            f"Issue #4927 lost a concurrent tombstone: {sorted(ids)}"
+        )
+    return {"concurrent_ids": sorted(expected), "server_ids": sorted(ids)}
 
 
 def check_issue_1233_ai_quota_concurrency(
@@ -2509,6 +2585,33 @@ def run_smoke(args: argparse.Namespace) -> int:
                 ISSUE_4956_WBS_ADMIN_REVIEW_SQL_FILES[2],
                 artifacts_dir,
             )
+            apply_sql_fixture(
+                conn,
+                ISSUE_4927_RECURRING_TOMBSTONE_SQL_FILES[0],
+                artifacts_dir,
+            )
+            apply_sql_fixture(
+                conn,
+                ISSUE_4927_RECURRING_TOMBSTONE_SQL_FILES[1],
+                artifacts_dir,
+            )
+            apply_sql_fixture(
+                conn,
+                ISSUE_4927_RECURRING_TOMBSTONE_SQL_FILES[1],
+                artifacts_dir,
+            )
+            apply_sql_fixture(
+                conn,
+                ISSUE_4927_RECURRING_TOMBSTONE_SQL_FILES[2],
+                artifacts_dir,
+            )
+            issue_4927_tombstone_concurrency = (
+                check_issue_4927_tombstone_concurrency(
+                    conn,
+                    connection_url,
+                    psycopg.connect,
+                )
+            )
             apply_sql_fixture(conn, ASSET_CHAT_MIGRATION, artifacts_dir)
             seed_asset_chat_fixture(conn)
             asset_chat_rls = check_asset_chat_rls(conn)
@@ -2536,6 +2639,9 @@ def run_smoke(args: argparse.Namespace) -> int:
             "issue_1233_resource_optimizer_contract": "passed",
             "issue_1233_ai_quota_concurrency": issue_1233_quota_concurrency,
             "issue_4956_wbs_admin_review_contract": "passed",
+            "issue_4927_recurring_tombstone_contract": (
+                issue_4927_tombstone_concurrency
+            ),
             "video_artifact_contract": "passed",
         },
         "edge_fixture": {

--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -464,9 +464,11 @@ def build_plan(sql_dir: Path, edge_fixture: Path, actual_edge_function: Path) ->
         "issue_4927_recurring_tombstone_checks": [
             "RPC normalizes empty, whitespace, duplicate, and NULL IDs",
             "add/remove of the same ID is fail-closed with removal winning",
-            "malformed existing mirror values are rejected without overwrite",
-            "direct whole-blob writes to the dedicated key are rejected",
-            "two concurrent authenticated additions both survive",
+            "mixed-type malformed mirror values are rejected without overwrite",
+            "authenticated INSERT, UPDATE, rename, DELETE, and spoofed-GUC writes are rejected",
+            "unrelated-key CRUD remains allowed",
+            "RPC guard state is restored after success",
+            "initial concurrent additions and a concurrent add/remove preserve the exact set",
             "migration applies twice in the disposable database",
         ],
         "video_artifact_contract": [
@@ -519,9 +521,20 @@ def check_issue_4927_tombstone_concurrency(
 ) -> dict[str, Any]:
     """Race two authenticated additions and require an atomic server union."""
 
+    with conn.cursor() as cur:
+        cur.execute("select set_config('app.recurring_tombstone_rpc', 'on', false)")
+        cur.execute(
+            "delete from public.asset_pref_mirror "
+            "where user_id = %s::uuid "
+            "and pref_key = 'recurring_fixed_costs_deleted'",
+            (ISSUE_4927_USER,),
+        )
+        cur.execute("select set_config('app.recurring_tombstone_rpc', 'off', false)")
+    conn.commit()
+
     barrier = threading.Barrier(2)
 
-    def add_once(item_id: str) -> None:
+    def apply_once(additions: list[str], removals: list[str]) -> None:
         with connect(connection_url, connect_timeout=10) as worker_conn:
             with worker_conn.cursor() as cur:
                 cur.execute("set role authenticated")
@@ -536,14 +549,14 @@ def check_issue_4927_tombstone_concurrency(
                 cur.execute(
                     "select public.apply_recurring_fixed_cost_tombstones"
                     "(%s, %s)",
-                    ([item_id], []),
+                    (additions, removals),
                 )
             worker_conn.commit()
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
         futures = [
-            executor.submit(add_once, "concurrent-a"),
-            executor.submit(add_once, "concurrent-b"),
+            executor.submit(apply_once, ["concurrent-a"], []),
+            executor.submit(apply_once, ["concurrent-b"], []),
         ]
         for future in futures:
             future.result(timeout=30)
@@ -560,11 +573,38 @@ def check_issue_4927_tombstone_concurrency(
         raise AssertionError("Issue #4927 tombstone mirror row is missing")
     ids = set(row[0] or [])
     expected = {"concurrent-a", "concurrent-b"}
-    if not expected.issubset(ids):
+    if ids != expected:
         raise AssertionError(
-            f"Issue #4927 lost a concurrent tombstone: {sorted(ids)}"
+            f"Issue #4927 initial concurrent union mismatch: {sorted(ids)}"
         )
-    return {"concurrent_ids": sorted(expected), "server_ids": sorted(ids)}
+
+    barrier = threading.Barrier(2)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(apply_once, ["concurrent-c"], []),
+            executor.submit(apply_once, [], ["concurrent-a"]),
+        ]
+        for future in futures:
+            future.result(timeout=30)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "select value -> 'ids' from public.asset_pref_mirror "
+            "where user_id = %s::uuid and pref_key = 'recurring_fixed_costs_deleted'",
+            (ISSUE_4927_USER,),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    ids = set(row[0] or []) if row is not None else set()
+    final_expected = {"concurrent-b", "concurrent-c"}
+    if ids != final_expected:
+        raise AssertionError(
+            f"Issue #4927 concurrent add/remove mismatch: {sorted(ids)}"
+        )
+    return {
+        "initial_concurrent_ids": sorted(expected),
+        "server_ids": sorted(ids),
+    }
 
 
 def check_issue_1233_ai_quota_concurrency(

--- a/supabase/migrations/20260828164000_atomic_recurring_fixed_cost_tombstones.sql
+++ b/supabase/migrations/20260828164000_atomic_recurring_fixed_cost_tombstones.sql
@@ -8,16 +8,34 @@ create or replace function public.apply_recurring_fixed_cost_tombstones(
 )
 returns jsonb
 language plpgsql
-security invoker
+security definer
 set search_path = pg_catalog, public
 as $$
 declare
   v_user_id uuid := auth.uid();
+  v_existing jsonb;
   v_value jsonb;
 begin
   if v_user_id is null then
     raise exception 'authentication required' using errcode = '42501';
   end if;
+
+  select mirror.value
+  into v_existing
+  from public.asset_pref_mirror as mirror
+  where mirror.user_id = v_user_id
+    and mirror.pref_key = 'recurring_fixed_costs_deleted'
+  for update;
+
+  if found and (
+    jsonb_typeof(v_existing) is distinct from 'object'
+    or jsonb_typeof(v_existing -> 'ids') is distinct from 'array'
+  ) then
+    raise exception 'recurring fixed cost tombstone mirror is malformed'
+      using errcode = '22023';
+  end if;
+
+  perform set_config('app.recurring_tombstone_rpc', 'on', true);
 
   insert into public.asset_pref_mirror as mirror (
     user_id,
@@ -38,10 +56,14 @@ begin
               select distinct btrim(raw.id) as id
               from unnest(coalesce(p_add_ids, array[]::text[])) as raw(id)
               where btrim(raw.id) <> ''
-                and not (
-                  btrim(raw.id) = any (
+                and not exists (
+                  select 1
+                  from unnest(
                     coalesce(p_remove_ids, array[]::text[])
-                  )
+                  ) as removed(id)
+                  where removed.id is not null
+                    and btrim(removed.id) <> ''
+                    and btrim(removed.id) = btrim(raw.id)
                 )
             ) as clean
           ),
@@ -78,10 +100,14 @@ begin
           ) as id
         ) as source
         where btrim(source.id) <> ''
-          and not (
-            btrim(source.id) = any (
+          and not exists (
+            select 1
+            from unnest(
               coalesce(p_remove_ids, array[]::text[])
-            )
+            ) as removed(id)
+            where removed.id is not null
+              and btrim(removed.id) <> ''
+              and btrim(removed.id) = btrim(source.id)
           )
       ) as merged
     ),
@@ -92,6 +118,33 @@ begin
 end;
 $$;
 
+create or replace function public.guard_recurring_fixed_cost_tombstone_writes()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+begin
+  if new.pref_key = 'recurring_fixed_costs_deleted'
+    and coalesce(
+      current_setting('app.recurring_tombstone_rpc', true),
+      ''
+    ) <> 'on'
+  then
+    raise exception 'use apply_recurring_fixed_cost_tombstones()'
+      using errcode = '42501';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists guard_recurring_fixed_cost_tombstone_writes
+  on public.asset_pref_mirror;
+create trigger guard_recurring_fixed_cost_tombstone_writes
+before insert or update on public.asset_pref_mirror
+for each row
+execute function public.guard_recurring_fixed_cost_tombstone_writes();
+
 revoke all on function public.apply_recurring_fixed_cost_tombstones(text[], text[])
   from public;
 revoke all on function public.apply_recurring_fixed_cost_tombstones(text[], text[])
@@ -101,3 +154,6 @@ grant execute on function public.apply_recurring_fixed_cost_tombstones(text[], t
 
 comment on function public.apply_recurring_fixed_cost_tombstones(text[], text[])
 is 'Atomically union/remove recurring fixed-cost tombstone IDs for auth.uid() (#4927).';
+
+revoke all on function public.guard_recurring_fixed_cost_tombstone_writes()
+  from public, anon, authenticated;

--- a/supabase/migrations/20260828164000_atomic_recurring_fixed_cost_tombstones.sql
+++ b/supabase/migrations/20260828164000_atomic_recurring_fixed_cost_tombstones.sql
@@ -1,0 +1,103 @@
+-- #4927: update recurring-fixed-cost tombstones without whole-blob lost updates.
+-- Concurrent devices serialize on the asset_pref_mirror primary key; every write
+-- unions additions with the current row and applies explicit removals atomically.
+
+create or replace function public.apply_recurring_fixed_cost_tombstones(
+  p_add_ids text[] default array[]::text[],
+  p_remove_ids text[] default array[]::text[]
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_value jsonb;
+begin
+  if v_user_id is null then
+    raise exception 'authentication required' using errcode = '42501';
+  end if;
+
+  insert into public.asset_pref_mirror as mirror (
+    user_id,
+    pref_key,
+    value,
+    updated_at
+  )
+  values (
+    v_user_id,
+    'recurring_fixed_costs_deleted',
+    jsonb_build_object(
+      'ids',
+      to_jsonb(
+        coalesce(
+          (
+            select array_agg(clean.id order by clean.id)
+            from (
+              select distinct btrim(raw.id) as id
+              from unnest(coalesce(p_add_ids, array[]::text[])) as raw(id)
+              where btrim(raw.id) <> ''
+                and not (
+                  btrim(raw.id) = any (
+                    coalesce(p_remove_ids, array[]::text[])
+                  )
+                )
+            ) as clean
+          ),
+          array[]::text[]
+        )
+      )
+    ),
+    now()
+  )
+  on conflict (user_id, pref_key) do update
+  set
+    value = (
+      select jsonb_build_object(
+        'ids',
+        coalesce(jsonb_agg(merged.id order by merged.id), '[]'::jsonb)
+      )
+      from (
+        select distinct btrim(source.id) as id
+        from (
+          select jsonb_array_elements_text(
+            case
+              when jsonb_typeof(mirror.value -> 'ids') = 'array'
+                then mirror.value -> 'ids'
+              else '[]'::jsonb
+            end
+          ) as id
+          union all
+          select jsonb_array_elements_text(
+            case
+              when jsonb_typeof(excluded.value -> 'ids') = 'array'
+                then excluded.value -> 'ids'
+              else '[]'::jsonb
+            end
+          ) as id
+        ) as source
+        where btrim(source.id) <> ''
+          and not (
+            btrim(source.id) = any (
+              coalesce(p_remove_ids, array[]::text[])
+            )
+          )
+      ) as merged
+    ),
+    updated_at = now()
+  returning mirror.value into v_value;
+
+  return v_value;
+end;
+$$;
+
+revoke all on function public.apply_recurring_fixed_cost_tombstones(text[], text[])
+  from public;
+revoke all on function public.apply_recurring_fixed_cost_tombstones(text[], text[])
+  from anon;
+grant execute on function public.apply_recurring_fixed_cost_tombstones(text[], text[])
+  to authenticated;
+
+comment on function public.apply_recurring_fixed_cost_tombstones(text[], text[])
+is 'Atomically union/remove recurring fixed-cost tombstone IDs for auth.uid() (#4927).';

--- a/supabase/migrations/20260828164000_atomic_recurring_fixed_cost_tombstones.sql
+++ b/supabase/migrations/20260828164000_atomic_recurring_fixed_cost_tombstones.sql
@@ -15,6 +15,7 @@ declare
   v_user_id uuid := auth.uid();
   v_existing jsonb;
   v_value jsonb;
+  v_previous_guard text;
 begin
   if v_user_id is null then
     raise exception 'authentication required' using errcode = '42501';
@@ -30,14 +31,27 @@ begin
   if found and (
     jsonb_typeof(v_existing) is distinct from 'object'
     or jsonb_typeof(v_existing -> 'ids') is distinct from 'array'
+    or exists (
+      select 1
+      from pg_catalog.jsonb_array_elements(
+        case
+          when jsonb_typeof(v_existing -> 'ids') = 'array'
+            then v_existing -> 'ids'
+          else '[]'::jsonb
+        end
+      ) as element(value)
+      where jsonb_typeof(element.value) is distinct from 'string'
+    )
   ) then
     raise exception 'recurring fixed cost tombstone mirror is malformed'
       using errcode = '22023';
   end if;
 
+  v_previous_guard := current_setting('app.recurring_tombstone_rpc', true);
   perform set_config('app.recurring_tombstone_rpc', 'on', true);
 
-  insert into public.asset_pref_mirror as mirror (
+  begin
+    insert into public.asset_pref_mirror as mirror (
     user_id,
     pref_key,
     value,
@@ -112,7 +126,22 @@ begin
       ) as merged
     ),
     updated_at = now()
-  returning mirror.value into v_value;
+    returning mirror.value into v_value;
+  exception
+    when others then
+      perform set_config(
+        'app.recurring_tombstone_rpc',
+        coalesce(v_previous_guard, ''),
+        true
+      );
+      raise;
+  end;
+
+  perform set_config(
+    'app.recurring_tombstone_rpc',
+    coalesce(v_previous_guard, ''),
+    true
+  );
 
   return v_value;
 end;
@@ -124,15 +153,41 @@ language plpgsql
 security invoker
 set search_path = pg_catalog, public
 as $$
+declare
+  v_rpc_owner name;
+  v_touches_protected boolean;
 begin
-  if new.pref_key = 'recurring_fixed_costs_deleted'
-    and coalesce(
-      current_setting('app.recurring_tombstone_rpc', true),
-      ''
-    ) <> 'on'
+  select pg_catalog.pg_get_userbyid(procedure.proowner)
+  into v_rpc_owner
+  from pg_catalog.pg_proc as procedure
+  where procedure.oid =
+    'public.apply_recurring_fixed_cost_tombstones(text[],text[])'
+      ::pg_catalog.regprocedure;
+
+  v_touches_protected := case tg_op
+    when 'INSERT' then new.pref_key = 'recurring_fixed_costs_deleted'
+    when 'UPDATE' then
+      old.pref_key = 'recurring_fixed_costs_deleted'
+      or new.pref_key = 'recurring_fixed_costs_deleted'
+    when 'DELETE' then old.pref_key = 'recurring_fixed_costs_deleted'
+    else false
+  end;
+
+  if v_touches_protected
+    and (
+      coalesce(
+        current_setting('app.recurring_tombstone_rpc', true),
+        ''
+      ) <> 'on'
+      or current_user is distinct from v_rpc_owner
+    )
   then
     raise exception 'use apply_recurring_fixed_cost_tombstones()'
       using errcode = '42501';
+  end if;
+
+  if tg_op = 'DELETE' then
+    return old;
   end if;
   return new;
 end;
@@ -141,7 +196,7 @@ $$;
 drop trigger if exists guard_recurring_fixed_cost_tombstone_writes
   on public.asset_pref_mirror;
 create trigger guard_recurring_fixed_cost_tombstone_writes
-before insert or update on public.asset_pref_mirror
+before insert or update or delete on public.asset_pref_mirror
 for each row
 execute function public.guard_recurring_fixed_cost_tombstone_writes();
 

--- a/supabase/tests/issue4927_recurring_tombstone_contract.sql
+++ b/supabase/tests/issue4927_recurring_tombstone_contract.sql
@@ -1,0 +1,108 @@
+-- Runtime PostgreSQL contract for Issue #4927. Any mismatch raises and fails
+-- the Testcontainers integration smoke.
+
+insert into auth.users (id)
+values ('00000000-0000-4000-8000-000000004927'::uuid)
+on conflict (id) do nothing;
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '00000000-0000-4000-8000-000000004927',
+  true
+);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+do $contract$
+declare
+  v_value jsonb;
+begin
+  v_value := public.apply_recurring_fixed_cost_tombstones(
+    array['alpha', 'beta', '', ' alpha ']::text[],
+    array[]::text[]
+  );
+  if v_value -> 'ids' is distinct from '["alpha", "beta"]'::jsonb then
+    raise exception 'initial tombstone normalization failed: %', v_value;
+  end if;
+
+  v_value := public.apply_recurring_fixed_cost_tombstones(
+    array['gamma', 'same']::text[],
+    array[' beta ', null, '', 'same']::text[]
+  );
+  if v_value -> 'ids' is distinct from '["alpha", "gamma"]'::jsonb then
+    raise exception 'atomic add/remove contract failed: %', v_value;
+  end if;
+
+  if exists (
+    select 1
+    from pg_catalog.pg_proc as procedure
+    where procedure.oid =
+      'public.apply_recurring_fixed_cost_tombstones(text[],text[])'::regprocedure
+      and (
+        not procedure.prosecdef
+        or not has_function_privilege(
+          'authenticated',
+          procedure.oid,
+          'execute'
+        )
+        or has_function_privilege('anon', procedure.oid, 'execute')
+      )
+  ) then
+    raise exception 'RPC privilege contract is invalid';
+  end if;
+end;
+$contract$;
+
+reset role;
+select set_config('app.recurring_tombstone_rpc', 'off', true);
+
+do $guard$
+begin
+  begin
+    update public.asset_pref_mirror
+    set value = '{"ids": ["overwritten"]}'::jsonb
+    where user_id = '00000000-0000-4000-8000-000000004927'::uuid
+      and pref_key = 'recurring_fixed_costs_deleted';
+    raise exception 'direct whole-blob update unexpectedly succeeded';
+  exception
+    when insufficient_privilege then
+      null;
+  end;
+end;
+$guard$;
+
+select set_config('app.recurring_tombstone_rpc', 'on', true);
+update public.asset_pref_mirror
+set value = '{"ids": "malformed"}'::jsonb
+where user_id = '00000000-0000-4000-8000-000000004927'::uuid
+  and pref_key = 'recurring_fixed_costs_deleted';
+select set_config('app.recurring_tombstone_rpc', 'off', true);
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '00000000-0000-4000-8000-000000004927',
+  true
+);
+do $malformed$
+begin
+  begin
+    perform public.apply_recurring_fixed_cost_tombstones(
+      array['must-not-overwrite']::text[],
+      array[]::text[]
+    );
+    raise exception 'malformed mirror unexpectedly accepted';
+  exception
+    when invalid_parameter_value then
+      null;
+  end;
+end;
+$malformed$;
+reset role;
+
+select set_config('app.recurring_tombstone_rpc', 'on', true);
+update public.asset_pref_mirror
+set value = '{"ids": []}'::jsonb
+where user_id = '00000000-0000-4000-8000-000000004927'::uuid
+  and pref_key = 'recurring_fixed_costs_deleted';
+select set_config('app.recurring_tombstone_rpc', 'off', true);

--- a/supabase/tests/issue4927_recurring_tombstone_contract.sql
+++ b/supabase/tests/issue4927_recurring_tombstone_contract.sql
@@ -5,6 +5,11 @@ insert into auth.users (id)
 values ('00000000-0000-4000-8000-000000004927'::uuid)
 on conflict (id) do nothing;
 
+-- Exercise the trigger itself rather than relying on ambient table grants in
+-- the disposable Testcontainers database.
+grant select, insert, update, delete on public.asset_pref_mirror
+  to authenticated;
+
 set local role authenticated;
 select set_config(
   'request.jwt.claim.sub',
@@ -12,17 +17,24 @@ select set_config(
   true
 );
 select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('app.recurring_tombstone_rpc', 'sentinel', true);
 
 do $contract$
 declare
   v_value jsonb;
 begin
   v_value := public.apply_recurring_fixed_cost_tombstones(
-    array['alpha', 'beta', '', ' alpha ']::text[],
+    array['alpha', 'beta', '', ' alpha ', null]::text[],
     array[]::text[]
   );
   if v_value -> 'ids' is distinct from '["alpha", "beta"]'::jsonb then
     raise exception 'initial tombstone normalization failed: %', v_value;
+  end if;
+
+  if current_setting('app.recurring_tombstone_rpc', true)
+    is distinct from 'sentinel'
+  then
+    raise exception 'RPC guard marker was not restored after success';
   end if;
 
   v_value := public.apply_recurring_fixed_cost_tombstones(
@@ -31,6 +43,14 @@ begin
   );
   if v_value -> 'ids' is distinct from '["alpha", "gamma"]'::jsonb then
     raise exception 'atomic add/remove contract failed: %', v_value;
+  end if;
+
+  v_value := public.apply_recurring_fixed_cost_tombstones(
+    null,
+    array[null, ' ']::text[]
+  );
+  if v_value -> 'ids' is distinct from '["alpha", "gamma"]'::jsonb then
+    raise exception 'NULL input contract failed: %', v_value;
   end if;
 
   if exists (
@@ -53,27 +73,111 @@ begin
 end;
 $contract$;
 
-reset role;
-select set_config('app.recurring_tombstone_rpc', 'off', true);
-
+-- An authenticated caller can set a custom GUC, so the guard must also prove
+-- that the write is executing under the SECURITY DEFINER RPC owner.
+select set_config('app.recurring_tombstone_rpc', 'on', true);
 do $guard$
 begin
   begin
-    update public.asset_pref_mirror
-    set value = '{"ids": ["overwritten"]}'::jsonb
-    where user_id = '00000000-0000-4000-8000-000000004927'::uuid
-      and pref_key = 'recurring_fixed_costs_deleted';
-    raise exception 'direct whole-blob update unexpectedly succeeded';
+    insert into public.asset_pref_mirror (user_id, pref_key, value)
+    values (
+      auth.uid(),
+      'recurring_fixed_costs_deleted',
+      '{"ids": ["insert-bypass"]}'::jsonb
+    );
+    raise exception 'direct protected insert unexpectedly succeeded';
   exception
-    when insufficient_privilege then
-      null;
+    when insufficient_privilege then null;
   end;
+
+  begin
+    update public.asset_pref_mirror
+    set value = '{"ids": ["update-bypass"]}'::jsonb
+    where user_id = auth.uid()
+      and pref_key = 'recurring_fixed_costs_deleted';
+    raise exception 'direct protected update unexpectedly succeeded';
+  exception
+    when insufficient_privilege then null;
+  end;
+
+  begin
+    update public.asset_pref_mirror
+    set pref_key = 'renamed-away'
+    where user_id = auth.uid()
+      and pref_key = 'recurring_fixed_costs_deleted';
+    raise exception 'protected-key rename unexpectedly succeeded';
+  exception
+    when insufficient_privilege then null;
+  end;
+
+  begin
+    delete from public.asset_pref_mirror
+    where user_id = auth.uid()
+      and pref_key = 'recurring_fixed_costs_deleted';
+    raise exception 'direct protected delete unexpectedly succeeded';
+  exception
+    when insufficient_privilege then null;
+  end;
+
+  insert into public.asset_pref_mirror (user_id, pref_key, value)
+  values (auth.uid(), 'issue4927_unrelated', '{"ok": true}'::jsonb);
+
+  update public.asset_pref_mirror
+  set value = '{"ok": false}'::jsonb,
+      pref_key = 'issue4927_unrelated_renamed'
+  where user_id = auth.uid()
+    and pref_key = 'issue4927_unrelated';
+
+  begin
+    update public.asset_pref_mirror
+    set pref_key = 'recurring_fixed_costs_deleted'
+    where user_id = auth.uid()
+      and pref_key = 'issue4927_unrelated_renamed';
+    raise exception 'rename into protected key unexpectedly succeeded';
+  exception
+    when insufficient_privilege then null;
+  end;
+
+  delete from public.asset_pref_mirror
+  where user_id = auth.uid()
+    and pref_key = 'issue4927_unrelated_renamed';
 end;
 $guard$;
 
+-- The successful RPC restored the marker; a direct write immediately after an
+-- RPC in the same transaction is still rejected.
+select set_config('app.recurring_tombstone_rpc', 'sentinel', true);
+do $post_rpc_guard$
+begin
+  perform public.apply_recurring_fixed_cost_tombstones(
+    array['post-rpc']::text[],
+    array[]::text[]
+  );
+  if current_setting('app.recurring_tombstone_rpc', true)
+    is distinct from 'sentinel'
+  then
+    raise exception 'RPC guard marker leaked after call';
+  end if;
+
+  begin
+    update public.asset_pref_mirror
+    set value = '{"ids": ["post-rpc-bypass"]}'::jsonb
+    where user_id = auth.uid()
+      and pref_key = 'recurring_fixed_costs_deleted';
+    raise exception 'post-RPC direct write unexpectedly succeeded';
+  exception
+    when insufficient_privilege then null;
+  end;
+end;
+$post_rpc_guard$;
+
+reset role;
+
+-- Owner-only fixture mutation poisons the row with mixed JSON element types.
+-- The RPC must reject it without changing the row.
 select set_config('app.recurring_tombstone_rpc', 'on', true);
 update public.asset_pref_mirror
-set value = '{"ids": "malformed"}'::jsonb
+set value = '{"ids": ["valid", 42, {}, null]}'::jsonb
 where user_id = '00000000-0000-4000-8000-000000004927'::uuid
   and pref_key = 'recurring_fixed_costs_deleted';
 select set_config('app.recurring_tombstone_rpc', 'off', true);
@@ -91,11 +195,19 @@ begin
       array['must-not-overwrite']::text[],
       array[]::text[]
     );
-    raise exception 'malformed mirror unexpectedly accepted';
+    raise exception 'mixed-type mirror unexpectedly accepted';
   exception
-    when invalid_parameter_value then
-      null;
+    when invalid_parameter_value then null;
   end;
+
+  if (
+    select value
+    from public.asset_pref_mirror
+    where user_id = auth.uid()
+      and pref_key = 'recurring_fixed_costs_deleted'
+  ) is distinct from '{"ids": ["valid", 42, {}, null]}'::jsonb then
+    raise exception 'malformed rejection changed the protected row';
+  end if;
 end;
 $malformed$;
 reset role;

--- a/test/scripts/test_testcontainers_supabase_smoke.py
+++ b/test/scripts/test_testcontainers_supabase_smoke.py
@@ -241,9 +241,11 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
         )
         checks = " ".join(plan["issue_4927_recurring_tombstone_checks"])
         self.assertIn("NULL IDs", checks)
-        self.assertIn("malformed", checks)
-        self.assertIn("whole-blob", checks)
-        self.assertIn("concurrent", checks)
+        self.assertIn("mixed-type malformed", checks)
+        self.assertIn("spoofed-GUC", checks)
+        self.assertIn("unrelated-key CRUD", checks)
+        self.assertIn("guard state", checks)
+        self.assertIn("concurrent add/remove", checks)
         self.assertIn("applies twice", checks)
 
     def test_plan_includes_note_comments_authorization_boundary(self) -> None:

--- a/test/scripts/test_testcontainers_supabase_smoke.py
+++ b/test/scripts/test_testcontainers_supabase_smoke.py
@@ -225,6 +225,27 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
         self.assertIn("manual_override", checks)
         self.assertIn("applies twice", checks)
 
+    def test_plan_includes_issue_4927_recurring_tombstone_contract(self) -> None:
+        plan = module.build_plan(
+            ROOT / "test" / "fixtures" / "testcontainers" / "sql",
+            ROOT / "test" / "fixtures" / "testcontainers" / "edge-db-smoke.ts",
+            ROOT / "supabase" / "functions" / "health-check" / "index.ts",
+        )
+        self.assertEqual(
+            plan["issue_4927_recurring_tombstone_sql"],
+            [
+                "supabase/migrations/20260612230000_asset_pref_mirror.sql",
+                "supabase/migrations/20260828164000_atomic_recurring_fixed_cost_tombstones.sql",
+                "supabase/tests/issue4927_recurring_tombstone_contract.sql",
+            ],
+        )
+        checks = " ".join(plan["issue_4927_recurring_tombstone_checks"])
+        self.assertIn("NULL IDs", checks)
+        self.assertIn("malformed", checks)
+        self.assertIn("whole-blob", checks)
+        self.assertIn("concurrent", checks)
+        self.assertIn("applies twice", checks)
+
     def test_plan_includes_note_comments_authorization_boundary(self) -> None:
         plan = module.build_plan(
             ROOT / "test" / "fixtures" / "testcontainers" / "sql",

--- a/test/services/asset_obsidian_vault_import_service_test.dart
+++ b/test/services/asset_obsidian_vault_import_service_test.dart
@@ -157,6 +157,121 @@ void main() {
 
     expect(preview.candidates, isEmpty);
     expect(preview.recognizedFileCount, 0);
-    expect(preview.warnings, contains('対応する残高表が見つかりませんでした。'));
+    expect(preview.warnings, contains('対応する残高表または解約済みサブスク表が見つかりませんでした。'));
+  });
+
+  test('解約・停止済みセクションだけを解析し、登録中サブスクへ一意に照合する', () {
+    final preview = service.preview(
+      files: [
+        file('company/SUBSCRIPTION_LIST.md', '''
+## 1. 直接確認済み 有効サブスクリプション
+| サービス名 | プラン・内容 | 月額（税込） | 次回更新日 | 判定 / 方針 | 備考 |
+| --- | --- | ---: | --- | --- | --- |
+| Notion | Plus | 1,650円 | 2026-09-01 | 継続 | 有効 |
+
+## 2. 解約・定期請求停止済みサービス
+| サービス名 | プラン・内容 | 終了日 / 停止日 | 状態 | 備考 |
+| --- | --- | --- | --- | --- |
+| Xbox Game Pass | Ultimate | 2026-08-20 | 解約完了 | 履歴は保持 |
+| netkeiba | プレミアム | 2026-08-21 | 停止済み | - |
+| 未確定サービス | - | 2026-08-22 | 解約予定 | まだ有効 |
+'''),
+      ],
+      existingBalances: const [],
+      existingSubscriptions: const [
+        AssetObsidianExistingSubscription(
+          id: 'sub_xbox',
+          name: 'MICROSOFT*XBOX GAME',
+          amount: 1550,
+        ),
+        AssetObsidianExistingSubscription(
+          id: 'sub_notion',
+          name: 'Notion',
+          amount: 1650,
+        ),
+      ],
+    );
+
+    expect(preview.recognizedFileCount, 0);
+    expect(preview.recognizedCancellationFileCount, 1);
+    expect(preview.subscriptionCancellations, hasLength(2));
+    final xbox = preview.subscriptionCancellations.singleWhere(
+      (candidate) => candidate.sourceSubscriptionName == 'Xbox Game Pass',
+    );
+    expect(xbox.status, AssetObsidianSubscriptionCancellationStatus.matched);
+    expect(xbox.matchedSubscriptionId, 'sub_xbox');
+    expect(xbox.matchedMonthlyAmount, 1550);
+    expect(xbox.isDeletable, isTrue);
+    final netkeiba = preview.subscriptionCancellations.singleWhere(
+      (candidate) => candidate.sourceSubscriptionName == 'netkeiba',
+    );
+    expect(
+      netkeiba.status,
+      AssetObsidianSubscriptionCancellationStatus.notRegistered,
+    );
+    expect(netkeiba.isDeletable, isFalse);
+    expect(
+      preview.initiallySelectedSubscriptionCancellations.map(
+        (candidate) => candidate.matchedSubscriptionId,
+      ),
+      ['sub_xbox'],
+    );
+  });
+
+  test('同名の登録中サブスクが複数ある場合は競合として削除不可にする', () {
+    final preview = service.preview(
+      files: [
+        file('vault/SUBSCRIPTION_LIST.md', '''
+## 解約・定期請求停止済みサービス
+| サービス名 | 終了日 / 停止日 | 状態 |
+| --- | --- | --- |
+| Yousician | 2026-08-20 | 解約済み |
+'''),
+      ],
+      existingBalances: const [],
+      existingSubscriptions: const [
+        AssetObsidianExistingSubscription(
+          id: 'sub_yousician_a',
+          name: 'Yousician',
+          amount: 2000,
+        ),
+        AssetObsidianExistingSubscription(
+          id: 'sub_yousician_b',
+          name: 'Yousician',
+          amount: 3000,
+        ),
+      ],
+    );
+
+    final candidate = preview.subscriptionCancellations.single;
+    expect(
+      candidate.status,
+      AssetObsidianSubscriptionCancellationStatus.conflict,
+    );
+    expect(candidate.isDeletable, isFalse);
+    expect(candidate.conflictingSubscriptionNames, ['Yousician', 'Yousician']);
+  });
+
+  test('有効一覧から消えただけのサブスクは削除候補にしない', () {
+    final preview = service.preview(
+      files: [
+        file('vault/SUBSCRIPTION_LIST.md', '''
+## 直接確認済み 有効サブスクリプション
+| サービス名 | 月額（税込） | 状態 |
+| --- | ---: | --- |
+| Notion | 1,650円 | 有効 |
+'''),
+      ],
+      existingBalances: const [],
+      existingSubscriptions: const [
+        AssetObsidianExistingSubscription(
+          id: 'sub_chatgpt',
+          name: 'ChatGPT',
+          amount: 3000,
+        ),
+      ],
+    );
+
+    expect(preview.subscriptionCancellations, isEmpty);
   });
 }

--- a/test/services/asset_obsidian_vault_import_service_test.dart
+++ b/test/services/asset_obsidian_vault_import_service_test.dart
@@ -274,4 +274,79 @@ void main() {
 
     expect(preview.subscriptionCancellations, isEmpty);
   });
+
+  test('区切り記号が異なる一般名は同一サブスクとして照合しない', () {
+    final preview = service.preview(
+      files: [
+        file('vault/SUBSCRIPTION_LIST.md', '''
+## 解約・定期請求停止済みサービス
+| サービス名 | 終了日 / 停止日 | 状態 |
+| --- | --- | --- |
+| A/B | 2026-08-20 | 解約完了 |
+| Foo-Bar | 2026-08-20 | 停止済み |
+'''),
+      ],
+      existingBalances: const [],
+      existingSubscriptions: const [
+        AssetObsidianExistingSubscription(
+          id: 'sub_ab',
+          name: 'AB',
+          amount: 1000,
+        ),
+        AssetObsidianExistingSubscription(
+          id: 'sub_foo',
+          name: 'Foo Bar',
+          amount: 1000,
+        ),
+      ],
+    );
+
+    expect(preview.subscriptionCancellations, hasLength(2));
+    expect(
+      preview.subscriptionCancellations.map((candidate) => candidate.status),
+      everyElement(AssetObsidianSubscriptionCancellationStatus.notRegistered),
+    );
+    expect(preview.initiallySelectedSubscriptionCancellations, isEmpty);
+  });
+
+  test('完了状態を含むだけの予定・否定表現は削除候補にしない', () {
+    final preview = service.preview(
+      files: [
+        file('vault/SUBSCRIPTION_LIST.md', '''
+## 解約・定期請求停止済みサービス
+| サービス名 | 終了日 / 停止日 | 状態 |
+| --- | --- | --- |
+| Service A | 2026-08-20 | 解約完了予定 |
+| Service B | 2026-08-20 | 未解約済み |
+| Service C | 2026-08-20 | 解約済みではない |
+| Service D | 2026-08-20 | 停止済み予定 |
+'''),
+      ],
+      existingBalances: const [],
+      existingSubscriptions: const [
+        AssetObsidianExistingSubscription(
+          id: 'sub_a',
+          name: 'Service A',
+          amount: 1000,
+        ),
+        AssetObsidianExistingSubscription(
+          id: 'sub_b',
+          name: 'Service B',
+          amount: 1000,
+        ),
+        AssetObsidianExistingSubscription(
+          id: 'sub_c',
+          name: 'Service C',
+          amount: 1000,
+        ),
+        AssetObsidianExistingSubscription(
+          id: 'sub_d',
+          name: 'Service D',
+          amount: 1000,
+        ),
+      ],
+    );
+
+    expect(preview.subscriptionCancellations, isEmpty);
+  });
 }

--- a/test/services/asset_recurring_tombstone_schema_test.dart
+++ b/test/services/asset_recurring_tombstone_schema_test.dart
@@ -44,6 +44,12 @@ void main() {
       sql,
       contains("current_setting('app.recurring_tombstone_rpc', true)"),
     );
+    expect(sql, contains('security invoker'));
+    expect(sql, contains('before insert or update or delete'));
+    expect(sql, contains("old.pref_key = 'recurring_fixed_costs_deleted'"));
+    expect(sql, contains("new.pref_key = 'recurring_fixed_costs_deleted'"));
+    expect(sql, contains('current_user is distinct from v_rpc_owner'));
+    expect(sql, contains("if tg_op = 'delete' then"));
   });
 
   test('atomically unions current and incoming IDs before explicit removal',
@@ -61,6 +67,20 @@ void main() {
         "jsonb_typeof(v_existing -> 'ids') is distinct from 'array'",
       ),
     );
+    expect(sql, contains('pg_catalog.jsonb_array_elements'));
+    expect(
+      sql,
+      contains("jsonb_typeof(element.value) is distinct from 'string'"),
+    );
+    expect(sql, contains('v_previous_guard text'));
+    expect(
+      RegExp(
+        r"coalesce\s*\(\s*v_previous_guard,\s*''\s*\)",
+        caseSensitive: false,
+        multiLine: true,
+      ).allMatches(sql).length,
+      greaterThanOrEqualTo(2),
+    );
     expect(sql, contains('returning mirror.value into v_value'));
   });
 
@@ -74,10 +94,17 @@ void main() {
     );
 
     final method = source
-        .split('Future<bool> _mirrorRecurringFixedCostsDeleted() async {')[1]
+        .split('Future<bool> _mirrorRecurringFixedCostsDeleted({')[1]
         .split('Future<void> _pullRecurringFixedCostDeleted()')[0];
     expect(method, isNot(contains(".from('asset_pref_mirror').upsert")));
-    expect(method, contains('_syncDirtyKeysStore.loadDirty'));
-    expect(method, contains('_syncDirtyKeysStore.updateDirty'));
+    expect(method, contains('_recurringTombstoneSyncService.sync'));
+
+    final syncService = File(
+      'lib/services/asset_recurring_tombstone_sync_service.dart',
+    ).readAsStringSync();
+    expect(syncService, contains('(_tail ?? Future<void>.value()).then'));
+    expect(syncService, contains('_dirtyKeysStore.loadDirty'));
+    expect(syncService, contains('_dirtyKeysStore.updateDirty'));
+    expect(syncService, contains('await afterSync()'));
   });
 }

--- a/test/services/asset_recurring_tombstone_schema_test.dart
+++ b/test/services/asset_recurring_tombstone_schema_test.dart
@@ -16,7 +16,8 @@ void main() {
     expect(
       sql,
       contains(
-          'create or replace function public.apply_recurring_fixed_cost_tombstones'),
+        'create or replace function public.apply_recurring_fixed_cost_tombstones',
+      ),
     );
     expect(sql, contains('security definer'));
     expect(sql, contains('v_user_id uuid := auth.uid()'));

--- a/test/services/asset_recurring_tombstone_schema_test.dart
+++ b/test/services/asset_recurring_tombstone_schema_test.dart
@@ -12,14 +12,13 @@ void main() {
     sql = File(_migrationPath).readAsStringSync().toLowerCase();
   });
 
-  test('uses an authenticated security-invoker RPC with a fixed mirror key',
-      () {
+  test('uses an authenticated fixed-key RPC and guards direct writes', () {
     expect(
       sql,
       contains(
           'create or replace function public.apply_recurring_fixed_cost_tombstones'),
     );
-    expect(sql, contains('security invoker'));
+    expect(sql, contains('security definer'));
     expect(sql, contains('v_user_id uuid := auth.uid()'));
     expect(sql, contains("'recurring_fixed_costs_deleted'"));
     expect(sql, isNot(contains('p_pref_key')));
@@ -37,6 +36,14 @@ void main() {
         '  from anon',
       ),
     );
+    expect(
+      sql,
+      contains('create trigger guard_recurring_fixed_cost_tombstone_writes'),
+    );
+    expect(
+      sql,
+      contains("current_setting('app.recurring_tombstone_rpc', true)"),
+    );
   });
 
   test('atomically unions current and incoming IDs before explicit removal',
@@ -46,6 +53,14 @@ void main() {
     expect(sql, contains("jsonb_typeof(excluded.value -> 'ids') = 'array'"));
     expect(sql, contains('select distinct btrim(source.id) as id'));
     expect(sql, contains('coalesce(p_remove_ids, array[]::text[])'));
+    expect(sql, contains('and not exists'));
+    expect(sql, contains('where removed.id is not null'));
+    expect(
+      sql,
+      contains(
+        "jsonb_typeof(v_existing -> 'ids') is distinct from 'array'",
+      ),
+    );
     expect(sql, contains('returning mirror.value into v_value'));
   });
 
@@ -59,9 +74,10 @@ void main() {
     );
 
     final method = source
-        .split('Future<void> _mirrorRecurringFixedCostsDeleted({')[1]
+        .split('Future<bool> _mirrorRecurringFixedCostsDeleted() async {')[1]
         .split('Future<void> _pullRecurringFixedCostDeleted()')[0];
     expect(method, isNot(contains(".from('asset_pref_mirror').upsert")));
-    expect(method, contains('throwOnFailure'));
+    expect(method, contains('_syncDirtyKeysStore.loadDirty'));
+    expect(method, contains('_syncDirtyKeysStore.updateDirty'));
   });
 }

--- a/test/services/asset_recurring_tombstone_schema_test.dart
+++ b/test/services/asset_recurring_tombstone_schema_test.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260828164000_atomic_recurring_fixed_cost_tombstones.sql';
+
+void main() {
+  late String sql;
+
+  setUpAll(() {
+    sql = File(_migrationPath).readAsStringSync().toLowerCase();
+  });
+
+  test('uses an authenticated security-invoker RPC with a fixed mirror key',
+      () {
+    expect(
+      sql,
+      contains(
+          'create or replace function public.apply_recurring_fixed_cost_tombstones'),
+    );
+    expect(sql, contains('security invoker'));
+    expect(sql, contains('v_user_id uuid := auth.uid()'));
+    expect(sql, contains("'recurring_fixed_costs_deleted'"));
+    expect(sql, isNot(contains('p_pref_key')));
+    expect(
+      sql,
+      contains(
+        'grant execute on function public.apply_recurring_fixed_cost_tombstones(text[], text[])\n'
+        '  to authenticated',
+      ),
+    );
+    expect(
+      sql,
+      contains(
+        'revoke all on function public.apply_recurring_fixed_cost_tombstones(text[], text[])\n'
+        '  from anon',
+      ),
+    );
+  });
+
+  test('atomically unions current and incoming IDs before explicit removal',
+      () {
+    expect(sql, contains('on conflict (user_id, pref_key) do update'));
+    expect(sql, contains("jsonb_typeof(mirror.value -> 'ids') = 'array'"));
+    expect(sql, contains("jsonb_typeof(excluded.value -> 'ids') = 'array'"));
+    expect(sql, contains('select distinct btrim(source.id) as id'));
+    expect(sql, contains('coalesce(p_remove_ids, array[]::text[])'));
+    expect(sql, contains('returning mirror.value into v_value'));
+  });
+
+  test('Flutter calls the RPC instead of replacing the tombstone blob', () {
+    final source = File(
+      'lib/pages/asset_management_page.dart',
+    ).readAsStringSync();
+    expect(
+      source,
+      contains(".rpc('apply_recurring_fixed_cost_tombstones', params:"),
+    );
+
+    final method = source
+        .split('Future<void> _mirrorRecurringFixedCostsDeleted({')[1]
+        .split('Future<void> _pullRecurringFixedCostDeleted()')[0];
+    expect(method, isNot(contains(".from('asset_pref_mirror').upsert")));
+    expect(method, contains('throwOnFailure'));
+  });
+}

--- a/test/services/asset_recurring_tombstone_sync_service_test.dart
+++ b/test/services/asset_recurring_tombstone_sync_service_test.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_recurring_tombstone_sync_service.dart';
+import 'package:my_web_app/services/asset_sync_dirty_keys_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    AssetSyncDirtyKeysStore.resetWriteLockForTest();
+    AssetRecurringTombstoneSyncService.resetSharedForTest();
+  });
+
+  test('serializes delayed delete then re-add through snapshot and ack',
+      () async {
+    const prefKey = 'recurring_fixed_costs_deleted';
+    final prefs = await SharedPreferences.getInstance();
+    final deleteService = AssetRecurringTombstoneSyncService.shared;
+    final readdService = AssetRecurringTombstoneSyncService.shared;
+    expect(identical(deleteService, readdService), isTrue);
+    final firstRpcStarted = Completer<void>();
+    final releaseFirstRpc = Completer<void>();
+    final serverIds = <String>{};
+    var rpcCalls = 0;
+
+    Future<void> fakeRpc(
+      List<String> additions,
+      List<String> removals,
+    ) async {
+      rpcCalls += 1;
+      if (rpcCalls == 1) {
+        firstRpcStarted.complete();
+        await releaseFirstRpc.future;
+      }
+      serverIds.addAll(additions);
+      serverIds.removeAll(removals);
+    }
+
+    await deleteService.queue(
+      prefKey,
+      'sub_xbox',
+      deleted: true,
+      prefs: prefs,
+    );
+    final deleteSync = deleteService.sync(
+      prefKey: prefKey,
+      prefs: prefs,
+      rpc: fakeRpc,
+    );
+    await firstRpcStarted.future;
+
+    await readdService.queue(
+      prefKey,
+      'sub_xbox',
+      deleted: false,
+      prefs: prefs,
+    );
+    final readdSync = readdService.sync(
+      prefKey: prefKey,
+      prefs: prefs,
+      rpc: fakeRpc,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(rpcCalls, 1, reason: 'the re-add RPC must wait for delete ack');
+
+    releaseFirstRpc.complete();
+    expect(await deleteSync, isTrue);
+    expect(await readdSync, isTrue);
+
+    expect(rpcCalls, 2);
+    expect(serverIds, isNot(contains('sub_xbox')));
+    expect(
+      await const AssetSyncDirtyKeysStore().loadDirty(
+        prefKey,
+        prefs: prefs,
+      ),
+      isEmpty,
+    );
+  });
+
+  test('a failed RPC keeps dirty state and does not poison the queue',
+      () async {
+    const prefKey = 'recurring_fixed_costs_deleted';
+    final prefs = await SharedPreferences.getInstance();
+    final service = AssetRecurringTombstoneSyncService();
+    var attempts = 0;
+
+    await service.queue(
+      prefKey,
+      'sub_retry',
+      deleted: true,
+      prefs: prefs,
+    );
+    final failed = await service.sync(
+      prefKey: prefKey,
+      prefs: prefs,
+      rpc: (_, __) async {
+        attempts += 1;
+        throw StateError('offline');
+      },
+    );
+    expect(failed, isFalse);
+    expect(
+      await const AssetSyncDirtyKeysStore().loadDirty(
+        prefKey,
+        prefs: prefs,
+      ),
+      contains('add:sub_retry'),
+    );
+
+    final serverIds = <String>{};
+    final retried = await service.sync(
+      prefKey: prefKey,
+      prefs: prefs,
+      rpc: (additions, removals) async {
+        attempts += 1;
+        serverIds.addAll(additions);
+        serverIds.removeAll(removals);
+      },
+    );
+    expect(retried, isTrue);
+    expect(attempts, 2);
+    expect(serverIds, contains('sub_retry'));
+    expect(
+      await const AssetSyncDirtyKeysStore().loadDirty(
+        prefKey,
+        prefs: prefs,
+      ),
+      isEmpty,
+    );
+  });
+
+  test('a failed current-mirror step keeps tombstone work retryable', () async {
+    const prefKey = 'recurring_fixed_costs_deleted';
+    final prefs = await SharedPreferences.getInstance();
+    final service = AssetRecurringTombstoneSyncService();
+    var rpcCalls = 0;
+    var currentMirrorCalls = 0;
+
+    await service.queue(
+      prefKey,
+      'sub_current_retry',
+      deleted: false,
+      prefs: prefs,
+    );
+    final failed = await service.sync(
+      prefKey: prefKey,
+      prefs: prefs,
+      rpc: (_, __) async {
+        rpcCalls += 1;
+      },
+      afterSync: () async {
+        currentMirrorCalls += 1;
+        throw StateError('current mirror offline');
+      },
+    );
+    expect(failed, isFalse);
+    expect(
+      await const AssetSyncDirtyKeysStore().loadDirty(
+        prefKey,
+        prefs: prefs,
+      ),
+      contains('remove:sub_current_retry'),
+    );
+
+    final retried = await service.sync(
+      prefKey: prefKey,
+      prefs: prefs,
+      rpc: (_, __) async {
+        rpcCalls += 1;
+      },
+      afterSync: () async {
+        currentMirrorCalls += 1;
+      },
+    );
+    expect(retried, isTrue);
+    expect(rpcCalls, 2);
+    expect(currentMirrorCalls, 2);
+    expect(
+      await const AssetSyncDirtyKeysStore().loadDirty(
+        prefKey,
+        prefs: prefs,
+      ),
+      isEmpty,
+    );
+  });
+}

--- a/test/services/asset_sync_dirty_keys_store_test.dart
+++ b/test/services/asset_sync_dirty_keys_store_test.dart
@@ -34,6 +34,29 @@ void main() {
       expect(await store.loadDirty('domB', prefs: sp), <String>{'x'});
     });
 
+    test('updateDirty atomically replaces opposing operation keys', () async {
+      final sp = await prefs();
+      await store.markDirty('tombstones', 'add:item', prefs: sp);
+
+      await store.updateDirty(
+        'tombstones',
+        addKeys: const <String>['remove:item'],
+        removeKeys: const <String>['add:item'],
+        prefs: sp,
+      );
+
+      expect(
+        await store.loadDirty('tombstones', prefs: sp),
+        <String>{'remove:item'},
+      );
+      await store.updateDirty(
+        'tombstones',
+        removeKeys: const <String>['remove:item'],
+        prefs: sp,
+      );
+      expect(await store.loadDirty('tombstones', prefs: sp), isEmpty);
+    });
+
     test('tolerates malformed json', () async {
       SharedPreferences.setMockInitialValues(<String, Object>{
         AssetSyncDirtyKeysStore.prefsKey: 'not json',

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -2547,6 +2547,65 @@ void main() {
     );
 
     testWidgets(
+      'subscription delete confirms history retention and records tombstone',
+      (tester) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          AssetRecurringFixedCostStore.prefsKey: jsonEncode(
+            AssetRecurringFixedCostStore.encodeMirrorValue(
+              const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'sub_xbox',
+                  name: 'Xbox Game Pass',
+                  amount: 1550,
+                  paymentDay: 7,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                ),
+              ],
+            ),
+          ),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 3000));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await _pumpAssetPage(tester);
+        final deleteButton = find.byTooltip('Xbox Game Pass を削除');
+        expect(deleteButton, findsOneWidget);
+        await tester.ensureVisible(deleteButton);
+        await tester.tap(deleteButton);
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('サブスクを削除'), findsOneWidget);
+        expect(find.textContaining('月額 ¥1,550'), findsOneWidget);
+        expect(find.textContaining('過去の月次履歴・取引履歴は残ります'), findsOneWidget);
+        await tester.tap(find.widgetWithText(TextButton, 'キャンセル'));
+        await tester.pump(const Duration(milliseconds: 100));
+        final afterCancel = await const AssetRecurringFixedCostStore().load();
+        expect(
+          afterCancel.map((cost) => cost.id),
+          contains('sub_xbox'),
+        );
+
+        await tester.tap(deleteButton);
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.tap(find.widgetWithText(FilledButton, '削除'));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final afterDelete = await const AssetRecurringFixedCostStore().load();
+        expect(
+          afterDelete.map((cost) => cost.id),
+          isNot(contains('sub_xbox')),
+        );
+        final preferences = await SharedPreferences.getInstance();
+        const tombstones = MirrorTombstoneStore(
+          storageKey: 'recurring_fixed_costs_deleted_v1',
+        );
+        expect(tombstones.activeIds(preferences), contains('sub_xbox'));
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
       'tombstoned recurring fixed cost is not resurfaced when the server '
       'mirror still contains it',
       (tester) async {

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/models/asset_obsidian_vault_import.dart';
 import 'package:my_web_app/pages/asset_management_page.dart';
 import 'package:my_web_app/services/asset_chat_privacy_settings_service.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
@@ -100,6 +101,76 @@ void main() {
     // static write-lock future を現在の zone の完了済み future へ再初期化する
     // (= 将来ログイン状態の編集 smoke が write 経路を踏んでも orphan-hang しない)。
     AssetSyncDirtyKeysStore.resetWriteLockForTest();
+  });
+
+  test('Obsidian解約候補は全変更前に現在のサブスクへ再照合する', () {
+    const current = <AssetRecurringFixedCost>[
+      AssetRecurringFixedCost(
+        id: 'sub_xbox',
+        name: 'Xbox Game Pass',
+        amount: 1550,
+        paymentDay: 7,
+        category: AssetRecurringFixedCostCategory.subscription,
+      ),
+    ];
+    const valid = AssetObsidianSubscriptionCancellationCandidate(
+      sourceSubscriptionName: 'Xbox Game Pass',
+      sourceStatus: '解約完了',
+      status: AssetObsidianSubscriptionCancellationStatus.matched,
+      sourcePaths: <String>['SUBSCRIPTION_LIST.md'],
+      matchedSubscriptionId: 'sub_xbox',
+      matchedSubscriptionName: 'Xbox Game Pass',
+      matchedMonthlyAmount: 1550,
+    );
+
+    expect(
+      validateObsidianSubscriptionCancellations(
+        const <AssetObsidianSubscriptionCancellationCandidate>[valid],
+        current,
+      ),
+      current,
+    );
+    expect(
+      () => validateObsidianSubscriptionCancellations(
+        const <AssetObsidianSubscriptionCancellationCandidate>[
+          AssetObsidianSubscriptionCancellationCandidate(
+            sourceSubscriptionName: 'Xbox Game Pass',
+            sourceStatus: '解約完了',
+            status: AssetObsidianSubscriptionCancellationStatus.notRegistered,
+            sourcePaths: <String>['SUBSCRIPTION_LIST.md'],
+            matchedSubscriptionId: 'sub_xbox',
+            matchedSubscriptionName: 'Xbox Game Pass',
+            matchedMonthlyAmount: 1550,
+          ),
+        ],
+        current,
+      ),
+      throwsStateError,
+    );
+    expect(
+      () => validateObsidianSubscriptionCancellations(
+        const <AssetObsidianSubscriptionCancellationCandidate>[valid, valid],
+        current,
+      ),
+      throwsStateError,
+    );
+    expect(
+      () => validateObsidianSubscriptionCancellations(
+        const <AssetObsidianSubscriptionCancellationCandidate>[
+          AssetObsidianSubscriptionCancellationCandidate(
+            sourceSubscriptionName: 'Xbox Game Pass',
+            sourceStatus: '解約完了',
+            status: AssetObsidianSubscriptionCancellationStatus.matched,
+            sourcePaths: <String>['SUBSCRIPTION_LIST.md'],
+            matchedSubscriptionId: 'sub_xbox',
+            matchedSubscriptionName: 'Xbox Game Pass',
+            matchedMonthlyAmount: 999,
+          ),
+        ],
+        current,
+      ),
+      throwsStateError,
+    );
   });
 
   group('AssetManagementPage smoke', () {

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -13,6 +13,7 @@ import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
+import 'package:my_web_app/services/asset_recurring_tombstone_sync_service.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_salary_day_store.dart';
 import 'package:my_web_app/services/asset_subscription_audit_store.dart';
@@ -69,10 +70,24 @@ class _ThrowingWatchlistService extends AssetWatchlistService {
   }
 }
 
+class _ThrowingRecurringFixedCostStore extends AssetRecurringFixedCostStore {
+  const _ThrowingRecurringFixedCostStore();
+
+  @override
+  Future<void> save(
+    List<AssetRecurringFixedCost> costs, {
+    SharedPreferences? prefs,
+  }) async {
+    throw StateError('simulated recurring fixed cost save failure');
+  }
+}
+
 /// 資産管理ページの widget スモーク足場 (#3260)。
 /// 未ログイン (auth.currentUser == null) では Supabase フェッチ群が
 /// 早期 return する性質を利用し、ネットワークなしで UI 契約だけを検証する。
 Future<void> _pumpAssetPage(WidgetTester tester) async {
+  AssetSyncDirtyKeysStore.resetWriteLockForTest();
+  AssetRecurringTombstoneSyncService.resetSharedForTest();
   await tester.pumpWidget(
     const MaterialApp(home: AssetManagementPage()),
   );
@@ -101,6 +116,7 @@ void main() {
     // static write-lock future を現在の zone の完了済み future へ再初期化する
     // (= 将来ログイン状態の編集 smoke が write 経路を踏んでも orphan-hang しない)。
     AssetSyncDirtyKeysStore.resetWriteLockForTest();
+    AssetRecurringTombstoneSyncService.resetSharedForTest();
   });
 
   test('Obsidian解約候補は全変更前に現在のサブスクへ再照合する', () {
@@ -2649,28 +2665,124 @@ void main() {
         expect(find.textContaining('月額 ¥1,550'), findsOneWidget);
         expect(find.textContaining('過去の月次履歴・取引履歴は残ります'), findsOneWidget);
         await tester.tap(find.widgetWithText(TextButton, 'キャンセル'));
-        await tester.pump(const Duration(milliseconds: 100));
+        await tester.pump(const Duration(milliseconds: 400));
+        expect(find.text('サブスクを削除'), findsNothing);
         final afterCancel = await const AssetRecurringFixedCostStore().load();
         expect(
           afterCancel.map((cost) => cost.id),
           contains('sub_xbox'),
         );
 
-        await tester.tap(deleteButton);
+        await tester.ensureVisible(deleteButton);
         await tester.pump(const Duration(milliseconds: 100));
-        await tester.tap(find.widgetWithText(FilledButton, '削除'));
+        await tester.tap(deleteButton.hitTestable());
         await tester.pump(const Duration(milliseconds: 300));
+        expect(find.text('サブスクを削除'), findsOneWidget);
+        final confirmDelete = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, '削除'),
+        );
+        confirmDelete.onPressed!();
+        await tester.pump(const Duration(milliseconds: 400));
+        expect(find.text('サブスクを削除'), findsNothing);
+        for (var attempt = 0; attempt < 50; attempt++) {
+          await tester.pump(const Duration(milliseconds: 100));
+          final persisted = await const AssetRecurringFixedCostStore().load();
+          if (persisted.every((cost) => cost.id != 'sub_xbox')) break;
+        }
 
         final afterDelete = await const AssetRecurringFixedCostStore().load();
-        expect(
-          afterDelete.map((cost) => cost.id),
-          isNot(contains('sub_xbox')),
-        );
         final preferences = await SharedPreferences.getInstance();
         const tombstones = MirrorTombstoneStore(
           storageKey: 'recurring_fixed_costs_deleted_v1',
         );
+        final activeTombstones = tombstones.activeIds(preferences);
+        final pendingSync = await const AssetSyncDirtyKeysStore().loadDirty(
+          'recurring_fixed_costs_deleted',
+          prefs: preferences,
+        );
+        expect(
+          afterDelete.map((cost) => cost.id),
+          isNot(contains('sub_xbox')),
+          reason: 'tombstones=$activeTombstones pending=$pendingSync',
+        );
+        expect(activeTombstones, contains('sub_xbox'));
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'failed subscription re-add save restores pending and tombstone state',
+      (tester) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          AssetRecurringFixedCostStore.prefsKey: jsonEncode(
+            AssetRecurringFixedCostStore.encodeMirrorValue(
+              const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'sub_xbox',
+                  name: 'Xbox Game Pass',
+                  amount: 1550,
+                  paymentDay: 7,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                ),
+              ],
+            ),
+          ),
+        });
+        AssetSyncDirtyKeysStore.resetWriteLockForTest();
+        AssetRecurringTombstoneSyncService.resetSharedForTest();
+        await tester.binding.setSurfaceSize(const Size(1200, 3000));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AssetManagementPage(
+              debugRecurringFixedCostStore: _ThrowingRecurringFixedCostStore(),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 400));
+
+        final preferences = await SharedPreferences.getInstance();
+        const tombstones = MirrorTombstoneStore(
+          storageKey: 'recurring_fixed_costs_deleted_v1',
+        );
+        await tombstones.addId(preferences, 'sub_xbox');
+        await const AssetSyncDirtyKeysStore().updateDirty(
+          'recurring_fixed_costs_deleted',
+          addKeys: <String>['add:sub_xbox'],
+          prefs: preferences,
+        );
+
+        final reviewMenu = find.byKey(
+          const Key('subscription_review_sub_xbox'),
+        );
+        await tester.ensureVisible(reviewMenu);
+        await tester.tap(reviewMenu);
+        await tester.pump(const Duration(milliseconds: 500));
+        final keepLabel = find.text('残す').last;
+        expect(keepLabel, findsOneWidget);
+        Navigator.of(tester.element(keepLabel)).pop(
+          AssetSubscriptionReviewDecision.keep,
+        );
+        await tester.pump(const Duration(milliseconds: 500));
+
+        final persisted = await const AssetRecurringFixedCostStore().load(
+          prefs: preferences,
+        );
+        expect(
+          persisted.single.subscriptionReviewDecision,
+          AssetSubscriptionReviewDecision.unreviewed,
+        );
         expect(tombstones.activeIds(preferences), contains('sub_xbox'));
+        expect(
+          await const AssetSyncDirtyKeysStore().loadDirty(
+            'recurring_fixed_costs_deleted',
+            prefs: preferences,
+          ),
+          contains('add:sub_xbox'),
+        );
+        expect(find.textContaining('元の状態を保持'), findsOneWidget);
 
         await _unmount(tester);
       },
@@ -2798,6 +2910,84 @@ void main() {
           storageKey: 'recurring_fixed_costs_deleted_v1',
         );
         expect(tombstones.activeIds(preferences), isNot(contains('sub_xbox')));
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'legacy local tombstone is journaled before remote-authoritative boot',
+      (tester) async {
+        AssetSyncDirtyKeysStore.resetWriteLockForTest();
+        AssetRecurringTombstoneSyncService.resetSharedForTest();
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          AssetRecurringFixedCostStore.prefsKey: jsonEncode(
+            AssetRecurringFixedCostStore.encodeMirrorValue(
+              const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'sub_legacy_deleted',
+                  name: 'Legacy deleted subscription',
+                  amount: 980,
+                  paymentDay: 8,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                ),
+              ],
+            ),
+          ),
+          'recurring_fixed_costs_deleted_v1': jsonEncode(
+            const <String>['sub_legacy_deleted'],
+          ),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AssetManagementPage(
+              debugRecurringFixedCostsDeletedMirror: <String, dynamic>{
+                'ids': <String>[],
+              },
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+        for (var attempt = 0; attempt < 30; attempt++) {
+          final preferences = await SharedPreferences.getInstance();
+          if (preferences.getBool(
+                'recurring_fixed_cost_tombstone_pending_v2_migrated',
+              ) ==
+              true) {
+            break;
+          }
+          await tester.pump(const Duration(milliseconds: 100));
+        }
+
+        final preferences = await SharedPreferences.getInstance();
+        const tombstones = MirrorTombstoneStore(
+          storageKey: 'recurring_fixed_costs_deleted_v1',
+        );
+        final activeTombstones = tombstones.activeIds(preferences);
+        final pendingSync = await const AssetSyncDirtyKeysStore().loadDirty(
+          'recurring_fixed_costs_deleted',
+          prefs: preferences,
+        );
+        final local = await const AssetRecurringFixedCostStore().load();
+        expect(
+          local.map((cost) => cost.id),
+          isNot(contains('sub_legacy_deleted')),
+          reason: 'tombstones=$activeTombstones pending=$pendingSync',
+        );
+        expect(
+          pendingSync,
+          contains('add:sub_legacy_deleted'),
+        );
+        expect(
+          preferences.getBool(
+            'recurring_fixed_cost_tombstone_pending_v2_migrated',
+          ),
+          isTrue,
+        );
 
         await _unmount(tester);
       },

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -2746,6 +2746,64 @@ void main() {
     );
 
     testWidgets(
+      'pending tombstone removal preserves a deliberately re-added subscription',
+      (tester) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          AssetRecurringFixedCostStore.prefsKey: jsonEncode(
+            AssetRecurringFixedCostStore.encodeMirrorValue(
+              const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'sub_xbox',
+                  name: 'Xbox Game Pass',
+                  amount: 1550,
+                  paymentDay: 7,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                ),
+              ],
+            ),
+          ),
+          'recurring_fixed_costs_deleted_v1': jsonEncode(
+            const <Map<String, String>>[
+              <String, String>{
+                'id': 'sub_xbox',
+                'at': '2026-08-27T00:00:00.000Z',
+              },
+            ],
+          ),
+          AssetSyncDirtyKeysStore.prefsKey: jsonEncode(
+            const <String, List<String>>{
+              'recurring_fixed_costs_deleted': <String>['remove:sub_xbox'],
+            },
+          ),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AssetManagementPage(
+              debugRecurringFixedCostsDeletedMirror: <String, dynamic>{
+                'ids': <String>[],
+              },
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final local = await const AssetRecurringFixedCostStore().load();
+        expect(local.map((cost) => cost.id), contains('sub_xbox'));
+        final preferences = await SharedPreferences.getInstance();
+        const tombstones = MirrorTombstoneStore(
+          storageKey: 'recurring_fixed_costs_deleted_v1',
+        );
+        expect(tombstones.activeIds(preferences), isNot(contains('sub_xbox')));
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
       'recurring fixed cost merges additively from the server mirror',
       (tester) async {
         // ローカルは fc_denki のみ。サーバは fc_denki + fc_gym を持つので、

--- a/test/widgets/asset_obsidian_vault_import_dialog_test.dart
+++ b/test/widgets/asset_obsidian_vault_import_dialog_test.dart
@@ -5,25 +5,25 @@ import 'package:my_web_app/widgets/asset_obsidian_vault_import_dialog.dart';
 
 void main() {
   AssetObsidianVaultSelection selection() => const AssetObsidianVaultSelection(
-        vaultName: 'company',
-        files: [
-          AssetObsidianVaultFile(
-            relativePath: 'company/ACCOUNTS_LIST.md',
-            byteSize: 200,
-            content: '''
+    vaultName: 'company',
+    files: [
+      AssetObsidianVaultFile(
+        relativePath: 'company/ACCOUNTS_LIST.md',
+        byteSize: 200,
+        content: '''
 | 確認日 | 口座・サービス名 | 最新確認残高 |
 | --- | --- | ---: |
 | 2026-08-26 | 現金 | 32,652円 |
 | 2026-08-24 | じぶん銀行 | 20,000円 |
 ''',
-          ),
-        ],
-      );
+      ),
+    ],
+  );
 
   testWidgets('差分プレビュー後に選択残高だけを確認して反映する', (tester) async {
     await tester.binding.setSurfaceSize(const Size(1200, 900));
     addTearDown(() => tester.binding.setSurfaceSize(null));
-    List<AssetObsidianImportCandidate>? applied;
+    AssetObsidianApplySelection? applied;
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -37,7 +37,7 @@ void main() {
               ),
             ],
             pickVault: () async => selection(),
-            onApply: (candidates) async => applied = candidates,
+            onApply: (selection) async => applied = selection,
           ),
         ),
       ),
@@ -48,21 +48,22 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('company'), findsOneWidget);
-    expect(find.text('候補 2件'), findsOneWidget);
+    expect(find.text('残高候補 2件'), findsOneWidget);
     expect(find.text('新規'), findsOneWidget);
     expect(find.text('古い'), findsOneWidget);
     expect(find.text('選択した1件を確認'), findsOneWidget);
 
     await tester.tap(find.text('選択した1件を確認'));
     await tester.pumpAndSettle();
-    expect(find.text('1件の残高を本日分として反映しますか？'), findsOneWidget);
+    expect(find.text('残高1件を反映しますか？'), findsOneWidget);
     expect(find.textContaining('使途不明金は自動生成しません'), findsOneWidget);
 
     await tester.tap(find.text('この内容で反映'));
     await tester.pumpAndSettle();
     expect(applied, isNotNull);
-    expect(applied, hasLength(1));
-    expect(applied!.single.accountName, '現金');
+    expect(applied!.balances, hasLength(1));
+    expect(applied!.balances.single.accountName, '現金');
+    expect(applied!.subscriptionCancellations, isEmpty);
   });
 
   testWidgets('フォルダー選択のキャンセル後もダイアログを維持する', (tester) async {
@@ -83,8 +84,74 @@ void main() {
 
     await tester.tap(find.text('Obsidian保管庫を選択'));
     await tester.pumpAndSettle();
-    expect(find.text('Obsidian保管庫から残高を取込'), findsOneWidget);
+    expect(find.text('Obsidian保管庫から資産情報を取込'), findsOneWidget);
     expect(find.text('Obsidian保管庫を選択'), findsOneWidget);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('解約済みサブスクをプレビューし、確認後に選択IDだけを渡す', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(560, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    AssetObsidianApplySelection? applied;
+    const cancellationSelection = AssetObsidianVaultSelection(
+      vaultName: 'company',
+      files: [
+        AssetObsidianVaultFile(
+          relativePath: 'company/SUBSCRIPTION_LIST.md',
+          byteSize: 300,
+          content: '''
+## 2. 解約・定期請求停止済みサービス
+| サービス名 | 終了日 / 停止日 | 状態 |
+| --- | --- | --- |
+| Xbox Game Pass | 2026-08-20 | 解約完了 |
+| netkeiba | 2026-08-21 | 停止済み |
+''',
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetObsidianVaultImportDialog(
+            pickerSupported: true,
+            existingBalances: const [],
+            existingSubscriptions: const [
+              AssetObsidianExistingSubscription(
+                id: 'sub_xbox',
+                name: 'Xbox Game Pass',
+                amount: 1550,
+              ),
+            ],
+            pickVault: () async => cancellationSelection,
+            onApply: (selection) async => applied = selection,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Obsidian保管庫を選択'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('解約表 1件'), findsOneWidget);
+    expect(find.text('解約済みサブスクの削除候補'), findsOneWidget);
+    expect(find.text('削除候補'), findsOneWidget);
+    expect(find.text('未登録'), findsOneWidget);
+    expect(find.text('選択した1件を確認'), findsOneWidget);
+
+    await tester.tap(find.text('選択した1件を確認'));
+    await tester.pumpAndSettle();
+    expect(find.text('サブスク1件を反映しますか？'), findsOneWidget);
+    expect(find.textContaining('過去の月次履歴・取引履歴は残します'), findsOneWidget);
+    expect(find.text('・Xbox Game Pass: ¥1,550/月'), findsOneWidget);
+
+    await tester.tap(find.text('この内容で反映'));
+    await tester.pumpAndSettle();
+    expect(applied, isNotNull);
+    expect(applied!.balances, isEmpty);
+    expect(applied!.subscriptionCancellations, hasLength(1));
+    expect(
+      applied!.subscriptionCancellations.single.matchedSubscriptionId,
+      'sub_xbox',
+    );
   });
 }

--- a/test/widgets/asset_obsidian_vault_import_dialog_test.dart
+++ b/test/widgets/asset_obsidian_vault_import_dialog_test.dart
@@ -140,13 +140,30 @@ void main() {
 
     expect(find.text('解約表 1件'), findsOneWidget);
     expect(find.text('解約済みサブスクの削除候補'), findsOneWidget);
-    expect(find.text('削除候補'), findsOneWidget);
+    expect(find.text('削除候補'), findsNWidgets(2));
     expect(find.text('未登録'), findsOneWidget);
     expect(find.text('選択した2件を確認'), findsOneWidget);
 
     final cancellationCheckboxes = find.byType(Checkbox);
     expect(cancellationCheckboxes, findsNWidgets(3));
-    await tester.tap(cancellationCheckboxes.at(1));
+    const notionCandidate = AssetObsidianSubscriptionCancellationCandidate(
+      sourceSubscriptionName: 'Notion',
+      sourceStatus: '解約済み',
+      status: AssetObsidianSubscriptionCancellationStatus.matched,
+      sourcePaths: <String>['company/SUBSCRIPTION_LIST.md'],
+      endedAt: '2026-08-21',
+      matchedSubscriptionId: 'sub_notion',
+      matchedSubscriptionName: 'Notion',
+      matchedMonthlyAmount: 1650,
+    );
+    final notionCheckbox = find.descendant(
+      of: find.byKey(
+        ValueKey('obsidian-cancellation-${notionCandidate.id}'),
+      ),
+      matching: find.byType(Checkbox),
+    );
+    expect(notionCheckbox, findsOneWidget);
+    await tester.tap(notionCheckbox);
     await tester.pumpAndSettle();
     expect(find.text('選択した1件を確認'), findsOneWidget);
 

--- a/test/widgets/asset_obsidian_vault_import_dialog_test.dart
+++ b/test/widgets/asset_obsidian_vault_import_dialog_test.dart
@@ -104,7 +104,7 @@ void main() {
 | サービス名 | 終了日 / 停止日 | 状態 |
 | --- | --- | --- |
 | Xbox Game Pass | 2026-08-20 | 解約完了 |
-| netkeiba | 2026-08-21 | 停止済み |
+| sub_xbox | 2026-08-21 | 停止済み |
 ''',
         ),
       ],
@@ -153,5 +153,56 @@ void main() {
       applied!.subscriptionCancellations.single.matchedSubscriptionId,
       'sub_xbox',
     );
+  });
+
+  testWidgets('最終確認で戻ると適用せずプレビューへ戻る', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    AssetObsidianApplySelection? applied;
+    const cancellationSelection = AssetObsidianVaultSelection(
+      vaultName: 'company',
+      files: [
+        AssetObsidianVaultFile(
+          relativePath: 'company/SUBSCRIPTION_LIST.md',
+          byteSize: 200,
+          content: '''
+## 解約・定期請求停止済みサービス
+| サービス名 | 終了日 / 停止日 | 状態 |
+| --- | --- | --- |
+| Xbox Game Pass | 2026-08-20 | 解約完了 |
+''',
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetObsidianVaultImportDialog(
+            pickerSupported: true,
+            existingBalances: const [],
+            existingSubscriptions: const [
+              AssetObsidianExistingSubscription(
+                id: 'sub_xbox',
+                name: 'Xbox Game Pass',
+                amount: 1550,
+              ),
+            ],
+            pickVault: () async => cancellationSelection,
+            onApply: (selection) async => applied = selection,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Obsidian保管庫を選択'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('選択した1件を確認'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, '戻る'));
+    await tester.pumpAndSettle();
+
+    expect(applied, isNull);
+    expect(find.text('解約済みサブスクの削除候補'), findsOneWidget);
+    expect(find.text('選択した1件を確認'), findsOneWidget);
   });
 }

--- a/test/widgets/asset_obsidian_vault_import_dialog_test.dart
+++ b/test/widgets/asset_obsidian_vault_import_dialog_test.dart
@@ -104,6 +104,7 @@ void main() {
 | サービス名 | 終了日 / 停止日 | 状態 |
 | --- | --- | --- |
 | Xbox Game Pass | 2026-08-20 | 解約完了 |
+| Notion | 2026-08-21 | 解約済み |
 | sub_xbox | 2026-08-21 | 停止済み |
 ''',
         ),
@@ -121,6 +122,11 @@ void main() {
                 name: 'Xbox Game Pass',
                 amount: 1550,
               ),
+              AssetObsidianExistingSubscription(
+                id: 'sub_notion',
+                name: 'Notion',
+                amount: 1650,
+              ),
             ],
             pickVault: () async => cancellationSelection,
             onApply: (selection) async => applied = selection,
@@ -136,6 +142,12 @@ void main() {
     expect(find.text('解約済みサブスクの削除候補'), findsOneWidget);
     expect(find.text('削除候補'), findsOneWidget);
     expect(find.text('未登録'), findsOneWidget);
+    expect(find.text('選択した2件を確認'), findsOneWidget);
+
+    final cancellationCheckboxes = find.byType(Checkbox);
+    expect(cancellationCheckboxes, findsNWidgets(3));
+    await tester.tap(cancellationCheckboxes.at(1));
+    await tester.pumpAndSettle();
     expect(find.text('選択した1件を確認'), findsOneWidget);
 
     await tester.tap(find.text('選択した1件を確認'));

--- a/test/widgets/asset_obsidian_vault_import_dialog_test.dart
+++ b/test/widgets/asset_obsidian_vault_import_dialog_test.dart
@@ -5,20 +5,20 @@ import 'package:my_web_app/widgets/asset_obsidian_vault_import_dialog.dart';
 
 void main() {
   AssetObsidianVaultSelection selection() => const AssetObsidianVaultSelection(
-    vaultName: 'company',
-    files: [
-      AssetObsidianVaultFile(
-        relativePath: 'company/ACCOUNTS_LIST.md',
-        byteSize: 200,
-        content: '''
+        vaultName: 'company',
+        files: [
+          AssetObsidianVaultFile(
+            relativePath: 'company/ACCOUNTS_LIST.md',
+            byteSize: 200,
+            content: '''
 | 確認日 | 口座・サービス名 | 最新確認残高 |
 | --- | --- | ---: |
 | 2026-08-26 | 現金 | 32,652円 |
 | 2026-08-24 | じぶん銀行 | 20,000円 |
 ''',
-      ),
-    ],
-  );
+          ),
+        ],
+      );
 
   testWidgets('差分プレビュー後に選択残高だけを確認して反映する', (tester) async {
     await tester.binding.setSurfaceSize(const Size(1200, 900));


### PR DESCRIPTION
## Summary
- add a subscription-specific deletion confirmation that retains historical monthly and transaction records
- parse only explicit completed cancellation/stop states from a local Obsidian vault and apply only selected, unambiguous current-subscription matches
- record recurring-cost deletion/re-add intent in a durable operation journal and serialize local state, tombstone RPC, current mirror, and exact acknowledgement through one app-scoped FIFO
- add a fixed-key SECURITY DEFINER RPC and guard the protected tombstone row against authenticated INSERT, UPDATE, rename, DELETE, and spoofed-GUC writes
- preserve rolling-upgrade tombstones, reject malformed mixed-type mirrors, and retain retry state after RPC/current-mirror failures

## Safety contract
- deletion candidates are fail-closed: exact completed status, current subscription category, stable ID/name/amount match, and explicit user selection are all required before any write
- delete/re-add writes are ordered and compensated locally; server tombstone and current-mirror writes cannot overlap out of order
- the protected server key is writable only while the fixed RPC executes as its owner
- absence, malformed input, unmatched names, ambiguous duplicates, and partial status text never trigger deletion

## Validation
- 34 focused Dart service/widget/store/page tests passed
- 21 Testcontainers harness unit tests passed
- Testcontainers plan includes migration reapply, runtime authorization/malformed contracts, initial add/add, and concurrent add/remove exact-set checks
- 1,984 migration timestamps scanned with no collisions
- two independent read-only subagent reviews: final GO, no P0/P1/P2 blockers
- `git diff --check`: passed

Local Docker daemon was unavailable, so the PostgreSQL runtime contract must pass in CI. A full local `flutter analyze --no-pub` was stopped when RAM crossed the configured safety threshold; the pushed CI lint/test and Testcontainers jobs are required before merge.

Closes #4927

## Minimal E2E Gate

- Implementation-detail independent: focused widget tests assert the visible preview, confirmation, cancellation, selected-only application, and retained-history message.
- Minimal scope: happy path, cancellation, unmatched/ambiguous safety, deletion persistence, retry, and upgrade recovery.
- E2E-Exception: browser directory selection requires an interactive native picker; deterministic widget tests cover the browser-visible contract without external file-system automation.

## High-risk Ultrareview Gate

- Reviewer: Codex #1 plus two independent read-only Codex subagents
- High-Risk-Ultrareview-Exception: Claude Code #1 ultrareview is unavailable in this Codex desktop task; Issue #4927 is a scoped data-integrity repair validated by deterministic focused tests, a disposable-Postgres CI contract, and two independent final GO reviews.