### PR TITLE
feat: Obsidian保管庫経由の安全なNotion移行ステージ

### DIFF
--- a/docs/OBSIDIAN_INGEST_PIPELINE.md
+++ b/docs/OBSIDIAN_INGEST_PIPELINE.md
@@ -52,6 +52,54 @@ python scripts\memory_ingest.py `
   --export-dir C:\Users\kanta\Documents\Obsidian\jibun-vault
 ```
 
+## Vault Migration Manifest
+
+Before staging an existing local vault for the site, create a local-only
+manifest outside the vault:
+
+```powershell
+python scripts\obsidian_vault_migration_manifest.py `
+  --vault C:\path\to\company-vault `
+  --output C:\tmp\company-vault-migration-manifest.json `
+  --credential-path relative\path\to\known-credential.json `
+  --fail-on-review
+```
+
+The command is read-only toward the vault and performs no network requests.
+It records Markdown structure, wikilink/embed resolution, attachment hashes,
+and migration classifications. It never includes note bodies or frontmatter
+values. `.obsidian`, `scripts`, `Templates`, agent instruction files, and
+credential-like paths are excluded without being opened or hashed. Hidden
+backup paths and migration `_control`/`_source` data are also excluded so a
+backup cannot be staged beside its active copy. Every other JSON file is kept
+unread and classified as structured data requiring separate review; use
+`--credential-path` to identify a known credential without inspecting it.
+Financial, debt, housing, legal, account, and subscription notes are marked
+`review_required` rather than auto-staged.
+
+The output must be outside the vault. Exit code `2` with `--fail-on-review`
+means the manifest was written successfully but manual review is still
+required; it does not mean files were uploaded.
+
+## Stage Structure In The Site
+
+Open `/notion-migration`, create or load a migration ledger, and use the
+Obsidian manifest card. Selection and validation happen in the browser before
+any request is made. The confirmation screen shows the auto-stage, review, and
+excluded counts.
+
+The site sends only the manifest digest, aggregate safety counts, and
+allowlisted structure for non-excluded Markdown notes and attachments. It does
+not send note bodies, frontmatter values, credential material, absolute paths,
+or even the relative paths of excluded files. Links or attachment references
+to an excluded path are removed from the staged structure.
+
+Staging is idempotent by migration batch and manifest SHA-256. Entries are
+written in bounded chunks to dedicated RLS-protected tables and never mixed
+with the Notion source-deletion ledger. A retry resumes the same manifest;
+partial failures remain marked `failed` until retried. Authenticated users can
+read, insert, and update only their own staging rows and cannot delete them.
+
 ## Acceptance Coverage
 
 - URL/text/GitHub input produces a Markdown note proposal.
@@ -62,13 +110,10 @@ python scripts\memory_ingest.py `
   links.
 - Every ingest attempt writes a JSONL audit record.
 
-## Next Slice
+## Remaining Migration Work
 
-The next application-level slice should add a small UI around the same script or
-an Edge Function wrapper:
-
-- paste URL/text
-- preview Markdown
-- edit before save
-- show related notes and duplicate warnings
-- export selected notes as a Vault zip
+- Review every `review_required` note before content import.
+- Resolve unresolved wikilinks and verify attachment rendering.
+- Import selected note bodies through a separately approved, encrypted path.
+- Complete the seven Notion parity checks before any Notion deletion or
+  subscription cancellation.

--- a/lib/ui/features/notion_migration/data/notion_migration_gateway.dart
+++ b/lib/ui/features/notion_migration/data/notion_migration_gateway.dart
@@ -28,6 +28,11 @@ abstract class NotionMigrationGateway {
   Future<NotionWbsReconciliation> reconcileWbs(String batchId);
 
   Future<NotionWbsStageSummary> stageWbs(String batchId);
+
+  Future<NotionVaultManifestStageSummary> stageVaultManifest({
+    required String batchId,
+    required NotionVaultManifestPreview manifest,
+  });
 }
 
 class SupabaseNotionMigrationGateway implements NotionMigrationGateway {
@@ -93,6 +98,12 @@ class SupabaseNotionMigrationGateway implements NotionMigrationGateway {
           .select()
           .eq('batch_id', batch.id)
           .limit(1),
+      _client
+          .from('notion_migration_vault_manifests')
+          .select()
+          .eq('batch_id', batch.id)
+          .order('created_at', ascending: false)
+          .limit(1),
     ]);
 
     final progressRows = results[0];
@@ -101,6 +112,7 @@ class SupabaseNotionMigrationGateway implements NotionMigrationGateway {
     final dataSourceRows = results[3];
     final capabilityRows = results[4];
     final stageRows = results[5];
+    final vaultManifestRows = results[6];
     final checksByItem = <String, int>{};
     for (final check in checkRows) {
       final itemId = check['item_id']?.toString();
@@ -141,6 +153,9 @@ class SupabaseNotionMigrationGateway implements NotionMigrationGateway {
       wbsStageSummary: stageRows.isEmpty
           ? null
           : NotionWbsStageSummary.fromJson(stageRows.first),
+      vaultManifestSummary: vaultManifestRows.isEmpty
+          ? null
+          : NotionVaultManifestStageSummary.fromJson(vaultManifestRows.first),
     );
   }
 
@@ -185,6 +200,105 @@ class SupabaseNotionMigrationGateway implements NotionMigrationGateway {
     return NotionWbsStageSummary.fromJson(data);
   }
 
+  @override
+  Future<NotionVaultManifestStageSummary> stageVaultManifest({
+    required String batchId,
+    required NotionVaultManifestPreview manifest,
+  }) async {
+    final userId = _userId;
+    String? manifestId;
+    try {
+      final manifestRow = await _client
+          .from('notion_migration_vault_manifests')
+          .upsert(
+            {
+              'batch_id': batchId,
+              'user_id': userId,
+              'schema_version': manifest.schemaVersion,
+              'vault_name': manifest.vaultName,
+              'source_file_name': manifest.sourceFileName,
+              'source_manifest_sha256': manifest.sourceManifestSha256,
+              'file_count': manifest.fileCount,
+              'auto_stage_count': manifest.autoStageCount,
+              'review_required_count': manifest.reviewRequiredCount,
+              'excluded_count': manifest.excludedCount,
+              'credential_candidate_count': manifest.credentialCandidateCount,
+              'unresolved_wikilink_occurrences':
+                  manifest.unresolvedWikilinkOccurrences,
+              'status': 'staging',
+              'staged_entry_count': 0,
+              'staged_at': null,
+              'last_error': null,
+            },
+            onConflict: 'batch_id,source_manifest_sha256',
+          )
+          .select()
+          .single();
+      manifestId = manifestRow['id']?.toString();
+      if (manifestId == null || manifestId.isEmpty) {
+        throw const NotionMigrationException('vault_manifest_id_missing');
+      }
+
+      const chunkSize = 100;
+      for (var start = 0; start < manifest.entries.length; start += chunkSize) {
+        final end = (start + chunkSize).clamp(0, manifest.entries.length);
+        final rows = manifest.entries.sublist(start, end).map((entry) {
+          return <String, dynamic>{
+            'manifest_id': manifestId,
+            'batch_id': batchId,
+            'user_id': userId,
+            'relative_path': entry.relativePath,
+            'category': entry.category,
+            'migration_action': entry.migrationAction,
+            'size_bytes': entry.sizeBytes,
+            'source_hash': entry.sourceHash,
+            'structure_metadata': entry.structureMetadata,
+          };
+        }).toList(growable: false);
+        await _client
+            .from('notion_migration_vault_entries')
+            .upsert(rows, onConflict: 'manifest_id,relative_path');
+      }
+
+      final stagedAt = DateTime.now().toUtc().toIso8601String();
+      final stagedRow = await _client
+          .from('notion_migration_vault_manifests')
+          .update({
+            'status': 'staged',
+            'staged_entry_count': manifest.entries.length,
+            'staged_at': stagedAt,
+            'last_error': null,
+          })
+          .eq('id', manifestId)
+          .eq('user_id', userId)
+          .select()
+          .single();
+      return NotionVaultManifestStageSummary.fromJson(stagedRow);
+    } catch (error) {
+      if (manifestId != null) {
+        try {
+          final detail = error.toString();
+          await _client
+              .from('notion_migration_vault_manifests')
+              .update({
+                'status': 'failed',
+                'last_error':
+                    detail.length <= 2000 ? detail : detail.substring(0, 2000),
+              })
+              .eq('id', manifestId)
+              .eq('user_id', userId);
+        } catch (_) {
+          // Preserve the original staging error.
+        }
+      }
+      if (error is NotionMigrationException) rethrow;
+      throw NotionMigrationException(
+        'vault_manifest_stage_failed',
+        error.toString(),
+      );
+    }
+  }
+
   Future<NotionInventoryActionResult> _runInventoryAction(
     String action,
     String batchId,
@@ -193,10 +307,7 @@ class SupabaseNotionMigrationGateway implements NotionMigrationGateway {
     return NotionInventoryActionResult.fromJson(data);
   }
 
-  Future<Map<String, dynamic>> _runAction(
-    String action,
-    String batchId,
-  ) async {
+  Future<Map<String, dynamic>> _runAction(String action, String batchId) async {
     _userId;
     try {
       final response = await _client.functions.invoke(

--- a/lib/ui/features/notion_migration/data/notion_vault_manifest_service.dart
+++ b/lib/ui/features/notion_migration/data/notion_vault_manifest_service.dart
@@ -1,0 +1,382 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:file_picker/file_picker.dart';
+
+import '../domain/notion_vault_manifest_models.dart';
+
+const int _maxManifestBytes = 10 * 1024 * 1024;
+const int _maxManifestEntries = 10000;
+final RegExp _sha256Pattern = RegExp(r'^[0-9a-f]{64}$');
+
+class NotionVaultManifestException implements Exception {
+  const NotionVaultManifestException(this.code);
+
+  final String code;
+
+  @override
+  String toString() => code;
+}
+
+class PickedNotionVaultManifest {
+  const PickedNotionVaultManifest({required this.name, required this.bytes});
+
+  final String name;
+  final Uint8List bytes;
+}
+
+abstract interface class NotionVaultManifestPicker {
+  Future<PickedNotionVaultManifest?> pick();
+}
+
+class FilePickerNotionVaultManifestPicker implements NotionVaultManifestPicker {
+  const FilePickerNotionVaultManifestPicker();
+
+  @override
+  Future<PickedNotionVaultManifest?> pick() async {
+    final result = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: const ['json'],
+      allowMultiple: false,
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return null;
+    final file = result.files.single;
+    final bytes = file.bytes;
+    if (bytes == null) {
+      throw const NotionVaultManifestException('manifest_bytes_unavailable');
+    }
+    return PickedNotionVaultManifest(name: file.name, bytes: bytes);
+  }
+}
+
+class NotionVaultManifestParser {
+  const NotionVaultManifestParser();
+
+  NotionVaultManifestPreview parse(PickedNotionVaultManifest source) {
+    if (source.bytes.isEmpty || source.bytes.length > _maxManifestBytes) {
+      throw const NotionVaultManifestException('manifest_size_invalid');
+    }
+
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(utf8.decode(source.bytes, allowMalformed: false));
+    } on FormatException {
+      throw const NotionVaultManifestException('manifest_json_invalid');
+    }
+    final root = _map(decoded, 'manifest_schema_invalid');
+    final schemaVersion = _integer(root['schema_version']);
+    final policy = _map(root['policy'], 'manifest_policy_invalid');
+    if (schemaVersion != 1 ||
+        root['local_only'] != true ||
+        root['source_absolute_path_included'] != false ||
+        policy['network_requests'] != false ||
+        policy['vault_files_copied'] != false ||
+        policy['note_body_or_property_values_included'] != false ||
+        policy['excluded_files_opened_or_hashed'] != false) {
+      throw const NotionVaultManifestException('manifest_policy_invalid');
+    }
+
+    final vaultName = _boundedString(root['vault_name'], 1, 200);
+    final summary = _map(root['summary'], 'manifest_summary_invalid');
+    final actionCounts = _map(
+      summary['action_counts'],
+      'manifest_summary_invalid',
+    );
+    final fileCount = _nonNegativeInteger(summary['file_count']);
+    final autoStageCount = _nonNegativeInteger(actionCounts['auto_stage']);
+    final reviewRequiredCount = _nonNegativeInteger(
+      actionCounts['review_required'],
+    );
+    final excludedCount = _nonNegativeInteger(actionCounts['exclude']);
+    final credentialCandidateCount = _nonNegativeInteger(
+      summary['credential_candidate_count'],
+    );
+    final unresolvedWikilinkOccurrences = _nonNegativeInteger(
+      summary['unresolved_wikilink_occurrences'],
+    );
+    if (fileCount != autoStageCount + reviewRequiredCount + excludedCount ||
+        credentialCandidateCount > excludedCount) {
+      throw const NotionVaultManifestException('manifest_summary_invalid');
+    }
+
+    final rawEntries = root['entries'];
+    if (rawEntries is! List ||
+        rawEntries.length != fileCount ||
+        rawEntries.length > _maxManifestEntries) {
+      throw const NotionVaultManifestException('manifest_entries_invalid');
+    }
+    final validatedEntries = <_ValidatedManifestEntry>[];
+    final excludedPaths = <String>{};
+    for (final rawEntry in rawEntries) {
+      final entry = _map(rawEntry, 'manifest_entry_invalid');
+      final relativePath = _safeRelativePath(entry['relative_path']);
+      final action = _boundedString(entry['migration_action'], 1, 30);
+      final category = _boundedString(entry['category'], 1, 40);
+      if (action == 'exclude') {
+        if (entry['sha256'] != null || entry['content_inspected'] != false) {
+          throw const NotionVaultManifestException(
+            'manifest_exclusion_policy_invalid',
+          );
+        }
+      }
+      validatedEntries.add(
+        _ValidatedManifestEntry(
+          data: entry,
+          relativePath: relativePath,
+          action: action,
+          category: category,
+        ),
+      );
+      if (action == 'exclude') {
+        excludedPaths.add(relativePath.toLowerCase());
+      }
+    }
+
+    var actualAutoStageCount = 0;
+    var actualReviewRequiredCount = 0;
+    var actualExcludedCount = 0;
+    var actualCredentialCandidateCount = 0;
+    var actualUnresolvedWikilinkOccurrences = 0;
+    final entries = <NotionVaultManifestEntry>[];
+    for (final validated in validatedEntries) {
+      final entry = validated.data;
+      final relativePath = validated.relativePath;
+      final action = validated.action;
+      final category = validated.category;
+      if (action == 'exclude') {
+        actualExcludedCount++;
+        if (category == 'credential_candidate') {
+          actualCredentialCandidateCount++;
+        }
+        continue;
+      }
+      if (!{'auto_stage', 'review_required'}.contains(action) ||
+          !{'note', 'attachment'}.contains(category)) {
+        throw const NotionVaultManifestException('manifest_entry_invalid');
+      }
+      if (action == 'auto_stage') {
+        actualAutoStageCount++;
+      } else {
+        actualReviewRequiredCount++;
+      }
+      final sourceHash = _boundedString(entry['sha256'], 64, 64);
+      if (!_sha256Pattern.hasMatch(sourceHash)) {
+        throw const NotionVaultManifestException('manifest_hash_invalid');
+      }
+      final structureMetadata = _safeStructureMetadata(
+        entry,
+        category,
+        excludedPaths,
+      );
+      if (category == 'note') {
+        final links = structureMetadata['wikilinks']! as List<dynamic>;
+        for (final rawLink in links) {
+          final link = rawLink as Map<String, dynamic>;
+          if (link['resolved'] != true) {
+            actualUnresolvedWikilinkOccurrences += link['occurrences']! as int;
+          }
+        }
+      }
+      entries.add(
+        NotionVaultManifestEntry(
+          relativePath: relativePath,
+          category: category,
+          migrationAction: action,
+          sizeBytes: _nonNegativeInteger(entry['size_bytes']),
+          sourceHash: sourceHash,
+          structureMetadata: structureMetadata,
+        ),
+      );
+    }
+    if (actualAutoStageCount != autoStageCount ||
+        actualReviewRequiredCount != reviewRequiredCount ||
+        actualExcludedCount != excludedCount ||
+        actualCredentialCandidateCount != credentialCandidateCount ||
+        actualUnresolvedWikilinkOccurrences != unresolvedWikilinkOccurrences) {
+      throw const NotionVaultManifestException('manifest_entries_invalid');
+    }
+
+    return NotionVaultManifestPreview(
+      sourceFileName: _safeFileName(source.name),
+      sourceManifestSha256: sha256.convert(source.bytes).toString(),
+      vaultName: vaultName,
+      schemaVersion: schemaVersion,
+      fileCount: fileCount,
+      autoStageCount: autoStageCount,
+      reviewRequiredCount: reviewRequiredCount,
+      excludedCount: excludedCount,
+      credentialCandidateCount: credentialCandidateCount,
+      unresolvedWikilinkOccurrences: unresolvedWikilinkOccurrences,
+      entries: List.unmodifiable(entries),
+    );
+  }
+
+  Map<String, dynamic> _safeStructureMetadata(
+    Map<String, dynamic> entry,
+    String category,
+    Set<String> excludedPaths,
+  ) {
+    if (category == 'attachment') {
+      return {
+        'referenced_by': _stringList(entry['referenced_by'], 4000)
+            .where((path) => !excludedPaths.contains(path.toLowerCase()))
+            .toList(growable: false),
+      };
+    }
+    final markdown = _map(entry['markdown'], 'manifest_markdown_invalid');
+    final rawLinks = markdown['wikilinks'];
+    if (rawLinks is! List || rawLinks.length > _maxManifestEntries) {
+      throw const NotionVaultManifestException('manifest_markdown_invalid');
+    }
+    final links = <Map<String, dynamic>>[];
+    for (final rawLink in rawLinks) {
+      final link = _map(rawLink, 'manifest_markdown_invalid');
+      final target = _boundedString(link['target'], 1, 4000);
+      String? resolvedRelativePath;
+      if (link['resolved_relative_path'] is String) {
+        resolvedRelativePath = _safeRelativePath(
+          link['resolved_relative_path'],
+        );
+      }
+      if (link['target_migration_action'] == 'exclude' ||
+          (resolvedRelativePath != null &&
+              excludedPaths.contains(resolvedRelativePath.toLowerCase())) ||
+          _targetCouldReferenceExcludedPath(target, excludedPaths)) {
+        continue;
+      }
+      links.add({
+        'target': target,
+        'embedded': link['embedded'] == true,
+        'occurrences': _nonNegativeInteger(link['occurrences']),
+        'resolved': link['resolved'] == true,
+        'ambiguous': link['ambiguous'] == true,
+        if (resolvedRelativePath != null)
+          'resolved_relative_path': resolvedRelativePath,
+      });
+    }
+    return {
+      'frontmatter_present': markdown['frontmatter_present'] == true,
+      'property_keys': _stringList(markdown['property_keys'], 200),
+      'wikilinks': links,
+      'external_link_count': _nonNegativeInteger(
+        markdown['external_link_count'],
+      ),
+      'callout_types': _safeCountMap(markdown['callout_types']),
+      'task_count': _nonNegativeInteger(markdown['task_count']),
+      'completed_task_count': _nonNegativeInteger(
+        markdown['completed_task_count'],
+      ),
+    };
+  }
+
+  bool _targetCouldReferenceExcludedPath(
+    String target,
+    Set<String> excludedPaths,
+  ) {
+    final normalized = target
+        .split('#')
+        .first
+        .split('^')
+        .first
+        .trim()
+        .replaceAll('\\', '/')
+        .toLowerCase();
+    if (normalized.isEmpty) return false;
+    final targetName = normalized.split('/').last;
+    final targetStem = targetName.contains('.')
+        ? targetName.substring(0, targetName.lastIndexOf('.'))
+        : targetName;
+    for (final path in excludedPaths) {
+      final excludedName = path.split('/').last;
+      final excludedStem = excludedName.contains('.')
+          ? excludedName.substring(0, excludedName.lastIndexOf('.'))
+          : excludedName;
+      if (normalized == path ||
+          targetName == excludedName ||
+          targetStem == excludedStem) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Map<String, int> _safeCountMap(dynamic value) {
+    final source = _map(value, 'manifest_markdown_invalid');
+    if (source.length > 100) {
+      throw const NotionVaultManifestException('manifest_markdown_invalid');
+    }
+    return {
+      for (final entry in source.entries)
+        _boundedString(entry.key, 1, 100): _nonNegativeInteger(entry.value),
+    };
+  }
+
+  List<String> _stringList(dynamic value, int maxLength) {
+    if (value is! List || value.length > _maxManifestEntries) {
+      throw const NotionVaultManifestException('manifest_entry_invalid');
+    }
+    return value
+        .map((item) => _boundedString(item, 1, maxLength))
+        .toList(growable: false);
+  }
+
+  Map<String, dynamic> _map(dynamic value, String code) {
+    if (value is! Map) throw NotionVaultManifestException(code);
+    return Map<String, dynamic>.from(value);
+  }
+
+  int _integer(dynamic value) {
+    if (value is int) return value;
+    if (value is num && value.isFinite && value == value.truncate()) {
+      return value.toInt();
+    }
+    throw const NotionVaultManifestException('manifest_number_invalid');
+  }
+
+  int _nonNegativeInteger(dynamic value) {
+    final parsed = _integer(value);
+    if (parsed < 0) {
+      throw const NotionVaultManifestException('manifest_number_invalid');
+    }
+    return parsed;
+  }
+
+  String _boundedString(dynamic value, int min, int max) {
+    if (value is! String || value.length < min || value.length > max) {
+      throw const NotionVaultManifestException('manifest_string_invalid');
+    }
+    return value;
+  }
+
+  String _safeRelativePath(dynamic value) {
+    final path = _boundedString(value, 1, 4000).replaceAll('\\', '/');
+    final segments = path.split('/');
+    if (path.startsWith('/') ||
+        RegExp(r'^[a-zA-Z]:').hasMatch(path) ||
+        segments.any((segment) => segment.isEmpty || segment == '..')) {
+      throw const NotionVaultManifestException('manifest_path_invalid');
+    }
+    return path;
+  }
+
+  String _safeFileName(String value) {
+    final normalized = value.replaceAll('\\', '/').split('/').last;
+    return _boundedString(normalized, 1, 255);
+  }
+}
+
+class _ValidatedManifestEntry {
+  const _ValidatedManifestEntry({
+    required this.data,
+    required this.relativePath,
+    required this.action,
+    required this.category,
+  });
+
+  final Map<String, dynamic> data;
+  final String relativePath;
+  final String action;
+  final String category;
+}

--- a/lib/ui/features/notion_migration/domain/notion_migration_models.dart
+++ b/lib/ui/features/notion_migration/domain/notion_migration_models.dart
@@ -1,3 +1,7 @@
+import 'notion_vault_manifest_models.dart';
+
+export 'notion_vault_manifest_models.dart';
+
 enum NotionMigrationBatchStatus {
   inventory,
   migrating,
@@ -19,14 +23,14 @@ enum NotionMigrationBatchStatus {
       };
 
   String get label => switch (this) {
-        inventory => '棚卸し中',
-        migrating => '移行中',
-        verifying => '照合中',
-        awaitingSourceDeletion => 'Notion側削除待ち',
-        completed => '完了',
-        paused => '一時停止',
-        failed => '要対応',
-      };
+    inventory => '棚卸し中',
+    migrating => '移行中',
+    verifying => '照合中',
+    awaitingSourceDeletion => 'Notion側削除待ち',
+    completed => '完了',
+    paused => '一時停止',
+    failed => '要対応',
+  };
 }
 
 enum NotionMigrationItemStatus {
@@ -56,17 +60,17 @@ enum NotionMigrationItemStatus {
       };
 
   String get label => switch (this) {
-        inventoried => '棚卸し済み',
-        queued => '移行待ち',
-        exporting => '書き出し中',
-        imported => '取込済み',
-        verifying => '照合中',
-        verified => '照合済み',
-        readyForSourceDeletion => 'Notion側削除可能',
-        sourceDeleted => 'Notion側削除済み',
-        failed => '要対応',
-        skipped => '対象外',
-      };
+    inventoried => '棚卸し済み',
+    queued => '移行待ち',
+    exporting => '書き出し中',
+    imported => '取込済み',
+    verifying => '照合中',
+    verified => '照合済み',
+    readyForSourceDeletion => 'Notion側削除可能',
+    sourceDeleted => 'Notion側削除済み',
+    failed => '要対応',
+    skipped => '対象外',
+  };
 }
 
 class NotionMigrationBatch {
@@ -88,7 +92,8 @@ class NotionMigrationBatch {
       status: NotionMigrationBatchStatus.fromStorage(
         json['status']?.toString(),
       ),
-      createdAt: DateTime.tryParse(json['created_at']?.toString() ?? '') ??
+      createdAt:
+          DateTime.tryParse(json['created_at']?.toString() ?? '') ??
           DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
     );
   }
@@ -179,6 +184,7 @@ class NotionMigrationSnapshot {
     this.capabilities = const <NotionCapability>[],
     this.wbsReconciliation,
     this.wbsStageSummary,
+    this.vaultManifestSummary,
   });
 
   final NotionMigrationBatch? batch;
@@ -187,6 +193,7 @@ class NotionMigrationSnapshot {
   final List<NotionCapability> capabilities;
   final NotionWbsReconciliation? wbsReconciliation;
   final NotionWbsStageSummary? wbsStageSummary;
+  final NotionVaultManifestStageSummary? vaultManifestSummary;
 }
 
 class NotionInventoryActionResult {
@@ -292,24 +299,24 @@ enum NotionParityStatus {
   blocked;
 
   static NotionParityStatus fromStorage(String? value) => switch (value) {
-        'planned' => planned,
-        'implemented' => implemented,
-        'verifying' => verifying,
-        'verified' => verified,
-        'gap' => gap,
-        'blocked' => blocked,
-        _ => inventory,
-      };
+    'planned' => planned,
+    'implemented' => implemented,
+    'verifying' => verifying,
+    'verified' => verified,
+    'gap' => gap,
+    'blocked' => blocked,
+    _ => inventory,
+  };
 
   String get label => switch (this) {
-        inventory => '棚卸し待ち',
-        planned => '実装予定',
-        implemented => '実装済み',
-        verifying => '実データ検証中',
-        verified => '検証済み',
-        gap => '不足',
-        blocked => '要対応',
-      };
+    inventory => '棚卸し待ち',
+    planned => '実装予定',
+    implemented => '実装済み',
+    verifying => '実データ検証中',
+    verified => '検証済み',
+    gap => '不足',
+    blocked => '要対応',
+  };
 }
 
 class NotionCapability {

--- a/lib/ui/features/notion_migration/domain/notion_migration_models.dart
+++ b/lib/ui/features/notion_migration/domain/notion_migration_models.dart
@@ -23,14 +23,14 @@ enum NotionMigrationBatchStatus {
       };
 
   String get label => switch (this) {
-    inventory => '棚卸し中',
-    migrating => '移行中',
-    verifying => '照合中',
-    awaitingSourceDeletion => 'Notion側削除待ち',
-    completed => '完了',
-    paused => '一時停止',
-    failed => '要対応',
-  };
+        inventory => '棚卸し中',
+        migrating => '移行中',
+        verifying => '照合中',
+        awaitingSourceDeletion => 'Notion側削除待ち',
+        completed => '完了',
+        paused => '一時停止',
+        failed => '要対応',
+      };
 }
 
 enum NotionMigrationItemStatus {
@@ -60,17 +60,17 @@ enum NotionMigrationItemStatus {
       };
 
   String get label => switch (this) {
-    inventoried => '棚卸し済み',
-    queued => '移行待ち',
-    exporting => '書き出し中',
-    imported => '取込済み',
-    verifying => '照合中',
-    verified => '照合済み',
-    readyForSourceDeletion => 'Notion側削除可能',
-    sourceDeleted => 'Notion側削除済み',
-    failed => '要対応',
-    skipped => '対象外',
-  };
+        inventoried => '棚卸し済み',
+        queued => '移行待ち',
+        exporting => '書き出し中',
+        imported => '取込済み',
+        verifying => '照合中',
+        verified => '照合済み',
+        readyForSourceDeletion => 'Notion側削除可能',
+        sourceDeleted => 'Notion側削除済み',
+        failed => '要対応',
+        skipped => '対象外',
+      };
 }
 
 class NotionMigrationBatch {
@@ -92,8 +92,7 @@ class NotionMigrationBatch {
       status: NotionMigrationBatchStatus.fromStorage(
         json['status']?.toString(),
       ),
-      createdAt:
-          DateTime.tryParse(json['created_at']?.toString() ?? '') ??
+      createdAt: DateTime.tryParse(json['created_at']?.toString() ?? '') ??
           DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
     );
   }
@@ -299,24 +298,24 @@ enum NotionParityStatus {
   blocked;
 
   static NotionParityStatus fromStorage(String? value) => switch (value) {
-    'planned' => planned,
-    'implemented' => implemented,
-    'verifying' => verifying,
-    'verified' => verified,
-    'gap' => gap,
-    'blocked' => blocked,
-    _ => inventory,
-  };
+        'planned' => planned,
+        'implemented' => implemented,
+        'verifying' => verifying,
+        'verified' => verified,
+        'gap' => gap,
+        'blocked' => blocked,
+        _ => inventory,
+      };
 
   String get label => switch (this) {
-    inventory => '棚卸し待ち',
-    planned => '実装予定',
-    implemented => '実装済み',
-    verifying => '実データ検証中',
-    verified => '検証済み',
-    gap => '不足',
-    blocked => '要対応',
-  };
+        inventory => '棚卸し待ち',
+        planned => '実装予定',
+        implemented => '実装済み',
+        verifying => '実データ検証中',
+        verified => '検証済み',
+        gap => '不足',
+        blocked => '要対応',
+      };
 }
 
 class NotionCapability {

--- a/lib/ui/features/notion_migration/domain/notion_vault_manifest_models.dart
+++ b/lib/ui/features/notion_migration/domain/notion_vault_manifest_models.dart
@@ -1,0 +1,104 @@
+class NotionVaultManifestEntry {
+  const NotionVaultManifestEntry({
+    required this.relativePath,
+    required this.category,
+    required this.migrationAction,
+    required this.sizeBytes,
+    required this.sourceHash,
+    required this.structureMetadata,
+  });
+
+  final String relativePath;
+  final String category;
+  final String migrationAction;
+  final int sizeBytes;
+  final String sourceHash;
+  final Map<String, dynamic> structureMetadata;
+
+  bool get requiresReview => migrationAction == 'review_required';
+}
+
+class NotionVaultManifestPreview {
+  const NotionVaultManifestPreview({
+    required this.sourceFileName,
+    required this.sourceManifestSha256,
+    required this.vaultName,
+    required this.schemaVersion,
+    required this.fileCount,
+    required this.autoStageCount,
+    required this.reviewRequiredCount,
+    required this.excludedCount,
+    required this.credentialCandidateCount,
+    required this.unresolvedWikilinkOccurrences,
+    required this.entries,
+  });
+
+  final String sourceFileName;
+  final String sourceManifestSha256;
+  final String vaultName;
+  final int schemaVersion;
+  final int fileCount;
+  final int autoStageCount;
+  final int reviewRequiredCount;
+  final int excludedCount;
+  final int credentialCandidateCount;
+  final int unresolvedWikilinkOccurrences;
+  final List<NotionVaultManifestEntry> entries;
+
+  int get stageableCount => autoStageCount + reviewRequiredCount;
+  bool get hasSafetyWarnings =>
+      reviewRequiredCount > 0 ||
+      credentialCandidateCount > 0 ||
+      unresolvedWikilinkOccurrences > 0;
+}
+
+class NotionVaultManifestStageSummary {
+  const NotionVaultManifestStageSummary({
+    required this.id,
+    required this.vaultName,
+    required this.sourceManifestSha256,
+    required this.fileCount,
+    required this.stagedEntryCount,
+    required this.reviewRequiredCount,
+    required this.excludedCount,
+    required this.credentialCandidateCount,
+    required this.unresolvedWikilinkOccurrences,
+    required this.status,
+    this.stagedAt,
+  });
+
+  factory NotionVaultManifestStageSummary.fromJson(Map<String, dynamic> json) {
+    int count(String key) {
+      final value = json[key];
+      if (value is int) return value;
+      if (value is num) return value.toInt();
+      return int.tryParse(value?.toString() ?? '') ?? 0;
+    }
+
+    return NotionVaultManifestStageSummary(
+      id: json['id']?.toString() ?? '',
+      vaultName: json['vault_name']?.toString() ?? '',
+      sourceManifestSha256: json['source_manifest_sha256']?.toString() ?? '',
+      fileCount: count('file_count'),
+      stagedEntryCount: count('staged_entry_count'),
+      reviewRequiredCount: count('review_required_count'),
+      excludedCount: count('excluded_count'),
+      credentialCandidateCount: count('credential_candidate_count'),
+      unresolvedWikilinkOccurrences: count('unresolved_wikilink_occurrences'),
+      status: json['status']?.toString() ?? 'staging',
+      stagedAt: DateTime.tryParse(json['staged_at']?.toString() ?? ''),
+    );
+  }
+
+  final String id;
+  final String vaultName;
+  final String sourceManifestSha256;
+  final int fileCount;
+  final int stagedEntryCount;
+  final int reviewRequiredCount;
+  final int excludedCount;
+  final int credentialCandidateCount;
+  final int unresolvedWikilinkOccurrences;
+  final String status;
+  final DateTime? stagedAt;
+}

--- a/lib/ui/features/notion_migration/notion_migration_feature.dart
+++ b/lib/ui/features/notion_migration/notion_migration_feature.dart
@@ -2,19 +2,29 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 import 'data/notion_migration_gateway.dart';
+import 'data/notion_vault_manifest_service.dart';
 import 'view_models/notion_migration_view_model.dart';
 import 'views/notion_migration_page.dart';
 
 class NotionMigrationFeature extends StatelessWidget {
-  const NotionMigrationFeature({super.key, this.gateway});
+  const NotionMigrationFeature({
+    super.key,
+    this.gateway,
+    this.vaultManifestPicker,
+    this.vaultManifestParser,
+  });
 
   final NotionMigrationGateway? gateway;
+  final NotionVaultManifestPicker? vaultManifestPicker;
+  final NotionVaultManifestParser? vaultManifestParser;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<NotionMigrationViewModel>(
       create: (_) => NotionMigrationViewModel(
         gateway: gateway ?? SupabaseNotionMigrationGateway(),
+        vaultManifestPicker: vaultManifestPicker,
+        vaultManifestParser: vaultManifestParser,
       )..load(),
       child: const NotionMigrationPage(),
     );

--- a/lib/ui/features/notion_migration/view_models/notion_migration_view_model.dart
+++ b/lib/ui/features/notion_migration/view_models/notion_migration_view_model.dart
@@ -11,11 +11,11 @@ class NotionMigrationViewModel extends ChangeNotifier {
     required NotionMigrationGateway gateway,
     NotionVaultManifestPicker? vaultManifestPicker,
     NotionVaultManifestParser? vaultManifestParser,
-  }) : _gateway = gateway,
-       _vaultManifestPicker =
-           vaultManifestPicker ?? const FilePickerNotionVaultManifestPicker(),
-       _vaultManifestParser =
-           vaultManifestParser ?? const NotionVaultManifestParser();
+  })  : _gateway = gateway,
+        _vaultManifestPicker =
+            vaultManifestPicker ?? const FilePickerNotionVaultManifestPicker(),
+        _vaultManifestParser =
+            vaultManifestParser ?? const NotionVaultManifestParser();
 
   final NotionMigrationGateway _gateway;
   final NotionVaultManifestPicker _vaultManifestPicker;
@@ -253,8 +253,7 @@ class NotionMigrationViewModel extends ChangeNotifier {
     _loadStatus = keepReady
         ? NotionMigrationLoadStatus.ready
         : NotionMigrationLoadStatus.failure;
-    _authenticationRequired =
-        error is NotionMigrationException &&
+    _authenticationRequired = error is NotionMigrationException &&
         error.code == 'authentication_required';
     _errorMessage = _authenticationRequired
         ? 'この機能を使うにはログインしてください。'
@@ -278,7 +277,8 @@ class NotionMigrationViewModel extends ChangeNotifier {
       return switch (error.code) {
         'admin_required' => 'WBS照合は管理者だけが実行できます。',
         'notion_not_configured' ||
-        'wbs_source_not_configured' => 'サーバー側のNotion WBS接続が未設定です。',
+        'wbs_source_not_configured' =>
+          'サーバー側のNotion WBS接続が未設定です。',
         'wbs_database_has_multiple_data_sources' =>
           'WBSデータベースに複数のデータソースがあります。対象IDをサーバー設定で明示してください。',
         'batch_not_found' => '移行台帳が見つかりません。再読み込みしてください。',
@@ -293,7 +293,8 @@ class NotionMigrationViewModel extends ChangeNotifier {
       return switch (error.code) {
         'admin_required' => 'WBS取込は管理者だけが実行できます。',
         'notion_not_configured' ||
-        'wbs_source_not_configured' => 'サーバー側のNotion WBS接続が未設定です。',
+        'wbs_source_not_configured' =>
+          'サーバー側のNotion WBS接続が未設定です。',
         'wbs_stage_inventory_incomplete' =>
           'Notion WBSの全ページを取得できなかったため、安全領域への取込を中止しました。',
         'batch_not_found' => '移行台帳が見つかりません。再読み込みしてください。',
@@ -308,7 +309,8 @@ class NotionMigrationViewModel extends ChangeNotifier {
       return switch (error.code) {
         'manifest_size_invalid' => 'manifestが空か、10MBの上限を超えています。',
         'manifest_json_invalid' => '選択したファイルは有効なJSONではありません。',
-        'manifest_policy_invalid' || 'manifest_exclusion_policy_invalid' =>
+        'manifest_policy_invalid' ||
+        'manifest_exclusion_policy_invalid' =>
           '安全ポリシーを確認できないmanifestのため取込を中止しました。',
         'manifest_path_invalid' => '安全でない相対パスを検出したため取込を中止しました。',
         'manifest_hash_invalid' => 'ファイル照合ハッシュが不正なため取込を中止しました。',

--- a/lib/ui/features/notion_migration/view_models/notion_migration_view_model.dart
+++ b/lib/ui/features/notion_migration/view_models/notion_migration_view_model.dart
@@ -1,15 +1,25 @@
 import 'package:flutter/foundation.dart';
 
 import '../data/notion_migration_gateway.dart';
+import '../data/notion_vault_manifest_service.dart';
 import '../domain/notion_migration_models.dart';
 
 enum NotionMigrationLoadStatus { initial, loading, ready, failure }
 
 class NotionMigrationViewModel extends ChangeNotifier {
-  NotionMigrationViewModel({required NotionMigrationGateway gateway})
-      : _gateway = gateway;
+  NotionMigrationViewModel({
+    required NotionMigrationGateway gateway,
+    NotionVaultManifestPicker? vaultManifestPicker,
+    NotionVaultManifestParser? vaultManifestParser,
+  }) : _gateway = gateway,
+       _vaultManifestPicker =
+           vaultManifestPicker ?? const FilePickerNotionVaultManifestPicker(),
+       _vaultManifestParser =
+           vaultManifestParser ?? const NotionVaultManifestParser();
 
   final NotionMigrationGateway _gateway;
+  final NotionVaultManifestPicker _vaultManifestPicker;
+  final NotionVaultManifestParser _vaultManifestParser;
 
   NotionMigrationLoadStatus _loadStatus = NotionMigrationLoadStatus.initial;
   NotionMigrationSnapshot _snapshot = const NotionMigrationSnapshot();
@@ -17,6 +27,9 @@ class NotionMigrationViewModel extends ChangeNotifier {
   bool _isInventoryRunning = false;
   bool _isReconciliationRunning = false;
   bool _isWbsStaging = false;
+  bool _isVaultManifestSelecting = false;
+  bool _isVaultManifestStaging = false;
+  NotionVaultManifestPreview? _vaultManifestPreview;
   bool _authenticationRequired = false;
   String? _errorMessage;
   String? _noticeMessage;
@@ -27,6 +40,9 @@ class NotionMigrationViewModel extends ChangeNotifier {
   bool get isInventoryRunning => _isInventoryRunning;
   bool get isReconciliationRunning => _isReconciliationRunning;
   bool get isWbsStaging => _isWbsStaging;
+  bool get isVaultManifestSelecting => _isVaultManifestSelecting;
+  bool get isVaultManifestStaging => _isVaultManifestStaging;
+  NotionVaultManifestPreview? get vaultManifestPreview => _vaultManifestPreview;
   bool get authenticationRequired => _authenticationRequired;
   String? get errorMessage => _errorMessage;
   String? get noticeMessage => _noticeMessage;
@@ -99,6 +115,7 @@ class NotionMigrationViewModel extends ChangeNotifier {
         capabilities: refreshed.capabilities,
         wbsReconciliation: result,
         wbsStageSummary: refreshed.wbsStageSummary,
+        vaultManifestSummary: refreshed.vaultManifestSummary,
       );
       _noticeMessage = result.deletionGatePassed
           ? 'WBSの全ID・全ミラー項目が一致しました。7項目の残りの検証が終わるまでNotion側は保持します。'
@@ -130,6 +147,7 @@ class NotionMigrationViewModel extends ChangeNotifier {
         capabilities: refreshed.capabilities,
         wbsReconciliation: refreshed.wbsReconciliation,
         wbsStageSummary: result,
+        vaultManifestSummary: refreshed.vaultManifestSummary,
       );
       _noticeMessage =
           'WBS ${result.stagedRows}行を安全領域へ保存しました。重複${result.duplicateRows}行と属性差分を解決するまで本番WBS・Notion側は変更しません。';
@@ -139,6 +157,69 @@ class NotionMigrationViewModel extends ChangeNotifier {
       return false;
     } finally {
       _isWbsStaging = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> selectVaultManifest() async {
+    if (_isVaultManifestSelecting || _isVaultManifestStaging) return false;
+    _isVaultManifestSelecting = true;
+    _errorMessage = null;
+    _noticeMessage = null;
+    notifyListeners();
+    try {
+      final picked = await _vaultManifestPicker.pick();
+      if (picked == null) return false;
+      final preview = _vaultManifestParser.parse(picked);
+      _vaultManifestPreview = preview;
+      _noticeMessage =
+          '${preview.stageableCount}件の構造情報を確認しました。本文・プロパティ値・除外${preview.excludedCount}件のパスは送信しません。';
+      return true;
+    } catch (error) {
+      _errorMessage = _vaultManifestError(error);
+      return false;
+    } finally {
+      _isVaultManifestSelecting = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> stageVaultManifest() async {
+    final batch = _snapshot.batch;
+    final preview = _vaultManifestPreview;
+    if (batch == null ||
+        preview == null ||
+        _isVaultManifestStaging ||
+        _isVaultManifestSelecting) {
+      return false;
+    }
+    _isVaultManifestStaging = true;
+    _errorMessage = null;
+    _noticeMessage = null;
+    notifyListeners();
+    try {
+      final result = await _gateway.stageVaultManifest(
+        batchId: batch.id,
+        manifest: preview,
+      );
+      final refreshed = await _gateway.loadLatest();
+      _snapshot = NotionMigrationSnapshot(
+        batch: refreshed.batch,
+        progress: refreshed.progress,
+        items: refreshed.items,
+        capabilities: refreshed.capabilities,
+        wbsReconciliation: refreshed.wbsReconciliation,
+        wbsStageSummary: refreshed.wbsStageSummary,
+        vaultManifestSummary: result,
+      );
+      _noticeMessage =
+          'Obsidian構造情報${result.stagedEntryCount}件を安全領域へ保存しました。除外${result.excludedCount}件のパス・本文・認証情報は保存していません。';
+      return true;
+    } catch (error) {
+      _errorMessage = _vaultManifestError(error, staging: true);
+      return false;
+    } finally {
+      _isVaultManifestStaging = false;
       notifyListeners();
     }
   }
@@ -172,7 +253,8 @@ class NotionMigrationViewModel extends ChangeNotifier {
     _loadStatus = keepReady
         ? NotionMigrationLoadStatus.ready
         : NotionMigrationLoadStatus.failure;
-    _authenticationRequired = error is NotionMigrationException &&
+    _authenticationRequired =
+        error is NotionMigrationException &&
         error.code == 'authentication_required';
     _errorMessage = _authenticationRequired
         ? 'この機能を使うにはログインしてください。'
@@ -196,8 +278,7 @@ class NotionMigrationViewModel extends ChangeNotifier {
       return switch (error.code) {
         'admin_required' => 'WBS照合は管理者だけが実行できます。',
         'notion_not_configured' ||
-        'wbs_source_not_configured' =>
-          'サーバー側のNotion WBS接続が未設定です。',
+        'wbs_source_not_configured' => 'サーバー側のNotion WBS接続が未設定です。',
         'wbs_database_has_multiple_data_sources' =>
           'WBSデータベースに複数のデータソースがあります。対象IDをサーバー設定で明示してください。',
         'batch_not_found' => '移行台帳が見つかりません。再読み込みしてください。',
@@ -212,8 +293,7 @@ class NotionMigrationViewModel extends ChangeNotifier {
       return switch (error.code) {
         'admin_required' => 'WBS取込は管理者だけが実行できます。',
         'notion_not_configured' ||
-        'wbs_source_not_configured' =>
-          'サーバー側のNotion WBS接続が未設定です。',
+        'wbs_source_not_configured' => 'サーバー側のNotion WBS接続が未設定です。',
         'wbs_stage_inventory_incomplete' =>
           'Notion WBSの全ページを取得できなかったため、安全領域への取込を中止しました。',
         'batch_not_found' => '移行台帳が見つかりません。再読み込みしてください。',
@@ -221,5 +301,26 @@ class NotionMigrationViewModel extends ChangeNotifier {
       };
     }
     return 'WBSの安全領域への取込に失敗しました。本番WBSとNotion側は変更していません。';
+  }
+
+  String _vaultManifestError(Object error, {bool staging = false}) {
+    if (error is NotionVaultManifestException) {
+      return switch (error.code) {
+        'manifest_size_invalid' => 'manifestが空か、10MBの上限を超えています。',
+        'manifest_json_invalid' => '選択したファイルは有効なJSONではありません。',
+        'manifest_policy_invalid' || 'manifest_exclusion_policy_invalid' =>
+          '安全ポリシーを確認できないmanifestのため取込を中止しました。',
+        'manifest_path_invalid' => '安全でない相対パスを検出したため取込を中止しました。',
+        'manifest_hash_invalid' => 'ファイル照合ハッシュが不正なため取込を中止しました。',
+        _ => 'Obsidian manifestを検証できませんでした。ローカル生成器で再作成してください。',
+      };
+    }
+    if (error is NotionMigrationException &&
+        error.code == 'authentication_required') {
+      return '安全領域へ保存するにはログインしてください。';
+    }
+    return staging
+        ? 'Obsidian構造情報の安全領域への保存に失敗しました。保管庫とNotion側は変更していません。'
+        : 'Obsidian manifestを読み込めませんでした。ファイルを確認してください。';
   }
 }

--- a/lib/ui/features/notion_migration/views/notion_migration_page.dart
+++ b/lib/ui/features/notion_migration/views/notion_migration_page.dart
@@ -30,59 +30,63 @@ class NotionMigrationPage extends StatelessWidget {
           listenable: viewModel,
           builder: (context, _) => switch (viewModel.loadStatus) {
             NotionMigrationLoadStatus.initial ||
-            NotionMigrationLoadStatus.loading =>
-              const Center(
-                child: CircularProgressIndicator(),
-              ),
+            NotionMigrationLoadStatus.loading => const Center(
+              child: CircularProgressIndicator(),
+            ),
             NotionMigrationLoadStatus.failure => _LoadFailure(
-                viewModel: viewModel,
-              ),
+              viewModel: viewModel,
+            ),
             NotionMigrationLoadStatus.ready => LayoutBuilder(
-                builder: (context, constraints) {
-                  final wide = constraints.maxWidth >= _wideBreakpoint;
-                  return SingleChildScrollView(
-                    padding: const EdgeInsets.all(20),
-                    child: Center(
-                      child: ConstrainedBox(
-                        constraints: const BoxConstraints(maxWidth: 1240),
-                        child: Column(
-                          key: Key(
-                            wide
-                                ? 'notion-migration-wide'
-                                : 'notion-migration-compact',
-                          ),
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            const _MigrationHero(),
-                            const SizedBox(height: 16),
-                            if (viewModel.errorMessage != null)
-                              _InlineMessage(message: viewModel.errorMessage!),
-                            if (viewModel.noticeMessage != null)
-                              _InlineMessage(
-                                message: viewModel.noticeMessage!,
-                                isSuccess: true,
-                              ),
-                            if (viewModel.snapshot.batch == null)
-                              _EmptyLedger(viewModel: viewModel)
-                            else
-                              _MigrationLedger(
-                                snapshot: viewModel.snapshot,
-                                wide: wide,
-                                viewModel: viewModel,
-                              ),
-                            const SizedBox(height: 20),
-                            const _SafetyGate(),
-                            const SizedBox(height: 20),
-                            _FeatureMatrix(
-                              capabilities: viewModel.snapshot.capabilities,
-                            ),
-                          ],
+              builder: (context, constraints) {
+                final wide = constraints.maxWidth >= _wideBreakpoint;
+                return SingleChildScrollView(
+                  padding: const EdgeInsets.all(20),
+                  child: Center(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 1240),
+                      child: Column(
+                        key: Key(
+                          wide
+                              ? 'notion-migration-wide'
+                              : 'notion-migration-compact',
                         ),
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const _MigrationHero(),
+                          const SizedBox(height: 16),
+                          if (viewModel.errorMessage != null)
+                            _InlineMessage(message: viewModel.errorMessage!),
+                          if (viewModel.noticeMessage != null)
+                            _InlineMessage(
+                              message: viewModel.noticeMessage!,
+                              isSuccess: true,
+                            ),
+                          if (viewModel.snapshot.batch == null)
+                            _EmptyLedger(viewModel: viewModel)
+                          else
+                            _MigrationLedger(
+                              snapshot: viewModel.snapshot,
+                              wide: wide,
+                              viewModel: viewModel,
+                            ),
+                          const SizedBox(height: 20),
+                          _VaultManifestCard(
+                            snapshot: viewModel.snapshot,
+                            viewModel: viewModel,
+                          ),
+                          const SizedBox(height: 20),
+                          const _SafetyGate(),
+                          const SizedBox(height: 20),
+                          _FeatureMatrix(
+                            capabilities: viewModel.snapshot.capabilities,
+                          ),
+                        ],
                       ),
                     ),
-                  );
-                },
-              ),
+                  ),
+                );
+              },
+            ),
           },
         ),
       ),
@@ -294,7 +298,8 @@ class _MigrationLedger extends StatelessWidget {
                     ),
                     OutlinedButton.icon(
                       key: const Key('notion-migration-inventory-expand'),
-                      onPressed: viewModel.isInventoryRunning ||
+                      onPressed:
+                          viewModel.isInventoryRunning ||
                               snapshot.progress.totalItems == 0
                           ? null
                           : () => unawaited(viewModel.expandInventory()),
@@ -308,7 +313,8 @@ class _MigrationLedger extends StatelessWidget {
                     ),
                     OutlinedButton.icon(
                       key: const Key('notion-migration-reconcile-wbs'),
-                      onPressed: viewModel.isReconciliationRunning ||
+                      onPressed:
+                          viewModel.isReconciliationRunning ||
                               viewModel.isInventoryRunning ||
                               snapshot.progress.totalItems == 0
                           ? null
@@ -323,7 +329,8 @@ class _MigrationLedger extends StatelessWidget {
                     ),
                     FilledButton.tonalIcon(
                       key: const Key('notion-migration-stage-wbs'),
-                      onPressed: viewModel.isWbsStaging ||
+                      onPressed:
+                          viewModel.isWbsStaging ||
                               viewModel.isReconciliationRunning ||
                               viewModel.isInventoryRunning ||
                               snapshot.wbsReconciliation == null
@@ -639,7 +646,8 @@ class _ItemPanel extends StatelessWidget {
                   subtitle: Text(
                     '${item.status.label} • 照合 ${item.passedChecks}/7',
                   ),
-                  trailing: item.status ==
+                  trailing:
+                      item.status ==
                           NotionMigrationItemStatus.readyForSourceDeletion
                       ? const Icon(Icons.verified, color: Colors.green)
                       : null,
@@ -652,12 +660,194 @@ class _ItemPanel extends StatelessWidget {
   }
 
   IconData _iconFor(String kind) => switch (kind) {
-        'database' || 'data_source' => Icons.table_chart_outlined,
-        'attachment' => Icons.attach_file,
-        'comment' => Icons.comment_outlined,
-        'teamspace' => Icons.groups_outlined,
-        _ => Icons.description_outlined,
-      };
+    'database' || 'data_source' => Icons.table_chart_outlined,
+    'attachment' => Icons.attach_file,
+    'comment' => Icons.comment_outlined,
+    'teamspace' => Icons.groups_outlined,
+    _ => Icons.description_outlined,
+  };
+}
+
+class _VaultManifestCard extends StatelessWidget {
+  const _VaultManifestCard({required this.snapshot, required this.viewModel});
+
+  final NotionMigrationSnapshot snapshot;
+  final NotionMigrationViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final preview = viewModel.vaultManifestPreview;
+    final staged = snapshot.vaultManifestSummary;
+    return Card(
+      key: const Key('notion-migration-vault-manifest-card'),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Row(
+              children: [
+                Icon(Icons.hub_outlined),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Obsidian保管庫を安全な中継地点にする',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+                  ),
+                ),
+                Chip(label: Text('ローカル先行')),
+              ],
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'ローカル生成したmanifestだけをブラウザ内で検証します。ノート本文・プロパティ値・'
+              '認証情報・除外ファイルのパスは送信せず、許可されたノートと添付の構造情報だけを'
+              '本番データとは分離した安全領域へ保存します。',
+              style: TextStyle(height: 1.5),
+            ),
+            const SizedBox(height: 14),
+            Wrap(
+              spacing: 12,
+              runSpacing: 10,
+              children: [
+                OutlinedButton.icon(
+                  key: const Key('notion-migration-vault-manifest-pick'),
+                  onPressed:
+                      viewModel.isVaultManifestSelecting ||
+                          viewModel.isVaultManifestStaging
+                      ? null
+                      : () => unawaited(viewModel.selectVaultManifest()),
+                  icon: viewModel.isVaultManifestSelecting
+                      ? const SizedBox.square(
+                          dimension: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.file_open_outlined),
+                  label: const Text('manifest JSONを選択'),
+                ),
+                FilledButton.tonalIcon(
+                  key: const Key('notion-migration-vault-manifest-stage'),
+                  onPressed:
+                      snapshot.batch == null ||
+                          preview == null ||
+                          viewModel.isVaultManifestSelecting ||
+                          viewModel.isVaultManifestStaging
+                      ? null
+                      : () => unawaited(_confirmAndStage(context)),
+                  icon: viewModel.isVaultManifestStaging
+                      ? const SizedBox.square(
+                          dimension: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.inventory_2_outlined),
+                  label: const Text('構造情報を安全領域へ保存'),
+                ),
+              ],
+            ),
+            if (snapshot.batch == null) ...[
+              const SizedBox(height: 8),
+              const Text('保存するには先に移行台帳を作成してください。'),
+            ],
+            if (preview != null) ...[
+              const SizedBox(height: 16),
+              Container(
+                key: const Key('notion-migration-vault-manifest-preview'),
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainerHigh,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      '${preview.vaultName} / ${preview.sourceFileName}',
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 10,
+                      runSpacing: 10,
+                      children: [
+                        _Metric(label: '全件', value: preview.fileCount),
+                        _Metric(label: '自動保存', value: preview.autoStageCount),
+                        _Metric(
+                          label: '要確認',
+                          value: preview.reviewRequiredCount,
+                          isWarning: preview.reviewRequiredCount > 0,
+                        ),
+                        _Metric(
+                          label: '除外',
+                          value: preview.excludedCount,
+                          isWarning: preview.excludedCount > 0,
+                        ),
+                        _Metric(
+                          label: '認証候補',
+                          value: preview.credentialCandidateCount,
+                          isWarning: preview.credentialCandidateCount > 0,
+                        ),
+                        _Metric(
+                          label: '未解決リンク',
+                          value: preview.unresolvedWikilinkOccurrences,
+                          isWarning: preview.unresolvedWikilinkOccurrences > 0,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+            if (staged != null) ...[
+              const SizedBox(height: 16),
+              Container(
+                key: const Key('notion-migration-vault-manifest-summary'),
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Text(
+                  '最新: ${staged.stagedEntryCount}件を${staged.status == 'staged' ? '保存済み' : '処理中'}。'
+                  '要確認${staged.reviewRequiredCount}件、除外${staged.excludedCount}件。'
+                  '除外パスと本文は保持していません。',
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmAndStage(BuildContext context) async {
+    final preview = viewModel.vaultManifestPreview;
+    if (preview == null) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('構造情報だけを保存しますか？'),
+        content: Text(
+          '${preview.stageableCount}件の相対パス、ハッシュ、リンク・タスク等の構造情報を保存します。'
+          'ノート本文、プロパティ値、認証情報、除外${preview.excludedCount}件のパスは送信しません。'
+          'Notionの元データと本番コンテンツは変更しません。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            key: const Key('notion-migration-vault-manifest-confirm'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('安全領域へ保存'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await viewModel.stageVaultManifest();
+    }
+  }
 }
 
 class _SafetyGate extends StatelessWidget {
@@ -710,9 +900,7 @@ class _FeatureMatrix extends StatelessWidget {
         .where((capability) => capability.isRequired)
         .toList(growable: false);
     final verified = required
-        .where(
-          (capability) => capability.status == NotionParityStatus.verified,
-        )
+        .where((capability) => capability.status == NotionParityStatus.verified)
         .length;
     return Column(
       key: const Key('notion-migration-feature-matrix'),
@@ -741,8 +929,8 @@ class _FeatureMatrix extends StatelessWidget {
               final columns = constraints.maxWidth >= 1000
                   ? 3
                   : constraints.maxWidth >= 620
-                      ? 2
-                      : 1;
+                  ? 2
+                  : 1;
               final width =
                   (constraints.maxWidth - (columns - 1) * 12) / columns;
               return Wrap(
@@ -786,10 +974,7 @@ class _CapabilityCard extends StatelessWidget {
                   ),
                 ),
                 Chip(
-                  avatar: Icon(
-                    _statusIcon(capability.status),
-                    size: 18,
-                  ),
+                  avatar: Icon(_statusIcon(capability.status), size: 18),
                   label: Text(capability.status.label),
                   backgroundColor: _statusColor(context, capability.status),
                 ),
@@ -822,22 +1007,21 @@ class _CapabilityCard extends StatelessWidget {
     return switch (status) {
       NotionParityStatus.verified => colors.primaryContainer,
       NotionParityStatus.gap ||
-      NotionParityStatus.blocked =>
-        colors.errorContainer,
+      NotionParityStatus.blocked => colors.errorContainer,
       NotionParityStatus.verifying => colors.tertiaryContainer,
       _ => colors.surfaceContainerHighest,
     };
   }
 
   IconData _statusIcon(NotionParityStatus status) => switch (status) {
-        NotionParityStatus.verified => Icons.verified_outlined,
-        NotionParityStatus.gap => Icons.warning_amber_outlined,
-        NotionParityStatus.blocked => Icons.block_outlined,
-        NotionParityStatus.verifying => Icons.fact_check_outlined,
-        NotionParityStatus.implemented => Icons.code_outlined,
-        NotionParityStatus.planned => Icons.event_note_outlined,
-        NotionParityStatus.inventory => Icons.inventory_2_outlined,
-      };
+    NotionParityStatus.verified => Icons.verified_outlined,
+    NotionParityStatus.gap => Icons.warning_amber_outlined,
+    NotionParityStatus.blocked => Icons.block_outlined,
+    NotionParityStatus.verifying => Icons.fact_check_outlined,
+    NotionParityStatus.implemented => Icons.code_outlined,
+    NotionParityStatus.planned => Icons.event_note_outlined,
+    NotionParityStatus.inventory => Icons.inventory_2_outlined,
+  };
 }
 
 class _LoadFailure extends StatelessWidget {

--- a/lib/ui/features/notion_migration/views/notion_migration_page.dart
+++ b/lib/ui/features/notion_migration/views/notion_migration_page.dart
@@ -30,63 +30,64 @@ class NotionMigrationPage extends StatelessWidget {
           listenable: viewModel,
           builder: (context, _) => switch (viewModel.loadStatus) {
             NotionMigrationLoadStatus.initial ||
-            NotionMigrationLoadStatus.loading => const Center(
-              child: CircularProgressIndicator(),
-            ),
+            NotionMigrationLoadStatus.loading =>
+              const Center(
+                child: CircularProgressIndicator(),
+              ),
             NotionMigrationLoadStatus.failure => _LoadFailure(
-              viewModel: viewModel,
-            ),
+                viewModel: viewModel,
+              ),
             NotionMigrationLoadStatus.ready => LayoutBuilder(
-              builder: (context, constraints) {
-                final wide = constraints.maxWidth >= _wideBreakpoint;
-                return SingleChildScrollView(
-                  padding: const EdgeInsets.all(20),
-                  child: Center(
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 1240),
-                      child: Column(
-                        key: Key(
-                          wide
-                              ? 'notion-migration-wide'
-                              : 'notion-migration-compact',
-                        ),
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          const _MigrationHero(),
-                          const SizedBox(height: 16),
-                          if (viewModel.errorMessage != null)
-                            _InlineMessage(message: viewModel.errorMessage!),
-                          if (viewModel.noticeMessage != null)
-                            _InlineMessage(
-                              message: viewModel.noticeMessage!,
-                              isSuccess: true,
-                            ),
-                          if (viewModel.snapshot.batch == null)
-                            _EmptyLedger(viewModel: viewModel)
-                          else
-                            _MigrationLedger(
+                builder: (context, constraints) {
+                  final wide = constraints.maxWidth >= _wideBreakpoint;
+                  return SingleChildScrollView(
+                    padding: const EdgeInsets.all(20),
+                    child: Center(
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 1240),
+                        child: Column(
+                          key: Key(
+                            wide
+                                ? 'notion-migration-wide'
+                                : 'notion-migration-compact',
+                          ),
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            const _MigrationHero(),
+                            const SizedBox(height: 16),
+                            if (viewModel.errorMessage != null)
+                              _InlineMessage(message: viewModel.errorMessage!),
+                            if (viewModel.noticeMessage != null)
+                              _InlineMessage(
+                                message: viewModel.noticeMessage!,
+                                isSuccess: true,
+                              ),
+                            if (viewModel.snapshot.batch == null)
+                              _EmptyLedger(viewModel: viewModel)
+                            else
+                              _MigrationLedger(
+                                snapshot: viewModel.snapshot,
+                                wide: wide,
+                                viewModel: viewModel,
+                              ),
+                            const SizedBox(height: 20),
+                            _VaultManifestCard(
                               snapshot: viewModel.snapshot,
-                              wide: wide,
                               viewModel: viewModel,
                             ),
-                          const SizedBox(height: 20),
-                          _VaultManifestCard(
-                            snapshot: viewModel.snapshot,
-                            viewModel: viewModel,
-                          ),
-                          const SizedBox(height: 20),
-                          const _SafetyGate(),
-                          const SizedBox(height: 20),
-                          _FeatureMatrix(
-                            capabilities: viewModel.snapshot.capabilities,
-                          ),
-                        ],
+                            const SizedBox(height: 20),
+                            const _SafetyGate(),
+                            const SizedBox(height: 20),
+                            _FeatureMatrix(
+                              capabilities: viewModel.snapshot.capabilities,
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                );
-              },
-            ),
+                  );
+                },
+              ),
           },
         ),
       ),
@@ -298,8 +299,7 @@ class _MigrationLedger extends StatelessWidget {
                     ),
                     OutlinedButton.icon(
                       key: const Key('notion-migration-inventory-expand'),
-                      onPressed:
-                          viewModel.isInventoryRunning ||
+                      onPressed: viewModel.isInventoryRunning ||
                               snapshot.progress.totalItems == 0
                           ? null
                           : () => unawaited(viewModel.expandInventory()),
@@ -313,8 +313,7 @@ class _MigrationLedger extends StatelessWidget {
                     ),
                     OutlinedButton.icon(
                       key: const Key('notion-migration-reconcile-wbs'),
-                      onPressed:
-                          viewModel.isReconciliationRunning ||
+                      onPressed: viewModel.isReconciliationRunning ||
                               viewModel.isInventoryRunning ||
                               snapshot.progress.totalItems == 0
                           ? null
@@ -329,8 +328,7 @@ class _MigrationLedger extends StatelessWidget {
                     ),
                     FilledButton.tonalIcon(
                       key: const Key('notion-migration-stage-wbs'),
-                      onPressed:
-                          viewModel.isWbsStaging ||
+                      onPressed: viewModel.isWbsStaging ||
                               viewModel.isReconciliationRunning ||
                               viewModel.isInventoryRunning ||
                               snapshot.wbsReconciliation == null
@@ -646,8 +644,7 @@ class _ItemPanel extends StatelessWidget {
                   subtitle: Text(
                     '${item.status.label} • 照合 ${item.passedChecks}/7',
                   ),
-                  trailing:
-                      item.status ==
+                  trailing: item.status ==
                           NotionMigrationItemStatus.readyForSourceDeletion
                       ? const Icon(Icons.verified, color: Colors.green)
                       : null,
@@ -660,12 +657,12 @@ class _ItemPanel extends StatelessWidget {
   }
 
   IconData _iconFor(String kind) => switch (kind) {
-    'database' || 'data_source' => Icons.table_chart_outlined,
-    'attachment' => Icons.attach_file,
-    'comment' => Icons.comment_outlined,
-    'teamspace' => Icons.groups_outlined,
-    _ => Icons.description_outlined,
-  };
+        'database' || 'data_source' => Icons.table_chart_outlined,
+        'attachment' => Icons.attach_file,
+        'comment' => Icons.comment_outlined,
+        'teamspace' => Icons.groups_outlined,
+        _ => Icons.description_outlined,
+      };
 }
 
 class _VaultManifestCard extends StatelessWidget {
@@ -712,8 +709,7 @@ class _VaultManifestCard extends StatelessWidget {
               children: [
                 OutlinedButton.icon(
                   key: const Key('notion-migration-vault-manifest-pick'),
-                  onPressed:
-                      viewModel.isVaultManifestSelecting ||
+                  onPressed: viewModel.isVaultManifestSelecting ||
                           viewModel.isVaultManifestStaging
                       ? null
                       : () => unawaited(viewModel.selectVaultManifest()),
@@ -727,8 +723,7 @@ class _VaultManifestCard extends StatelessWidget {
                 ),
                 FilledButton.tonalIcon(
                   key: const Key('notion-migration-vault-manifest-stage'),
-                  onPressed:
-                      snapshot.batch == null ||
+                  onPressed: snapshot.batch == null ||
                           preview == null ||
                           viewModel.isVaultManifestSelecting ||
                           viewModel.isVaultManifestStaging
@@ -929,8 +924,8 @@ class _FeatureMatrix extends StatelessWidget {
               final columns = constraints.maxWidth >= 1000
                   ? 3
                   : constraints.maxWidth >= 620
-                  ? 2
-                  : 1;
+                      ? 2
+                      : 1;
               final width =
                   (constraints.maxWidth - (columns - 1) * 12) / columns;
               return Wrap(
@@ -1007,21 +1002,22 @@ class _CapabilityCard extends StatelessWidget {
     return switch (status) {
       NotionParityStatus.verified => colors.primaryContainer,
       NotionParityStatus.gap ||
-      NotionParityStatus.blocked => colors.errorContainer,
+      NotionParityStatus.blocked =>
+        colors.errorContainer,
       NotionParityStatus.verifying => colors.tertiaryContainer,
       _ => colors.surfaceContainerHighest,
     };
   }
 
   IconData _statusIcon(NotionParityStatus status) => switch (status) {
-    NotionParityStatus.verified => Icons.verified_outlined,
-    NotionParityStatus.gap => Icons.warning_amber_outlined,
-    NotionParityStatus.blocked => Icons.block_outlined,
-    NotionParityStatus.verifying => Icons.fact_check_outlined,
-    NotionParityStatus.implemented => Icons.code_outlined,
-    NotionParityStatus.planned => Icons.event_note_outlined,
-    NotionParityStatus.inventory => Icons.inventory_2_outlined,
-  };
+        NotionParityStatus.verified => Icons.verified_outlined,
+        NotionParityStatus.gap => Icons.warning_amber_outlined,
+        NotionParityStatus.blocked => Icons.block_outlined,
+        NotionParityStatus.verifying => Icons.fact_check_outlined,
+        NotionParityStatus.implemented => Icons.code_outlined,
+        NotionParityStatus.planned => Icons.event_note_outlined,
+        NotionParityStatus.inventory => Icons.inventory_2_outlined,
+      };
 }
 
 class _LoadFailure extends StatelessWidget {

--- a/scripts/obsidian_vault_migration_manifest.py
+++ b/scripts/obsidian_vault_migration_manifest.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Create a local-only migration manifest for an Obsidian vault.
+
+The scanner never performs network requests or copies vault files. Credential
+candidates and excluded configuration/instruction paths are classified from
+their path only: they are not opened or hashed. Markdown output contains
+structure (properties, wikilinks, embeds, callout/task counts), never note body
+text or property values.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import sys
+import tempfile
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+READ_CHUNK_BYTES = 1024 * 1024
+
+PRUNED_DIRECTORIES = {".git"}
+SYSTEM_DIRECTORIES = {".obsidian"}
+SCRIPT_DIRECTORIES = {"scripts"}
+TEMPLATE_DIRECTORIES = {"templates"}
+MIGRATION_METADATA_DIRECTORIES = {"_control", "_source"}
+INSTRUCTION_FILE_NAMES = {
+    "agents.md",
+    "claude.md",
+    "codex.md",
+}
+SENSITIVE_NOTE_STEMS = {
+    "accounts_list",
+    "debt_management",
+    "financial_records",
+    "housing_records",
+    "legal_and_business_tasks",
+    "subscription_list",
+}
+CREDENTIAL_SUFFIXES = {
+    ".cer",
+    ".crt",
+    ".env",
+    ".jks",
+    ".key",
+    ".p12",
+    ".pem",
+    ".pfx",
+}
+CREDENTIAL_NAME_HINT = re.compile(
+    r"(?i)(?:credential|oauth|private[-_ ]?key|secret|service[-_ ]?account|token)"
+)
+ATTACHMENT_SUFFIXES = {
+    ".avif",
+    ".bmp",
+    ".csv",
+    ".doc",
+    ".docx",
+    ".gif",
+    ".heic",
+    ".jpeg",
+    ".jpg",
+    ".m4a",
+    ".mov",
+    ".mp3",
+    ".mp4",
+    ".ogg",
+    ".pdf",
+    ".png",
+    ".ppt",
+    ".pptx",
+    ".svg",
+    ".tif",
+    ".tiff",
+    ".tsv",
+    ".wav",
+    ".webm",
+    ".webp",
+    ".xls",
+    ".xlsx",
+    ".zip",
+}
+
+WIKILINK = re.compile(r"(!?)\[\[([^\[\]]+?)\]\]")
+EXTERNAL_LINK = re.compile(r"(?<!!)\[[^\]\r\n]+\]\(https?://[^)\s]+(?:\s+[^)]*)?\)")
+CALLOUT = re.compile(r"(?im)^\s*>\s*\[!([a-z0-9_-]+)\]")
+TASK = re.compile(r"(?im)^\s*[-*+]\s+\[([ x])\]\s+")
+FRONTMATTER_KEY = re.compile(r"^([^\s#][^:\r\n]*?)\s*:")
+
+
+@dataclass(frozen=True)
+class VaultEntry:
+    path: Path
+    relative_path: str
+    size_bytes: int
+    is_symlink: bool = False
+
+
+def _arguments(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument(
+        "--sensitive-note",
+        action="append",
+        default=[],
+        help=(
+            "Additional Markdown filename or stem that must require manual "
+            "review. May be repeated."
+        ),
+    )
+    parser.add_argument(
+        "--credential-path",
+        action="append",
+        default=[],
+        help=(
+            "Known credential path relative to the vault. It is classified "
+            "without being opened or hashed. May be repeated."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-review",
+        action="store_true",
+        help="Return exit code 2 when review-required or credential files exist.",
+    )
+    return parser.parse_args(argv)
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_paths(vault: Path, output: Path) -> tuple[Path, Path]:
+    vault = vault.expanduser().resolve(strict=True)
+    if not vault.is_dir():
+        raise ValueError(f"vault is not a directory: {vault}")
+    if vault.is_symlink():
+        raise ValueError("symlink vault roots are not scanned")
+
+    output = output.expanduser().resolve()
+    if _is_relative_to(output, vault):
+        raise ValueError("output must be outside the vault to keep it read-only")
+    return vault, output
+
+
+def _walk_vault(vault: Path) -> Iterable[VaultEntry]:
+    def visit(directory: Path, relative_directory: PurePosixPath) -> Iterable[VaultEntry]:
+        with os.scandir(directory) as iterator:
+            entries = sorted(iterator, key=lambda entry: entry.name.casefold())
+        for entry in entries:
+            relative = relative_directory / entry.name
+            relative_path = relative.as_posix()
+            if entry.is_symlink():
+                stat = entry.stat(follow_symlinks=False)
+                yield VaultEntry(
+                    path=Path(entry.path),
+                    relative_path=relative_path,
+                    size_bytes=stat.st_size,
+                    is_symlink=True,
+                )
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                if entry.name.casefold() in PRUNED_DIRECTORIES:
+                    continue
+                yield from visit(Path(entry.path), relative)
+                continue
+            if entry.is_file(follow_symlinks=False):
+                stat = entry.stat(follow_symlinks=False)
+                yield VaultEntry(
+                    path=Path(entry.path),
+                    relative_path=relative_path,
+                    size_bytes=stat.st_size,
+                )
+
+    return visit(vault, PurePosixPath())
+
+
+def _path_parts(entry: VaultEntry) -> tuple[str, ...]:
+    return tuple(part.casefold() for part in PurePosixPath(entry.relative_path).parts)
+
+
+def _classify(
+    entry: VaultEntry,
+    sensitive_note_stems: set[str],
+    credential_paths: set[str],
+) -> tuple[str, str, str]:
+    parts = _path_parts(entry)
+    path = entry.path
+    name = path.name.casefold()
+    suffix = path.suffix.casefold()
+    stem = path.stem.casefold()
+
+    if entry.is_symlink:
+        return "symlink", "exclude", "symlink_not_followed"
+    if any(part in SYSTEM_DIRECTORIES for part in parts[:-1]):
+        return "system_config", "exclude", "obsidian_configuration"
+    if any(part.startswith(".") for part in parts):
+        return "hidden_path", "exclude", "hidden_or_backup_path"
+    if any(part in SCRIPT_DIRECTORIES for part in parts[:-1]):
+        return "script", "exclude", "executable_or_automation"
+    if any(part in TEMPLATE_DIRECTORIES for part in parts[:-1]):
+        return "template", "exclude", "template_requires_separate_review"
+    if any(part in MIGRATION_METADATA_DIRECTORIES for part in parts[:-1]):
+        return "migration_metadata", "exclude", "raw_or_control_migration_data"
+    if name in INSTRUCTION_FILE_NAMES:
+        return "instruction", "exclude", "agent_or_workspace_instruction"
+    if entry.relative_path.casefold() in credential_paths:
+        return "credential_candidate", "exclude", "explicit_credential_path"
+    if suffix in CREDENTIAL_SUFFIXES or CREDENTIAL_NAME_HINT.search(name):
+        return "credential_candidate", "exclude", "credential_candidate_path"
+    if suffix == ".json":
+        return "structured_data", "exclude", "json_requires_separate_review"
+    if suffix == ".md" and stem in sensitive_note_stems:
+        return "note", "review_required", "sensitive_note_policy"
+    if suffix == ".md":
+        return "note", "auto_stage", "markdown_note"
+    if suffix in ATTACHMENT_SUFFIXES:
+        return "attachment", "auto_stage", "supported_attachment"
+    return "unsupported", "exclude", "unsupported_file_type"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(READ_CHUNK_BYTES):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _frontmatter_keys(lines: list[str]) -> tuple[bool, list[str]]:
+    if not lines or lines[0].strip() != "---":
+        return False, []
+    keys: set[str] = set()
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return True, sorted(keys, key=str.casefold)
+        if line.startswith((" ", "\t")):
+            continue
+        match = FRONTMATTER_KEY.match(line)
+        if match:
+            keys.add(match.group(1).strip())
+    return False, []
+
+
+def _link_target(raw: str) -> str:
+    target = raw.split("|", 1)[0].strip()
+    return target
+
+
+def _read_markdown_metadata(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8-sig", errors="replace")
+    frontmatter_present, property_keys = _frontmatter_keys(text.splitlines())
+
+    link_counts: Counter[tuple[str, bool]] = Counter()
+    for match in WIKILINK.finditer(text):
+        target = _link_target(match.group(2))
+        if target:
+            link_counts[(target, bool(match.group(1)))] += 1
+    links = [
+        {
+            "target": target,
+            "embedded": embedded,
+            "occurrences": count,
+        }
+        for (target, embedded), count in sorted(
+            link_counts.items(), key=lambda item: (item[0][0].casefold(), item[0][1])
+        )
+    ]
+
+    callout_types = Counter(match.group(1).casefold() for match in CALLOUT.finditer(text))
+    tasks = [match.group(1).casefold() for match in TASK.finditer(text)]
+    return {
+        "frontmatter_present": frontmatter_present,
+        "property_keys": property_keys,
+        "wikilinks": links,
+        "external_link_count": len(EXTERNAL_LINK.findall(text)),
+        "callout_types": dict(sorted(callout_types.items())),
+        "task_count": len(tasks),
+        "completed_task_count": sum(value == "x" for value in tasks),
+    }
+
+
+def _record_for(
+    entry: VaultEntry,
+    sensitive_note_stems: set[str],
+    credential_paths: set[str],
+) -> dict[str, Any]:
+    category, action, reason = _classify(
+        entry, sensitive_note_stems, credential_paths
+    )
+    inspect_content = category == "note" and action != "exclude"
+    hash_content = action != "exclude" and category in {"note", "attachment"}
+    record: dict[str, Any] = {
+        "relative_path": entry.relative_path,
+        "category": category,
+        "migration_action": action,
+        "reason": reason,
+        "size_bytes": entry.size_bytes,
+        "content_inspected": inspect_content,
+        "sha256": _sha256(entry.path) if hash_content else None,
+    }
+    if inspect_content:
+        record["markdown"] = _read_markdown_metadata(entry.path)
+    return record
+
+
+def _target_base(target: str) -> str:
+    return target.split("#", 1)[0].split("^", 1)[0].strip().replace("\\", "/")
+
+
+def _target_indexes(
+    records: list[dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, list[dict[str, Any]]]]:
+    exact: dict[str, dict[str, Any]] = {}
+    by_stem: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        relative = PurePosixPath(record["relative_path"])
+        exact[relative.as_posix().casefold()] = record
+        exact[relative.with_suffix("").as_posix().casefold()] = record
+        by_stem[relative.stem.casefold()].append(record)
+    return exact, by_stem
+
+
+def _resolve_link(
+    source_path: str,
+    target: str,
+    exact: dict[str, dict[str, Any]],
+    by_stem: dict[str, list[dict[str, Any]]],
+) -> tuple[dict[str, Any] | None, bool]:
+    base = _target_base(target)
+    if not base:
+        return exact.get(source_path.casefold()), False
+    source_parent = PurePosixPath(source_path).parent
+    candidates = [
+        PurePosixPath(base).as_posix().casefold(),
+        (source_parent / base).as_posix().casefold(),
+    ]
+    for candidate in candidates:
+        if candidate in exact:
+            return exact[candidate], False
+    stem_matches = by_stem.get(PurePosixPath(base).stem.casefold(), [])
+    if len(stem_matches) == 1:
+        return stem_matches[0], False
+    return None, len(stem_matches) > 1
+
+
+def _resolve_graph(records: list[dict[str, Any]]) -> tuple[int, set[str]]:
+    exact, by_stem = _target_indexes(records)
+    unresolved = 0
+    referenced_attachments: set[str] = set()
+    attachment_sources: dict[str, set[str]] = defaultdict(set)
+
+    for record in records:
+        markdown = record.get("markdown")
+        if markdown is None:
+            continue
+        resolved_links: list[dict[str, Any]] = []
+        for link in markdown["wikilinks"]:
+            target_record, ambiguous = _resolve_link(
+                record["relative_path"], link["target"], exact, by_stem
+            )
+            resolved_path = (
+                target_record["relative_path"] if target_record is not None else None
+            )
+            is_resolved = target_record is not None
+            if not is_resolved:
+                unresolved += link["occurrences"]
+            resolved_links.append(
+                {
+                    **link,
+                    "resolved": is_resolved,
+                    "ambiguous": ambiguous,
+                    "resolved_relative_path": resolved_path,
+                    "target_migration_action": (
+                        target_record["migration_action"]
+                        if target_record is not None
+                        else None
+                    ),
+                }
+            )
+            if (
+                link["embedded"]
+                and target_record is not None
+                and target_record["category"] == "attachment"
+            ):
+                referenced_attachments.add(target_record["relative_path"])
+                attachment_sources[target_record["relative_path"]].add(
+                    record["relative_path"]
+                )
+        markdown["wikilinks"] = resolved_links
+
+    for record in records:
+        if record["category"] == "attachment":
+            record["referenced_by"] = sorted(
+                attachment_sources.get(record["relative_path"], set()),
+                key=str.casefold,
+            )
+    return unresolved, referenced_attachments
+
+
+def build_manifest(
+    vault: Path,
+    *,
+    additional_sensitive_notes: Iterable[str] = (),
+    credential_paths: Iterable[str] = (),
+) -> dict[str, Any]:
+    sensitive_note_stems = set(SENSITIVE_NOTE_STEMS)
+    sensitive_note_stems.update(
+        Path(value).stem.casefold() for value in additional_sensitive_notes
+    )
+    normalized_credential_paths = {
+        PurePosixPath(value.replace("\\", "/")).as_posix().casefold()
+        for value in credential_paths
+    }
+    entries = [
+        _record_for(entry, sensitive_note_stems, normalized_credential_paths)
+        for entry in _walk_vault(vault)
+    ]
+    entries.sort(key=lambda entry: entry["relative_path"].casefold())
+    unresolved_links, referenced_attachments = _resolve_graph(entries)
+
+    action_counts = Counter(entry["migration_action"] for entry in entries)
+    category_counts = Counter(entry["category"] for entry in entries)
+    attachment_paths = {
+        entry["relative_path"]
+        for entry in entries
+        if entry["category"] == "attachment"
+        and entry["migration_action"] != "exclude"
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "local_only": True,
+        "vault_name": vault.name,
+        "source_absolute_path_included": False,
+        "policy": {
+            "network_requests": False,
+            "vault_files_copied": False,
+            "note_body_or_property_values_included": False,
+            "excluded_files_opened_or_hashed": False,
+        },
+        "entries": entries,
+        "summary": {
+            "file_count": len(entries),
+            "action_counts": dict(sorted(action_counts.items())),
+            "category_counts": dict(sorted(category_counts.items())),
+            "review_required_count": action_counts["review_required"],
+            "credential_candidate_count": category_counts["credential_candidate"],
+            "unresolved_wikilink_occurrences": unresolved_links,
+            "unreferenced_attachment_count": len(
+                attachment_paths - referenced_attachments
+            ),
+        },
+    }
+
+
+def _write_manifest(manifest: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(manifest, ensure_ascii=False, indent=2) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, output)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _arguments(argv)
+    try:
+        vault, output = _validate_paths(args.vault, args.output)
+        manifest = build_manifest(
+            vault,
+            additional_sensitive_notes=args.sensitive_note,
+            credential_paths=args.credential_path,
+        )
+        _write_manifest(manifest, output)
+    except (OSError, ValueError) as error:
+        print(f"Obsidian vault manifest failed: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(manifest["summary"], ensure_ascii=False, sort_keys=True))
+    needs_review = (
+        manifest["summary"]["review_required_count"] > 0
+        or manifest["summary"]["credential_candidate_count"] > 0
+    )
+    return 2 if args.fail_on_review and needs_review else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/migrations/20260827025642_add_notion_vault_manifest_staging.sql
+++ b/supabase/migrations/20260827025642_add_notion_vault_manifest_staging.sql
@@ -1,0 +1,161 @@
+-- Store only a local Obsidian manifest's digest, aggregate safety counts, and
+-- allowlisted note/attachment structure. Note bodies, excluded paths, and
+-- credential material never belong in these tables.
+
+create table public.notion_migration_vault_manifests (
+  id uuid primary key default gen_random_uuid(),
+  batch_id uuid not null,
+  user_id uuid not null default auth.uid(),
+  schema_version integer not null check (schema_version = 1),
+  vault_name text not null check (char_length(vault_name) between 1 and 200),
+  source_file_name text not null check (
+    char_length(source_file_name) between 1 and 255
+    and position('/' in source_file_name) = 0
+    and position(chr(92) in source_file_name) = 0
+  ),
+  source_manifest_sha256 text not null check (
+    source_manifest_sha256 ~ '^[0-9a-f]{64}$'
+  ),
+  file_count integer not null check (file_count >= 0),
+  auto_stage_count integer not null check (auto_stage_count >= 0),
+  review_required_count integer not null check (review_required_count >= 0),
+  excluded_count integer not null check (excluded_count >= 0),
+  credential_candidate_count integer not null check (
+    credential_candidate_count >= 0
+    and credential_candidate_count <= excluded_count
+  ),
+  unresolved_wikilink_occurrences bigint not null default 0 check (
+    unresolved_wikilink_occurrences >= 0
+  ),
+  status text not null default 'staging' check (
+    status in ('staging', 'staged', 'failed')
+  ),
+  staged_entry_count integer not null default 0 check (
+    staged_entry_count >= 0
+    and staged_entry_count <= auto_stage_count + review_required_count
+  ),
+  last_error text check (
+    last_error is null or char_length(last_error) <= 2000
+  ),
+  staged_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (id, batch_id, user_id),
+  unique (batch_id, source_manifest_sha256),
+  foreign key (batch_id, user_id)
+    references public.notion_migration_batches(id, user_id)
+    on delete cascade,
+  check (file_count = auto_stage_count + review_required_count + excluded_count),
+  check (
+    status <> 'staged'
+    or (
+      staged_at is not null
+      and staged_entry_count = auto_stage_count + review_required_count
+    )
+  )
+);
+
+create table public.notion_migration_vault_entries (
+  id uuid primary key default gen_random_uuid(),
+  manifest_id uuid not null,
+  batch_id uuid not null,
+  user_id uuid not null default auth.uid(),
+  relative_path text not null check (
+    char_length(relative_path) between 1 and 4000
+    and relative_path !~ '(^/|(^|/)\.\.(/|$)|^[a-zA-Z]:)'
+    and position(chr(92) in relative_path) = 0
+  ),
+  category text not null check (category in ('note', 'attachment')),
+  migration_action text not null check (
+    migration_action in ('auto_stage', 'review_required')
+  ),
+  size_bytes bigint not null check (size_bytes >= 0),
+  source_hash text not null check (source_hash ~ '^[0-9a-f]{64}$'),
+  structure_metadata jsonb not null default '{}'::jsonb check (
+    jsonb_typeof(structure_metadata) = 'object'
+  ),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (manifest_id, relative_path),
+  check (
+    (
+      category = 'note'
+      and structure_metadata - array[
+        'frontmatter_present',
+        'property_keys',
+        'wikilinks',
+        'external_link_count',
+        'callout_types',
+        'task_count',
+        'completed_task_count'
+      ]::text[] = '{}'::jsonb
+    )
+    or (
+      category = 'attachment'
+      and structure_metadata - array['referenced_by']::text[] = '{}'::jsonb
+    )
+  ),
+  foreign key (manifest_id, batch_id, user_id)
+    references public.notion_migration_vault_manifests(id, batch_id, user_id)
+    on delete cascade
+);
+
+create index notion_migration_vault_manifests_owner_batch_idx
+  on public.notion_migration_vault_manifests (user_id, batch_id, created_at desc);
+create index notion_migration_vault_manifests_batch_owner_idx
+  on public.notion_migration_vault_manifests (batch_id, user_id);
+create index notion_migration_vault_entries_owner_manifest_idx
+  on public.notion_migration_vault_entries (
+    user_id, manifest_id, migration_action
+  );
+
+alter table public.notion_migration_vault_manifests enable row level security;
+alter table public.notion_migration_vault_entries enable row level security;
+
+create policy notion_migration_vault_manifests_select_own
+  on public.notion_migration_vault_manifests
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+create policy notion_migration_vault_manifests_insert_own
+  on public.notion_migration_vault_manifests
+  for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+create policy notion_migration_vault_manifests_update_own
+  on public.notion_migration_vault_manifests
+  for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+create policy notion_migration_vault_entries_select_own
+  on public.notion_migration_vault_entries
+  for select to authenticated
+  using ((select auth.uid()) = user_id);
+create policy notion_migration_vault_entries_insert_own
+  on public.notion_migration_vault_entries
+  for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+create policy notion_migration_vault_entries_update_own
+  on public.notion_migration_vault_entries
+  for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+revoke all on table public.notion_migration_vault_manifests
+  from public, anon, authenticated;
+revoke all on table public.notion_migration_vault_entries
+  from public, anon, authenticated;
+grant select, insert, update
+  on table public.notion_migration_vault_manifests to authenticated;
+grant select, insert, update
+  on table public.notion_migration_vault_entries to authenticated;
+grant select, insert, update, delete
+  on table public.notion_migration_vault_manifests to service_role;
+grant select, insert, update, delete
+  on table public.notion_migration_vault_entries to service_role;
+
+create trigger notion_migration_vault_manifests_touch_updated_at
+  before update on public.notion_migration_vault_manifests
+  for each row execute function public.notion_migration_touch_updated_at();
+create trigger notion_migration_vault_entries_touch_updated_at
+  before update on public.notion_migration_vault_entries
+  for each row execute function public.notion_migration_touch_updated_at();

--- a/test/scripts/test_obsidian_vault_migration_manifest.py
+++ b/test/scripts/test_obsidian_vault_migration_manifest.py
@@ -1,0 +1,215 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from scripts import obsidian_vault_migration_manifest as vault_manifest
+
+
+class ObsidianVaultMigrationManifestTest(unittest.TestCase):
+    def _fixture(self, root: Path) -> Path:
+        vault = root / "company"
+        (vault / "Projects").mkdir(parents=True)
+        (vault / "Attachments").mkdir()
+        (vault / ".obsidian").mkdir()
+        (vault / "scripts").mkdir()
+        (vault / "Templates").mkdir()
+        (vault / ".batch-backup").mkdir()
+
+        (vault / "HOME.md").write_text(
+            """---
+title: Home
+tags:
+  - private
+---
+# Home
+[[Projects/Plan|Plan]]
+![[Attachments/photo.jpg|300]]
+[[Missing]]
+[external](https://example.com)
+> [!warning] Review
+- [x] done
+- [ ] todo
+""",
+            encoding="utf-8",
+        )
+        (vault / "Projects" / "Plan.md").write_text(
+            "# Plan\n[[HOME]]\n", encoding="utf-8"
+        )
+        (vault / "FINANCIAL_RECORDS.md").write_text(
+            "# Finance\naccount: private-value\n", encoding="utf-8"
+        )
+        (vault / "Attachments" / "photo.jpg").write_bytes(b"jpeg fixture")
+        (vault / "Attachments" / "unused.pdf").write_bytes(b"pdf fixture")
+        (vault / ".obsidian" / "app.json").write_text(
+            '{"secret": "must-not-be-read"}', encoding="utf-8"
+        )
+        (vault / "scripts" / "helper.py").write_text(
+            "TOKEN = 'must-not-be-read'\n", encoding="utf-8"
+        )
+        (vault / "Templates" / "Daily.md").write_text(
+            "secret: must-not-be-read\n", encoding="utf-8"
+        )
+        (vault / "AGENTS.md").write_text(
+            "secret: must-not-be-read\n", encoding="utf-8"
+        )
+        (vault / "service-account.json").write_text(
+            '{"private_key": "must-not-be-read"}', encoding="utf-8"
+        )
+        (vault / "catalog.json").write_text(
+            '{"kind": "benign-but-review-first"}', encoding="utf-8"
+        )
+        (vault / ".batch-backup" / "old.md").write_text(
+            "must-not-be-read\n", encoding="utf-8"
+        )
+        return vault
+
+    def test_builds_structural_manifest_and_resolves_graph(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            vault = self._fixture(Path(temporary_directory))
+
+            manifest = vault_manifest.build_manifest(vault)
+
+            self.assertTrue(manifest["local_only"])
+            self.assertFalse(manifest["source_absolute_path_included"])
+            self.assertEqual(manifest["summary"]["file_count"], 12)
+            self.assertEqual(manifest["summary"]["review_required_count"], 1)
+            self.assertEqual(manifest["summary"]["credential_candidate_count"], 1)
+            self.assertEqual(
+                manifest["summary"]["unresolved_wikilink_occurrences"], 1
+            )
+            self.assertEqual(manifest["summary"]["unreferenced_attachment_count"], 1)
+
+            by_path = {
+                entry["relative_path"]: entry for entry in manifest["entries"]
+            }
+            home = by_path["HOME.md"]
+            self.assertEqual(home["markdown"]["property_keys"], ["tags", "title"])
+            self.assertEqual(home["markdown"]["external_link_count"], 1)
+            self.assertEqual(home["markdown"]["callout_types"], {"warning": 1})
+            self.assertEqual(home["markdown"]["task_count"], 2)
+            self.assertEqual(home["markdown"]["completed_task_count"], 1)
+            targets = {
+                link["target"]: link for link in home["markdown"]["wikilinks"]
+            }
+            self.assertEqual(
+                targets["Projects/Plan"]["resolved_relative_path"],
+                "Projects/Plan.md",
+            )
+            self.assertEqual(
+                targets["Attachments/photo.jpg"]["resolved_relative_path"],
+                "Attachments/photo.jpg",
+            )
+            self.assertFalse(targets["Missing"]["resolved"])
+            self.assertEqual(
+                by_path["Attachments/photo.jpg"]["referenced_by"], ["HOME.md"]
+            )
+
+            self.assertEqual(
+                by_path["FINANCIAL_RECORDS.md"]["migration_action"],
+                "review_required",
+            )
+            for excluded in (
+                ".obsidian/app.json",
+                "scripts/helper.py",
+                "Templates/Daily.md",
+                "AGENTS.md",
+                "service-account.json",
+                "catalog.json",
+                ".batch-backup/old.md",
+            ):
+                self.assertEqual(by_path[excluded]["migration_action"], "exclude")
+                self.assertIsNone(by_path[excluded]["sha256"])
+                self.assertFalse(by_path[excluded]["content_inspected"])
+            self.assertEqual(by_path["catalog.json"]["category"], "structured_data")
+            self.assertEqual(by_path[".batch-backup/old.md"]["category"], "hidden_path")
+
+            rendered = json.dumps(manifest, ensure_ascii=False)
+            self.assertNotIn("must-not-be-read", rendered)
+            self.assertNotIn("private-value", rendered)
+
+    def test_excluded_credentials_are_never_hashed_or_opened(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            vault = root / "vault"
+            vault.mkdir()
+            note = vault / "note.md"
+            credential = vault / "company-service-account.json"
+            note.write_text("# Safe\n", encoding="utf-8")
+            credential.write_text('{"private_key": "blocked"}', encoding="utf-8")
+
+            original_hash = vault_manifest._sha256
+            original_metadata = vault_manifest._read_markdown_metadata
+
+            def guarded_hash(path: Path) -> str:
+                self.assertNotEqual(path, credential)
+                return original_hash(path)
+
+            def guarded_metadata(path: Path):
+                self.assertNotEqual(path, credential)
+                return original_metadata(path)
+
+            with mock.patch.object(vault_manifest, "_sha256", side_effect=guarded_hash), mock.patch.object(
+                vault_manifest,
+                "_read_markdown_metadata",
+                side_effect=guarded_metadata,
+            ):
+                manifest = vault_manifest.build_manifest(vault)
+
+            credential_record = next(
+                entry
+                for entry in manifest["entries"]
+                if entry["relative_path"] == credential.name
+            )
+            self.assertEqual(credential_record["category"], "credential_candidate")
+            self.assertIsNone(credential_record["sha256"])
+
+    def test_explicit_credential_path_is_classified_without_reading_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            vault = Path(temporary_directory) / "vault"
+            vault.mkdir()
+            credential = vault / "random-id.json"
+            credential.write_text('{"private_key": "blocked"}', encoding="utf-8")
+
+            with mock.patch.object(
+                vault_manifest,
+                "_sha256",
+                side_effect=AssertionError("credential must not be hashed"),
+            ), mock.patch.object(
+                vault_manifest,
+                "_read_markdown_metadata",
+                side_effect=AssertionError("credential must not be opened"),
+            ):
+                manifest = vault_manifest.build_manifest(
+                    vault, credential_paths=[credential.name]
+                )
+
+            record = manifest["entries"][0]
+            self.assertEqual(record["category"], "credential_candidate")
+            self.assertEqual(record["reason"], "explicit_credential_path")
+
+    def test_output_inside_vault_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            vault = Path(temporary_directory) / "vault"
+            vault.mkdir()
+            output = vault / "manifest.json"
+            with self.assertRaisesRegex(ValueError, "outside the vault"):
+                vault_manifest._validate_paths(vault, output)
+
+    def test_cli_output_is_deterministic_and_fail_on_review_returns_two(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            vault = self._fixture(root)
+            output = root / "manifest.json"
+            command = ["--vault", str(vault), "--output", str(output)]
+
+            self.assertEqual(vault_manifest.main(command), 0)
+            first = output.read_bytes()
+            self.assertEqual(vault_manifest.main(command), 0)
+            self.assertEqual(output.read_bytes(), first)
+            self.assertEqual(vault_manifest.main([*command, "--fail-on-review"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/services/notion_vault_manifest_schema_test.dart
+++ b/test/services/notion_vault_manifest_schema_test.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260827025642_add_notion_vault_manifest_staging.sql';
+
+void main() {
+  late String sql;
+
+  setUpAll(() {
+    sql = File(
+      _migrationPath,
+    ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+  });
+
+  test('stores manifests separately from Notion source-deletion items', () {
+    expect(
+      sql,
+      contains('create table public.notion_migration_vault_manifests'),
+    );
+    expect(sql, contains('create table public.notion_migration_vault_entries'));
+    expect(sql, isNot(contains("source_kind text")));
+    expect(
+      sql,
+      contains(
+        "category text not null check (category in ('note', 'attachment'))",
+      ),
+    );
+    expect(
+      sql,
+      contains("migration_action in ('auto_stage', 'review_required')"),
+    );
+    expect(
+      sql,
+      contains("structure_metadata - array['referenced_by']::text[]"),
+    );
+    expect(sql, isNot(contains("'body'")));
+    expect(sql, isNot(contains("'property_values'")));
+    expect(
+      sql,
+      contains(r"relative_path !~ '(^/|(^|/)\.\.(/|$)|^[a-za-z]:)'"),
+    );
+  });
+
+  test('enforces manifest counts, digest, and completed staging state', () {
+    expect(sql, contains("source_manifest_sha256 ~ '^[0-9a-f]{64}\$'"));
+    expect(
+      sql,
+      contains(
+        'check (file_count = auto_stage_count + review_required_count + excluded_count)',
+      ),
+    );
+    expect(
+      sql,
+      contains(
+        'and staged_entry_count = auto_stage_count + review_required_count',
+      ),
+    );
+    expect(sql, contains('unique (batch_id, source_manifest_sha256)'));
+    expect(sql, contains('unique (manifest_id, relative_path)'));
+  });
+
+  test('binds child rows to the same batch and owner', () {
+    expect(
+      sql,
+      contains(
+        'foreign key (batch_id, user_id)\n'
+        '    references public.notion_migration_batches(id, user_id)',
+      ),
+    );
+    expect(
+      sql,
+      contains(
+        'foreign key (manifest_id, batch_id, user_id)\n'
+        '    references public.notion_migration_vault_manifests(id, batch_id, user_id)',
+      ),
+    );
+  });
+
+  test('RLS exposes owned rows to authenticated users without delete', () {
+    for (final table in <String>[
+      'notion_migration_vault_manifests',
+      'notion_migration_vault_entries',
+    ]) {
+      expect(
+        sql,
+        contains('alter table public.$table enable row level security'),
+      );
+      expect(
+        RegExp(
+          'create policy ${table}_select_own.*?'
+          r'for select to authenticated\s+'
+          r'using \(\(select auth\.uid\(\)\) = user_id\)',
+          dotAll: true,
+        ).hasMatch(sql),
+        isTrue,
+      );
+      expect(
+        RegExp('create policy ${table}_delete_own').hasMatch(sql),
+        isFalse,
+      );
+      expect(
+        sql,
+        contains(
+          'grant select, insert, update\n'
+          '  on table public.$table to authenticated',
+        ),
+      );
+      expect(sql, isNot(contains('on table public.$table to anon')));
+    }
+  });
+}

--- a/test/services/notion_vault_manifest_schema_test.dart
+++ b/test/services/notion_vault_manifest_schema_test.dart
@@ -20,7 +20,7 @@ void main() {
       contains('create table public.notion_migration_vault_manifests'),
     );
     expect(sql, contains('create table public.notion_migration_vault_entries'));
-    expect(sql, isNot(contains("source_kind text")));
+    expect(sql, isNot(contains('source_kind text')));
     expect(
       sql,
       contains(

--- a/test/ui/features/notion_migration/notion_migration_test.dart
+++ b/test/ui/features/notion_migration/notion_migration_test.dart
@@ -1,6 +1,10 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/ui/features/notion_migration/data/notion_migration_gateway.dart';
+import 'package:my_web_app/ui/features/notion_migration/data/notion_vault_manifest_service.dart';
 import 'package:my_web_app/ui/features/notion_migration/domain/notion_migration_models.dart';
 import 'package:my_web_app/ui/features/notion_migration/notion_migration_feature.dart';
 import 'package:my_web_app/ui/features/notion_migration/view_models/notion_migration_view_model.dart';
@@ -150,10 +154,7 @@ void main() {
       find.byKey(const Key('notion-migration-reconcile-wbs')),
       findsOneWidget,
     );
-    expect(
-      find.byKey(const Key('notion-migration-stage-wbs')),
-      findsOneWidget,
-    );
+    expect(find.byKey(const Key('notion-migration-stage-wbs')), findsOneWidget);
     expect(
       find.byKey(const Key('notion-migration-wbs-reconciliation')),
       findsOneWidget,
@@ -182,15 +183,75 @@ void main() {
 
     expect(find.byKey(const Key('login-page')), findsOneWidget);
   });
+
+  testWidgets('vault manifest previews and stages allowlisted structure only', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 1500);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final gateway = _FakeGateway(snapshot: _sampleSnapshot());
+
+    await tester.pumpWidget(
+      _app(
+        gateway,
+        vaultManifestPicker: _FakeVaultManifestPicker(_pickedManifest()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final pickButton = find.byKey(
+      const Key('notion-migration-vault-manifest-pick'),
+    );
+    await tester.ensureVisible(pickButton);
+    await tester.tap(pickButton);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('notion-migration-vault-manifest-preview')),
+      findsOneWidget,
+    );
+    expect(find.text('自動保存'), findsOneWidget);
+    expect(find.text('認証候補'), findsOneWidget);
+
+    final stageButton = find.byKey(
+      const Key('notion-migration-vault-manifest-stage'),
+    );
+    await tester.ensureVisible(stageButton);
+    await tester.tap(stageButton);
+    await tester.pumpAndSettle();
+    expect(find.text('構造情報だけを保存しますか？'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const Key('notion-migration-vault-manifest-confirm')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(gateway.stagedManifest, isNotNull);
+    expect(gateway.stagedManifest!.entries, hasLength(1));
+    expect(gateway.stagedManifest!.entries.single.relativePath, 'HOME.md');
+    expect(
+      find.byKey(const Key('notion-migration-vault-manifest-summary')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('除外パスと本文は保持していません'), findsOneWidget);
+  });
 }
 
-Widget _app(NotionMigrationGateway gateway) {
+Widget _app(
+  NotionMigrationGateway gateway, {
+  NotionVaultManifestPicker? vaultManifestPicker,
+}) {
   return MaterialApp(
     routes: {
       '/login': (_) =>
           const Scaffold(body: Text('Login', key: Key('login-page'))),
     },
-    home: NotionMigrationFeature(gateway: gateway),
+    home: NotionMigrationFeature(
+      gateway: gateway,
+      vaultManifestPicker: vaultManifestPicker,
+    ),
   );
 }
 
@@ -263,9 +324,10 @@ NotionMigrationSnapshot _sampleSnapshot() {
 
 class _FakeGateway implements NotionMigrationGateway {
   _FakeGateway({NotionMigrationSnapshot? snapshot})
-      : _snapshot = snapshot ?? const NotionMigrationSnapshot();
+    : _snapshot = snapshot ?? const NotionMigrationSnapshot();
 
   NotionMigrationSnapshot _snapshot;
+  NotionVaultManifestPreview? stagedManifest;
 
   @override
   Future<NotionMigrationSnapshot> loadLatest() async => _snapshot;
@@ -332,10 +394,98 @@ class _FakeGateway implements NotionMigrationGateway {
       invalidTaskIds: 0,
     );
   }
+
+  @override
+  Future<NotionVaultManifestStageSummary> stageVaultManifest({
+    required String batchId,
+    required NotionVaultManifestPreview manifest,
+  }) async {
+    stagedManifest = manifest;
+    return NotionVaultManifestStageSummary(
+      id: '44444444-4444-4444-8444-444444444444',
+      vaultName: manifest.vaultName,
+      sourceManifestSha256: manifest.sourceManifestSha256,
+      fileCount: manifest.fileCount,
+      stagedEntryCount: manifest.entries.length,
+      reviewRequiredCount: manifest.reviewRequiredCount,
+      excludedCount: manifest.excludedCount,
+      credentialCandidateCount: manifest.credentialCandidateCount,
+      unresolvedWikilinkOccurrences: manifest.unresolvedWikilinkOccurrences,
+      status: 'staged',
+      stagedAt: DateTime.utc(2026, 8, 27),
+    );
+  }
 }
 
 class _AuthenticationRequiredGateway extends _FakeGateway {
   @override
   Future<NotionMigrationSnapshot> loadLatest() =>
       Future.error(const NotionMigrationException('authentication_required'));
+}
+
+class _FakeVaultManifestPicker implements NotionVaultManifestPicker {
+  const _FakeVaultManifestPicker(this.value);
+
+  final PickedNotionVaultManifest value;
+
+  @override
+  Future<PickedNotionVaultManifest?> pick() async => value;
+}
+
+PickedNotionVaultManifest _pickedManifest() {
+  const noteHash =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  final manifest = <String, dynamic>{
+    'schema_version': 1,
+    'local_only': true,
+    'vault_name': 'company',
+    'source_absolute_path_included': false,
+    'policy': <String, dynamic>{
+      'network_requests': false,
+      'vault_files_copied': false,
+      'note_body_or_property_values_included': false,
+      'excluded_files_opened_or_hashed': false,
+    },
+    'entries': <Map<String, dynamic>>[
+      <String, dynamic>{
+        'relative_path': 'HOME.md',
+        'category': 'note',
+        'migration_action': 'auto_stage',
+        'size_bytes': 120,
+        'content_inspected': true,
+        'sha256': noteHash,
+        'markdown': <String, dynamic>{
+          'frontmatter_present': false,
+          'property_keys': <String>[],
+          'wikilinks': <Map<String, dynamic>>[],
+          'external_link_count': 0,
+          'callout_types': <String, int>{},
+          'task_count': 2,
+          'completed_task_count': 1,
+        },
+      },
+      <String, dynamic>{
+        'relative_path': 'private/service-account.json',
+        'category': 'credential_candidate',
+        'migration_action': 'exclude',
+        'size_bytes': 2048,
+        'content_inspected': false,
+        'sha256': null,
+      },
+    ],
+    'summary': <String, dynamic>{
+      'file_count': 2,
+      'action_counts': <String, int>{
+        'auto_stage': 1,
+        'review_required': 0,
+        'exclude': 1,
+      },
+      'credential_candidate_count': 1,
+      'unresolved_wikilink_occurrences': 0,
+    },
+  };
+  return PickedNotionVaultManifest(
+    name: 'company-manifest.json',
+    bytes: Uint8List.fromList(utf8.encode(jsonEncode(manifest))),
+  );
 }

--- a/test/ui/features/notion_migration/notion_migration_test.dart
+++ b/test/ui/features/notion_migration/notion_migration_test.dart
@@ -324,7 +324,7 @@ NotionMigrationSnapshot _sampleSnapshot() {
 
 class _FakeGateway implements NotionMigrationGateway {
   _FakeGateway({NotionMigrationSnapshot? snapshot})
-    : _snapshot = snapshot ?? const NotionMigrationSnapshot();
+      : _snapshot = snapshot ?? const NotionMigrationSnapshot();
 
   NotionMigrationSnapshot _snapshot;
   NotionVaultManifestPreview? stagedManifest;

--- a/test/ui/features/notion_migration/notion_vault_manifest_service_test.dart
+++ b/test/ui/features/notion_migration/notion_vault_manifest_service_test.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/ui/features/notion_migration/data/notion_vault_manifest_service.dart';
+
+void main() {
+  const parser = NotionVaultManifestParser();
+
+  test('keeps only allowlisted structure and omits every excluded path', () {
+    final preview = parser.parse(_picked(_manifest()));
+
+    expect(preview.fileCount, 3);
+    expect(preview.stageableCount, 2);
+    expect(preview.excludedCount, 1);
+    expect(preview.credentialCandidateCount, 1);
+    expect(preview.entries, hasLength(2));
+    expect(
+      preview.entries.map((entry) => entry.relativePath),
+      isNot(contains('private/service-account.json')),
+    );
+    expect(
+      jsonEncode(
+        preview.entries.map((entry) => entry.structureMetadata).toList(),
+      ),
+      isNot(contains('service-account')),
+    );
+    expect(preview.entries.first.structureMetadata, isNot(contains('body')));
+    expect(
+      preview.entries.first.structureMetadata,
+      isNot(contains('property_values')),
+    );
+    expect(preview.sourceManifestSha256, hasLength(64));
+  });
+
+  test('rejects a manifest without the local-only safety contract', () {
+    final manifest = _manifest();
+    manifest['local_only'] = false;
+
+    expect(
+      () => parser.parse(_picked(manifest)),
+      throwsA(
+        isA<NotionVaultManifestException>().having(
+          (error) => error.code,
+          'code',
+          'manifest_policy_invalid',
+        ),
+      ),
+    );
+  });
+
+  test('rejects traversal paths before staging', () {
+    final manifest = _manifest();
+    final entries = manifest['entries']! as List<Map<String, dynamic>>;
+    entries.first['relative_path'] = '../outside.md';
+
+    expect(
+      () => parser.parse(_picked(manifest)),
+      throwsA(
+        isA<NotionVaultManifestException>().having(
+          (error) => error.code,
+          'code',
+          'manifest_path_invalid',
+        ),
+      ),
+    );
+  });
+
+  test('rejects excluded entries that were opened or hashed', () {
+    final manifest = _manifest();
+    final entries = manifest['entries']! as List<Map<String, dynamic>>;
+    entries.last['sha256'] =
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+    expect(
+      () => parser.parse(_picked(manifest)),
+      throwsA(
+        isA<NotionVaultManifestException>().having(
+          (error) => error.code,
+          'code',
+          'manifest_exclusion_policy_invalid',
+        ),
+      ),
+    );
+  });
+}
+
+PickedNotionVaultManifest _picked(Map<String, dynamic> manifest) {
+  return PickedNotionVaultManifest(
+    name: 'company-vault-manifest.json',
+    bytes: Uint8List.fromList(utf8.encode(jsonEncode(manifest))),
+  );
+}
+
+Map<String, dynamic> _manifest() {
+  const noteHash =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const reviewHash =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  return <String, dynamic>{
+    'schema_version': 1,
+    'local_only': true,
+    'vault_name': 'company',
+    'source_absolute_path_included': false,
+    'policy': <String, dynamic>{
+      'network_requests': false,
+      'vault_files_copied': false,
+      'note_body_or_property_values_included': false,
+      'excluded_files_opened_or_hashed': false,
+    },
+    'entries': <Map<String, dynamic>>[
+      <String, dynamic>{
+        'relative_path': 'HOME.md',
+        'category': 'note',
+        'migration_action': 'auto_stage',
+        'reason': 'markdown_note',
+        'size_bytes': 120,
+        'content_inspected': true,
+        'sha256': noteHash,
+        'markdown': <String, dynamic>{
+          'frontmatter_present': true,
+          'property_keys': <String>['title'],
+          'wikilinks': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'target': 'Finance',
+              'embedded': false,
+              'occurrences': 1,
+              'resolved': true,
+              'ambiguous': false,
+              'resolved_relative_path': 'Finance.md',
+            },
+            <String, dynamic>{
+              'target': 'private/service-account.json',
+              'embedded': false,
+              'occurrences': 1,
+              'resolved': true,
+              'ambiguous': false,
+              'resolved_relative_path': 'private/service-account.json',
+              'target_migration_action': 'exclude',
+            },
+          ],
+          'external_link_count': 0,
+          'callout_types': <String, int>{'note': 1},
+          'task_count': 2,
+          'completed_task_count': 1,
+          'body': 'must never survive the allowlist',
+          'property_values': <String, String>{'title': 'secret'},
+        },
+      },
+      <String, dynamic>{
+        'relative_path': 'Finance.md',
+        'category': 'note',
+        'migration_action': 'review_required',
+        'reason': 'sensitive_note_name',
+        'size_bytes': 80,
+        'content_inspected': true,
+        'sha256': reviewHash,
+        'markdown': <String, dynamic>{
+          'frontmatter_present': false,
+          'property_keys': <String>[],
+          'wikilinks': <Map<String, dynamic>>[],
+          'external_link_count': 0,
+          'callout_types': <String, int>{},
+          'task_count': 0,
+          'completed_task_count': 0,
+        },
+      },
+      <String, dynamic>{
+        'relative_path': 'private/service-account.json',
+        'category': 'credential_candidate',
+        'migration_action': 'exclude',
+        'reason': 'explicit_credential_path',
+        'size_bytes': 2048,
+        'content_inspected': false,
+        'sha256': null,
+      },
+    ],
+    'summary': <String, dynamic>{
+      'file_count': 3,
+      'action_counts': <String, int>{
+        'auto_stage': 1,
+        'review_required': 1,
+        'exclude': 1,
+      },
+      'category_counts': <String, int>{'note': 2, 'credential_candidate': 1},
+      'review_required_count': 1,
+      'credential_candidate_count': 1,
+      'unresolved_wikilink_occurrences': 0,
+      'unreferenced_attachment_count': 0,
+    },
+  };
+}


### PR DESCRIPTION
## 概要
- ローカルObsidian保管庫から本文・プロパティ値を含まない決定的manifestを生成
- 除外ファイルを開かず・ハッシュせず、除外パスも本番へ送信しないブラウザ検証を追加
- RLS所有者専用の独立ステージング表へ、許可された構造情報だけを100件単位で冪等保存
- Notion元データ削除・本番コンテンツ反映・サブスク解約は既存の7項目ゲートで引き続き禁止

## 検証
- Python manifestテスト 5件成功
- Notion migration Dart解析 0件
- manifestパーサーテスト 4件成功
- SQL/RLS制約テスト 4件成功
- Notion migration widget/modelテスト 11件成功
- 実保管庫manifest: 全90件、自動31件、要確認6件、除外53件。認証候補は未読・未ハッシュ

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude ultrareview runtime is unavailable in this Codex-only task; deterministic security and DB smoke gates remain mandatory.
- Security: allowlisted browser parser、DBキー制約、所有者RLS、認証情報と除外パスの非送信をテスト済み。
- Rollback: UIコミットをrevertしても追加テーブルは既存Notion台帳へ影響しない。必要時は証跡保全後にservice_roleで追加2表のみ撤去する。
- Prod smoke: migration適用と本番routeの表示・認証境界をマージ後に確認する。
- Observability: manifest status、staged_entry_count、last_error、staged_atを所有者別に保持する。
- Unresolved findings: none in deterministic checks and AI Agent Code Review; Claude ultrareview is covered by the exception above.

## Minimal E2E Gate
- Implementation-detail independent: widget test asserts user-visible file selection、safety counts、confirmation、staged summary rather than private internals.
- Minimal scope: happy path、unsafe manifest rejection、authentication/empty stateを対象化。
- E2E: Flutter integration_test or Playwright route is deferred because the flow requires an authenticated production Data API session and native file picker.
- E2E-Exception: user-visible widget coverage plus DB smoke validates this additive staging slice without uploading the private local vault in CI.

Related: #974