### PR TITLE
虎プロフィール拡充ラウンド7

### DIFF
--- a/assets/data/tiger_reviewer_profiles.json
+++ b/assets/data/tiger_reviewer_profiles.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
-  "snapshot_date": "2026-08-28",
-  "source_snapshot": "canonical tiger-personas.json (2026-08-28)",
+  "snapshot_date": "2026-08-29",
+  "source_snapshot": "canonical tiger-personas.json (2026-08-29)",
   "reviewer_count": 125,
   "disclaimer": "年齢は生年月日を公開一次情報で確認できた場合のみ、スナップショット日時点で表示します。未確認の年齢は推測していません。肩書き・事業内容・出演実績は公開情報から構成したスナップショットです。",
   "profiles": [
@@ -11,7 +11,7 @@
       "roster_status": "current",
       "birth_date": null,
       "birth_date_source_url": null,
-      "company_role": "アマソラクリニック 院長",
+      "company_role": "アマソラクリニック（院長）（美容クリニック）",
       "business_summary": "医学部受験塾、美容クリニック、インドアゴルフ場、D2Cサプリ事業",
       "business_domains": [
         "教育・スクール",
@@ -118,7 +118,6 @@
         }
       ],
       "review_style_tags": [
-        "founder_empathy",
         "growth_first",
         "balanced_risk",
         "replicability_and_store_economics"
@@ -196,7 +195,7 @@
       "evidence_source_ids": [
         "S006",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -259,9 +258,9 @@
         "生年月日の一次公開情報"
       ],
       "evidence_source_ids": [
-        "S007",
-        "S002",
         "S008",
+        "S002",
+        "S007",
         "S004"
       ]
     },
@@ -316,6 +315,7 @@
       ],
       "review_style_tags": [
         "founder_empathy",
+        "growth_first",
         "balanced_risk",
         "gross_margin_and_repeat_purchase"
       ],
@@ -325,7 +325,7 @@
       "evidence_source_ids": [
         "S009",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -388,7 +388,7 @@
       "evidence_source_ids": [
         "S010",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -455,7 +455,7 @@
       "evidence_source_ids": [
         "S011",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -516,7 +516,7 @@
       "evidence_source_ids": [
         "S012",
         "S002",
-        "S008"
+        "S007"
       ]
     },
     {
@@ -533,8 +533,8 @@
         "経営支援・コンサルティング",
         "教育・スクール"
       ],
-      "appearances": 69,
-      "investment_count": 19,
+      "appearances": 70,
+      "investment_count": 20,
       "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、数字ゴリゴリタイプ。と説明している。",
       "profile_url": "https://reiwanotora.jp/tiger/hiraide-shin/",
       "evidence_confidence": 5.0,
@@ -579,7 +579,7 @@
       "evidence_source_ids": [
         "S013",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -646,7 +646,7 @@
       "evidence_source_ids": [
         "S014",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -710,7 +710,7 @@
       "evidence_source_ids": [
         "S015",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -776,7 +776,7 @@
       "evidence_source_ids": [
         "S016",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -839,7 +839,7 @@
       "evidence_source_ids": [
         "S017",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -901,7 +901,7 @@
       "evidence_source_ids": [
         "S018",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -962,7 +962,7 @@
       "evidence_source_ids": [
         "S019",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1026,7 +1026,7 @@
       "evidence_source_ids": [
         "S020",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -1089,7 +1089,7 @@
       "evidence_source_ids": [
         "S021",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1150,7 +1150,7 @@
       "evidence_source_ids": [
         "S022",
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -1165,9 +1165,9 @@
       "business_domains": [
         "マーケティング・メディア"
       ],
-      "appearances": 213,
-      "investment_count": 57,
-      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディアの公開職歴と、番組集計上の出演213回・出資57回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "appearances": 214,
+      "investment_count": 58,
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。マーケティング・メディアの公開職歴と、番組集計上の出演214回・出資58回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
       "profile_url": "https://reiwanotora.jp/tiger/takeuchi-kouichi/",
       "evidence_confidence": 4.0,
       "profile_completeness_percent": 67,
@@ -1211,7 +1211,7 @@
       "evidence_source_ids": [
         "S023",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1277,7 +1277,7 @@
       "evidence_source_ids": [
         "S024",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -1338,7 +1338,7 @@
       "evidence_source_ids": [
         "S025",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1405,7 +1405,7 @@
       "evidence_source_ids": [
         "S026",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1469,7 +1469,7 @@
       "evidence_source_ids": [
         "S027",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1487,7 +1487,7 @@
         "人材・採用・組織",
         "製造・エネルギー・環境"
       ],
-      "appearances": 44,
+      "appearances": 45,
       "investment_count": 12,
       "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、人情タイプ。と説明している。",
       "profile_url": "https://reiwanotora.jp/tiger/son-shunichirou/",
@@ -1532,7 +1532,7 @@
       "evidence_source_ids": [
         "S028",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1597,7 +1597,7 @@
       "evidence_source_ids": [
         "S029",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1664,7 +1664,7 @@
       "evidence_source_ids": [
         "S030",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1725,7 +1725,7 @@
       "evidence_source_ids": [
         "S031",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1790,7 +1790,7 @@
       "evidence_source_ids": [
         "S032",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -1855,7 +1855,7 @@
       "evidence_source_ids": [
         "S033",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -1918,7 +1918,7 @@
       "evidence_source_ids": [
         "S034",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -1979,7 +1979,7 @@
       "evidence_source_ids": [
         "S035",
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -2045,7 +2045,7 @@
       "evidence_source_ids": [
         "S036",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -2238,7 +2238,7 @@
       "evidence_source_ids": [
         "S039",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -2300,7 +2300,7 @@
       "evidence_source_ids": [
         "S040",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -2315,7 +2315,7 @@
         "IT・SaaS・プラットフォーム",
         "小売・通販・EC"
       ],
-      "appearances": 10,
+      "appearances": 11,
       "investment_count": 2,
       "public_viewpoint_summary": "本人公式プロフィールの『志願者との向き合い方』欄では、寄り添うタイプと説明している。",
       "profile_url": "https://reiwanotora.jp/tiger/nishida-ken/",
@@ -2363,7 +2363,7 @@
       "evidence_source_ids": [
         "S041",
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -2551,7 +2551,7 @@
       "evidence_source_ids": [
         "S044",
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -2623,16 +2623,16 @@
       "roster_status": "historical",
       "birth_date": null,
       "birth_date_source_url": null,
-      "company_role": "株式会社晴れる屋 代表",
+      "company_role": "株式会社トモハッピー（カードゲーム売買業。YouTuber）",
       "business_summary": "小売・通販・EC、エンタメ・クリエイター、マーケティング・メディア",
       "business_domains": [
-        "小売・通販・EC",
         "エンタメ・クリエイター",
-        "マーケティング・メディア"
+        "マーケティング・メディア",
+        "小売・通販・EC"
       ],
       "appearances": 340,
       "investment_count": 110,
-      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。小売・通販・EC、エンタメ・クリエイター、マーケティング・メディアの公開職歴と、番組集計上の出演340回・出資110回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
+      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。エンタメ・クリエイター、マーケティング・メディア、小売・通販・ECの公開職歴と、番組集計上の出演340回・出資110回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
       "profile_url": "https://atsu-blog.com/tigerfunding-president-list/",
       "evidence_confidence": 3.3,
       "profile_completeness_percent": 57,
@@ -2742,7 +2742,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -2804,7 +2804,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -2867,7 +2867,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -2931,7 +2931,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -2992,7 +2992,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3055,7 +3055,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -3119,7 +3119,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3180,7 +3180,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -3243,7 +3243,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -3303,7 +3303,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3364,7 +3364,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -3426,7 +3426,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3486,7 +3486,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3546,7 +3546,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3607,7 +3607,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3667,7 +3667,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3731,7 +3731,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -3796,7 +3796,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -3857,7 +3857,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -3917,7 +3917,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -3981,7 +3981,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -4044,7 +4044,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -4110,7 +4110,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -4172,7 +4172,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -4301,7 +4301,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -4366,7 +4366,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -4430,7 +4430,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -4492,7 +4492,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -4553,7 +4553,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003"
+        "S007"
       ]
     },
     {
@@ -4618,7 +4618,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -4679,7 +4679,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -4745,7 +4745,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -4806,7 +4806,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -4869,7 +4869,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -4931,7 +4931,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -4994,7 +4994,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -5055,7 +5055,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -5116,7 +5116,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -5177,7 +5177,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -5243,7 +5243,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -5304,7 +5304,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -5365,7 +5365,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -5426,7 +5426,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008"
+        "S003"
       ]
     },
     {
@@ -5501,7 +5501,7 @@
         "S002",
         "S047",
         "S048",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -5588,7 +5588,7 @@
         "S050",
         "S051",
         "S052",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -5652,6 +5652,7 @@
         }
       ],
       "review_style_tags": [
+        "growth_first",
         "evidence_demanding",
         "acquisition_and_conversion",
         "gross_margin_and_repeat_purchase"
@@ -5665,7 +5666,7 @@
         "S002",
         "S053",
         "S054",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -5891,7 +5892,7 @@
       "evidence_source_ids": [
         "S002",
         "S060",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -6043,7 +6044,7 @@
         "S062",
         "S063",
         "S064",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -6127,7 +6128,7 @@
         "S065",
         "S066",
         "S067",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -6209,7 +6210,7 @@
         "S068",
         "S069",
         "S070",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -6270,7 +6271,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -6280,44 +6281,51 @@
       "roster_status": "historical",
       "birth_date": null,
       "birth_date_source_url": null,
-      "company_role": "HAB株式会社代表取締役CEO",
-      "business_summary": "専門サービス・生活支援",
+      "company_role": "株式会社Reuter CEO。社長歴25年・CHRO歴20年と本人プロフィールで説明し、『雇わない経営』と『雇われないキャリア』を支援",
+      "business_summary": "人事・組織支援、雇用に依存しない経営とキャリアの支援",
       "business_domains": [
-        "専門サービス・生活支援"
+        "人材・採用・組織",
+        "経営支援・コンサルティング"
       ],
       "appearances": 3,
       "investment_count": 1,
-      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。専門サービス・生活支援の公開職歴と、番組集計上の出演3回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
-      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/",
-      "evidence_confidence": 2.3,
-      "profile_completeness_percent": 48,
-      "review_reflection_percent": 47,
-      "review_reflection_mode": "neutral_guarded",
-      "review_application_rule": "中立スキャンを優先し、プロフィール由来の情報は質問候補の生成にのみ限定して反映します。本人の実際の意見として断定したり、口調を模倣したりしません。",
+      "public_viewpoint_summary": "本人発信では、経済的成果だけでなく世のため人のために価値を開くこと、努力した人が努力に見合う環境を得られることを事業上の大義として掲げている。",
+      "profile_url": "https://note.com/hab_go/n/n91441408a962",
+      "evidence_links": [
+        {
+          "label": "現職肩書き・事業領域・公開方針（本人発信）",
+          "url": "https://note.com/hab_go/n/n91441408a962"
+        }
+      ],
+      "evidence_confidence": 3.3,
+      "profile_completeness_percent": 65,
+      "review_reflection_percent": 72,
+      "review_reflection_mode": "profile_balanced",
+      "review_application_rule": "中立スキャンを軸に、確認済みプロフィール由来の観点だけを補助的に反映します。本人の実際の意見として断定したり、口調を模倣したりしません。",
       "review_focus_dimensions": [
+        {
+          "dimension": "market_demand",
+          "label": "市場需要",
+          "weight_percent": 15,
+          "question": "実在する顧客は誰で、需要を示す一次データは何か。"
+        },
+        {
+          "dimension": "founder_execution",
+          "label": "実行力",
+          "weight_percent": 15,
+          "question": "創業者とチームに、この計画をやり切った証拠があるか。"
+        },
         {
           "dimension": "customer_pain",
           "label": "顧客課題",
-          "weight_percent": 16,
+          "weight_percent": 13,
           "question": "顧客の未解決課題は、支払いを伴うほど強いか。"
-        },
-        {
-          "dimension": "revenue_model",
-          "label": "収益モデル",
-          "weight_percent": 15,
-          "question": "誰が、何に、いくら、どの頻度で支払うのか。"
         },
         {
           "dimension": "unit_economics",
           "label": "単位経済性",
-          "weight_percent": 15,
+          "weight_percent": 13,
           "question": "顧客・注文・店舗単位の粗利、獲得費、回収期間は成立するか。"
-        },
-        {
-          "dimension": "market_demand",
-          "label": "市場需要",
-          "weight_percent": 14,
-          "question": "実在する顧客は誰で、需要を示す一次データは何か。"
         }
       ],
       "review_style_tags": [
@@ -6331,7 +6339,8 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S071",
+        "S003",
         "S004"
       ]
     },
@@ -6339,60 +6348,82 @@
       "seat": 99,
       "name": "愛沢 えみり",
       "roster_status": "historical",
-      "birth_date": null,
-      "birth_date_source_url": null,
-      "company_role": "株式会社 voyage代表",
-      "business_summary": "人材・採用・組織",
+      "birth_date": "1988-09-01",
+      "birth_date_source_url": "https://aizawaemiri.com/introduce",
+      "company_role": "株式会社VOYAGE代表取締役。デジタルマーケティング支援、SNS運用代行、YouTube企画編集、広告代理、メディア、アパレル、EC、モデルプロダクション、店舗プロデュースを展開",
+      "business_summary": "デジタルマーケティング、SNS・YouTube運用、広告、メディア、アパレル・EC、モデルプロダクション、店舗プロデュース",
       "business_domains": [
-        "人材・採用・組織"
+        "マーケティング・メディア",
+        "小売・通販・EC",
+        "美容・ウェルネス",
+        "エンタメ・クリエイター"
       ],
       "appearances": 3,
       "investment_count": 1,
-      "public_viewpoint_summary": "直接帰属できる審査発言は今回未確認。人材・採用・組織の公開職歴と、番組集計上の出演3回・出資1回から質問優先度だけを限定的にモデル化し、本人の見解としては扱わない。",
-      "profile_url": "https://atsu-blog.com/tigerfunding-president-list/2/",
-      "evidence_confidence": 2.3,
-      "profile_completeness_percent": 48,
-      "review_reflection_percent": 47,
-      "review_reflection_mode": "neutral_guarded",
-      "review_application_rule": "中立スキャンを優先し、プロフィール由来の情報は質問候補の生成にのみ限定して反映します。本人の実際の意見として断定したり、口調を模倣したりしません。",
+      "public_viewpoint_summary": "公式の代表メッセージでは、顧客層や社会の変化に合わせて商品と発信を更新すること、相手の話を聞いて組織を改善すること、企業トップが自ら発信し認知と採用につなげることを重視している。",
+      "profile_url": "https://aizawaemiri.com/introduce",
+      "evidence_links": [
+        {
+          "label": "生年月日・肩書き・事業内容（本人公式プロフィール）",
+          "url": "https://aizawaemiri.com/introduce"
+        },
+        {
+          "label": "現職肩書き・事業内容（会社公式）",
+          "url": "https://un-voyage.net/company/"
+        },
+        {
+          "label": "公開された経営方針（会社公式代表メッセージ）",
+          "url": "https://un-voyage.net/vision/"
+        }
+      ],
+      "evidence_confidence": 3.3,
+      "profile_completeness_percent": 80,
+      "review_reflection_percent": 72,
+      "review_reflection_mode": "profile_balanced",
+      "review_application_rule": "中立スキャンを軸に、確認済みプロフィール由来の観点だけを補助的に反映します。本人の実際の意見として断定したり、口調を模倣したりしません。",
       "review_focus_dimensions": [
-        {
-          "dimension": "customer_pain",
-          "label": "顧客課題",
-          "weight_percent": 15,
-          "question": "顧客の未解決課題は、支払いを伴うほど強いか。"
-        },
-        {
-          "dimension": "scalability",
-          "label": "拡張性",
-          "weight_percent": 14,
-          "question": "代表者の労働量を増やさず再現・拡大できるか。"
-        },
         {
           "dimension": "market_demand",
           "label": "市場需要",
-          "weight_percent": 13,
+          "weight_percent": 25,
           "question": "実在する顧客は誰で、需要を示す一次データは何か。"
         },
         {
-          "dimension": "revenue_model",
-          "label": "収益モデル",
-          "weight_percent": 13,
-          "question": "誰が、何に、いくら、どの頻度で支払うのか。"
+          "dimension": "go_to_market",
+          "label": "顧客獲得",
+          "weight_percent": 25,
+          "question": "最初の顧客をどの経路・費用で獲得し、検証できるか。"
+        },
+        {
+          "dimension": "unit_economics",
+          "label": "単位経済性",
+          "weight_percent": 12,
+          "question": "顧客・注文・店舗単位の粗利、獲得費、回収期間は成立するか。"
+        },
+        {
+          "dimension": "competitive_advantage",
+          "label": "競争優位性",
+          "weight_percent": 11,
+          "question": "既存代替より選ばれ続ける、模倣されにくい理由は何か。"
         }
       ],
       "review_style_tags": [
-        "balanced_risk"
+        "customer_first",
+        "balanced_risk",
+        "acquisition_and_conversion",
+        "gross_margin_and_repeat_purchase"
       ],
       "next_research_targets": [
-        "生年月日の一次公開情報",
         "現職肩書き・事業内容の一次公開情報",
         "本人の審査姿勢が確認できる一次公開情報",
         "出演・出資実績の追加検証"
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S072",
+        "S073",
+        "S074",
+        "S003",
         "S004"
       ]
     },
@@ -6409,13 +6440,13 @@
         "経営支援・コンサルティング",
         "人材・採用・組織"
       ],
-      "appearances": 4,
+      "appearances": 5,
       "investment_count": 1,
       "public_viewpoint_summary": "SNS予算の費用対効果、数字管理、顧客同士の協業可能性を検討し、率直で実務的な改善案を出す。",
       "profile_url": "https://reiwanotora.jp/komon/mihara-takuto/",
-      "evidence_confidence": 3.3,
-      "profile_completeness_percent": 65,
-      "review_reflection_percent": 72,
+      "evidence_confidence": 3.7,
+      "profile_completeness_percent": 68,
+      "review_reflection_percent": 76,
       "review_reflection_mode": "profile_balanced",
       "review_application_rule": "中立スキャンを軸に、確認済みプロフィール由来の観点だけを補助的に反映します。本人の実際の意見として断定したり、口調を模倣したりしません。",
       "review_focus_dimensions": [
@@ -6458,7 +6489,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S071"
+        "S075"
       ]
     },
     {
@@ -6522,7 +6553,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S072",
+        "S076",
         "S004"
       ]
     },
@@ -6583,7 +6614,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S003",
+        "S007",
         "S004"
       ]
     },
@@ -6650,7 +6681,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S073",
+        "S077",
         "S004"
       ]
     },
@@ -6715,7 +6746,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S074",
+        "S078",
         "S004"
       ]
     },
@@ -6779,7 +6810,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S074",
+        "S078",
         "S004"
       ]
     },
@@ -6841,7 +6872,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -6903,7 +6934,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -6967,8 +6998,8 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S075",
-        "S008",
+        "S079",
+        "S003",
         "S004"
       ]
     },
@@ -7033,7 +7064,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S076",
+        "S080",
         "S004"
       ]
     },
@@ -7095,7 +7126,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S008",
+        "S003",
         "S004"
       ]
     },
@@ -7161,7 +7192,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S077",
+        "S081",
         "S004"
       ]
     },
@@ -7226,7 +7257,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S078"
+        "S082"
       ]
     },
     {
@@ -7291,7 +7322,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S079"
+        "S083"
       ]
     },
     {
@@ -7355,7 +7386,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S080"
+        "S084"
       ]
     },
     {
@@ -7417,7 +7448,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S081"
+        "S085"
       ]
     },
     {
@@ -7489,9 +7520,9 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S082",
-        "S083",
-        "S003",
+        "S086",
+        "S087",
+        "S007",
         "S004"
       ]
     },
@@ -7558,7 +7589,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S084",
+        "S088",
         "S004"
       ]
     },
@@ -7621,8 +7652,8 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S085",
-        "S008",
+        "S089",
+        "S003",
         "S004"
       ]
     },
@@ -7697,9 +7728,9 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S086",
-        "S087",
-        "S008",
+        "S090",
+        "S091",
+        "S003",
         "S004"
       ]
     },
@@ -7764,7 +7795,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S088",
+        "S092",
         "S004"
       ]
     },
@@ -7829,7 +7860,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S089",
+        "S093",
         "S004"
       ]
     },
@@ -7894,7 +7925,7 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S090",
+        "S094",
         "S004"
       ]
     },
@@ -7968,8 +7999,8 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S091",
-        "S092"
+        "S095",
+        "S096"
       ]
     },
     {
@@ -8043,9 +8074,9 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S093",
-        "S094",
-        "S008"
+        "S097",
+        "S098",
+        "S003"
       ]
     },
     {
@@ -8124,19 +8155,19 @@
       ],
       "evidence_source_ids": [
         "S002",
-        "S095",
-        "S096",
-        "S003"
+        "S099",
+        "S100",
+        "S007"
       ]
     }
   ],
   "enrichment": {
-    "round": 6,
+    "round": 7,
     "batch_size": 5,
     "policy": "一次公開情報を優先し、未確認情報は推測しない。プロフィール由来のレビュー観点は証拠強度に応じて段階反映する。",
-    "average_profile_completeness_percent": 65.9,
-    "average_review_reflection_percent": 71.3,
-    "verified_birth_dates": 8,
+    "average_profile_completeness_percent": 66.3,
+    "average_review_reflection_percent": 71.7,
+    "verified_birth_dates": 9,
     "next_batch": [
       {
         "seat": 116,
@@ -8161,30 +8192,30 @@
         ]
       },
       {
-        "seat": 98,
-        "name": "ロイター豪",
-        "profile_completeness_percent": 48,
-        "research_targets": [
-          "生年月日の一次公開情報",
-          "現職肩書き・事業内容の一次公開情報",
-          "本人の審査姿勢が確認できる一次公開情報",
-          "出演・出資実績の追加検証"
-        ]
-      },
-      {
-        "seat": 99,
-        "name": "愛沢 えみり",
-        "profile_completeness_percent": 48,
-        "research_targets": [
-          "生年月日の一次公開情報",
-          "現職肩書き・事業内容の一次公開情報",
-          "本人の審査姿勢が確認できる一次公開情報",
-          "出演・出資実績の追加検証"
-        ]
-      },
-      {
         "seat": 102,
         "name": "泉舞",
+        "profile_completeness_percent": 48,
+        "research_targets": [
+          "生年月日の一次公開情報",
+          "現職肩書き・事業内容の一次公開情報",
+          "本人の審査姿勢が確認できる一次公開情報",
+          "出演・出資実績の追加検証"
+        ]
+      },
+      {
+        "seat": 104,
+        "name": "川原ひろし",
+        "profile_completeness_percent": 48,
+        "research_targets": [
+          "生年月日の一次公開情報",
+          "現職肩書き・事業内容の一次公開情報",
+          "本人の審査姿勢が確認できる一次公開情報",
+          "出演・出資実績の追加検証"
+        ]
+      },
+      {
+        "seat": 105,
+        "name": "安田久",
         "profile_completeness_percent": 48,
         "research_targets": [
           "生年月日の一次公開情報",

--- a/test/models/tiger_reviewer_profile_test.dart
+++ b/test/models/tiger_reviewer_profile_test.dart
@@ -16,10 +16,10 @@ void main() {
 
       expect(catalog.schemaVersion, 2);
       expect(catalog.profilesBySeat, hasLength(125));
-      expect(catalog.enrichmentRound, greaterThanOrEqualTo(6));
+      expect(catalog.enrichmentRound, greaterThanOrEqualTo(7));
       expect(catalog.averageProfileCompletenessPercent, greaterThan(0));
       expect(catalog.averageReviewReflectionPercent, greaterThan(0));
-      expect(catalog.verifiedBirthDates, 8);
+      expect(catalog.verifiedBirthDates, 9);
       expect(catalog.nextBatchNames, hasLength(5));
       expect(catalog.profilesBySeat.keys.toSet(), hasLength(125));
       expect(
@@ -92,6 +92,21 @@ void main() {
       final makita = catalog.profilesBySeat[96]!;
       expect(makita.ageLabel(DateTime(2026, 8, 28)), '41歳（2026年8月28日時点）');
       expect(makita.companyRole, contains('代表取締役副社長'));
+      final reuter = catalog.profilesBySeat[98]!;
+      expect(reuter.ageLabel(DateTime(2026, 8, 29)), '公開情報未確認');
+      expect(reuter.companyRole, contains('株式会社Reuter'));
+      expect(reuter.businessDomains, contains('人材・採用・組織'));
+      expect(reuter.reviewReflectionPercent, 72);
+      expect(reuter.reviewReflectionMode, 'profile_balanced');
+      expect(reuter.evidenceLinks, hasLength(1));
+      final aizawa = catalog.profilesBySeat[99]!;
+      expect(aizawa.ageLabel(DateTime(2026, 8, 29)), '37歳（2026年8月29日時点）');
+      expect(aizawa.companyRole, contains('株式会社VOYAGE'));
+      expect(aizawa.businessDomains, contains('マーケティング・メディア'));
+      expect(aizawa.profileCompletenessPercent, 80);
+      expect(aizawa.reviewReflectionPercent, 72);
+      expect(aizawa.reviewReflectionMode, 'profile_balanced');
+      expect(aizawa.evidenceLinks, hasLength(3));
       final kataishi = catalog.profilesBySeat[125]!;
       expect(kataishi.ageLabel(DateTime(2026, 8, 25)), '32歳（2026年8月25日時点）');
       expect(


### PR DESCRIPTION
## Summary
- advance the Tiger public profile catalog to enrichment round 7
- add first-party evidence for ロイター豪 and 愛沢えみり, including 愛沢えみり's verified birth date
- move both evidence-backed profiles from neutral_guarded to profile_balanced without changing lane scoring weights
- preserve unknown fields for 渡正行, 足立暢, and 泉舞 rather than inferring facts

## Validation
- `python test/scripts/test_tiger_profile_enrichment.py`
- `python scripts/tiger_profile_enrichment.py --round 7 --check`
- installed canonical `validate_personas.py`
- installed deterministic `test_reviewer_selection.py`
- `flutter test --no-pub test/models/tiger_reviewer_profile_test.dart`
- `flutter test --no-pub test/pages/tiger_review_lane_status_page_test.dart`
- targeted Flutter analyze via `scripts/quality_gate.py`
- `flutter analyze --no-pub`

## Minimal E2E Gate
- Implementation-detail independent: the bundled public catalog is parsed through the production model and the narrow reviewer page expands age, title, business, and evidence fields.
- Minimal scope: one catalog asset and its model-level regression assertions; no production code or lane scoring rules changed.
- E2E-Exception: existing focused model and narrow widget coverage is the minimal browser-independent E2E boundary for an asset-only update; production desktop/mobile browser QA follows deployment.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: no protected logic, auth, payments, dependencies, migrations, or infrastructure changed; required CI plus post-merge production proof remains mandatory.