### PR TITLE
fix: label Claude Academy lesson as Anthropic

### DIFF
--- a/supabase/migrations/20260828225730_fix_claude_academy_video_provider.sql
+++ b/supabase/migrations/20260828225730_fix_claude_academy_video_provider.sql
@@ -1,0 +1,36 @@
+-- AI大学: Claude Academy動画を正しいAnthropicプロバイダーへ関連付ける。
+
+INSERT INTO ai_university_content (
+  provider,
+  category,
+  title,
+  content,
+  source_url,
+  published_at,
+  sort_order,
+  is_active
+)
+SELECT
+  'anthropic',
+  category,
+  title,
+  content,
+  source_url,
+  published_at,
+  sort_order,
+  true
+FROM ai_university_content
+WHERE provider = 'openai'
+  AND category = 'video_claude_academy_overview'
+ON CONFLICT (provider, category) DO UPDATE SET
+  title = EXCLUDED.title,
+  content = EXCLUDED.content,
+  source_url = EXCLUDED.source_url,
+  published_at = EXCLUDED.published_at,
+  sort_order = EXCLUDED.sort_order,
+  is_active = EXCLUDED.is_active;
+
+UPDATE ai_university_content
+SET is_active = false
+WHERE provider = 'openai'
+  AND category = 'video_claude_academy_overview';

--- a/test/services/ai_university_claude_academy_provider_fix_test.dart
+++ b/test/services/ai_university_claude_academy_provider_fix_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  const migrationPath =
+      'supabase/migrations/20260828225730_fix_claude_academy_video_provider.sql';
+
+  test('Claude Academy video is reassigned from OpenAI to Anthropic', () {
+    final sql = File(migrationPath).readAsStringSync();
+
+    expect(sql, contains("'anthropic'"));
+    expect(sql, contains("provider = 'openai'"));
+    expect(sql, contains("category = 'video_claude_academy_overview'"));
+    expect(sql, contains('ON CONFLICT (provider, category) DO UPDATE'));
+    expect(sql, contains('SET is_active = false'));
+  });
+}


### PR DESCRIPTION
## Summary
- move the Claude Academy public-video lesson to the existing `anthropic` provider
- keep the already-deployed `openai` row as inactive forward-only history
- preserve idempotency when the correction migration is replayed
- add a focused provider-correction contract test

## Validation
- provider correction + original seed tests: passed
- `ai_university_content.py check-ui`: passed
- `git diff --check`: passed

## Rollback
Use a forward-only migration to reactivate the desired provider row; do not alter the public YouTube video.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Content-only corrective seed migration; no schema, RLS, Edge Function, or application-code change.