### PR TITLE
fix: 01.AIモデル選定講座の虎レビュー指摘を解消 (#4737)

### DIFF
--- a/lib/pages/gemini_university_v2_page.dart
+++ b/lib/pages/gemini_university_v2_page.dart
@@ -23,6 +23,7 @@ import '../services/gamification_service.dart';
 import '../services/theme_service.dart';
 import '../services/user_data_finetune_readiness_service.dart';
 import '../widgets/ai_university_latest_info_task_card.dart';
+import '../widgets/ai_university_model_selection_task_card.dart';
 import '../widgets/ai_university_published_video_banner.dart';
 import '../widgets/ai_university_youtube_embed.dart';
 import '../widgets/ai_university_youtube_viewer_route.dart';
@@ -5700,11 +5701,14 @@ class AiUniversityPage extends StatefulWidget {
     this.initialProviderId,
     this.contentAnalytics,
     this.learningOutcomeAnalytics,
+    this.modelSelectionLearningOutcomeAnalytics,
   });
 
   final String? initialProviderId;
   final AiUniversityContentAnalytics? contentAnalytics;
   final AiUniversityLearningOutcomeAnalytics? learningOutcomeAnalytics;
+  final AiUniversityLearningOutcomeAnalytics?
+      modelSelectionLearningOutcomeAnalytics;
 
   @override
   State<AiUniversityPage> createState() => _AiUniversityPageState();
@@ -5724,6 +5728,8 @@ class _AiUniversityPageState extends State<AiUniversityPage>
   final _supabase = Supabase.instance.client;
   late final AiUniversityContentAnalytics _contentAnalytics;
   late final AiUniversityLearningOutcomeAnalytics _learningOutcomeAnalytics;
+  late final AiUniversityLearningOutcomeAnalytics
+      _modelSelectionLearningOutcomeAnalytics;
 
   List<String> _providers = [];
   Map<String, List<Map<String, dynamic>>> _content = {};
@@ -5764,6 +5770,12 @@ class _AiUniversityPageState extends State<AiUniversityPage>
         AiUniversityContentAnalytics.supabase(_supabase);
     _learningOutcomeAnalytics = widget.learningOutcomeAnalytics ??
         AiUniversityLearningOutcomeAnalytics.supabase(_supabase);
+    _modelSelectionLearningOutcomeAnalytics =
+        widget.modelSelectionLearningOutcomeAnalytics ??
+            AiUniversityLearningOutcomeAnalytics.supabase(
+              _supabase,
+              task: AiUniversityLearningOutcomeTask.modelSelection,
+            );
     _fetchContent();
     _loadAnsweredQuizzes();
     _loadRlhfSnapshot();
@@ -7965,16 +7977,21 @@ class _AiUniversityPageState extends State<AiUniversityPage>
     final youtubeVideoId =
         AiUniversityVideoLessonService.youtubeVideoIdFromUrl(sourceUrl);
     final isLatestInfoTask = provider == '01ai' && category == 'news';
+    final isModelSelectionTask = provider == '01ai' && category == 'models';
+    final learningOutcomeAnalytics = isModelSelectionTask
+        ? _modelSelectionLearningOutcomeAnalytics
+        : _learningOutcomeAnalytics;
+    final hasLearningOutcomeTask = isLatestInfoTask || isModelSelectionTask;
     final taskViewKey = row['id']?.toString() ?? '$provider:$category';
 
     return Card(
       margin: const EdgeInsets.only(bottom: 8),
       color: surface,
       child: ExpansionTile(
-        onExpansionChanged: isLatestInfoTask
+        onExpansionChanged: hasLearningOutcomeTask
             ? (expanded) {
                 if (expanded && _viewedLearningOutcomeTasks.add(taskViewKey)) {
-                  _learningOutcomeAnalytics.recordViewed().ignore();
+                  learningOutcomeAnalytics.recordViewed().ignore();
                 }
               }
             : null,
@@ -8070,6 +8087,13 @@ class _AiUniversityPageState extends State<AiUniversityPage>
                   const SizedBox(height: 16),
                   AiUniversityLatestInfoTaskCard(
                     onSubmit: _learningOutcomeAnalytics.recordCompleted,
+                  ),
+                ],
+                if (isModelSelectionTask) ...[
+                  const SizedBox(height: 16),
+                  AiUniversityModelSelectionTaskCard(
+                    onSubmit:
+                        _modelSelectionLearningOutcomeAnalytics.recordCompleted,
                   ),
                 ],
                 if (youtubeVideoId != null) ...[

--- a/lib/services/ai_university_learning_outcome_analytics.dart
+++ b/lib/services/ai_university_learning_outcome_analytics.dart
@@ -5,6 +5,29 @@ typedef AiUniversityLearningOutcomeWriter = Future<void> Function(
   Map<String, Object> row,
 );
 
+enum AiUniversityLearningOutcomeTask {
+  latestInfo(
+    taskVersion: '01ai_latest_20260828_v1',
+    provider: '01ai',
+    category: 'news',
+  ),
+  modelSelection(
+    taskVersion: '01ai_models_20260829_v1',
+    provider: '01ai',
+    category: 'models',
+  );
+
+  const AiUniversityLearningOutcomeTask({
+    required this.taskVersion,
+    required this.provider,
+    required this.category,
+  });
+
+  final String taskVersion;
+  final String provider;
+  final String category;
+}
+
 /// Anonymous, course-bounded learning outcome analytics.
 ///
 /// Only the fixed task identity and aggregate metrics are accepted. Learner
@@ -13,12 +36,16 @@ typedef AiUniversityLearningOutcomeWriter = Future<void> Function(
 class AiUniversityLearningOutcomeAnalytics {
   const AiUniversityLearningOutcomeAnalytics({
     AiUniversityLearningOutcomeWriter? writer,
+    this.task = AiUniversityLearningOutcomeTask.latestInfo,
   }) : _writer = writer;
 
   factory AiUniversityLearningOutcomeAnalytics.supabase(
-    SupabaseClient client,
-  ) {
+    SupabaseClient client, {
+    AiUniversityLearningOutcomeTask task =
+        AiUniversityLearningOutcomeTask.latestInfo,
+  }) {
     return AiUniversityLearningOutcomeAnalytics(
+      task: task,
       writer: (row) async {
         await client.from('ai_university_learning_outcome_events').insert(row);
       },
@@ -37,12 +64,13 @@ class AiUniversityLearningOutcomeAnalytics {
   };
 
   final AiUniversityLearningOutcomeWriter? _writer;
+  final AiUniversityLearningOutcomeTask task;
 
   Future<bool> recordViewed() => _record(<String, Object>{
         'event_name': 'task_viewed',
-        'task_version': taskVersion,
-        'provider': '01ai',
-        'category': 'news',
+        'task_version': task.taskVersion,
+        'provider': task.provider,
+        'category': task.category,
       });
 
   Future<bool> recordCompleted({
@@ -54,9 +82,9 @@ class AiUniversityLearningOutcomeAnalytics {
 
     return _record(<String, Object>{
       'event_name': 'task_completed',
-      'task_version': taskVersion,
-      'provider': '01ai',
-      'category': 'news',
+      'task_version': task.taskVersion,
+      'provider': task.provider,
+      'category': task.category,
       'correct_answers': correctAnswers,
       'total_questions': 3,
       'self_rating': selfRating,

--- a/lib/widgets/ai_university_model_selection_task_card.dart
+++ b/lib/widgets/ai_university_model_selection_task_card.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+
+typedef AiUniversityModelSelectionTaskSubmit = Future<bool> Function({
+  required int correctAnswers,
+  required int selfRating,
+});
+
+class AiUniversityModelSelectionTaskCard extends StatefulWidget {
+  const AiUniversityModelSelectionTaskCard({super.key, required this.onSubmit});
+
+  final AiUniversityModelSelectionTaskSubmit onSubmit;
+
+  @override
+  State<AiUniversityModelSelectionTaskCard> createState() =>
+      _AiUniversityModelSelectionTaskCardState();
+}
+
+class _ModelSelectionQuestion {
+  const _ModelSelectionQuestion({
+    required this.prompt,
+    required this.options,
+    required this.correctIndex,
+  });
+
+  final String prompt;
+  final List<String> options;
+  final int correctIndex;
+}
+
+class _AiUniversityModelSelectionTaskCardState
+    extends State<AiUniversityModelSelectionTaskCard> {
+  static const List<_ModelSelectionQuestion> _questions = [
+    _ModelSelectionQuestion(
+      prompt: '3K以内の短い文章処理で、料金を最優先する場合は？',
+      options: ['yi-large-turbo', 'yi-large', 'yi-vision'],
+      correctIndex: 0,
+    ),
+    _ModelSelectionQuestion(
+      prompt: '20Kの文書を使う複雑な推論には？',
+      options: ['yi-large-turbo', 'yi-large', 'yi-vision'],
+      correctIndex: 1,
+    ),
+    _ModelSelectionQuestion(
+      prompt: '10K以内の図表をOCRして説明する用途には？',
+      options: ['yi-large-turbo', 'yi-large', 'yi-vision'],
+      correctIndex: 2,
+    ),
+  ];
+
+  final List<int?> _answers = List<int?>.filled(_questions.length, null);
+  bool _comparisonCompleted = false;
+  int? _selfRating;
+  bool _submitting = false;
+  bool _submitted = false;
+  int? _correctAnswers;
+
+  bool get _canSubmit =>
+      !_submitting &&
+      !_submitted &&
+      _comparisonCompleted &&
+      _selfRating != null &&
+      _answers.every((answer) => answer != null);
+
+  Future<void> _submit() async {
+    if (!_canSubmit) return;
+    final correctAnswers = List<int>.generate(
+      _questions.length,
+      (index) => _answers[index] == _questions[index].correctIndex ? 1 : 0,
+    ).fold<int>(0, (total, value) => total + value);
+
+    setState(() => _submitting = true);
+    final accepted = await widget.onSubmit(
+      correctAnswers: correctAnswers,
+      selfRating: _selfRating!,
+    );
+    if (!mounted) return;
+    setState(() {
+      _submitting = false;
+      if (accepted) {
+        _submitted = true;
+        _correctAnswers = correctAnswers;
+      }
+    });
+    if (!accepted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('結果を送信できませんでした。時間をおいて再試行してください。')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0xFF0F1929),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: const Color(0xFF7E57C2).withValues(alpha: 0.55),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Row(
+            children: [
+              Icon(Icons.compare_arrows, color: Color(0xFFB39DDB)),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '用途・予算・文脈長でモデルを選ぶ',
+                  style: TextStyle(
+                    color: Color(0xFFE5E7EB),
+                    fontWeight: FontWeight.w700,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            '公式モデル表を確認し、3つの条件に合うモデルを選んでください。回答本文や個人情報は送信しません。',
+            style: TextStyle(color: Color(0xFFB0B0B0), height: 1.6),
+          ),
+          const SizedBox(height: 12),
+          ...List<Widget>.generate(_questions.length, (questionIndex) {
+            final question = _questions[questionIndex];
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${questionIndex + 1}. ${question.prompt}',
+                    style: const TextStyle(
+                      color: Color(0xFFE5E7EB),
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: List<Widget>.generate(
+                      question.options.length,
+                      (optionIndex) => ChoiceChip(
+                        key: Key(
+                          'model-selection-q$questionIndex-o$optionIndex',
+                        ),
+                        label: Text(question.options[optionIndex]),
+                        selected: _answers[questionIndex] == optionIndex,
+                        onSelected: _submitted
+                            ? null
+                            : (_) => setState(
+                                  () => _answers[questionIndex] = optionIndex,
+                                ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }),
+          CheckboxListTile(
+            key: const Key('model-selection-comparison-completed'),
+            contentPadding: EdgeInsets.zero,
+            value: _comparisonCompleted,
+            onChanged: _submitted
+                ? null
+                : (value) =>
+                    setState(() => _comparisonCompleted = value ?? false),
+            title: const Text(
+              '用途・予算・文脈長の比較メモを作成した',
+              style: TextStyle(color: Color(0xFFE5E7EB)),
+            ),
+            controlAffinity: ListTileControlAffinity.leading,
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            '選定理由を自分で説明できる度合い（1〜5）',
+            style: TextStyle(
+              color: Color(0xFFE5E7EB),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 8,
+            children: List<Widget>.generate(5, (index) {
+              final rating = index + 1;
+              return ChoiceChip(
+                key: Key('model-selection-rating-$rating'),
+                label: Text('$rating'),
+                selected: _selfRating == rating,
+                onSelected: _submitted
+                    ? null
+                    : (_) => setState(() => _selfRating = rating),
+              );
+            }),
+          ),
+          const SizedBox(height: 14),
+          if (_submitted)
+            Text(
+              '送信済み: $_correctAnswers / ${_questions.length} 問正解',
+              key: const Key('model-selection-submitted-result'),
+              style: const TextStyle(
+                color: Color(0xFF81C784),
+                fontWeight: FontWeight.w700,
+              ),
+            )
+          else if (_submitting)
+            const LinearProgressIndicator()
+          else
+            FilledButton.icon(
+              key: const Key('model-selection-submit'),
+              onPressed: _canSubmit ? _submit : null,
+              icon: const Icon(Icons.send_outlined),
+              label: const Text('匿名結果を送信'),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/supabase/migrations/20260829093000_remediate_01ai_model_selection_course.sql
+++ b/supabase/migrations/20260829093000_remediate_01ai_model_selection_course.sql
@@ -1,0 +1,110 @@
+-- Tiger remediation #4737: replace the stale 01.AI model list with a dated
+-- official-document snapshot, a live availability check, and a measurable
+-- model-selection task that stores no learner text or identifiers.
+-- nocheck: time-relative -- fixed evidence dates make this migration replayable.
+
+update public.ai_university_content
+set content = $markdown$
+## 01.AI (Yi) モデル一覧
+
+**公式ドキュメント確認日: 2026-08-29 (JST)**
+
+### 公式ドキュメントのモデル表
+
+| モデル | 文脈長 | 主な用途 | 入力 / 出力（100万token） |
+| --- | ---: | --- | ---: |
+| `yi-large` | 32K | 複雑な推論・予測・自然言語理解 | $3 / $3 |
+| `yi-large-turbo` | 4K | 短い文脈での高品質・コスト重視処理 | $0.19 / $0.19 |
+| `yi-large-fc` | 32K | tool useを伴うエージェント・workflow | $3 / $3 |
+| `yi-vision` | 16K | 画像・図表・OCR・視覚推論 | $0.19 / $0.19 |
+
+この表は確認日時点の公式ドキュメントの記載です。契約・アカウント・地域による**実際の利用可能モデル**は、認証済みのモデル一覧APIを利用時点で確認してください。
+
+### 稼働モデルを確認する
+
+```bash
+curl --location 'https://api.01.ai/v1/models' \
+  --header "Authorization: Bearer $YI_API_KEY"
+```
+
+レスポンスの `data[].id` が、その認証情報で利用できるモデルIDです。APIキーやレスポンス本文を講座へ貼り付けないでください。
+
+### 定期差分の確認手順
+
+1. 利用前と月1回、上の認証済みAPIを実行する。
+2. `data[].id` を昇順に並べ、前回の**確認日とモデルID一覧**に対して追加・削除を比較する。
+3. 公式ドキュメントの文脈長・用途・料金と照合する。
+4. 差分があれば、確認日、追加・削除モデル、用途・料金の変更をこの講座へ反映する。
+
+### 5分課題
+
+公式モデル表を開き、**用途・予算・必要文脈長**を1行ずつ書いてからモデルを選んでください。下の3問と自己評価を送ると、回答本文や個人情報を保存せず、課題の閲覧数・完了数・正答数・自己評価だけを匿名集計します。
+$markdown$,
+    source_url = 'https://platform.01.ai/docs',
+    published_at = date '2026-08-29',
+    target_audience =
+      '01.AI APIのモデルを用途、予算、必要文脈長で選びたい学習者',
+    observable_learning_outcome =
+      '認証済みモデル一覧を確認し、用途、予算、必要文脈長から適切なモデルを選定できる',
+    assessment_verification_method =
+      '用途、予算、必要文脈長を扱う3問、課題完了申告、5段階自己評価を匿名集計する',
+    evidence_source_url = 'https://platform.01.ai/docs',
+    evidence_verified_at = timestamptz '2026-08-29 00:00:00+09'
+where provider = '01ai'
+  and category = 'models';
+
+alter table public.ai_university_learning_outcome_events
+  drop constraint if exists ai_university_learning_outcome_events_task_version_check,
+  drop constraint if exists ai_university_learning_outcome_events_provider_check,
+  drop constraint if exists ai_university_learning_outcome_events_category_check;
+
+alter table public.ai_university_learning_outcome_events
+  add constraint ai_university_learning_outcome_task_identity check (
+    (
+      task_version = '01ai_latest_20260828_v1'
+      and provider = '01ai'
+      and category = 'news'
+    )
+    or (
+      task_version = '01ai_models_20260829_v1'
+      and provider = '01ai'
+      and category = 'models'
+    )
+  );
+comment on table public.ai_university_learning_outcome_events is
+  'Privacy-minimal anonymous outcome counters for finite 01.AI learning tasks.';
+
+drop policy if exists "anonymous clients insert bounded learning outcomes"
+  on public.ai_university_learning_outcome_events;
+create policy "anonymous clients insert bounded learning outcomes"
+  on public.ai_university_learning_outcome_events
+  for insert
+  to anon, authenticated
+  with check (
+    (
+      (
+        task_version = '01ai_latest_20260828_v1'
+        and provider = '01ai'
+        and category = 'news'
+      )
+      or (
+        task_version = '01ai_models_20260829_v1'
+        and provider = '01ai'
+        and category = 'models'
+      )
+    )
+    and (
+      (
+        event_name = 'task_viewed'
+        and correct_answers is null
+        and total_questions is null
+        and self_rating is null
+      )
+      or (
+        event_name = 'task_completed'
+        and correct_answers between 0 and 3
+        and total_questions = 3
+        and self_rating between 1 and 5
+      )
+    )
+  );

--- a/test/services/ai_university_latest_info_remediation_schema_test.dart
+++ b/test/services/ai_university_latest_info_remediation_schema_test.dart
@@ -54,7 +54,7 @@ void main() {
 
     expect(page, contains("provider == '01ai' && category == 'news'"));
     expect(page, contains('_viewedLearningOutcomeTasks.add(taskViewKey)'));
-    expect(page, contains('_learningOutcomeAnalytics.recordViewed()'));
+    expect(page, contains('learningOutcomeAnalytics.recordViewed()'));
     expect(page, contains('AiUniversityLatestInfoTaskCard('));
     expect(
       page,

--- a/test/services/ai_university_learning_outcome_analytics_test.dart
+++ b/test/services/ai_university_learning_outcome_analytics_test.dart
@@ -56,4 +56,28 @@ void main() {
     );
     expect(writes, 0);
   });
+
+  test('model-selection task uses its fixed category and version', () async {
+    final rows = <Map<String, Object>>[];
+    final analytics = AiUniversityLearningOutcomeAnalytics(
+      task: AiUniversityLearningOutcomeTask.modelSelection,
+      writer: (row) async => rows.add(row),
+    );
+
+    expect(await analytics.recordViewed(), isTrue);
+    expect(
+      await analytics.recordCompleted(correctAnswers: 3, selfRating: 5),
+      isTrue,
+    );
+
+    expect(rows.first, <String, Object>{
+      'event_name': 'task_viewed',
+      'task_version': '01ai_models_20260829_v1',
+      'provider': '01ai',
+      'category': 'models',
+    });
+    expect(rows.last['correct_answers'], 3);
+    expect(rows.last['total_questions'], 3);
+    expect(rows.last['self_rating'], 5);
+  });
 }

--- a/test/services/ai_university_model_selection_remediation_schema_test.dart
+++ b/test/services/ai_university_model_selection_remediation_schema_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final migration = File(
+    'supabase/migrations/'
+    '20260829093000_remediate_01ai_model_selection_course.sql',
+  );
+
+  test(
+    '01.AI model lesson is dated and has an authenticated diff procedure',
+    () {
+      final sql = migration.readAsStringSync();
+
+      expect(sql, contains('公式ドキュメント確認日: 2026-08-29 (JST)'));
+      expect(sql, contains('https://api.01.ai/v1/models'));
+      expect(sql, contains(r'Authorization: Bearer $YI_API_KEY'));
+      expect(sql, contains('data[].id'));
+      expect(sql, contains('前回の**確認日とモデルID一覧**'));
+      expect(sql, contains('用途・予算・必要文脈長'));
+      expect(sql, contains("where provider = '01ai'"));
+      expect(sql, contains("and category = 'models'"));
+    },
+  );
+
+  test('model-selection outcome events stay finite and anonymous', () {
+    final sql = migration.readAsStringSync();
+
+    expect(sql, contains("task_version = '01ai_models_20260829_v1'"));
+    expect(sql, contains("category = 'models'"));
+    expect(sql, contains('correct_answers between 0 and 3'));
+    expect(sql, contains('total_questions = 3'));
+    expect(sql, contains('self_rating between 1 and 5'));
+    expect(sql, contains('to anon, authenticated'));
+    expect(sql, isNot(contains('user_id')));
+    expect(sql, isNot(contains('session_id')));
+    expect(sql, isNot(contains('answer_text')));
+    expect(sql, isNot(contains('free_text')));
+  });
+
+  test('model lesson renders its task and records task-bounded analytics', () {
+    final page = File(
+      'lib/pages/gemini_university_v2_page.dart',
+    ).readAsStringSync();
+
+    expect(page, contains("provider == '01ai' && category == 'models'"));
+    expect(page, contains('AiUniversityModelSelectionTaskCard('));
+    expect(page, contains('AiUniversityLearningOutcomeTask.modelSelection'));
+    expect(
+      page,
+      contains('_modelSelectionLearningOutcomeAnalytics.recordCompleted'),
+    );
+  });
+}

--- a/test/widgets/ai_university_model_selection_task_card_test.dart
+++ b/test/widgets/ai_university_model_selection_task_card_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/ai_university_model_selection_task_card.dart';
+
+void main() {
+  Future<void> tapVisible(WidgetTester tester, Finder finder) async {
+    await tester.ensureVisible(finder);
+    await tester.tap(finder);
+    await tester.pump();
+  }
+
+  testWidgets('requires comparison, all answers, and self-rating', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: AiUniversityModelSelectionTaskCard(
+              onSubmit: ({required correctAnswers, required selfRating}) async {
+                return true;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final submit = find.byKey(const Key('model-selection-submit'));
+    expect(tester.widget<FilledButton>(submit).onPressed, isNull);
+
+    await tapVisible(tester, find.byKey(const Key('model-selection-q0-o0')));
+    await tapVisible(tester, find.byKey(const Key('model-selection-q1-o1')));
+    await tapVisible(tester, find.byKey(const Key('model-selection-q2-o2')));
+    await tapVisible(
+      tester,
+      find.byKey(const Key('model-selection-comparison-completed')),
+    );
+    await tapVisible(tester, find.byKey(const Key('model-selection-rating-4')));
+
+    await tester.ensureVisible(submit);
+    expect(tester.widget<FilledButton>(submit).onPressed, isNotNull);
+  });
+
+  testWidgets('submits only aggregate correctness and self-rating', (
+    tester,
+  ) async {
+    int? submittedCorrectAnswers;
+    int? submittedSelfRating;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: AiUniversityModelSelectionTaskCard(
+              onSubmit: ({required correctAnswers, required selfRating}) async {
+                submittedCorrectAnswers = correctAnswers;
+                submittedSelfRating = selfRating;
+                return true;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tapVisible(tester, find.byKey(const Key('model-selection-q0-o0')));
+    await tapVisible(tester, find.byKey(const Key('model-selection-q1-o0')));
+    await tapVisible(tester, find.byKey(const Key('model-selection-q2-o2')));
+    await tapVisible(
+      tester,
+      find.byKey(const Key('model-selection-comparison-completed')),
+    );
+    await tapVisible(tester, find.byKey(const Key('model-selection-rating-5')));
+    await tapVisible(tester, find.byKey(const Key('model-selection-submit')));
+    await tester.pumpAndSettle();
+
+    expect(submittedCorrectAnswers, 2);
+    expect(submittedSelfRating, 5);
+    expect(
+      find.byKey(const Key('model-selection-submitted-result')),
+      findsOneWidget,
+    );
+    expect(find.text('送信済み: 2 / 3 問正解'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Replace the stale 01.AI model-list lesson with a 2026-08-29 official-doc snapshot and an authenticated `GET /v1/models` monthly diff procedure.
- Add a three-question model-selection task covering purpose, budget, and context length.
- Extend the existing anonymous outcome table with a finite `01ai/models` task identity; store only view/completion, correctness, and self-rating aggregates.

Closes #4737

## Validation
- `flutter test test/services/ai_university_learning_outcome_analytics_test.dart test/services/ai_university_model_selection_remediation_schema_test.dart test/widgets/ai_university_model_selection_task_card_test.dart test/widgets/ai_university_latest_info_task_card_test.dart test/services/ai_university_latest_info_remediation_schema_test.dart` — 13 passed (Flutter 3.38.10 / Dart 3.10.9).
- `flutter analyze --no-pub` — one trailing-comma lint found; fixed.
- `dart analyze lib/services/ai_university_learning_outcome_analytics.dart` — passed after the fix.
- `dart format --output=none --set-exit-if-changed .` — 1437 files, 0 changes.
- `python scripts/check_migration_timestamps.py` — 1988 unique timestamps, no collision.
- `python scripts/check_migration_time_relative_check.py` — passed.
- `git diff --cached --check` — passed.

## Minimal E2E Gate
- Implementation-detail independent: widget tests assert the visible task requirements, answer interactions, disabled/enabled submit state, and aggregate result output.
- Minimal scope: initial disabled state, complete happy path, and mixed-answer aggregate.
- E2E-Exception: This course-specific card has no cross-route transaction; focused widget tests cover its user-visible input/output. The required production workflow provides the public route and migration smoke.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 was unavailable in this automation; bounded RLS migration is covered by fixed-task allowlists, no-PII schema tests, pinned Flutter tests, rollback notes, and required CI DB smoke.

## High-risk release evidence
- Security: anonymous/authenticated clients retain bounded INSERT only; the allowed task tuples are finite and clients receive no SELECT.
- Rollback: use a forward migration to disable the model card, remove the `01ai/models` tuple, and restore the prior lesson text.
- Data migration: one existing `01ai/models` row receives fixed evidence dates; no learner rows are rewritten.
- Production smoke: required CI applies migrations, runs DB/Edge smoke, deploys the web build, and reports the deployment run.
- Observability: the service-role summary exposes view count, completion rate, average correctness, and average self-rating by task version.
- Unresolved findings: none.