### PR TITLE
fix(ci): harden health monitor schedule recovery

### DIFF
--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -25,7 +25,8 @@ name: Health Monitor (統合ヘルスモニター)
 
 on:
   schedule:
-    - cron: "0 */2 * * *"  # 毎2時間 (2026-06-15 ci-audit: 毎時→2時間, 360runs/月削減 / cs-check 7*/2 の直前に実行)
+    # #4935: avoid GitHub Actions' top-of-hour congestion while still preceding cs-check at :07.
+    - cron: "3 */2 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/scripts/schedule_resilience_watch.py
+++ b/scripts/schedule_resilience_watch.py
@@ -32,6 +32,8 @@ BAD_CONCLUSIONS = {
 }
 REPOSITORY_RUNS_PER_PAGE = 100
 REPOSITORY_RUNS_MAX_PAGES = 10
+# Keep stale runs visible long enough to classify them instead of reporting them missing.
+REPOSITORY_REVALIDATION_MIN_HOURS = 24
 
 
 @dataclass(frozen=True)
@@ -112,13 +114,13 @@ def repository_revalidation_start(
         created_at = parse_time(str(newest.get("created_at") or ""))
         if created_at is None:
             raise ValueError("Workflow run is missing created_at")
-        if (
-            target.max_age_hours <= 0
-            or now - created_at <= timedelta(hours=target.max_age_hours)
-        ):
-            return created_at - timedelta(seconds=1)
+        return created_at - timedelta(seconds=1)
 
-    window_hours = target.max_age_hours if target.max_age_hours > 0 else 24 * 30
+    window_hours = (
+        max(target.max_age_hours, REPOSITORY_REVALIDATION_MIN_HOURS)
+        if target.max_age_hours > 0
+        else 24 * 30
+    )
     window_start = now - timedelta(hours=window_hours)
     if target.introduced_at is None:
         return window_start
@@ -351,6 +353,22 @@ def evaluate_target(
         return {**base, "action": "healthy", "reason": "latest-success"}
 
     if conclusion in BAD_CONCLUSIONS:
+        if (
+            target.max_age_hours > 0
+            and age_hours is not None
+            and age_hours > target.max_age_hours
+        ):
+            return {
+                **base,
+                "action": "alert",
+                "reason": "stale-failure",
+                "title": f"[Schedule監視] {target.key} stale schedule",
+                "body": (
+                    f"Latest scheduled run for `{target.workflow_file}` failed and is "
+                    f"{age_hours:.1f}h old, exceeding the {target.max_age_hours}h guard. "
+                    f"Run: {run_url(latest)}"
+                ),
+            }
         if run_attempt < max_attempts:
             return {
                 **base,

--- a/scripts/schedule_resilience_watch_test.py
+++ b/scripts/schedule_resilience_watch_test.py
@@ -7,6 +7,7 @@ import io
 import os
 import unittest
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 from schedule_resilience_watch import (
@@ -108,6 +109,14 @@ class ScheduleResilienceWatchTest(unittest.TestCase):
         self.assertEqual(targets["notion-sync"].event, "schedule")
         self.assertEqual(targets["deploy-prod"].event, "push")
 
+    def test_health_monitor_avoids_top_of_hour_congestion(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[1] / ".github/workflows/health-monitor.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('cron: "3 */2 * * *"', workflow)
+        self.assertNotIn('cron: "0 */2 * * *"', workflow)
+
     def test_workflow_runs_filters_by_requested_event(self) -> None:
         class RecordingClient(GitHubClient):
             requested_path = ""
@@ -185,7 +194,7 @@ class ScheduleResilienceWatchTest(unittest.TestCase):
         )
 
         created_after = repository_revalidation_start(TARGET, [stale], NOW)
-        runs = merge_revalidated_runs([stale], [fresh], created_after=created_after)
+        runs = merge_revalidated_runs([stale], [fresh, stale], created_after=created_after)
         result = evaluate_target(TARGET, runs, NOW, max_attempts=2)
 
         self.assertEqual(result["action"], "healthy")
@@ -200,14 +209,36 @@ class ScheduleResilienceWatchTest(unittest.TestCase):
         created_after = repository_revalidation_start(TARGET, [stale_failure], NOW)
         runs = merge_revalidated_runs(
             [stale_failure],
-            [],
+            [stale_failure],
             created_after=created_after,
         )
 
         result = evaluate_target(TARGET, runs, NOW, max_attempts=2)
 
         self.assertEqual(result["action"], "alert")
-        self.assertEqual(result["reason"], "missing-run")
+        self.assertEqual(result["reason"], "stale-failure")
+
+    def test_stale_success_is_not_misreported_as_missing(self) -> None:
+        stale_success = run(
+            id=2,
+            created_at=(NOW - timedelta(hours=5)).isoformat().replace("+00:00", "Z"),
+        )
+        created_after = repository_revalidation_start(TARGET, [stale_success], NOW)
+        runs = merge_revalidated_runs(
+            [stale_success],
+            [stale_success],
+            created_after=created_after,
+        )
+
+        result = evaluate_target(TARGET, runs, NOW, max_attempts=2)
+
+        self.assertEqual(result["action"], "alert")
+        self.assertEqual(result["reason"], "stale-success")
+
+    def test_repository_fallback_without_primary_uses_a_full_day(self) -> None:
+        created_after = repository_revalidation_start(TARGET, [], NOW)
+
+        self.assertEqual(created_after, NOW - timedelta(hours=24))
 
     def test_fresh_primary_must_be_confirmed_by_repository_listing(self) -> None:
         fresh = run(id=7)


### PR DESCRIPTION
## Summary

- Move `health-monitor` from minute `:00` to `:03` every two hours, while keeping it ahead of `cs-check` at `:07`.
- Revalidate the latest primary run even when it is older than the freshness guard and use a 24-hour minimum repository lookback when the primary endpoint is empty.
- Distinguish confirmed `stale-success` and `stale-failure` from a true `missing-run`; never rerun an already stale failed run.
- Add focused regression coverage for the schedule minute, stale success/failure classification, repository confirmation, and fallback window.

## Related Issue

Refs #4935

The Issue intentionally remains open through merge. It will be closed only after an actual post-merge `schedule` event succeeds and the resilience watcher confirms recovery.

## Root cause

GitHub documents that scheduled workflows can be delayed or dropped during high load at the start of every hour and recommends scheduling at another minute: https://docs.github.com/en/actions/how-tos/troubleshoot-workflows#delayed-scheduled-workflows

The watcher also queried only the three-hour freshness window when the workflow-specific endpoint was empty, so a real five-hour-old run was excluded and misclassified as `missing-run` instead of `stale-success`.

## Validation

- `python -m py_compile scripts/schedule_resilience_watch.py scripts/schedule_resilience_watch_test.py`
- `python scripts/schedule_resilience_watch_test.py` — 29 tests passed
- Python YAML parse of `.github/workflows/health-monitor.yml`
- `git diff --check`
- Live repository dry-run — `health-monitor` now resolves to `alert / stale-success`, not `missing-run`

## Minimal E2E Gate

- E2E exception: no UI or user route changed. Deterministic Python tests cover recent success, missing run, stale success, stale failure, retry safety, repository confirmation, and the cron regression.
- No browser, Flutter, database, migration, generated image, or environment-variable change.

## Feature-freeze compatibility

This is a focused bug/CI reliability fix allowed by #1640; it does not add product functionality.

## Subagent record

- Critical-Issue reviewer: read-only audit of the oldest critical Issues; confirmed they remain blocked on real users, payments, approvals, or account recovery.
- High-priority researcher: read-only audit of the oldest high Issues; selected #4935 as the first feature-freeze-compatible executable candidate and isolated the stale-run boundary defect.
- Validation impact: the research directly defined the stale-success regression and post-merge schedule proof requirement.
- Cleanup impact: both subagents made no files, branches, worktrees, GitHub writes, builds, or tests; no cleanup is required.

## Rollout / risk

- Breaking changes: none.
- No special deployment step is required.
- Post-merge proof: wait for a real `schedule` run at minute `:03`, then confirm the resilience watcher reports the target healthy and closes or permits closure of #4935.
## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: The trigger is wording-only in rollout and stale-failure safety notes; this focused schedule-monitoring bug fix changes no security-sensitive data path or production data.
