### PR TITLE
fix: restore anonymous core-hub memo reactions

### DIFF
--- a/lib/pages/memo_reactions_page.dart
+++ b/lib/pages/memo_reactions_page.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../services/public_memo_service.dart';
+
 /// メモリアクション確認ページ
 /// 公開メモへのリアクション（絵文字）の集計と投票を表示
 class MemoReactionsPage extends StatefulWidget {
-  const MemoReactionsPage({super.key});
+  final MemoReactionService? publicMemoService;
+
+  const MemoReactionsPage({super.key, this.publicMemoService});
 
   @override
   State<MemoReactionsPage> createState() => _MemoReactionsPageState();
 }
 
 class _MemoReactionsPageState extends State<MemoReactionsPage> {
-  final _supabase = Supabase.instance.client;
+  late final MemoReactionService _publicMemoService;
   final _memoIdController = TextEditingController();
   bool _isLoading = false;
   String? _errorMessage;
@@ -29,6 +33,13 @@ class _MemoReactionsPageState extends State<MemoReactionsPage> {
   };
 
   @override
+  void initState() {
+    super.initState();
+    _publicMemoService =
+        widget.publicMemoService ?? PublicMemoService(Supabase.instance.client);
+  }
+
+  @override
   void dispose() {
     _memoIdController.dispose();
     super.dispose();
@@ -42,30 +53,14 @@ class _MemoReactionsPageState extends State<MemoReactionsPage> {
       return;
     }
 
-    if (_supabase.auth.currentUser == null) {
-      setState(() => _isLoading = false);
-      return;
-    }
     setState(() {
       _isLoading = true;
       _errorMessage = null;
     });
 
     try {
-      final response = await _supabase.functions.invoke(
-        'core-hub',
-        body: {'action': 'memo.share_list', 'memo_id': memoId},
-      );
-      final data = response.data;
-      if (data is Map<String, dynamic>) {
-        final rawReactions = data['reactions'] as Map<String, dynamic>? ?? {};
-        final rawUser = data['userReactions'] as List<dynamic>? ?? [];
-        setState(() {
-          _reactions =
-              rawReactions.map((k, v) => MapEntry(k, (v as num).toInt()));
-          _userReactions = rawUser.map((e) => e.toString()).toList();
-        });
-      }
+      final data = await _publicMemoService.loadReactions(memoId);
+      _applyReactionPayload(data);
     } catch (e) {
       if (mounted) setState(() => _errorMessage = 'リアクション取得に失敗しました: $e');
     } finally {
@@ -74,24 +69,41 @@ class _MemoReactionsPageState extends State<MemoReactionsPage> {
   }
 
   Future<void> _toggle(String reaction) async {
-    if (_supabase.auth.currentUser == null) {
-      setState(() => _isLoading = false);
-      return;
-    }
     final memoId = int.tryParse(_memoIdController.text.trim());
     if (memoId == null) return;
 
     try {
-      await _supabase.functions.invoke(
-        'core-hub',
-        body: {'action': 'memo.share', 'memo_id': memoId, 'reaction': reaction},
+      final data = await _publicMemoService.toggleReaction(
+        memoId: memoId,
+        reaction: reaction,
       );
-      await _load();
+      _applyReactionPayload(data);
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = 'リアクション送信に失敗しました: $e');
       }
     }
+  }
+
+  void _applyReactionPayload(Map<String, dynamic> data) {
+    final rawReactions = data['reactions'];
+    final rawUser = data['userReactions'];
+    final reactions = <String, int>{};
+    if (rawReactions is Map) {
+      for (final entry in rawReactions.entries) {
+        if (entry.value is num) {
+          reactions[entry.key.toString()] = (entry.value as num).toInt();
+        }
+      }
+    }
+    final userReactions = rawUser is List
+        ? rawUser.map((value) => value.toString()).toList()
+        : <String>[];
+    if (!mounted) return;
+    setState(() {
+      _reactions = reactions;
+      _userReactions = userReactions;
+    });
   }
 
   @override

--- a/lib/services/public_memo_service.dart
+++ b/lib/services/public_memo_service.dart
@@ -5,7 +5,16 @@ import '../utils/app_logger.dart';
 import 'app_share_service.dart';
 import 'supabase_runtime_config.dart';
 
-class PublicMemoService {
+abstract interface class MemoReactionService {
+  Future<Map<String, dynamic>> loadReactions(int memoId);
+
+  Future<Map<String, dynamic>> toggleReaction({
+    required int memoId,
+    required String reaction,
+  });
+}
+
+class PublicMemoService implements MemoReactionService {
   static const String publicMemoShareSignal = 'public_memo_share';
   static const String publicMemoCopySignal = 'public_memo_copy';
 
@@ -73,27 +82,40 @@ class PublicMemoService {
     ].join('\n\n');
   }
 
+  @override
   Future<Map<String, dynamic>> loadReactions(int memoId) async {
     final response = await _supabase.functions.invoke(
       'core-hub',
-      body: <String, dynamic>{'action': 'memo.react.list', 'memo_id': memoId},
+      body: buildLoadReactionsRequest(memoId),
     );
     return _asMap(response.data);
   }
 
+  @override
   Future<Map<String, dynamic>> toggleReaction({
     required int memoId,
     required String reaction,
   }) async {
     final response = await _supabase.functions.invoke(
       'core-hub',
-      body: <String, dynamic>{
-        'action': 'memo.react.toggle',
-        'memo_id': memoId,
-        'reaction': reaction,
-      },
+      body: buildToggleReactionRequest(memoId: memoId, reaction: reaction),
     );
     return _asMap(response.data);
+  }
+
+  static Map<String, dynamic> buildLoadReactionsRequest(int memoId) {
+    return <String, dynamic>{'action': 'memo.react.list', 'memo_id': memoId};
+  }
+
+  static Map<String, dynamic> buildToggleReactionRequest({
+    required int memoId,
+    required String reaction,
+  }) {
+    return <String, dynamic>{
+      'action': 'memo.react.toggle',
+      'memo_id': memoId,
+      'reaction': reaction,
+    };
   }
 
   static String _buildShareExcerpt(String? content) {

--- a/supabase/functions/core-hub/action_registry.ts
+++ b/supabase/functions/core-hub/action_registry.ts
@@ -1,0 +1,66 @@
+export type CoreHubAuthPolicy = "anonymous" | "user" | "service_role";
+
+export interface CoreHubActionDefinition {
+  auth: CoreHubAuthPolicy;
+}
+
+export const CORE_HUB_ACTION_REGISTRY = {
+  "memo.share": { auth: "user" },
+  "memo.share_list": { auth: "user" },
+  "memo.react": { auth: "user" },
+  "memo.react.list": { auth: "anonymous" },
+  "memo.react.toggle": { auth: "anonymous" },
+  "memo.ogp": { auth: "user" },
+  "memo.public.view": { auth: "anonymous" },
+  "memo.public.list": { auth: "anonymous" },
+  "memo.public.search": { auth: "anonymous" },
+  "memo.public.related": { auth: "anonymous" },
+  "blog.public.view": { auth: "anonymous" },
+  "blog.public.list": { auth: "anonymous" },
+  "ogp.fetch": { auth: "user" },
+  "note.comment.list": { auth: "user" },
+  "note.comment.add": { auth: "user" },
+  "note.comment.delete": { auth: "user" },
+  "notification.list": { auth: "user" },
+  "notification.create": { auth: "user" },
+  "notification.mark_read": { auth: "user" },
+  "notification.mark_all": { auth: "user" },
+  "notification.broadcast_release": { auth: "service_role" },
+  "slack.notify": { auth: "service_role" },
+  "discord.notify": { auth: "service_role" },
+  "user.profile": { auth: "user" },
+  "user.update": { auth: "user" },
+  "onboarding.get": { auth: "user" },
+  "onboarding.complete": { auth: "user" },
+  "feature_request.list": { auth: "user" },
+  "feature_request.vote": { auth: "user" },
+  "feature_request.analyze_attachment": { auth: "user" },
+  "feature_request.existing_issues": { auth: "user" },
+  "feature_request.submit": { auth: "user" },
+  "feedback.submit": { auth: "user" },
+  "notify.feature": { auth: "user" },
+  "notify.feature_request": { auth: "service_role" },
+  "personal.dashboard": { auth: "user" },
+  "achievements.list": { auth: "user" },
+  "achievements.add": { auth: "user" },
+  "analytics.summary": { auth: "user" },
+  "system.status": { auth: "user" },
+  "system.proactive_diagnostics": { auth: "service_role" },
+  "page.share_generate": { auth: "anonymous" },
+  "design.screens.list": { auth: "user" },
+  "design.audit.upsert": { auth: "user" },
+  "design.rollout.upsert": { auth: "user" },
+} as const satisfies Record<string, CoreHubActionDefinition>;
+
+export type CoreHubAction = keyof typeof CORE_HUB_ACTION_REGISTRY;
+
+export function coreHubActionDefinition(
+  action: string,
+): CoreHubActionDefinition | null {
+  if (!Object.hasOwn(CORE_HUB_ACTION_REGISTRY, action)) return null;
+  return CORE_HUB_ACTION_REGISTRY[action as CoreHubAction];
+}
+
+export function isCoreHubAction(action: string): action is CoreHubAction {
+  return coreHubActionDefinition(action) !== null;
+}

--- a/supabase/functions/core-hub/action_registry_test.ts
+++ b/supabase/functions/core-hub/action_registry_test.ts
@@ -1,0 +1,87 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  CORE_HUB_ACTION_REGISTRY,
+  type CoreHubAuthPolicy,
+} from "./action_registry.ts";
+
+const EXPECTED_ACTIONS: Record<CoreHubAuthPolicy, string[]> = {
+  anonymous: [
+    "blog.public.list",
+    "blog.public.view",
+    "memo.public.list",
+    "memo.public.related",
+    "memo.public.search",
+    "memo.public.view",
+    "memo.react.list",
+    "memo.react.toggle",
+    "page.share_generate",
+  ],
+  service_role: [
+    "discord.notify",
+    "notification.broadcast_release",
+    "notify.feature_request",
+    "slack.notify",
+    "system.proactive_diagnostics",
+  ],
+  user: [
+    "achievements.add",
+    "achievements.list",
+    "analytics.summary",
+    "design.audit.upsert",
+    "design.rollout.upsert",
+    "design.screens.list",
+    "feature_request.analyze_attachment",
+    "feature_request.existing_issues",
+    "feature_request.list",
+    "feature_request.submit",
+    "feature_request.vote",
+    "feedback.submit",
+    "memo.ogp",
+    "memo.react",
+    "memo.share",
+    "memo.share_list",
+    "note.comment.add",
+    "note.comment.delete",
+    "note.comment.list",
+    "notification.create",
+    "notification.list",
+    "notification.mark_all",
+    "notification.mark_read",
+    "notify.feature",
+    "ogp.fetch",
+    "onboarding.complete",
+    "onboarding.get",
+    "personal.dashboard",
+    "system.status",
+    "user.profile",
+    "user.update",
+  ],
+};
+
+Deno.test("all 45 dispatcher actions have one explicit auth policy", async () => {
+  const actual: Record<CoreHubAuthPolicy, string[]> = {
+    anonymous: [],
+    service_role: [],
+    user: [],
+  };
+  for (
+    const [action, definition] of Object.entries(
+      CORE_HUB_ACTION_REGISTRY,
+    )
+  ) {
+    actual[definition.auth].push(action);
+  }
+  for (const actions of Object.values(actual)) actions.sort();
+
+  assertEquals(actual, EXPECTED_ACTIONS);
+  assertEquals(Object.keys(CORE_HUB_ACTION_REGISTRY).length, 45);
+
+  const indexSource = await Deno.readTextFile(
+    new URL("./index.ts", import.meta.url),
+  );
+  const switchActions = Array.from(
+    indexSource.matchAll(/^\s*case\s+"([^"]+)"/gm),
+    (match) => match[1],
+  ).sort();
+  assertEquals(switchActions, Object.keys(CORE_HUB_ACTION_REGISTRY).sort());
+});

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -2,6 +2,10 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 import {
+  type CoreHubAction,
+  coreHubActionDefinition,
+} from "./action_registry.ts";
+import {
   createSupabaseMemoReactionStore,
   handleMemoReactionAction,
   type MemoReactionAction,
@@ -835,13 +839,23 @@ async function createFeatureRequestWbsTask(
   return { ...data, github_issue_number: params.issueNumber };
 }
 
-serve(async (req: Request) => {
+export interface CoreHubRequestDependencies {
+  createAdminClient?: () => SupabaseClient;
+  authenticateUser?: (req: Request) => Promise<string | null>;
+  handleMemoReaction?: typeof handleMemoReactionAction;
+  serviceRoleKey?: string;
+  reportError?: (error: unknown) => void;
+}
+
+export async function handleCoreHubRequest(
+  req: Request,
+  dependencies: CoreHubRequestDependencies = {},
+): Promise<Response> {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }
 
   try {
-    const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
     // deno-lint-ignore no-explicit-any
     let body: Record<string, any> = {};
     if (req.method === "GET" || req.method === "HEAD") {
@@ -861,38 +875,31 @@ serve(async (req: Request) => {
       }
     }
 
-    const action: string = body.action ?? "";
-    const serviceRoleActions = new Set([
-      "notify.feature_request",
-      "notification.broadcast_release",
-      "system.proactive_diagnostics",
-      "slack.notify",
-      "discord.notify",
-    ]);
-    // Anonymous-allowed actions (no auth required / page-specific cache)
-    const anonymousActions = new Set([
-      "page.share_generate",
-      "memo.public.view",
-      "memo.public.list",
-      "memo.public.search",
-      "memo.public.related",
-      "blog.public.view",
-      "blog.public.list",
-    ]);
+    const rawAction = typeof body.action === "string" ? body.action : "";
+    const actionDefinition = coreHubActionDefinition(rawAction);
+    if (actionDefinition === null) {
+      return json({ error: `Unknown action: ${rawAction}` }, 400);
+    }
+    const action: CoreHubAction = rawAction as CoreHubAction;
     const bearer = (req.headers.get("authorization") ?? "").replace(
       /^Bearer\s+/i,
       "",
     ).trim();
-    const isServiceRole = SERVICE_ROLE_KEY !== "" &&
-      bearer === SERVICE_ROLE_KEY;
+    const serviceRoleKey = dependencies.serviceRoleKey ?? SERVICE_ROLE_KEY;
+    const isServiceRole = serviceRoleKey !== "" && bearer === serviceRoleKey;
     let userId = "";
-    if (anonymousActions.has(action)) {
+    if (actionDefinition.auth === "anonymous") {
       // skip auth — anonymous OK
-    } else if (!(serviceRoleActions.has(action) && isServiceRole)) {
-      const authed = await getUserId(req);
+    } else if (actionDefinition.auth === "service_role") {
+      if (!isServiceRole) return json({ error: "Unauthorized" }, 401);
+    } else {
+      const authed = await (dependencies.authenticateUser ?? getUserId)(req);
       if (!authed) return json({ error: "Unauthorized" }, 401);
       userId = authed;
     }
+
+    const admin = dependencies.createAdminClient?.() ??
+      createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
 
     switch (action) {
       // ---- Memo sharing ----
@@ -928,7 +935,9 @@ serve(async (req: Request) => {
       // ip_hash は server 側で `x-forwarded-for` を sha256 して生成する (clientは送らない)。
       case "memo.react.list":
       case "memo.react.toggle": {
-        const result = await handleMemoReactionAction({
+        const result = await (
+          dependencies.handleMemoReaction ?? handleMemoReactionAction
+        )({
           action: action as MemoReactionAction,
           body,
           headers: req.headers,
@@ -2953,13 +2962,21 @@ description: ${pageDescription}
       }
 
       default:
-        return json({ error: `Unknown action: ${action}` }, 400);
+        return assertUnreachableAction(action);
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return json({ error: message }, 500);
+    (dependencies.reportError ?? console.error)(err);
+    return json({ error: "Internal server error" }, 500);
   }
-});
+}
+
+function assertUnreachableAction(action: never): Response {
+  return json({ error: `Unknown action: ${String(action)}` }, 400);
+}
+
+if (import.meta.main) {
+  serve((req) => handleCoreHubRequest(req));
+}
 
 // ---- Helpers for notify.feature_request ----
 function _escapeHtml(value: string): string {

--- a/supabase/functions/core-hub/index_test.ts
+++ b/supabase/functions/core-hub/index_test.ts
@@ -1,0 +1,91 @@
+import {
+  assertEquals,
+  assertFalse,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { handleCoreHubRequest } from "./index.ts";
+
+function post(action: string): Request {
+  return new Request("https://example.test/functions/v1/core-hub", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ action, memo_id: 42, reaction: "👍" }),
+  });
+}
+
+for (const action of ["memo.react.list", "memo.react.toggle"]) {
+  Deno.test(`${action} reaches the route without authentication`, async () => {
+    let authenticateCalled = false;
+    const response = await handleCoreHubRequest(post(action), {
+      createAdminClient: () => ({}) as never,
+      authenticateUser: () => {
+        authenticateCalled = true;
+        return Promise.resolve(null);
+      },
+      handleMemoReaction: (input) =>
+        Promise.resolve({
+          status: 200,
+          payload: { routedAction: input.action },
+        }),
+      reportError: () => {},
+    });
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.json(), { routedAction: action });
+    assertFalse(authenticateCalled);
+  });
+}
+
+Deno.test("unknown actions return 400 before authentication", async () => {
+  let authenticateCalled = false;
+  const response = await handleCoreHubRequest(post("memo.react.unknown"), {
+    createAdminClient: () => {
+      throw new Error("admin client must not be created");
+    },
+    authenticateUser: () => {
+      authenticateCalled = true;
+      return Promise.resolve(null);
+    },
+    reportError: () => {},
+  });
+
+  assertEquals(response.status, 400);
+  assertEquals(await response.json(), {
+    error: "Unknown action: memo.react.unknown",
+  });
+  assertFalse(authenticateCalled);
+});
+
+Deno.test("unexpected route exceptions are sanitized", async () => {
+  let reportedError: unknown;
+  const response = await handleCoreHubRequest(post("memo.react.list"), {
+    createAdminClient: () => ({}) as never,
+    handleMemoReaction: () => {
+      throw new Error("database password leaked in backend message");
+    },
+    reportError: (error) => {
+      reportedError = error;
+    },
+  });
+
+  assertEquals(response.status, 500);
+  assertEquals(await response.json(), { error: "Internal server error" });
+  assertEquals(reportedError instanceof Error, true);
+});
+
+Deno.test("user actions still require an authenticated user", async () => {
+  const response = await handleCoreHubRequest(post("memo.share"), {
+    authenticateUser: () => Promise.resolve(null),
+    reportError: () => {},
+  });
+  assertEquals(response.status, 401);
+  assertEquals(await response.json(), { error: "Unauthorized" });
+});
+
+Deno.test("service-role actions reject an anonymous bearer", async () => {
+  const response = await handleCoreHubRequest(post("slack.notify"), {
+    serviceRoleKey: "expected-service-role-key",
+    reportError: () => {},
+  });
+  assertEquals(response.status, 401);
+  assertEquals(await response.json(), { error: "Unauthorized" });
+});

--- a/test/pages/memo_reactions_page_test.dart
+++ b/test/pages/memo_reactions_page_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/memo_reactions_page.dart';
+import 'package:my_web_app/services/public_memo_service.dart';
+
+class FakeMemoReactionService implements MemoReactionService {
+  final List<int> loadedMemoIds = <int>[];
+  final List<({int memoId, String reaction})> toggles =
+      <({int memoId, String reaction})>[];
+
+  @override
+  Future<Map<String, dynamic>> loadReactions(int memoId) async {
+    loadedMemoIds.add(memoId);
+    return <String, dynamic>{
+      'reactions': <String, int>{'👍': 2},
+      'userReactions': <String>[],
+    };
+  }
+
+  @override
+  Future<Map<String, dynamic>> toggleReaction({
+    required int memoId,
+    required String reaction,
+  }) async {
+    toggles.add((memoId: memoId, reaction: reaction));
+    return <String, dynamic>{
+      'reactions': <String, int>{'👍': 3},
+      'userReactions': <String>['👍'],
+    };
+  }
+}
+
+void main() {
+  testWidgets('loads and toggles anonymous reactions through the service', (
+    tester,
+  ) async {
+    final service = FakeMemoReactionService();
+    await tester.pumpWidget(
+      MaterialApp(home: MemoReactionsPage(publicMemoService: service)),
+    );
+
+    await tester.enterText(find.byType(TextField), '42');
+    await tester.tap(find.text('取得'));
+    await tester.pumpAndSettle();
+
+    expect(service.loadedMemoIds, <int>[42]);
+    expect(find.text('2'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('いいね 2件'));
+    await tester.pumpAndSettle();
+
+    expect(service.toggles, <({int memoId, String reaction})>[
+      (memoId: 42, reaction: '👍'),
+    ]);
+    expect(find.text('3'), findsOneWidget);
+    expect(find.bySemanticsLabel('いいね 3件 選択中'), findsOneWidget);
+  });
+}

--- a/test/services/public_memo_service_test.dart
+++ b/test/services/public_memo_service_test.dart
@@ -48,4 +48,23 @@ void main() {
       );
     });
   });
+
+  group('PublicMemoService reaction contract', () {
+    test('load request uses only memo.react.list', () {
+      expect(PublicMemoService.buildLoadReactionsRequest(42), {
+        'action': 'memo.react.list',
+        'memo_id': 42,
+      });
+    });
+
+    test('toggle request uses only memo.react.toggle', () {
+      expect(
+        PublicMemoService.buildToggleReactionRequest(
+          memoId: 42,
+          reaction: '👍',
+        ),
+        {'action': 'memo.react.toggle', 'memo_id': 42, 'reaction': '👍'},
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Outcome
- allow `memo.react.list` and `memo.react.toggle` through the typed anonymous policy
- route `MemoReactionsPage` through `PublicMemoService` instead of legacy `memo.share*` actions
- define one typed registry for all 45 core-hub actions and sanitize unexpected route exceptions
- add route, registry, service, and widget contract tests
- rebase onto the current `origin/main` and add the analyzer-required `@override` annotations

## Validation
- `deno lint supabase/functions/core-hub/action_registry.ts supabase/functions/core-hub/action_registry_test.ts supabase/functions/core-hub/index.ts supabase/functions/core-hub/index_test.ts supabase/functions/core-hub/_smoke_test.ts`
- `deno test --node-modules-dir=auto --allow-env --allow-read supabase/functions/core-hub/action_registry_test.ts supabase/functions/core-hub/index_test.ts supabase/functions/core-hub/_smoke_test.ts` (12 passed)
- pre-commit fast quality gate and commit-message gates passed
- `git diff --check`

## Flutter CI note
Local Flutter validation was not run because the repository requires Flutter 3.38.10 while the installed SDK is 3.41.7; the repository preflight returned `product_change_allowed=false`. The pinned Flutter analysis and tests remain required CI gates and must pass before merge.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Issue #4937 requires route, widget, and service contract coverage; the exact anonymous reaction I/O is covered there, while a credentialed end-to-end harness is not available for this bounded repair.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 ultrareview was unavailable; repository owner explicitly requested production deployment after reviewing PR #4987, and Codex #1 ran the scoped deterministic security and release checks.

## High-risk release assessment
- Security: only the two exact reaction actions become anonymous; user and service-role action tests prove their authentication remains enforced, and unknown actions fail before authentication.
- Rollback: revert this PR's merge commit and redeploy; there is no schema or data migration.
- Data migration: none.
- Production smoke: after deployment, an unauthenticated `memo.react.list` request must return the reaction contract rather than 401, and the deployed commit must match the successful workflow.
- Observability: unexpected server exceptions are reported through the existing error reporter while the client receives a sanitized 500 response.
- Unresolved ultrareview findings: none recorded; Claude Code #1 ultrareview was not run under the explicit exception above.

## Human review acknowledgement
The repository owner reviewed the failing PR state and explicitly requested continuation through production deployment on 2026-08-29.

Closes #4937
