### PR TITLE
fix(wbs): repair admin RLS and review gate (#4956)

### DIFF
--- a/scripts/testcontainers_supabase_smoke.py
+++ b/scripts/testcontainers_supabase_smoke.py
@@ -6,8 +6,9 @@ disposable Postgres container, applies a small migration/seed fixture, verifies
 the Issue #2773 fail-closed RLS migration, Issue #2484 asset-chat isolation,
 Issue #4091 app-analytics write boundary, and Issue #1202 voice-dubbing quota
 state machine, Issue #1233 resource-optimizer tenant/analysis/quota contracts,
-checks the real Edge Function import policy, Issue #2668 note-comment
-authorization, and runs a Deno HTTP fixture against the container.
+Issue #4956 WBS administrator/review contracts, checks the real Edge Function
+import policy, Issue #2668 note-comment authorization, and runs a Deno HTTP
+fixture against the container.
 Logs are written as
 artifacts so CI failures point to the migration, function, or seed boundary that
 broke.
@@ -126,6 +127,14 @@ ISSUE_1233_RESOURCE_OPTIMIZER_SQL_FILES = (
 )
 ISSUE_1233_REAPPLIED_MIGRATIONS = ISSUE_1233_RESOURCE_OPTIMIZER_SQL_FILES[3:5]
 ISSUE_1233_CONCURRENT_USER = "00000000-0000-4000-8000-000000001235"
+ISSUE_4956_WBS_ADMIN_REVIEW_SQL_FILES = (
+    ROOT / "supabase" / "tests" / "issue4956_wbs_admin_review_bootstrap.sql",
+    ROOT
+    / "supabase"
+    / "migrations"
+    / "20260828153722_repair_wbs_admin_review_contract.sql",
+    ROOT / "supabase" / "tests" / "issue4956_wbs_admin_review_contract.sql",
+)
 VIDEO_ARTIFACT_SQL_FILES = (
     ROOT / "supabase" / "tests" / "video_service_bootstrap.sql",
     ROOT / "supabase" / "migrations" / "20260819165405_create_first_party_video_service.sql",
@@ -423,6 +432,21 @@ def build_plan(sql_dir: Path, edge_fixture: Path, actual_edge_function: Path) ->
             "parallel AI quota consumes at the daily boundary are atomic with "
             "exactly one winner",
             "cooldown and ten-request UTC daily limit do not affect another user",
+        ],
+        "issue_4956_wbs_admin_review_sql": [
+            path.relative_to(ROOT).as_posix()
+            for path in ISSUE_4956_WBS_ADMIN_REVIEW_SQL_FILES
+        ],
+        "issue_4956_wbs_admin_review_checks": [
+            "both WBS admin policies use user_profiles.user_id through the hardened helper",
+            "non-admin writes remain denied even when a legacy profile id collides",
+            "administrator task and milestone writes succeed through authenticated RLS",
+            "OPEN Issues preserve in_progress/100/requested review readiness",
+            "pending/100 auto-requests review regardless of trigger ordering",
+            "rejected OPEN Issues cannot become completed/100",
+            "blank and NULL Issue sync states fail closed until explicitly CLOSED",
+            "manual_override is accepted only as an explicit administrator write",
+            "migration applies twice in the disposable database",
         ],
         "video_artifact_contract": [
             path.relative_to(ROOT).as_posix() for path in VIDEO_ARTIFACT_SQL_FILES
@@ -2465,6 +2489,26 @@ def run_smoke(args: argparse.Namespace) -> int:
                 connection_url,
                 psycopg.connect,
             )
+            apply_sql_fixture(
+                conn,
+                ISSUE_4956_WBS_ADMIN_REVIEW_SQL_FILES[0],
+                artifacts_dir,
+            )
+            apply_sql_fixture(
+                conn,
+                ISSUE_4956_WBS_ADMIN_REVIEW_SQL_FILES[1],
+                artifacts_dir,
+            )
+            apply_sql_fixture(
+                conn,
+                ISSUE_4956_WBS_ADMIN_REVIEW_SQL_FILES[1],
+                artifacts_dir,
+            )
+            apply_sql_fixture(
+                conn,
+                ISSUE_4956_WBS_ADMIN_REVIEW_SQL_FILES[2],
+                artifacts_dir,
+            )
             apply_sql_fixture(conn, ASSET_CHAT_MIGRATION, artifacts_dir)
             seed_asset_chat_fixture(conn)
             asset_chat_rls = check_asset_chat_rls(conn)
@@ -2491,6 +2535,7 @@ def run_smoke(args: argparse.Namespace) -> int:
             "voice_dubbing_quota_contract": "passed",
             "issue_1233_resource_optimizer_contract": "passed",
             "issue_1233_ai_quota_concurrency": issue_1233_quota_concurrency,
+            "issue_4956_wbs_admin_review_contract": "passed",
             "video_artifact_contract": "passed",
         },
         "edge_fixture": {

--- a/supabase/migrations/20260828153722_repair_wbs_admin_review_contract.sql
+++ b/supabase/migrations/20260828153722_repair_wbs_admin_review_contract.sql
@@ -1,0 +1,79 @@
+-- Issue #4956: repair the WBS admin authorization and review-ready state.
+--
+-- user_profiles.id is a profile row identifier. Supabase auth identities are
+-- stored in user_profiles.user_id and must be checked through the hardened
+-- SECURITY DEFINER helper so the user_profiles RLS policy cannot recurse.
+
+DROP POLICY IF EXISTS "wbs_milestones_admin_write"
+  ON public.wbs_milestones;
+CREATE POLICY "wbs_milestones_admin_write"
+  ON public.wbs_milestones
+  FOR ALL
+  TO authenticated
+  USING ((SELECT public.is_user_admin((SELECT auth.uid()))))
+  WITH CHECK ((SELECT public.is_user_admin((SELECT auth.uid()))));
+
+DROP POLICY IF EXISTS "wbs_tasks_admin_write"
+  ON public.wbs_tasks;
+CREATE POLICY "wbs_tasks_admin_write"
+  ON public.wbs_tasks
+  FOR ALL
+  TO authenticated
+  USING ((SELECT public.is_user_admin((SELECT auth.uid()))))
+  WITH CHECK ((SELECT public.is_user_admin((SELECT auth.uid()))));
+
+-- OPEN GitHub Issues may reach the explicit review-ready state
+-- (in_progress / 100 / requested), but cannot become completed until an
+-- approved review status or an explicit human manual override is recorded.
+CREATE OR REPLACE FUNCTION public.wbs_guard_open_github_issue_completion()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.github_issue_number IS NOT NULL
+     AND upper(
+       coalesce(nullif(btrim(NEW.github_issue_state), ''), 'OPEN')
+     ) <> 'CLOSED'
+     AND lower(coalesce(NEW.ai_review_status, 'pending')) NOT IN
+       ('approved', 'verified', 'passed', 'manual_override') THEN
+    IF NEW.status = 'completed' THEN
+      NEW.status := 'in_progress';
+    END IF;
+
+    IF lower(coalesce(NEW.ai_review_status, 'pending')) = 'pending'
+       AND coalesce(NEW.progress, 0) >= 100 THEN
+      -- This guard sorts before the legacy wbs_request_ai_review trigger.
+      -- Normalize here so trigger ordering cannot erase auto-review readiness.
+      NEW.status := 'in_progress';
+      NEW.progress := 100;
+      NEW.ai_review_status := 'requested';
+    ELSIF lower(coalesce(NEW.ai_review_status, 'pending')) = 'requested' THEN
+      NEW.status := 'in_progress';
+      NEW.progress := 100;
+    ELSIF coalesce(NEW.progress, 0) >= 100 THEN
+      NEW.progress := 99;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS wbs_open_github_issue_completion_guard
+  ON public.wbs_tasks;
+CREATE TRIGGER wbs_open_github_issue_completion_guard
+  BEFORE INSERT OR UPDATE ON public.wbs_tasks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.wbs_guard_open_github_issue_completion();
+
+COMMENT ON FUNCTION public.wbs_guard_open_github_issue_completion() IS
+  'Keeps linked Issues incomplete unless explicitly CLOSED while preserving '
+  'explicit review-ready '
+  '(in_progress/100/requested) state, including pending-to-requested auto '
+  'normalization before the legacy review trigger; manual_override is an '
+  'explicit human administrator decision and is never assigned by this trigger.';
+
+COMMENT ON COLUMN public.wbs_tasks.ai_review_status IS
+  'pending -> requested at review readiness -> approved/rejected; '
+  'manual_override is reserved for an explicit human administrator decision.';

--- a/supabase/tests/issue4956_wbs_admin_review_bootstrap.sql
+++ b/supabase/tests/issue4956_wbs_admin_review_bootstrap.sql
@@ -1,0 +1,177 @@
+-- Minimal predecessor schema for the Issue #4956 runtime contract. The shared
+-- Testcontainers fixture already supplies wbs_tasks and Supabase auth helpers.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.user_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid UNIQUE NOT NULL,
+  is_admin boolean NOT NULL DEFAULT false
+);
+
+ALTER TABLE public.wbs_tasks
+  ADD COLUMN IF NOT EXISTS progress integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS github_issue_number integer,
+  ADD COLUMN IF NOT EXISTS github_issue_state text,
+  ADD COLUMN IF NOT EXISTS ai_review_status text NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+CREATE TABLE IF NOT EXISTS public.wbs_milestones (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text UNIQUE NOT NULL,
+  name text NOT NULL,
+  target_date date NOT NULL
+);
+
+ALTER TABLE public.wbs_tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.wbs_milestones ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE public.wbs_tasks, public.wbs_milestones
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.is_user_admin(check_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  SELECT COALESCE(
+    (SELECT profile.is_admin
+       FROM public.user_profiles AS profile
+      WHERE profile.user_id = check_user_id),
+    false
+  );
+$$;
+
+-- Recreate the broken predecessor policies to prove the repair replaces them.
+DROP POLICY IF EXISTS "wbs_tasks_admin_write" ON public.wbs_tasks;
+CREATE POLICY "wbs_tasks_admin_write"
+  ON public.wbs_tasks
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE id = auth.uid() AND is_admin = true
+    )
+  );
+
+DROP POLICY IF EXISTS "wbs_milestones_admin_write" ON public.wbs_milestones;
+CREATE POLICY "wbs_milestones_admin_write"
+  ON public.wbs_milestones
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE id = auth.uid() AND is_admin = true
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.wbs_guard_open_github_issue_completion()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.github_issue_number IS NOT NULL
+     AND upper(coalesce(NEW.github_issue_state, 'OPEN')) = 'OPEN'
+     AND lower(coalesce(NEW.ai_review_status, 'pending')) NOT IN
+       ('approved', 'verified', 'passed', 'manual_override') THEN
+    IF coalesce(NEW.progress, 0) >= 100 THEN
+      NEW.progress := 99;
+    END IF;
+    IF NEW.status = 'completed' THEN
+      NEW.status := 'in_progress';
+    END IF;
+    IF NEW.ai_review_status = 'requested' THEN
+      NEW.ai_review_status := 'pending';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- Install the production predecessor auto-request trigger too. PostgreSQL runs
+-- same-kind triggers alphabetically, so the OPEN-Issue guard executes first.
+CREATE OR REPLACE FUNCTION public.wbs_request_ai_review_on_complete()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.progress = 100
+     AND OLD.progress < 100
+     AND NEW.ai_review_status = 'pending' THEN
+    NEW.ai_review_status := 'requested';
+    NEW.status := 'in_progress';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS wbs_open_github_issue_completion_guard
+  ON public.wbs_tasks;
+CREATE TRIGGER wbs_open_github_issue_completion_guard
+  BEFORE INSERT OR UPDATE ON public.wbs_tasks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.wbs_guard_open_github_issue_completion();
+
+DROP TRIGGER IF EXISTS wbs_request_ai_review ON public.wbs_tasks;
+CREATE TRIGGER wbs_request_ai_review
+  BEFORE UPDATE OF progress ON public.wbs_tasks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.wbs_request_ai_review_on_complete();
+
+INSERT INTO auth.users (id)
+VALUES
+  ('00000000-0000-4000-8000-000000004956'),
+  ('00000000-0000-4000-8000-000000004957'),
+  ('00000000-0000-4000-8000-000000004958')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.user_profiles (id, user_id, is_admin)
+VALUES
+  (
+    '00000000-0000-4000-8000-000000014956',
+    '00000000-0000-4000-8000-000000004956',
+    true
+  ),
+  (
+    '00000000-0000-4000-8000-000000014957',
+    '00000000-0000-4000-8000-000000004957',
+    false
+  ),
+  (
+    -- A legacy id lookup would incorrectly grant the non-admin auth identity.
+    '00000000-0000-4000-8000-000000004957',
+    '00000000-0000-4000-8000-000000004958',
+    true
+  )
+ON CONFLICT (id) DO UPDATE
+SET user_id = EXCLUDED.user_id,
+    is_admin = EXCLUDED.is_admin;
+
+INSERT INTO public.wbs_tasks (
+  id,
+  title,
+  status,
+  owner_instance,
+  progress,
+  github_issue_number,
+  github_issue_state,
+  ai_review_status
+)
+VALUES (
+  '00000000-0000-4000-8000-000000024956',
+  'Issue #4956 review contract fixture',
+  'in_progress',
+  'Codex #1',
+  0,
+  4956,
+  'OPEN',
+  'pending'
+)
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/tests/issue4956_wbs_admin_review_contract.sql
+++ b/supabase/tests/issue4956_wbs_admin_review_contract.sql
@@ -1,0 +1,384 @@
+-- Runtime PostgreSQL contract for Issue #4956. Any mismatch raises and fails
+-- the Testcontainers integration smoke.
+
+DO $contract$
+DECLARE
+  v_policy record;
+  v_policy_count integer := 0;
+  v_admin_helper_definition text;
+  v_admin_helper_is_security_definer boolean;
+  v_admin_helper_config text[];
+  v_function_definition text;
+  v_guard_enabled text;
+  v_guard_definition text;
+  v_guard_function text;
+BEGIN
+  IF (
+    SELECT count(*)
+    FROM pg_catalog.pg_class AS relation
+    JOIN pg_catalog.pg_namespace AS namespace
+      ON namespace.oid = relation.relnamespace
+    WHERE namespace.nspname = 'public'
+      AND relation.relname IN ('wbs_tasks', 'wbs_milestones')
+      AND relation.relrowsecurity
+  ) <> 2 THEN
+    RAISE EXCEPTION 'WBS RLS is not enabled on both managed tables';
+  END IF;
+
+  FOR v_policy IN
+    SELECT
+      tablename,
+      roles,
+      qual,
+      with_check
+    FROM pg_catalog.pg_policies
+    WHERE schemaname = 'public'
+      AND policyname IN (
+        'wbs_tasks_admin_write',
+        'wbs_milestones_admin_write'
+      )
+    ORDER BY tablename
+  LOOP
+    v_policy_count := v_policy_count + 1;
+    IF v_policy.roles IS DISTINCT FROM ARRAY['authenticated']::name[] THEN
+      RAISE EXCEPTION 'unexpected WBS policy roles: %', row_to_json(v_policy);
+    END IF;
+    IF v_policy.qual NOT LIKE '%is_user_admin%auth.uid%' THEN
+      RAISE EXCEPTION 'WBS USING does not use admin helper: %', row_to_json(v_policy);
+    END IF;
+    IF v_policy.with_check NOT LIKE '%is_user_admin%auth.uid%' THEN
+      RAISE EXCEPTION 'WBS WITH CHECK missing: %', row_to_json(v_policy);
+    END IF;
+    IF v_policy.qual LIKE '%user_profiles%id%' OR
+       v_policy.with_check LIKE '%user_profiles%id%' THEN
+      RAISE EXCEPTION 'legacy profile id lookup survived: %', row_to_json(v_policy);
+    END IF;
+  END LOOP;
+
+  IF v_policy_count <> 2 THEN
+    RAISE EXCEPTION 'expected two WBS admin policies, found %', v_policy_count;
+  END IF;
+
+  IF (
+    SELECT count(*)
+    FROM pg_catalog.pg_trigger
+    WHERE tgrelid = 'public.wbs_tasks'::regclass
+      AND NOT tgisinternal
+      AND tgname IN (
+        'wbs_open_github_issue_completion_guard',
+        'wbs_request_ai_review'
+      )
+  ) <> 2 THEN
+    RAISE EXCEPTION 'production WBS review trigger pair is incomplete';
+  END IF;
+
+  SELECT
+    lower(pg_catalog.pg_get_functiondef(procedure.oid)),
+    procedure.prosecdef,
+    coalesce(procedure.proconfig, ARRAY[]::text[])
+  INTO
+    v_admin_helper_definition,
+    v_admin_helper_is_security_definer,
+    v_admin_helper_config
+  FROM pg_catalog.pg_proc AS procedure
+  WHERE procedure.oid = 'public.is_user_admin(uuid)'::regprocedure;
+  IF v_admin_helper_definition NOT LIKE '%user_id = check_user_id%' THEN
+    RAISE EXCEPTION 'admin helper does not use user_profiles.user_id';
+  END IF;
+  IF NOT v_admin_helper_is_security_definer THEN
+    RAISE EXCEPTION 'admin helper is not SECURITY DEFINER';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM unnest(v_admin_helper_config) AS setting
+    WHERE setting IN ('search_path=', 'search_path=""')
+  ) THEN
+    RAISE EXCEPTION 'admin helper search_path is not pinned empty: %',
+      v_admin_helper_config;
+  END IF;
+
+  SELECT
+    trigger.tgenabled,
+    lower(pg_catalog.pg_get_triggerdef(trigger.oid)),
+    procedure.proname
+  INTO v_guard_enabled, v_guard_definition, v_guard_function
+  FROM pg_catalog.pg_trigger AS trigger
+  JOIN pg_catalog.pg_proc AS procedure
+    ON procedure.oid = trigger.tgfoid
+  WHERE trigger.tgrelid = 'public.wbs_tasks'::regclass
+    AND trigger.tgname = 'wbs_open_github_issue_completion_guard'
+    AND NOT trigger.tgisinternal;
+  IF NOT FOUND
+     OR v_guard_enabled NOT IN ('O', 'A')
+     OR v_guard_function IS DISTINCT FROM
+       'wbs_guard_open_github_issue_completion'
+     OR v_guard_definition NOT LIKE '%before insert or update%'
+  THEN
+    RAISE EXCEPTION
+      'OPEN-Issue guard trigger binding is invalid: enabled=%, function=%, def=%',
+      v_guard_enabled,
+      v_guard_function,
+      v_guard_definition;
+  END IF;
+
+  SELECT pg_catalog.pg_get_functiondef(
+    'public.wbs_guard_open_github_issue_completion()'::regprocedure
+  ) INTO v_function_definition;
+  v_function_definition := lower(v_function_definition);
+  IF v_function_definition LIKE '%new.ai_review_status := ''manual_override''%' THEN
+    RAISE EXCEPTION 'guard assigns manual_override automatically';
+  END IF;
+  IF v_function_definition LIKE '%new.ai_review_status := ''pending''%' THEN
+    RAISE EXCEPTION 'guard still erases requested review state';
+  END IF;
+END;
+$contract$;
+
+-- A real administrator is recognized by user_profiles.user_id even though the
+-- profile row id is intentionally different from the auth identity.
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  '00000000-0000-4000-8000-000000004956',
+  true
+);
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+
+INSERT INTO public.wbs_milestones (code, name, target_date)
+VALUES ('issue-4956-admin', 'Issue #4956 admin contract', current_date)
+ON CONFLICT (code) DO UPDATE SET name = EXCLUDED.name;
+
+UPDATE public.wbs_tasks
+SET status = 'pending',
+    progress = 10,
+    ai_review_status = 'requested'
+WHERE id = '00000000-0000-4000-8000-000000024956';
+
+DO $contract$
+DECLARE
+  v_task record;
+BEGIN
+  SELECT status, progress, ai_review_status
+    INTO v_task
+  FROM public.wbs_tasks
+  WHERE id = '00000000-0000-4000-8000-000000024956';
+  IF v_task.status IS DISTINCT FROM 'in_progress'
+     OR v_task.progress IS DISTINCT FROM 100
+     OR v_task.ai_review_status IS DISTINCT FROM 'requested' THEN
+    RAISE EXCEPTION 'review-ready transition was not preserved: %',
+      row_to_json(v_task);
+  END IF;
+END;
+$contract$;
+
+-- The production pending/100 path automatically enters review readiness even
+-- though the alphabetically earlier OPEN-Issue guard runs first.
+UPDATE public.wbs_tasks
+SET status = 'pending',
+    progress = 0,
+    ai_review_status = 'pending'
+WHERE id = '00000000-0000-4000-8000-000000024956';
+
+UPDATE public.wbs_tasks
+SET status = 'completed',
+    progress = 100,
+    ai_review_status = 'pending'
+WHERE id = '00000000-0000-4000-8000-000000024956';
+
+DO $contract$
+DECLARE
+  v_task record;
+BEGIN
+  SELECT status, progress, ai_review_status
+    INTO v_task
+  FROM public.wbs_tasks
+  WHERE id = '00000000-0000-4000-8000-000000024956';
+  IF v_task.status IS DISTINCT FROM 'in_progress'
+     OR v_task.progress IS DISTINCT FROM 100
+     OR v_task.ai_review_status IS DISTINCT FROM 'requested' THEN
+    RAISE EXCEPTION 'pending review did not auto-request at 100: %',
+      row_to_json(v_task);
+  END IF;
+END;
+$contract$;
+
+-- A rejected/unapproved completion cannot reuse 100% or become completed.
+UPDATE public.wbs_tasks
+SET status = 'completed',
+    progress = 100,
+    ai_review_status = 'rejected'
+WHERE id = '00000000-0000-4000-8000-000000024956';
+
+DO $contract$
+DECLARE
+  v_task record;
+BEGIN
+  SELECT status, progress, ai_review_status
+    INTO v_task
+  FROM public.wbs_tasks
+  WHERE id = '00000000-0000-4000-8000-000000024956';
+  IF v_task.status IS DISTINCT FROM 'in_progress'
+     OR v_task.progress IS DISTINCT FROM 99
+     OR v_task.ai_review_status IS DISTINCT FROM 'rejected' THEN
+    RAISE EXCEPTION 'rejected completion escaped the guard: %',
+      row_to_json(v_task);
+  END IF;
+END;
+$contract$;
+
+-- Blank and NULL sync states are unsynchronized, not proof of Issue closure.
+UPDATE public.wbs_tasks
+SET status = 'completed',
+    progress = 100,
+    ai_review_status = 'rejected',
+    github_issue_state = '   '
+WHERE id = '00000000-0000-4000-8000-000000024956';
+
+DO $contract$
+DECLARE
+  v_task record;
+BEGIN
+  SELECT status, progress, ai_review_status
+    INTO v_task
+  FROM public.wbs_tasks
+  WHERE id = '00000000-0000-4000-8000-000000024956';
+  IF v_task.status IS DISTINCT FROM 'in_progress'
+     OR v_task.progress IS DISTINCT FROM 99
+     OR v_task.ai_review_status IS DISTINCT FROM 'rejected' THEN
+    RAISE EXCEPTION 'blank Issue state bypassed completion guard: %',
+      row_to_json(v_task);
+  END IF;
+END;
+$contract$;
+
+UPDATE public.wbs_tasks
+SET status = 'completed',
+    progress = 100,
+    ai_review_status = 'rejected',
+    github_issue_state = NULL
+WHERE id = '00000000-0000-4000-8000-000000024956';
+
+DO $contract$
+DECLARE
+  v_task record;
+BEGIN
+  SELECT status, progress, ai_review_status
+    INTO v_task
+  FROM public.wbs_tasks
+  WHERE id = '00000000-0000-4000-8000-000000024956';
+  IF v_task.status IS DISTINCT FROM 'in_progress'
+     OR v_task.progress IS DISTINCT FROM 99
+     OR v_task.ai_review_status IS DISTINCT FROM 'rejected' THEN
+    RAISE EXCEPTION 'NULL Issue state bypassed completion guard: %',
+      row_to_json(v_task);
+  END IF;
+END;
+$contract$;
+
+-- An explicitly CLOSED linked Issue is allowed to retain completion even when
+-- its previous review state was rejected.
+UPDATE public.wbs_tasks
+SET status = 'completed',
+    progress = 100,
+    ai_review_status = 'rejected',
+    github_issue_state = 'CLOSED'
+WHERE id = '00000000-0000-4000-8000-000000024956';
+
+DO $contract$
+DECLARE
+  v_task record;
+BEGIN
+  SELECT status, progress, ai_review_status
+    INTO v_task
+  FROM public.wbs_tasks
+  WHERE id = '00000000-0000-4000-8000-000000024956';
+  IF v_task.status IS DISTINCT FROM 'completed'
+     OR v_task.progress IS DISTINCT FROM 100
+     OR v_task.ai_review_status IS DISTINCT FROM 'rejected' THEN
+    RAISE EXCEPTION 'explicitly CLOSED Issue remained blocked: %',
+      row_to_json(v_task);
+  END IF;
+END;
+$contract$;
+
+-- manual_override remains possible only as this explicit administrator write.
+UPDATE public.wbs_tasks
+SET status = 'completed',
+    progress = 100,
+    ai_review_status = 'manual_override',
+    github_issue_state = 'OPEN'
+WHERE id = '00000000-0000-4000-8000-000000024956';
+
+DO $contract$
+DECLARE
+  v_task record;
+BEGIN
+  SELECT status, progress, ai_review_status
+    INTO v_task
+  FROM public.wbs_tasks
+  WHERE id = '00000000-0000-4000-8000-000000024956';
+  IF v_task.status IS DISTINCT FROM 'completed'
+     OR v_task.progress IS DISTINCT FROM 100
+     OR v_task.ai_review_status IS DISTINCT FROM 'manual_override' THEN
+    RAISE EXCEPTION 'explicit administrator override was not preserved: %',
+      row_to_json(v_task);
+  END IF;
+END;
+$contract$;
+RESET ROLE;
+
+-- The non-admin auth identity has a colliding legacy profile id belonging to
+-- another admin. It must still be denied because only user_id is authoritative.
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  '00000000-0000-4000-8000-000000004957',
+  true
+);
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+
+DO $contract$
+BEGIN
+  BEGIN
+    INSERT INTO public.wbs_tasks (
+      id,
+      title,
+      status,
+      owner_instance,
+      progress
+    ) VALUES (
+      '00000000-0000-4000-8000-000000034956',
+      'unauthorized WBS task',
+      'pending',
+      'Codex #1',
+      0
+    );
+    RAISE EXCEPTION 'non-admin task insert unexpectedly succeeded';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL;
+  END;
+
+  BEGIN
+    INSERT INTO public.wbs_milestones (code, name, target_date)
+    VALUES ('issue-4956-non-admin', 'Unauthorized milestone', current_date);
+    RAISE EXCEPTION 'non-admin milestone insert unexpectedly succeeded';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL;
+  END;
+END;
+$contract$;
+
+DO $contract$
+DECLARE
+  v_rows bigint;
+BEGIN
+  UPDATE public.wbs_tasks
+  SET title = 'unauthorized overwrite'
+  WHERE id = '00000000-0000-4000-8000-000000024956';
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  IF v_rows <> 0 THEN
+    RAISE EXCEPTION 'non-admin updated an administrator WBS task';
+  END IF;
+END;
+$contract$;
+RESET ROLE;

--- a/test/scripts/test_testcontainers_supabase_smoke.py
+++ b/test/scripts/test_testcontainers_supabase_smoke.py
@@ -203,6 +203,28 @@ class TestTestcontainersSupabaseSmoke(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertNotIn("alter default privileges", bootstrap.lower())
 
+    def test_plan_includes_issue_4956_wbs_admin_review_contract(self) -> None:
+        plan = module.build_plan(
+            ROOT / "test" / "fixtures" / "testcontainers" / "sql",
+            ROOT / "test" / "fixtures" / "testcontainers" / "edge-db-smoke.ts",
+            ROOT / "supabase" / "functions" / "health-check" / "index.ts",
+        )
+        self.assertEqual(
+            plan["issue_4956_wbs_admin_review_sql"],
+            [
+                "supabase/tests/issue4956_wbs_admin_review_bootstrap.sql",
+                "supabase/migrations/20260828153722_repair_wbs_admin_review_contract.sql",
+                "supabase/tests/issue4956_wbs_admin_review_contract.sql",
+            ],
+        )
+        checks = " ".join(plan["issue_4956_wbs_admin_review_checks"])
+        self.assertIn("legacy profile id collides", checks)
+        self.assertIn("in_progress/100/requested", checks)
+        self.assertIn("trigger ordering", checks)
+        self.assertIn("fail closed", checks)
+        self.assertIn("manual_override", checks)
+        self.assertIn("applies twice", checks)
+
     def test_plan_includes_note_comments_authorization_boundary(self) -> None:
         plan = module.build_plan(
             ROOT / "test" / "fixtures" / "testcontainers" / "sql",


### PR DESCRIPTION
## Summary
- replace the broken `user_profiles.id = auth.uid()` WBS policies with the hardened `public.is_user_admin((select auth.uid()))` boundary in both `USING` and `WITH CHECK`
- preserve `in_progress / 100 / requested` review readiness while preventing linked Issues from completing unless explicitly `CLOSED` or approved/manual-overridden
- fail closed for NULL, blank, whitespace, and unknown Issue sync states
- add a disposable PostgreSQL contract that reproduces the legacy ID collision, trigger-order, and unsynchronized-state failures and reapplies the migration twice

Closes #4956

## Validation
- `python test/scripts/test_testcontainers_supabase_smoke.py` (20 passed)
- `python scripts/testcontainers_supabase_smoke.py --plan`
- `python scripts/check_migration_timestamps.py --dir supabase/migrations`
- `python scripts/check_migration_time_relative_check.py`
- `git diff --check origin/main...HEAD`
- local Docker daemon was unavailable; the required GitHub Actions Testcontainers job is the authoritative runtime PostgreSQL proof

## Independent subagent review
- Role: read-only Security/RLS reviewer
- Scope: admin identity mapping, RLS `USING`/`WITH CHECK`, review-state transitions, trigger ordering/binding, fail-closed Issue state handling, `manual_override`, migration idempotency, and contract fidelity
- Result: GO with no remaining P0-P3 findings; merge only after deterministic Testcontainers/CI is green
- Validation impact: review findings added pending/100 auto-request normalization, incomplete `requested` tuple normalization, helper/trigger metadata assertions, and NULL/blank state fail-closed cases
- Cleanup impact: no files, processes, branches, or worktrees created by the reviewer

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 ultrareview is unavailable in this Codex desktop task; Issue #4956 is a scoped P0 security repair validated by deterministic Testcontainers contracts and an independent read-only subagent review.